### PR TITLE
Seconday Menu Indentation System

### DIFF
--- a/src/app/component/data-request/data-request.menus.ts
+++ b/src/app/component/data-request/data-request.menus.ts
@@ -11,5 +11,5 @@ export const dataRequestMenuItem = MenuRoute({
   label: "Data Request",
   route: dataRequestRoute,
   tooltip: () => "Request customized data from the website",
-  order: { priority: 7, indentation: 0 }
+  order: { priority: 7 }
 });

--- a/src/app/component/data-request/data-request.menus.ts
+++ b/src/app/component/data-request/data-request.menus.ts
@@ -11,5 +11,5 @@ export const dataRequestMenuItem = MenuRoute({
   label: "Data Request",
   route: dataRequestRoute,
   tooltip: () => "Request customized data from the website",
-  order: { priority: 7 }
+  order: 7
 });

--- a/src/app/component/home/home.menus.ts
+++ b/src/app/component/home/home.menus.ts
@@ -12,5 +12,5 @@ export const homeMenuItem = MenuRoute({
   label: "Home",
   route: homeRoute,
   tooltip: () => "Home page",
-  order: { priority: 1 }
+  order: 1
 });

--- a/src/app/component/home/home.menus.ts
+++ b/src/app/component/home/home.menus.ts
@@ -12,5 +12,5 @@ export const homeMenuItem = MenuRoute({
   label: "Home",
   route: homeRoute,
   tooltip: () => "Home page",
-  order: { priority: 1, indentation: 0 }
+  order: { priority: 1 }
 });

--- a/src/app/component/profile/pages/my-edit/my-edit.component.ts
+++ b/src/app/component/profile/pages/my-edit/my-edit.component.ts
@@ -13,12 +13,16 @@ import {
   myAccountCategory,
   myAccountMenuItem
 } from "../../profile.menus";
+import { myProfileMenuItemActions } from "../profile/my-profile.component copy";
 import data from "./my-edit.json";
 
 @Page({
   category: myAccountCategory,
   menus: {
-    actions: List<AnyMenuItem>([myAccountMenuItem, editMyAccountMenuItem]),
+    actions: List<AnyMenuItem>([
+      myAccountMenuItem,
+      ...myProfileMenuItemActions
+    ]),
     links: List()
   },
   self: editMyAccountMenuItem

--- a/src/app/component/profile/pages/profile/my-profile.component copy.ts
+++ b/src/app/component/profile/pages/profile/my-profile.component copy.ts
@@ -16,40 +16,42 @@ import {
   myAccountMenuItem
 } from "../../profile.menus";
 
+export const myProfileMenuItemActions = [
+  editMyAccountMenuItem,
+  MenuLink({
+    icon: ["fas", "globe-asia"],
+    label: "My Projects",
+    uri: "BROKEN LINK",
+    tooltip: user => `Projects ${user.userName} can access`,
+    predicate: user => !!user
+  }),
+  MenuLink({
+    icon: ["fas", "map-marker-alt"],
+    label: "My Sites",
+    uri: "BROKEN LINK",
+    tooltip: user => `Sites ${user.userName} can access`,
+    predicate: user => !!user
+  }),
+  MenuLink({
+    icon: ["fas", "bookmark"],
+    label: "My Bookmarks",
+    uri: "BROKEN LINK",
+    tooltip: user => `Bookmarks created by ${user.userName}`,
+    predicate: user => !!user
+  }),
+  MenuLink({
+    icon: ["fas", "bullseye"],
+    label: "My Annotations",
+    uri: "BROKEN LINK",
+    tooltip: user => `Annotations created by ${user.userName}`,
+    predicate: user => !!user
+  })
+];
+
 @Page({
   category: myAccountCategory,
   menus: {
-    actions: List<AnyMenuItem>([
-      editMyAccountMenuItem,
-      MenuLink({
-        icon: ["fas", "globe-asia"],
-        label: "My Projects",
-        uri: "BROKEN LINK",
-        tooltip: user => `Projects ${user.userName} can access`,
-        predicate: user => !!user
-      }),
-      MenuLink({
-        icon: ["fas", "map-marker-alt"],
-        label: "My Sites",
-        uri: "BROKEN LINK",
-        tooltip: user => `Sites ${user.userName} can access`,
-        predicate: user => !!user
-      }),
-      MenuLink({
-        icon: ["fas", "bookmark"],
-        label: "My Bookmarks",
-        uri: "BROKEN LINK",
-        tooltip: user => `Bookmarks created by ${user.userName}`,
-        predicate: user => !!user
-      }),
-      MenuLink({
-        icon: ["fas", "bullseye"],
-        label: "My Annotations",
-        uri: "BROKEN LINK",
-        tooltip: user => `Annotations created by ${user.userName}`,
-        predicate: user => !!user
-      })
-    ]),
+    actions: List<AnyMenuItem>(myProfileMenuItemActions),
     links: List()
   },
   self: myAccountMenuItem

--- a/src/app/component/profile/pages/profile/their-profile.component.ts
+++ b/src/app/component/profile/pages/profile/their-profile.component.ts
@@ -17,40 +17,42 @@ import {
   theirProfileMenuItem
 } from "../../profile.menus";
 
+export const theirProfileMenuItemActions = [
+  theirEditProfileMenuItem,
+  MenuLink({
+    icon: ["fas", "globe-asia"],
+    label: "Their Projects",
+    uri: "BROKEN LINK",
+    tooltip: () => "Projects they can access",
+    predicate: user => !!user
+  }),
+  MenuLink({
+    icon: ["fas", "map-marker-alt"],
+    label: "Their Sites",
+    uri: "BROKEN LINK",
+    tooltip: () => "Sites they can access",
+    predicate: user => !!user
+  }),
+  MenuLink({
+    icon: ["fas", "bookmark"],
+    label: "Their Bookmarks",
+    uri: "BROKEN LINK",
+    tooltip: () => "Bookmarks created by them",
+    predicate: user => !!user
+  }),
+  MenuLink({
+    icon: ["fas", "bullseye"],
+    label: "Their Annotations",
+    uri: "BROKEN LINK",
+    tooltip: () => "Annotations created by them",
+    predicate: user => !!user
+  })
+];
+
 @Page({
   category: theirProfileCategory,
   menus: {
-    actions: List<AnyMenuItem>([
-      theirEditProfileMenuItem,
-      MenuLink({
-        icon: ["fas", "globe-asia"],
-        label: "Their Projects",
-        uri: "BROKEN LINK",
-        tooltip: () => "Projects they can access",
-        predicate: user => !!user
-      }),
-      MenuLink({
-        icon: ["fas", "map-marker-alt"],
-        label: "Their Sites",
-        uri: "BROKEN LINK",
-        tooltip: () => "Sites they can access",
-        predicate: user => !!user
-      }),
-      MenuLink({
-        icon: ["fas", "bookmark"],
-        label: "Their Bookmarks",
-        uri: "BROKEN LINK",
-        tooltip: () => "Bookmarks created by them",
-        predicate: user => !!user
-      }),
-      MenuLink({
-        icon: ["fas", "bullseye"],
-        label: "Their Annotations",
-        uri: "BROKEN LINK",
-        tooltip: () => "Annotations created by them",
-        predicate: user => !!user
-      })
-    ]),
+    actions: List<AnyMenuItem>(theirProfileMenuItemActions),
     links: List()
   },
   self: theirProfileMenuItem

--- a/src/app/component/profile/pages/their-edit/their-edit.component.ts
+++ b/src/app/component/profile/pages/their-edit/their-edit.component.ts
@@ -14,6 +14,7 @@ import {
   theirProfileCategory,
   theirProfileMenuItem
 } from "../../profile.menus";
+import { theirProfileMenuItemActions } from "../profile/their-profile.component";
 import data from "./their-edit.json";
 
 @Page({
@@ -21,7 +22,7 @@ import data from "./their-edit.json";
   menus: {
     actions: List<AnyMenuItem>([
       theirProfileMenuItem,
-      theirEditProfileMenuItem
+      ...theirProfileMenuItemActions
     ]),
     links: List()
   },

--- a/src/app/component/profile/profile.menus.ts
+++ b/src/app/component/profile/profile.menus.ts
@@ -23,7 +23,7 @@ export const myAccountMenuItem = MenuRoute({
   route: myAccountRoute,
   tooltip: () => "View profile",
   predicate: isLoggedInPredicate,
-  order: { priority: 2, indentation: 0 }
+  order: { priority: 2 }
 });
 
 export const editMyAccountMenuItem = MenuRoute({
@@ -34,8 +34,7 @@ export const editMyAccountMenuItem = MenuRoute({
   tooltip: () => "Change the details for your profile",
   predicate: isLoggedInPredicate,
   order: {
-    priority: myAccountMenuItem.order.priority,
-    indentation: myAccountMenuItem.order.indentation + 1
+    priority: myAccountMenuItem.order.priority
   }
 });
 

--- a/src/app/component/profile/profile.menus.ts
+++ b/src/app/component/profile/profile.menus.ts
@@ -23,7 +23,7 @@ export const myAccountMenuItem = MenuRoute({
   route: myAccountRoute,
   tooltip: () => "View profile",
   predicate: isLoggedInPredicate,
-  order: { priority: 2 }
+  order: 2
 });
 
 export const editMyAccountMenuItem = MenuRoute({
@@ -32,10 +32,7 @@ export const editMyAccountMenuItem = MenuRoute({
   route: myAccountMenuItem.route.add("edit"),
   parent: myAccountMenuItem,
   tooltip: () => "Change the details for your profile",
-  predicate: isLoggedInPredicate,
-  order: {
-    priority: myAccountMenuItem.order.priority
-  }
+  predicate: isLoggedInPredicate
 });
 
 /**
@@ -64,6 +61,5 @@ export const theirEditProfileMenuItem = MenuRoute({
   route: theirProfileMenuItem.route.add("edit"),
   parent: theirProfileMenuItem,
   tooltip: () => "Change the details for this profile",
-  predicate: isAdminPredicate,
-  order: editMyAccountMenuItem.order
+  predicate: isAdminPredicate
 });

--- a/src/app/component/projects/projects.menus.ts
+++ b/src/app/component/projects/projects.menus.ts
@@ -26,7 +26,7 @@ export const projectsMenuItem = MenuRoute({
   label: "Projects",
   route: projectsRoute,
   tooltip: () => "View projects I have access too",
-  order: { priority: 4 }
+  order: 4
 });
 
 export const newProjectMenuItem = MenuRoute({
@@ -35,9 +35,7 @@ export const newProjectMenuItem = MenuRoute({
   route: projectsRoute.add("new"),
   tooltip: () => "Create a new project",
   predicate: isLoggedInPredicate,
-  order: {
-    priority: projectsMenuItem.order.priority
-  }
+  parent: projectsMenuItem
 });
 
 export const requestProjectMenuItem = MenuRoute({
@@ -46,9 +44,7 @@ export const requestProjectMenuItem = MenuRoute({
   route: projectsRoute.add("request"),
   tooltip: () => "Request access to a project not listed here",
   predicate: isLoggedInPredicate,
-  order: {
-    priority: projectsMenuItem.order.priority
-  }
+  parent: projectsMenuItem
 });
 
 export const projectMenuItem = MenuRoute({
@@ -56,10 +52,7 @@ export const projectMenuItem = MenuRoute({
   label: "Project",
   route: projectsRoute.add(":projectId"),
   tooltip: () => "The current project",
-  parent: projectsMenuItem,
-  order: {
-    priority: projectsMenuItem.order.priority
-  }
+  parent: projectsMenuItem
 });
 
 export const projectCategory: Category = {
@@ -74,10 +67,7 @@ export const editProjectMenuItem = MenuRoute({
   route: projectMenuItem.route.add("edit"),
   parent: projectMenuItem,
   tooltip: () => "Change the details for this project",
-  predicate: isOwnerPredicate,
-  order: {
-    priority: projectMenuItem.order.priority
-  }
+  predicate: isOwnerPredicate
 });
 
 export const exploreAudioProjectMenuItem = MenuLink({
@@ -101,8 +91,5 @@ export const deleteProjectMenuItem = MenuRoute({
   route: projectMenuItem.route.add("delete"),
   parent: projectMenuItem,
   tooltip: () => "Delete this project",
-  predicate: isOwnerPredicate,
-  order: {
-    priority: projectMenuItem.order.priority
-  }
+  predicate: isOwnerPredicate
 });

--- a/src/app/component/projects/projects.menus.ts
+++ b/src/app/component/projects/projects.menus.ts
@@ -26,7 +26,7 @@ export const projectsMenuItem = MenuRoute({
   label: "Projects",
   route: projectsRoute,
   tooltip: () => "View projects I have access too",
-  order: { priority: 4, indentation: 0 }
+  order: { priority: 4 }
 });
 
 export const newProjectMenuItem = MenuRoute({
@@ -36,8 +36,7 @@ export const newProjectMenuItem = MenuRoute({
   tooltip: () => "Create a new project",
   predicate: isLoggedInPredicate,
   order: {
-    priority: projectsMenuItem.order.priority,
-    indentation: projectsMenuItem.order.indentation + 1
+    priority: projectsMenuItem.order.priority
   }
 });
 
@@ -48,8 +47,7 @@ export const requestProjectMenuItem = MenuRoute({
   tooltip: () => "Request access to a project not listed here",
   predicate: isLoggedInPredicate,
   order: {
-    priority: projectsMenuItem.order.priority,
-    indentation: projectsMenuItem.order.indentation + 1
+    priority: projectsMenuItem.order.priority
   }
 });
 
@@ -58,9 +56,9 @@ export const projectMenuItem = MenuRoute({
   label: "Project",
   route: projectsRoute.add(":projectId"),
   tooltip: () => "The current project",
+  parent: projectsMenuItem,
   order: {
-    priority: projectsMenuItem.order.priority,
-    indentation: projectsMenuItem.order.indentation + 1
+    priority: projectsMenuItem.order.priority
   }
 });
 
@@ -78,8 +76,7 @@ export const editProjectMenuItem = MenuRoute({
   tooltip: () => "Change the details for this project",
   predicate: isOwnerPredicate,
   order: {
-    priority: projectMenuItem.order.priority,
-    indentation: projectMenuItem.order.indentation + 1
+    priority: projectMenuItem.order.priority
   }
 });
 
@@ -106,7 +103,6 @@ export const deleteProjectMenuItem = MenuRoute({
   tooltip: () => "Delete this project",
   predicate: isOwnerPredicate,
   order: {
-    priority: projectMenuItem.order.priority,
-    indentation: projectMenuItem.order.indentation + 1
+    priority: projectMenuItem.order.priority
   }
 });

--- a/src/app/component/report-problem/report-problem.menus.ts
+++ b/src/app/component/report-problem/report-problem.menus.ts
@@ -11,5 +11,5 @@ export const reportProblemMenuItem = MenuRoute({
   label: "Report Problem",
   route: reportProblemsRoute,
   tooltip: () => "Report a problem with the website",
-  order: { priority: 9 }
+  order: 9
 });

--- a/src/app/component/report-problem/report-problem.menus.ts
+++ b/src/app/component/report-problem/report-problem.menus.ts
@@ -11,5 +11,5 @@ export const reportProblemMenuItem = MenuRoute({
   label: "Report Problem",
   route: reportProblemsRoute,
   tooltip: () => "Report a problem with the website",
-  order: { priority: 9, indentation: 0 }
+  order: { priority: 9 }
 });

--- a/src/app/component/security/security.menus.ts
+++ b/src/app/component/security/security.menus.ts
@@ -16,7 +16,7 @@ export const loginMenuItem = MenuRoute({
   tooltip: () => "Log into the website",
   route: securityRoute.add("login"),
   predicate: isGuestPredicate,
-  order: { priority: 2 }
+  order: 2
 });
 
 export const registerMenuItem = MenuRoute({
@@ -25,7 +25,7 @@ export const registerMenuItem = MenuRoute({
   route: securityRoute.add("register"),
   tooltip: () => "Create an account",
   predicate: isGuestPredicate,
-  order: { priority: 3 }
+  order: 3
 });
 
 export const confirmAccountMenuItem = MenuRoute({
@@ -33,8 +33,7 @@ export const confirmAccountMenuItem = MenuRoute({
   label: "Confirm account",
   route: securityRoute.add("confirmation"),
   tooltip: () => "Resend the email to confirm your account",
-  parent: loginMenuItem,
-  order: { priority: 2 }
+  parent: loginMenuItem
 });
 
 export const resetPasswordMenuItem = MenuRoute({
@@ -42,8 +41,7 @@ export const resetPasswordMenuItem = MenuRoute({
   label: "Reset password",
   route: securityRoute.add("reset_password"),
   tooltip: () => "Send an email to reset your password",
-  parent: loginMenuItem,
-  order: { priority: 2 }
+  parent: loginMenuItem
 });
 
 export const unlockAccountMenuItem = MenuRoute({
@@ -51,6 +49,5 @@ export const unlockAccountMenuItem = MenuRoute({
   label: "Unlock account",
   route: securityRoute.add("unlock_account"),
   tooltip: () => "Send an email to unlock your account",
-  parent: loginMenuItem,
-  order: { priority: 2 }
+  parent: loginMenuItem
 });

--- a/src/app/component/security/security.menus.ts
+++ b/src/app/component/security/security.menus.ts
@@ -10,21 +10,13 @@ export const securityCategory: Category = {
   route: securityRoute
 };
 
-export const confirmAccountMenuItem = MenuRoute({
-  icon: ["fas", "envelope"],
-  label: "Confirm account",
-  route: securityRoute.add("confirmation"),
-  tooltip: () => "Resend the email to confirm your account",
-  order: { priority: 2, indentation: 1 }
-});
-
 export const loginMenuItem = MenuRoute({
   icon: ["fas", "sign-in-alt"],
   label: "Log in",
   tooltip: () => "Log into the website",
   route: securityRoute.add("login"),
   predicate: isGuestPredicate,
-  order: { priority: 2, indentation: 0 }
+  order: { priority: 2 }
 });
 
 export const registerMenuItem = MenuRoute({
@@ -33,7 +25,16 @@ export const registerMenuItem = MenuRoute({
   route: securityRoute.add("register"),
   tooltip: () => "Create an account",
   predicate: isGuestPredicate,
-  order: { priority: 3, indentation: 0 }
+  order: { priority: 3 }
+});
+
+export const confirmAccountMenuItem = MenuRoute({
+  icon: ["fas", "envelope"],
+  label: "Confirm account",
+  route: securityRoute.add("confirmation"),
+  tooltip: () => "Resend the email to confirm your account",
+  parent: loginMenuItem,
+  order: { priority: 2 }
 });
 
 export const resetPasswordMenuItem = MenuRoute({
@@ -41,7 +42,8 @@ export const resetPasswordMenuItem = MenuRoute({
   label: "Reset password",
   route: securityRoute.add("reset_password"),
   tooltip: () => "Send an email to reset your password",
-  order: { priority: 2, indentation: 1 }
+  parent: loginMenuItem,
+  order: { priority: 2 }
 });
 
 export const unlockAccountMenuItem = MenuRoute({
@@ -49,5 +51,6 @@ export const unlockAccountMenuItem = MenuRoute({
   label: "Unlock account",
   route: securityRoute.add("unlock_account"),
   tooltip: () => "Send an email to unlock your account",
-  order: { priority: 2, indentation: 1 }
+  parent: loginMenuItem,
+  order: { priority: 2 }
 });

--- a/src/app/component/shared/menu/menu.component.spec.ts
+++ b/src/app/component/shared/menu/menu.component.spec.ts
@@ -222,14 +222,14 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 1, indentation: 0 }
+      order: { priority: 1 }
     });
     const internalLink2Obj = MenuRoute({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 2, indentation: 0 }
+      order: { priority: 2 }
     });
 
     component.menuType = "action";
@@ -361,14 +361,14 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       uri: "http://brokenlink/",
-      order: { priority: 1, indentation: 0 }
+      order: { priority: 1 }
     });
     const externalLink2Obj = MenuLink({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       uri: "http://brokenlink/",
-      order: { priority: 2, indentation: 0 }
+      order: { priority: 2 }
     });
 
     component.menuType = "action";
@@ -496,14 +496,14 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       action: () => {},
-      order: { priority: 1, indentation: 0 }
+      order: { priority: 1 }
     });
     const button2Obj = MenuAction({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       action: () => {},
-      order: { priority: 2, indentation: 0 }
+      order: { priority: 2 }
     });
 
     component.menuType = "action";
@@ -549,21 +549,21 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       action: () => {},
-      order: { priority: 1, indentation: 0 }
+      order: { priority: 1 }
     });
     const externalLinkObj = MenuLink({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       uri: "http://brokenlink/",
-      order: { priority: 2, indentation: 0 }
+      order: { priority: 2 }
     });
     const internalLinkObj = MenuRoute({
       label: "label c",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 3, indentation: 0 }
+      order: { priority: 3 }
     });
 
     component.menuType = "action";
@@ -737,14 +737,14 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 2, indentation: 0 }
+      order: { priority: 2 }
     });
     const internalLink2Obj = MenuRoute({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 1, indentation: 0 }
+      order: { priority: 1 }
     });
 
     component.menuType = "secondary";
@@ -795,14 +795,14 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 2, indentation: 0 }
+      order: { priority: 2 }
     });
     const internalLink2Obj = MenuRoute({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 1, indentation: 0 }
+      order: { priority: 1 }
     });
 
     component.menuType = "action";
@@ -971,7 +971,7 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 2, indentation: 0 }
+      order: { priority: 2 }
     });
 
     component.menuType = "secondary";
@@ -1028,7 +1028,7 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 2, indentation: 0 }
+      order: { priority: 2 }
     });
 
     component.menuType = "action";
@@ -1073,20 +1073,20 @@ describe("MenuComponent", () => {
     );
   });
 
-  it("should not order links with duplicate priority and indentation alphabetically on action menu", () => {
+  it("should not order links with duplicate priority alphabetically on action menu", () => {
     const internalLink1Obj = MenuRoute({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 1, indentation: 0 }
+      order: { priority: 1 }
     });
     const internalLink2Obj = MenuRoute({
       label: "label a",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 1, indentation: 0 }
+      order: { priority: 1 }
     });
 
     component.menuType = "action";
@@ -1131,20 +1131,20 @@ describe("MenuComponent", () => {
     );
   });
 
-  it("should order links with duplicate priority and indentation alphabetically on secondary menu", () => {
+  it("should order links with duplicate priority alphabetically on secondary menu", () => {
     const internalLink1Obj = MenuRoute({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 1, indentation: 0 }
+      order: { priority: 1 }
     });
     const internalLink2Obj = MenuRoute({
       label: "label a",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 1, indentation: 0 }
+      order: { priority: 1 }
     });
 
     component.menuType = "secondary";
@@ -1189,20 +1189,21 @@ describe("MenuComponent", () => {
     );
   });
 
-  it("should order links with duplicate priority by indentation on secondary menu", () => {
-    const internalLink1Obj = MenuRoute({
-      label: "label a",
-      icon: ["fas", "home"],
-      tooltip: () => "tooltip",
-      route: StrongRoute.Base.add("home"),
-      order: { priority: 1, indentation: 1 }
-    });
+  it("should order links with duplicate priority by parent on secondary menu", () => {
     const internalLink2Obj = MenuRoute({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 1, indentation: 0 }
+      order: { priority: 1 }
+    });
+    const internalLink1Obj = MenuRoute({
+      label: "label a",
+      icon: ["fas", "home"],
+      tooltip: () => "tooltip",
+      route: StrongRoute.Base.add("home"),
+      parent: internalLink2Obj,
+      order: { priority: 1 }
     });
 
     component.menuType = "secondary";
@@ -1247,20 +1248,21 @@ describe("MenuComponent", () => {
     );
   });
 
-  it("should not order links with duplicate priority by indentation on action menu", () => {
-    const internalLink1Obj = MenuRoute({
-      label: "label a",
-      icon: ["fas", "home"],
-      tooltip: () => "tooltip",
-      route: StrongRoute.Base.add("home"),
-      order: { priority: 1, indentation: 1 }
-    });
+  it("should not order links with duplicate priority by parent on action menu", () => {
     const internalLink2Obj = MenuRoute({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 1, indentation: 0 }
+      order: { priority: 1 }
+    });
+    const internalLink1Obj = MenuRoute({
+      label: "label a",
+      icon: ["fas", "home"],
+      tooltip: () => "tooltip",
+      route: StrongRoute.Base.add("home"),
+      parent: internalLink2Obj,
+      order: { priority: 1 }
     });
 
     component.menuType = "action";
@@ -1306,19 +1308,20 @@ describe("MenuComponent", () => {
   });
 
   it("should order sub-links on secondary menu", () => {
-    const internalLink1Obj = MenuRoute({
-      label: "label a",
-      icon: ["fas", "home"],
-      tooltip: () => "tooltip",
-      route: StrongRoute.Base.add("home"),
-      order: { priority: 1, indentation: 2 }
-    });
     const internalLink2Obj = MenuRoute({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 1, indentation: 1 }
+      order: { priority: 1 }
+    });
+    const internalLink1Obj = MenuRoute({
+      label: "label a",
+      icon: ["fas", "home"],
+      tooltip: () => "tooltip",
+      route: StrongRoute.Base.add("home"),
+      parent: internalLink2Obj,
+      order: { priority: 1 }
     });
 
     component.menuType = "secondary";
@@ -1371,14 +1374,14 @@ describe("MenuComponent", () => {
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("home"),
-        order: { priority: 1, indentation: 0 }
+        order: { priority: 1 }
       }),
       MenuRoute({
         label: "label a",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("house"),
-        order: { priority: 2, indentation: 0 }
+        order: { priority: 2 }
       })
     ]);
     fixture.detectChanges();
@@ -1393,7 +1396,7 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 1, indentation: 0 }
+      order: { priority: 1 }
     });
     internalLinkComponent1.placement = "left";
     internalLinkComponent1.tooltip = "tooltip";
@@ -1419,14 +1422,14 @@ describe("MenuComponent", () => {
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("home"),
-        order: { priority: 1, indentation: 0 }
+        order: { priority: 1 }
       }),
       MenuRoute({
         label: "label a",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("house"),
-        order: { priority: 2, indentation: 0 }
+        order: { priority: 2 }
       })
     ]);
     fixture.detectChanges();
@@ -1441,7 +1444,7 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 1, indentation: 0 }
+      order: { priority: 1 }
     });
     internalLinkComponent1.placement = "right";
     internalLinkComponent1.tooltip = "tooltip";
@@ -1467,14 +1470,14 @@ describe("MenuComponent", () => {
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("home"),
-        order: { priority: 1, indentation: 0 }
+        order: { priority: 1 }
       }),
       MenuRoute({
         label: "label b",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("house"),
-        order: { priority: 2, indentation: 0 },
+        order: { priority: 2 },
         predicate: () => false
       })
     ]);
@@ -1490,7 +1493,7 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 1, indentation: 0 }
+      order: { priority: 1 }
     });
     internalLinkComponent1.placement = "left";
     internalLinkComponent1.tooltip = "tooltip";
@@ -1516,14 +1519,14 @@ describe("MenuComponent", () => {
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("home"),
-        order: { priority: 1, indentation: 0 }
+        order: { priority: 1 }
       }),
       MenuRoute({
         label: "label b",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("house"),
-        order: { priority: 2, indentation: 0 },
+        order: { priority: 2 },
         predicate: () => false
       })
     ]);
@@ -1539,7 +1542,7 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 1, indentation: 0 }
+      order: { priority: 1 }
     });
     internalLinkComponent1.placement = "right";
     internalLinkComponent1.tooltip = "tooltip";
@@ -1568,14 +1571,14 @@ describe("MenuComponent", () => {
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("home"),
-        order: { priority: 1, indentation: 0 }
+        order: { priority: 1 }
       }),
       MenuRoute({
         label: "label b",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("house"),
-        order: { priority: 2, indentation: 0 },
+        order: { priority: 2 },
         predicate: user => {
           expect(user).toBeFalsy();
           return !user;
@@ -1601,14 +1604,14 @@ describe("MenuComponent", () => {
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("home"),
-        order: { priority: 1, indentation: 0 }
+        order: { priority: 1 }
       }),
       MenuRoute({
         label: "label b",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("house"),
-        order: { priority: 2, indentation: 0 },
+        order: { priority: 2 },
         predicate: user => {
           expect(user).toBeFalsy();
           return !user;
@@ -1640,14 +1643,14 @@ describe("MenuComponent", () => {
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("home"),
-        order: { priority: 1, indentation: 0 }
+        order: { priority: 1 }
       }),
       MenuRoute({
         label: "label b",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("house"),
-        order: { priority: 2, indentation: 0 },
+        order: { priority: 2 },
         predicate: user => {
           expect(user).toBeTruthy();
           expect(user.authToken).toBe("xxxxxxxxxxxxxxxxxxxx");

--- a/src/app/component/shared/menu/menu.component.spec.ts
+++ b/src/app/component/shared/menu/menu.component.spec.ts
@@ -222,14 +222,14 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 1 }
+      order: 1
     });
     const internalLink2Obj = MenuRoute({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 2 }
+      order: 2
     });
 
     component.menuType = "action";
@@ -361,14 +361,14 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       uri: "http://brokenlink/",
-      order: { priority: 1 }
+      order: 1
     });
     const externalLink2Obj = MenuLink({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       uri: "http://brokenlink/",
-      order: { priority: 2 }
+      order: 2
     });
 
     component.menuType = "action";
@@ -496,14 +496,14 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       action: () => {},
-      order: { priority: 1 }
+      order: 1
     });
     const button2Obj = MenuAction({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       action: () => {},
-      order: { priority: 2 }
+      order: 2
     });
 
     component.menuType = "action";
@@ -549,21 +549,22 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       action: () => {},
-      order: { priority: 1 }
+      order: 1
     });
     const externalLinkObj = MenuLink({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       uri: "http://brokenlink/",
-      order: { priority: 2 }
+      order: 2,
+      indentation: 0
     });
     const internalLinkObj = MenuRoute({
       label: "label c",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 3 }
+      order: 3
     });
 
     component.menuType = "action";
@@ -737,14 +738,14 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 2 }
+      order: 2
     });
     const internalLink2Obj = MenuRoute({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 1 }
+      order: 1
     });
 
     component.menuType = "secondary";
@@ -795,14 +796,14 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 2 }
+      order: 2
     });
     const internalLink2Obj = MenuRoute({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 1 }
+      order: 1
     });
 
     component.menuType = "action";
@@ -971,7 +972,7 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 2 }
+      order: 2
     });
 
     component.menuType = "secondary";
@@ -1028,7 +1029,7 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 2 }
+      order: 2
     });
 
     component.menuType = "action";
@@ -1079,14 +1080,14 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 1 }
+      order: 1
     });
     const internalLink2Obj = MenuRoute({
       label: "label a",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 1 }
+      order: 1
     });
 
     component.menuType = "action";
@@ -1137,14 +1138,14 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 1 }
+      order: 1
     });
     const internalLink2Obj = MenuRoute({
       label: "label a",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 1 }
+      order: 1
     });
 
     component.menuType = "secondary";
@@ -1189,72 +1190,13 @@ describe("MenuComponent", () => {
     );
   });
 
-  it("should not order links with duplicate priority on action menu", () => {
-    const internalLink2Obj = MenuRoute({
-      label: "label b",
-      icon: ["fas", "home"],
-      tooltip: () => "tooltip",
-      route: StrongRoute.Base.add("house"),
-      order: { priority: 1 }
-    });
-    const internalLink1Obj = MenuRoute({
-      label: "label a",
-      icon: ["fas", "home"],
-      tooltip: () => "tooltip",
-      route: StrongRoute.Base.add("home"),
-      parent: internalLink2Obj,
-      order: { priority: 1 }
-    });
-
-    component.menuType = "action";
-    component.links = List<AnyMenuItem>([internalLink1Obj, internalLink2Obj]);
-    fixture.detectChanges();
-
-    const internalLinkFixture1 = TestBed.createComponent(
-      MenuInternalLinkComponent
-    );
-    const internalLinkComponent1 = internalLinkFixture1.componentInstance;
-    internalLinkComponent1.id = "action-tooltip-0";
-    internalLinkComponent1.link = internalLink1Obj;
-    internalLinkComponent1.placement = "left";
-    internalLinkComponent1.tooltip = "tooltip";
-    internalLinkFixture1.detectChanges();
-
-    const internalLinkFixture2 = TestBed.createComponent(
-      MenuInternalLinkComponent
-    );
-    const internalLinkComponent2 = internalLinkFixture2.componentInstance;
-    internalLinkComponent2.id = "action-tooltip-1";
-    internalLinkComponent2.link = internalLink2Obj;
-    internalLinkComponent2.placement = "left";
-    internalLinkComponent2.tooltip = "tooltip";
-    internalLinkFixture2.detectChanges();
-
-    const links = fixture.debugElement.nativeElement.querySelectorAll(
-      "app-menu-internal-link"
-    );
-    expect(links.length).toBe(2, "Should be two internal links");
-
-    const internalLink1 = internalLinkFixture1.debugElement.nativeElement;
-    const internalLink2 = internalLinkFixture2.debugElement.nativeElement;
-
-    expect(links[0].innerHTML).toEqual(
-      internalLink1.innerHTML,
-      "First internal link HTML should match"
-    );
-    expect(links[1].innerHTML).toEqual(
-      internalLink2.innerHTML,
-      "Second internal link HTML should match"
-    );
-  });
-
   it("should order sub-links on secondary menu", () => {
     const internalLink2Obj = MenuRoute({
       label: "label b",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 1, indentation: 1 }
+      order: 1
     });
     const internalLink1Obj = MenuRoute({
       label: "label a",
@@ -1262,7 +1204,7 @@ describe("MenuComponent", () => {
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
       parent: internalLink2Obj,
-      order: { priority: 1, indentation: 2 }
+      order: 1
     });
 
     component.menuType = "secondary";
@@ -1315,14 +1257,14 @@ describe("MenuComponent", () => {
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("home"),
-        order: { priority: 1 }
+        order: 1
       }),
       MenuRoute({
         label: "label a",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("house"),
-        order: { priority: 2 }
+        order: 2
       })
     ]);
     fixture.detectChanges();
@@ -1337,7 +1279,7 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 1 }
+      order: 1
     });
     internalLinkComponent1.placement = "left";
     internalLinkComponent1.tooltip = "tooltip";
@@ -1363,14 +1305,14 @@ describe("MenuComponent", () => {
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("home"),
-        order: { priority: 1 }
+        order: 1
       }),
       MenuRoute({
         label: "label a",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("house"),
-        order: { priority: 2 }
+        order: 2
       })
     ]);
     fixture.detectChanges();
@@ -1385,7 +1327,7 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 1 }
+      order: 1
     });
     internalLinkComponent1.placement = "right";
     internalLinkComponent1.tooltip = "tooltip";
@@ -1411,14 +1353,14 @@ describe("MenuComponent", () => {
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("home"),
-        order: { priority: 1 }
+        order: 1
       }),
       MenuRoute({
         label: "label b",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("house"),
-        order: { priority: 2 },
+        order: 2,
         predicate: () => false
       })
     ]);
@@ -1434,7 +1376,7 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 1 }
+      order: 1
     });
     internalLinkComponent1.placement = "left";
     internalLinkComponent1.tooltip = "tooltip";
@@ -1460,14 +1402,14 @@ describe("MenuComponent", () => {
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("home"),
-        order: { priority: 1 }
+        order: 1
       }),
       MenuRoute({
         label: "label b",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("house"),
-        order: { priority: 2 },
+        order: 2,
         predicate: () => false
       })
     ]);
@@ -1483,7 +1425,7 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
-      order: { priority: 1 }
+      order: 1
     });
     internalLinkComponent1.placement = "right";
     internalLinkComponent1.tooltip = "tooltip";
@@ -1512,14 +1454,14 @@ describe("MenuComponent", () => {
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("home"),
-        order: { priority: 1 }
+        order: 1
       }),
       MenuRoute({
         label: "label b",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("house"),
-        order: { priority: 2 },
+        order: 2,
         predicate: user => {
           expect(user).toBeFalsy();
           return !user;
@@ -1545,14 +1487,14 @@ describe("MenuComponent", () => {
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("home"),
-        order: { priority: 1 }
+        order: 1
       }),
       MenuRoute({
         label: "label b",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("house"),
-        order: { priority: 2 },
+        order: 2,
         predicate: user => {
           expect(user).toBeFalsy();
           return !user;
@@ -1584,14 +1526,14 @@ describe("MenuComponent", () => {
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("home"),
-        order: { priority: 1 }
+        order: 1
       }),
       MenuRoute({
         label: "label b",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
         route: StrongRoute.Base.add("house"),
-        order: { priority: 2 },
+        order: 2,
         predicate: user => {
           expect(user).toBeTruthy();
           expect(user.authToken).toBe("xxxxxxxxxxxxxxxxxxxx");

--- a/src/app/component/shared/menu/menu.component.spec.ts
+++ b/src/app/component/shared/menu/menu.component.spec.ts
@@ -1189,66 +1189,7 @@ describe("MenuComponent", () => {
     );
   });
 
-  it("should order links with duplicate priority by parent on secondary menu", () => {
-    const internalLink2Obj = MenuRoute({
-      label: "label b",
-      icon: ["fas", "home"],
-      tooltip: () => "tooltip",
-      route: StrongRoute.Base.add("house"),
-      order: { priority: 1 }
-    });
-    const internalLink1Obj = MenuRoute({
-      label: "label a",
-      icon: ["fas", "home"],
-      tooltip: () => "tooltip",
-      route: StrongRoute.Base.add("home"),
-      parent: internalLink2Obj,
-      order: { priority: 1 }
-    });
-
-    component.menuType = "secondary";
-    component.links = List<AnyMenuItem>([internalLink1Obj, internalLink2Obj]);
-    fixture.detectChanges();
-
-    const internalLinkFixture1 = TestBed.createComponent(
-      MenuInternalLinkComponent
-    );
-    const internalLinkComponent1 = internalLinkFixture1.componentInstance;
-    internalLinkComponent1.id = "secondary-tooltip-1";
-    internalLinkComponent1.link = internalLink1Obj;
-    internalLinkComponent1.placement = "right";
-    internalLinkComponent1.tooltip = "tooltip";
-    internalLinkFixture1.detectChanges();
-
-    const internalLinkFixture2 = TestBed.createComponent(
-      MenuInternalLinkComponent
-    );
-    const internalLinkComponent2 = internalLinkFixture2.componentInstance;
-    internalLinkComponent2.id = "secondary-tooltip-0";
-    internalLinkComponent2.link = internalLink2Obj;
-    internalLinkComponent2.placement = "right";
-    internalLinkComponent2.tooltip = "tooltip";
-    internalLinkFixture2.detectChanges();
-
-    const links = fixture.debugElement.nativeElement.querySelectorAll(
-      "app-menu-internal-link"
-    );
-    expect(links.length).toBe(2, "Should be two internal links");
-
-    const internalLink1 = internalLinkFixture1.debugElement.nativeElement;
-    const internalLink2 = internalLinkFixture2.debugElement.nativeElement;
-
-    expect(links[0].innerHTML).toEqual(
-      internalLink2.innerHTML,
-      "First internal link HTML should match"
-    );
-    expect(links[1].innerHTML).toEqual(
-      internalLink1.innerHTML,
-      "Second internal link HTML should match"
-    );
-  });
-
-  it("should not order links with duplicate priority by parent on action menu", () => {
+  it("should not order links with duplicate priority on action menu", () => {
     const internalLink2Obj = MenuRoute({
       label: "label b",
       icon: ["fas", "home"],
@@ -1313,7 +1254,7 @@ describe("MenuComponent", () => {
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("house"),
-      order: { priority: 1 }
+      order: { priority: 1, indentation: 1 }
     });
     const internalLink1Obj = MenuRoute({
       label: "label a",
@@ -1321,7 +1262,7 @@ describe("MenuComponent", () => {
       tooltip: () => "tooltip",
       route: StrongRoute.Base.add("home"),
       parent: internalLink2Obj,
-      order: { priority: 1 }
+      order: { priority: 1, indentation: 2 }
     });
 
     component.menuType = "secondary";

--- a/src/app/component/shared/menu/menu.component.ts
+++ b/src/app/component/shared/menu/menu.component.ts
@@ -180,17 +180,17 @@ export class MenuComponent implements OnInit, OnDestroy {
    */
   private compare(a: AnyMenuItem, b: AnyMenuItem): number {
     // If no order, return alphabetical order
-    if (!a.order && !b.order) {
+    if (!a.order?.priority && !b.order?.priority) {
       return a.label < b.label ? -1 : 1;
     }
 
     // If only a has order, return a
-    if (a.order && !b.order) {
+    if (a.order && !b.order?.priority) {
       return -1;
     }
 
     // If only b has order, return b
-    if (b.order && !a.order) {
+    if (b.order && !a.order?.priority) {
       return 1;
     }
 

--- a/src/app/component/shared/menu/menu.component.ts
+++ b/src/app/component/shared/menu/menu.component.ts
@@ -104,15 +104,11 @@ export class MenuComponent implements OnInit, OnDestroy {
    */
   calculatePadding(link: AnyMenuItem) {
     // Only the secondary menu implements this option
-    if (
-      this.menuType !== "secondary" ||
-      !link.order ||
-      !link.order.indentation
-    ) {
+    if (this.menuType !== "secondary" || !link.indentation) {
       return "0em";
     }
 
-    return `${link.order.indentation}em`;
+    return `${link.indentation}em`;
   }
 
   /**
@@ -180,31 +176,31 @@ export class MenuComponent implements OnInit, OnDestroy {
    */
   private compare(a: AnyMenuItem, b: AnyMenuItem): number {
     // If no order, return alphabetical order
-    if (!a.order?.priority && !b.order?.priority) {
+    if (!a.order && !b.order) {
       return a.label < b.label ? -1 : 1;
     }
 
     // If only a has order, return a
-    if (a.order && !b.order?.priority) {
+    if (a.order && !b.order) {
       return -1;
     }
 
     // If only b has order, return b
-    if (b.order && !a.order?.priority) {
+    if (b.order && !a.order) {
       return 1;
     }
 
     // If both have the same order number,
     // prioritize based on indentation and alphabetical order
-    if (a.order.priority === b.order.priority) {
-      if (a.order.indentation === b.order.indentation) {
+    if (a.order === b.order) {
+      if (a.indentation === b.indentation) {
         return a.label < b.label ? -1 : 1;
       }
 
-      return a.order.indentation < b.order.indentation ? -1 : 1;
+      return a.indentation < b.indentation ? -1 : 1;
     }
 
     // Return the menu item with the lower order value
-    return a.order.priority < b.order.priority ? -1 : 1;
+    return a.order < b.order ? -1 : 1;
   }
 }

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
@@ -668,7 +668,7 @@ describe("SecondaryMenuComponent", () => {
       private childRoute = this.parentRoute.add("house");
       private parentLink = MenuRoute({
         label: "ZZZCustom Label", // Force to be last link
-        icon: ["fas", "question-square"],
+        icon: ["fas", "question"],
         tooltip: () => "Custom Tooltip 1",
         route: this.parentRoute
       });
@@ -732,7 +732,7 @@ describe("SecondaryMenuComponent", () => {
     expect(label.innerText.trim()).toBe("ZZZCustom Label");
     expect(icon.attributes.getNamedItem("ng-reflect-icon-prop")).toBeTruthy();
     expect(icon.attributes.getNamedItem("ng-reflect-icon-prop").value).toBe(
-      "fas,question-square"
+      "fas,question"
     );
 
     item = menuElements[defaultLinks.count() + 3 - 2 - 1].querySelector(
@@ -769,7 +769,7 @@ describe("SecondaryMenuComponent", () => {
       });
       private parentLink = MenuRoute({
         label: "ZZZZCustom Label", // Force to be last link
-        icon: ["fas", "question-square"],
+        icon: ["fas", "question"],
         tooltip: () => "Custom Tooltip 2",
         route: this.parentRoute,
         parent: this.grandParentLink
@@ -854,7 +854,7 @@ describe("SecondaryMenuComponent", () => {
     expect(label.innerText.trim()).toBe("ZZZZCustom Label");
     expect(icon.attributes.getNamedItem("ng-reflect-icon-prop")).toBeTruthy();
     expect(icon.attributes.getNamedItem("ng-reflect-icon-prop").value).toBe(
-      "fas,question-square"
+      "fas,question"
     );
 
     item = menuElements[defaultLinks.count() + 4 - 2 - 1].querySelector(
@@ -875,6 +875,373 @@ describe("SecondaryMenuComponent", () => {
     expect(icon.attributes.getNamedItem("ng-reflect-icon-prop")).toBeTruthy();
     expect(icon.attributes.getNamedItem("ng-reflect-icon-prop").value).toBe(
       "fas,question-circle"
+    );
+  });
+
+  it("should create menu link with no indentation", () => {
+    class MockActivatedRoute {
+      private route = StrongRoute.Base.add("/");
+
+      public params = new BehaviorSubject<any>({});
+      public data = new BehaviorSubject<PageInfoInterface>(
+        new PageInfo(SecondaryMenuComponent, {
+          self: MenuRoute({
+            label: "Custom Label",
+            icon: ["fas", "question-circle"],
+            tooltip: () => "Custom Tooltip",
+            route: this.route,
+            order: {
+              priority: 10
+            }
+          }),
+          category: {
+            label: "Custom Category",
+            icon: ["fas", "home"],
+            route: this.route
+          },
+          menus: {
+            actions: List<AnyMenuItem>([]),
+            links: List<NavigableMenuItem>([
+              MenuRoute({
+                label: "ZZZCustom Label", // Force to be last link
+                icon: ["fas", "tag"],
+                tooltip: () => "Custom Tooltip",
+                route: this.route
+              })
+            ])
+          }
+        } as PageInfoInterface)
+      );
+    }
+
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, HttpClientModule, SharedModule],
+      declarations: [SecondaryMenuComponent],
+      providers: [
+        ...testAppInitializer,
+        { provide: ActivatedRoute, useClass: MockActivatedRoute }
+      ]
+    }).compileComponents();
+    fixture = TestBed.createComponent(SecondaryMenuComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+
+    // Number of elements should be the default links,
+    // plus self link, plus menu title, plus added link,
+    // minus 2 links which require authentication
+    const menuElements = fixture.nativeElement.querySelectorAll("li.nav-item");
+    expect(menuElements.length).toBe(defaultLinks.count() + 3 - 2);
+
+    const item = menuElements[defaultLinks.count() + 3 - 2 - 1];
+    expect(item).toBeTruthy();
+    expect(item.computedStyleMap().has("padding-left")).toBeTruthy();
+    expect(item.computedStyleMap().get("padding-left").value).toBe(0);
+  });
+
+  it("should overwrite indentation value of ordered menu item", () => {
+    class MockActivatedRoute {
+      private route = StrongRoute.Base.add("/");
+
+      public params = new BehaviorSubject<any>({});
+      public data = new BehaviorSubject<PageInfoInterface>(
+        new PageInfo(SecondaryMenuComponent, {
+          self: MenuRoute({
+            label: "Custom Label",
+            icon: ["fas", "question-circle"],
+            tooltip: () => "Custom Tooltip",
+            route: this.route,
+            order: {
+              priority: 10,
+              indentation: 5
+            }
+          }),
+          category: {
+            label: "Custom Category",
+            icon: ["fas", "home"],
+            route: this.route
+          },
+          menus: {
+            actions: List<AnyMenuItem>([]),
+            links: List<NavigableMenuItem>([
+              MenuRoute({
+                label: "ZZZCustom Label", // Force to be last link
+                icon: ["fas", "tag"],
+                tooltip: () => "Custom Tooltip",
+                route: this.route
+              })
+            ])
+          }
+        } as PageInfoInterface)
+      );
+    }
+
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, HttpClientModule, SharedModule],
+      declarations: [SecondaryMenuComponent],
+      providers: [
+        ...testAppInitializer,
+        { provide: ActivatedRoute, useClass: MockActivatedRoute }
+      ]
+    }).compileComponents();
+    fixture = TestBed.createComponent(SecondaryMenuComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+
+    // Number of elements should be the default links,
+    // plus self link, plus menu title, plus added link,
+    // minus 2 links which require authentication
+    const menuElements = fixture.nativeElement.querySelectorAll("li.nav-item");
+    expect(menuElements.length).toBe(defaultLinks.count() + 3 - 2);
+
+    const item = menuElements[defaultLinks.count() + 3 - 2 - 1];
+    expect(item).toBeTruthy();
+    expect(item.computedStyleMap().has("padding-left")).toBeTruthy();
+    expect(item.computedStyleMap().get("padding-left").value).toBe(0);
+  });
+
+  it("should should set padding on menu item with parent", () => {
+    class MockActivatedRoute {
+      private parentRoute = StrongRoute.Base.add("home");
+      private childRoute = this.parentRoute.add("house");
+      private parentLink = MenuRoute({
+        label: "ZZZCustom Label", // Force to be last link
+        icon: ["fas", "question"],
+        tooltip: () => "Custom Tooltip 1",
+        route: this.parentRoute,
+        order: { priority: 10 }
+      });
+
+      public params = new BehaviorSubject<any>({});
+      public data = new BehaviorSubject<PageInfoInterface>(
+        new PageInfo(SecondaryMenuComponent, {
+          self: MenuRoute({
+            label: "ZZZZCustom Label", // Force to be last link
+            icon: ["fas", "question-circle"],
+            tooltip: () => "Custom Tooltip 2",
+            route: this.childRoute,
+            parent: this.parentLink,
+            order: { priority: 10 }
+          }),
+          category: {
+            label: "Custom Category",
+            icon: ["fas", "home"],
+            route: this.parentRoute
+          },
+          menus: {
+            actions: List<AnyMenuItem>([]),
+            links: List<NavigableMenuItem>([])
+          }
+        } as PageInfoInterface)
+      );
+    }
+
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, HttpClientModule, SharedModule],
+      declarations: [SecondaryMenuComponent],
+      providers: [
+        ...testAppInitializer,
+        { provide: ActivatedRoute, useClass: MockActivatedRoute }
+      ]
+    }).compileComponents();
+    fixture = TestBed.createComponent(SecondaryMenuComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+
+    // Number of elements should be the default links,
+    // plus self link, plus parent, plus menu title, plus added link,
+    // minus 2 links which require authentication
+    const menuElements = fixture.nativeElement.querySelectorAll("li.nav-item");
+
+    expect(menuElements.length).toBe(defaultLinks.count() + 3 - 2);
+
+    const child = menuElements[defaultLinks.count() + 3 - 2 - 1];
+    expect(child).toBeTruthy();
+    expect(child.computedStyleMap().has("padding-left")).toBeTruthy();
+    expect(child.computedStyleMap().get("padding-left").value).toBeGreaterThan(
+      0
+    );
+
+    const parent = menuElements[defaultLinks.count() + 3 - 2 - 2];
+    expect(parent).toBeTruthy();
+    expect(parent.computedStyleMap().has("padding-left")).toBeTruthy();
+    expect(parent.computedStyleMap().get("padding-left").value).toBe(0);
+  });
+
+  it("should should set padding on menu item with grand-parent", () => {
+    class MockActivatedRoute {
+      private grandParentRoute = StrongRoute.Base.add("home");
+      private parentRoute = this.grandParentRoute.add("house");
+      private childRoute = this.parentRoute.add("room");
+      private grandParentLink = MenuRoute({
+        label: "ZZZCustom Label", // Force to be last link
+        icon: ["fas", "tag"],
+        tooltip: () => "Custom Tooltip 1",
+        route: this.parentRoute,
+        order: {
+          priority: 10
+        }
+      });
+      private parentLink = MenuRoute({
+        label: "ZZZZCustom Label", // Force to be last link
+        icon: ["fas", "question"],
+        tooltip: () => "Custom Tooltip 2",
+        route: this.parentRoute,
+        parent: this.grandParentLink,
+        order: {
+          priority: 10
+        }
+      });
+
+      public params = new BehaviorSubject<any>({});
+      public data = new BehaviorSubject<PageInfoInterface>(
+        new PageInfo(SecondaryMenuComponent, {
+          self: MenuRoute({
+            label: "ZZZZZCustom Label", // Force to be last link
+            icon: ["fas", "question-circle"],
+            tooltip: () => "Custom Tooltip 3",
+            route: this.childRoute,
+            parent: this.parentLink,
+            order: {
+              priority: 10
+            }
+          }),
+          category: {
+            label: "Custom Category",
+            icon: ["fas", "home"],
+            route: this.parentRoute
+          },
+          menus: {
+            actions: List<AnyMenuItem>([]),
+            links: List<NavigableMenuItem>([])
+          }
+        } as PageInfoInterface)
+      );
+    }
+
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, HttpClientModule, SharedModule],
+      declarations: [SecondaryMenuComponent],
+      providers: [
+        ...testAppInitializer,
+        { provide: ActivatedRoute, useClass: MockActivatedRoute }
+      ]
+    }).compileComponents();
+    fixture = TestBed.createComponent(SecondaryMenuComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+
+    // Number of elements should be the default links,
+    // plus self link, plus parent, plus menu title, plus added link,
+    // minus 2 links which require authentication
+    const menuElements = fixture.nativeElement.querySelectorAll("li.nav-item");
+
+    expect(menuElements.length).toBe(defaultLinks.count() + 4 - 2);
+
+    const grandParent = menuElements[defaultLinks.count() + 4 - 2 - 3];
+    expect(grandParent).toBeTruthy();
+    expect(grandParent.computedStyleMap().has("padding-left")).toBeTruthy();
+    expect(grandParent.computedStyleMap().get("padding-left").value).toBe(0);
+
+    const parent = menuElements[defaultLinks.count() + 4 - 2 - 2];
+    expect(parent).toBeTruthy();
+    expect(parent.computedStyleMap().has("padding-left")).toBeTruthy();
+    expect(parent.computedStyleMap().get("padding-left").value).toBeGreaterThan(
+      0
+    );
+    const parentPadding = parent.computedStyleMap().get("padding-left").value;
+
+    const child = menuElements[defaultLinks.count() + 4 - 2 - 1];
+    expect(child).toBeTruthy();
+    expect(child.computedStyleMap().has("padding-left")).toBeTruthy();
+    expect(child.computedStyleMap().get("padding-left").value).toBeGreaterThan(
+      parentPadding
+    );
+  });
+
+  it("should should set padding on menu item with grand-parent without priority", () => {
+    class MockActivatedRoute {
+      private grandParentRoute = StrongRoute.Base.add("home");
+      private parentRoute = this.grandParentRoute.add("house");
+      private childRoute = this.parentRoute.add("room");
+      private grandParentLink = MenuRoute({
+        label: "ZZZCustom Label", // Force to be last link
+        icon: ["fas", "tag"],
+        tooltip: () => "Custom Tooltip 1",
+        route: this.parentRoute
+      });
+      private parentLink = MenuRoute({
+        label: "ZZZZCustom Label", // Force to be last link
+        icon: ["fas", "question"],
+        tooltip: () => "Custom Tooltip 2",
+        route: this.parentRoute,
+        parent: this.grandParentLink
+      });
+
+      public params = new BehaviorSubject<any>({});
+      public data = new BehaviorSubject<PageInfoInterface>(
+        new PageInfo(SecondaryMenuComponent, {
+          self: MenuRoute({
+            label: "ZZZZZCustom Label", // Force to be last link
+            icon: ["fas", "question-circle"],
+            tooltip: () => "Custom Tooltip 3",
+            route: this.childRoute,
+            parent: this.parentLink
+          }),
+          category: {
+            label: "Custom Category",
+            icon: ["fas", "home"],
+            route: this.parentRoute
+          },
+          menus: {
+            actions: List<AnyMenuItem>([]),
+            links: List<NavigableMenuItem>([])
+          }
+        } as PageInfoInterface)
+      );
+    }
+
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, HttpClientModule, SharedModule],
+      declarations: [SecondaryMenuComponent],
+      providers: [
+        ...testAppInitializer,
+        { provide: ActivatedRoute, useClass: MockActivatedRoute }
+      ]
+    }).compileComponents();
+    fixture = TestBed.createComponent(SecondaryMenuComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+
+    // Number of elements should be the default links,
+    // plus self link, plus parent, plus menu title, plus added link,
+    // minus 2 links which require authentication
+    const menuElements = fixture.nativeElement.querySelectorAll("li.nav-item");
+
+    expect(menuElements.length).toBe(defaultLinks.count() + 4 - 2);
+
+    const grandParent = menuElements[defaultLinks.count() + 4 - 2 - 3];
+    expect(grandParent).toBeTruthy();
+    expect(grandParent.computedStyleMap().has("padding-left")).toBeTruthy();
+    expect(grandParent.computedStyleMap().get("padding-left").value).toBe(0);
+
+    const parent = menuElements[defaultLinks.count() + 4 - 2 - 2];
+    expect(parent).toBeTruthy();
+    expect(parent.computedStyleMap().has("padding-left")).toBeTruthy();
+    expect(parent.computedStyleMap().get("padding-left").value).toBeGreaterThan(
+      0
+    );
+    const parentPadding = parent.computedStyleMap().get("padding-left").value;
+
+    const child = menuElements[defaultLinks.count() + 4 - 2 - 1];
+    expect(child).toBeTruthy();
+    expect(child.computedStyleMap().has("padding-left")).toBeTruthy();
+    expect(child.computedStyleMap().get("padding-left").value).toBeGreaterThan(
+      parentPadding
     );
   });
 });

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
@@ -891,7 +891,7 @@ describe("SecondaryMenuComponent", () => {
             tooltip: () => "Custom Tooltip",
             route: this.route,
             order: {
-              priority: 10
+              priority: 100
             }
           }),
           category: {
@@ -935,8 +935,8 @@ describe("SecondaryMenuComponent", () => {
 
     const item = menuElements[defaultLinks.count() + 3 - 2 - 1];
     expect(item).toBeTruthy();
-    expect(item.computedStyleMap().has("padding-left")).toBeTruthy();
-    expect(item.computedStyleMap().get("padding-left").value).toBe(0);
+    expect(item.attributes.style).toBeTruthy();
+    expect(item.attributes.style.value).toBe("padding-left: 0em;");
   });
 
   it("should overwrite indentation value of ordered menu item", () => {
@@ -952,7 +952,7 @@ describe("SecondaryMenuComponent", () => {
             tooltip: () => "Custom Tooltip",
             route: this.route,
             order: {
-              priority: 10,
+              priority: 100,
               indentation: 5
             }
           }),
@@ -997,11 +997,11 @@ describe("SecondaryMenuComponent", () => {
 
     const item = menuElements[defaultLinks.count() + 3 - 2 - 1];
     expect(item).toBeTruthy();
-    expect(item.computedStyleMap().has("padding-left")).toBeTruthy();
-    expect(item.computedStyleMap().get("padding-left").value).toBe(0);
+    expect(item.attributes.style).toBeTruthy();
+    expect(item.attributes.style.value).toBe("padding-left: 0em;");
   });
 
-  it("should should set padding on menu item with parent", () => {
+  it("should set padding on menu item with parent", () => {
     class MockActivatedRoute {
       private parentRoute = StrongRoute.Base.add("home");
       private childRoute = this.parentRoute.add("house");
@@ -1010,7 +1010,7 @@ describe("SecondaryMenuComponent", () => {
         icon: ["fas", "question"],
         tooltip: () => "Custom Tooltip 1",
         route: this.parentRoute,
-        order: { priority: 10 }
+        order: { priority: 100 }
       });
 
       public params = new BehaviorSubject<any>({});
@@ -1022,7 +1022,7 @@ describe("SecondaryMenuComponent", () => {
             tooltip: () => "Custom Tooltip 2",
             route: this.childRoute,
             parent: this.parentLink,
-            order: { priority: 10 }
+            order: { priority: 100 }
           }),
           category: {
             label: "Custom Category",
@@ -1058,16 +1058,15 @@ describe("SecondaryMenuComponent", () => {
     expect(menuElements.length).toBe(defaultLinks.count() + 3 - 2);
 
     const child = menuElements[defaultLinks.count() + 3 - 2 - 1];
-    expect(child).toBeTruthy();
-    expect(child.computedStyleMap().has("padding-left")).toBeTruthy();
-    expect(child.computedStyleMap().get("padding-left").value).toBeGreaterThan(
-      0
-    );
-
     const parent = menuElements[defaultLinks.count() + 3 - 2 - 2];
+
+    expect(child).toBeTruthy();
+    expect(child.attributes.style).toBeTruthy();
+    expect(child.attributes.style.value).toBe("padding-left: 1em;");
+
     expect(parent).toBeTruthy();
-    expect(parent.computedStyleMap().has("padding-left")).toBeTruthy();
-    expect(parent.computedStyleMap().get("padding-left").value).toBe(0);
+    expect(parent.attributes.style).toBeTruthy();
+    expect(parent.attributes.style.value).toBe("padding-left: 0em;");
   });
 
   it("should should set padding on menu item with grand-parent", () => {
@@ -1081,7 +1080,7 @@ describe("SecondaryMenuComponent", () => {
         tooltip: () => "Custom Tooltip 1",
         route: this.parentRoute,
         order: {
-          priority: 10
+          priority: 100
         }
       });
       private parentLink = MenuRoute({
@@ -1091,7 +1090,7 @@ describe("SecondaryMenuComponent", () => {
         route: this.parentRoute,
         parent: this.grandParentLink,
         order: {
-          priority: 10
+          priority: 100
         }
       });
 
@@ -1105,7 +1104,7 @@ describe("SecondaryMenuComponent", () => {
             route: this.childRoute,
             parent: this.parentLink,
             order: {
-              priority: 10
+              priority: 100
             }
           }),
           category: {
@@ -1142,24 +1141,20 @@ describe("SecondaryMenuComponent", () => {
     expect(menuElements.length).toBe(defaultLinks.count() + 4 - 2);
 
     const grandParent = menuElements[defaultLinks.count() + 4 - 2 - 3];
-    expect(grandParent).toBeTruthy();
-    expect(grandParent.computedStyleMap().has("padding-left")).toBeTruthy();
-    expect(grandParent.computedStyleMap().get("padding-left").value).toBe(0);
-
     const parent = menuElements[defaultLinks.count() + 4 - 2 - 2];
-    expect(parent).toBeTruthy();
-    expect(parent.computedStyleMap().has("padding-left")).toBeTruthy();
-    expect(parent.computedStyleMap().get("padding-left").value).toBeGreaterThan(
-      0
-    );
-    const parentPadding = parent.computedStyleMap().get("padding-left").value;
-
     const child = menuElements[defaultLinks.count() + 4 - 2 - 1];
+
     expect(child).toBeTruthy();
-    expect(child.computedStyleMap().has("padding-left")).toBeTruthy();
-    expect(child.computedStyleMap().get("padding-left").value).toBeGreaterThan(
-      parentPadding
-    );
+    expect(child.attributes.style).toBeTruthy();
+    expect(child.attributes.style.value).toBe("padding-left: 2em;");
+
+    expect(parent).toBeTruthy();
+    expect(parent.attributes.style).toBeTruthy();
+    expect(parent.attributes.style.value).toBe("padding-left: 1em;");
+
+    expect(grandParent).toBeTruthy();
+    expect(grandParent.attributes.style).toBeTruthy();
+    expect(grandParent.attributes.style.value).toBe("padding-left: 0em;");
   });
 
   it("should should set padding on menu item with grand-parent without priority", () => {
@@ -1225,23 +1220,19 @@ describe("SecondaryMenuComponent", () => {
     expect(menuElements.length).toBe(defaultLinks.count() + 4 - 2);
 
     const grandParent = menuElements[defaultLinks.count() + 4 - 2 - 3];
-    expect(grandParent).toBeTruthy();
-    expect(grandParent.computedStyleMap().has("padding-left")).toBeTruthy();
-    expect(grandParent.computedStyleMap().get("padding-left").value).toBe(0);
-
     const parent = menuElements[defaultLinks.count() + 4 - 2 - 2];
-    expect(parent).toBeTruthy();
-    expect(parent.computedStyleMap().has("padding-left")).toBeTruthy();
-    expect(parent.computedStyleMap().get("padding-left").value).toBeGreaterThan(
-      0
-    );
-    const parentPadding = parent.computedStyleMap().get("padding-left").value;
-
     const child = menuElements[defaultLinks.count() + 4 - 2 - 1];
+
     expect(child).toBeTruthy();
-    expect(child.computedStyleMap().has("padding-left")).toBeTruthy();
-    expect(child.computedStyleMap().get("padding-left").value).toBeGreaterThan(
-      parentPadding
-    );
+    expect(child.attributes.style).toBeTruthy();
+    expect(child.attributes.style.value).toBe("padding-left: 2em;");
+
+    expect(parent).toBeTruthy();
+    expect(parent.attributes.style).toBeTruthy();
+    expect(parent.attributes.style.value).toBe("padding-left: 1em;");
+
+    expect(grandParent).toBeTruthy();
+    expect(grandParent.attributes.style).toBeTruthy();
+    expect(grandParent.attributes.style.value).toBe("padding-left: 0em;");
   });
 });

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
@@ -890,71 +890,8 @@ describe("SecondaryMenuComponent", () => {
             icon: ["fas", "question-circle"],
             tooltip: () => "Custom Tooltip",
             route: this.route,
-            order: {
-              priority: 100
-            }
-          }),
-          category: {
-            label: "Custom Category",
-            icon: ["fas", "home"],
-            route: this.route
-          },
-          menus: {
-            actions: List<AnyMenuItem>([]),
-            links: List<NavigableMenuItem>([
-              MenuRoute({
-                label: "ZZZCustom Label", // Force to be last link
-                icon: ["fas", "tag"],
-                tooltip: () => "Custom Tooltip",
-                route: this.route
-              })
-            ])
-          }
-        } as PageInfoInterface)
-      );
-    }
-
-    TestBed.configureTestingModule({
-      imports: [RouterTestingModule, HttpClientModule, SharedModule],
-      declarations: [SecondaryMenuComponent],
-      providers: [
-        ...testAppInitializer,
-        { provide: ActivatedRoute, useClass: MockActivatedRoute }
-      ]
-    }).compileComponents();
-    fixture = TestBed.createComponent(SecondaryMenuComponent);
-    component = fixture.componentInstance;
-
-    fixture.detectChanges();
-
-    // Number of elements should be the default links,
-    // plus self link, plus menu title, plus added link,
-    // minus 2 links which require authentication
-    const menuElements = fixture.nativeElement.querySelectorAll("li.nav-item");
-    expect(menuElements.length).toBe(defaultLinks.count() + 3 - 2);
-
-    const item = menuElements[defaultLinks.count() + 3 - 2 - 1];
-    expect(item).toBeTruthy();
-    expect(item.attributes.style).toBeTruthy();
-    expect(item.attributes.style.value).toBe("padding-left: 0em;");
-  });
-
-  it("should overwrite indentation value of ordered menu item", () => {
-    class MockActivatedRoute {
-      private route = StrongRoute.Base.add("/");
-
-      public params = new BehaviorSubject<any>({});
-      public data = new BehaviorSubject<PageInfoInterface>(
-        new PageInfo(SecondaryMenuComponent, {
-          self: MenuRoute({
-            label: "Custom Label",
-            icon: ["fas", "question-circle"],
-            tooltip: () => "Custom Tooltip",
-            route: this.route,
-            order: {
-              priority: 100,
-              indentation: 5
-            }
+            order: 100,
+            indentation: 0
           }),
           category: {
             label: "Custom Category",
@@ -1010,7 +947,8 @@ describe("SecondaryMenuComponent", () => {
         icon: ["fas", "question"],
         tooltip: () => "Custom Tooltip 1",
         route: this.parentRoute,
-        order: { priority: 100 }
+        order: 100,
+        indentation: 0
       });
 
       public params = new BehaviorSubject<any>({});
@@ -1022,7 +960,8 @@ describe("SecondaryMenuComponent", () => {
             tooltip: () => "Custom Tooltip 2",
             route: this.childRoute,
             parent: this.parentLink,
-            order: { priority: 100 }
+            order: 100,
+            indentation: 1
           }),
           category: {
             label: "Custom Category",
@@ -1079,9 +1018,8 @@ describe("SecondaryMenuComponent", () => {
         icon: ["fas", "tag"],
         tooltip: () => "Custom Tooltip 1",
         route: this.parentRoute,
-        order: {
-          priority: 100
-        }
+        order: 100,
+        indentation: 0
       });
       private parentLink = MenuRoute({
         label: "ZZZZCustom Label", // Force to be last link
@@ -1089,9 +1027,8 @@ describe("SecondaryMenuComponent", () => {
         tooltip: () => "Custom Tooltip 2",
         route: this.parentRoute,
         parent: this.grandParentLink,
-        order: {
-          priority: 100
-        }
+        order: 100,
+        indentation: 1
       });
 
       public params = new BehaviorSubject<any>({});
@@ -1103,9 +1040,8 @@ describe("SecondaryMenuComponent", () => {
             tooltip: () => "Custom Tooltip 3",
             route: this.childRoute,
             parent: this.parentLink,
-            order: {
-              priority: 100
-            }
+            order: 100,
+            indentation: 2
           }),
           category: {
             label: "Custom Category",

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.ts
@@ -54,13 +54,21 @@ export class SecondaryMenuComponent implements OnInit, OnDestroy {
           indentation++;
         }
 
+        // Update indentation values
         if (current.order) {
           current.order.indentation = indentation;
+        } else {
+          current.order = { indentation };
         }
 
         parentMenuRoutes.forEach(parent => {
           indentation--;
-          parent.order.indentation = indentation;
+
+          if (parent.order) {
+            parent.order.indentation = indentation;
+          } else {
+            parent.order = { indentation };
+          }
         });
 
         // with any links from route

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.ts
@@ -42,7 +42,6 @@ export class SecondaryMenuComponent implements OnInit, OnDestroy {
         const defaultLinks = DefaultMenu.contextLinks;
 
         // and current page
-        let indentation = 0;
         const current = page.self;
 
         // and parent pages
@@ -51,25 +50,7 @@ export class SecondaryMenuComponent implements OnInit, OnDestroy {
         while (menuRoute.parent) {
           menuRoute = menuRoute.parent;
           parentMenuRoutes.push(menuRoute);
-          indentation++;
         }
-
-        // Update indentation values
-        if (current.order) {
-          current.order.indentation = indentation;
-        } else {
-          current.order = { indentation };
-        }
-
-        parentMenuRoutes.forEach(parent => {
-          indentation--;
-
-          if (parent.order) {
-            parent.order.indentation = indentation;
-          } else {
-            parent.order = { indentation };
-          }
-        });
 
         // with any links from route
         const links = page.menus?.links

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.ts
@@ -42,6 +42,7 @@ export class SecondaryMenuComponent implements OnInit, OnDestroy {
         const defaultLinks = DefaultMenu.contextLinks;
 
         // and current page
+        let indentation = 0;
         const current = page.self;
 
         // and parent pages
@@ -50,7 +51,17 @@ export class SecondaryMenuComponent implements OnInit, OnDestroy {
         while (menuRoute.parent) {
           menuRoute = menuRoute.parent;
           parentMenuRoutes.push(menuRoute);
+          indentation++;
         }
+
+        if (current.order) {
+          current.order.indentation = indentation;
+        }
+
+        parentMenuRoutes.forEach(parent => {
+          indentation--;
+          parent.order.indentation = indentation;
+        });
 
         // with any links from route
         const links = page.menus?.links

--- a/src/app/component/sites/sites.menus.ts
+++ b/src/app/component/sites/sites.menus.ts
@@ -29,8 +29,7 @@ export const newSiteMenuItem = MenuRoute({
   predicate: isLoggedInPredicate,
   parent: projectMenuItem,
   order: {
-    priority: projectMenuItem.order.priority,
-    indentation: projectMenuItem.order.indentation + 1
+    priority: projectMenuItem.order.priority
   }
 });
 
@@ -41,8 +40,7 @@ export const siteMenuItem = MenuRoute({
   tooltip: () => "The current site",
   parent: projectMenuItem,
   order: {
-    priority: projectMenuItem.order.priority,
-    indentation: projectMenuItem.order.indentation + 1
+    priority: projectMenuItem.order.priority
   }
 });
 
@@ -69,8 +67,7 @@ export const editSiteMenuItem = MenuRoute({
   tooltip: () => "Change the details for this site",
   predicate: isOwnerPredicate,
   order: {
-    priority: siteMenuItem.order.priority,
-    indentation: siteMenuItem.order.indentation + 1
+    priority: siteMenuItem.order.priority
   }
 });
 
@@ -82,8 +79,7 @@ export const harvestMenuItem = MenuRoute({
   tooltip: () => "Upload new audio to this site",
   predicate: isAdminPredicate,
   order: {
-    priority: siteMenuItem.order.priority,
-    indentation: siteMenuItem.order.indentation + 1
+    priority: siteMenuItem.order.priority
   }
 });
 
@@ -103,7 +99,6 @@ export const deleteSiteMenuItem = MenuRoute({
   tooltip: () => "Delete this site",
   predicate: isOwnerPredicate,
   order: {
-    priority: siteMenuItem.order.priority,
-    indentation: siteMenuItem.order.indentation + 1
+    priority: siteMenuItem.order.priority
   }
 });

--- a/src/app/component/sites/sites.menus.ts
+++ b/src/app/component/sites/sites.menus.ts
@@ -27,10 +27,7 @@ export const newSiteMenuItem = MenuRoute({
   route: sitesRoute.add("new"),
   tooltip: () => "Create a new site",
   predicate: isLoggedInPredicate,
-  parent: projectMenuItem,
-  order: {
-    priority: projectMenuItem.order.priority
-  }
+  parent: projectMenuItem
 });
 
 export const siteMenuItem = MenuRoute({
@@ -38,10 +35,7 @@ export const siteMenuItem = MenuRoute({
   label: "Site",
   route: sitesRoute.add(":siteId"),
   tooltip: () => "The current site",
-  parent: projectMenuItem,
-  order: {
-    priority: projectMenuItem.order.priority
-  }
+  parent: projectMenuItem
 });
 
 export const exploreAudioSiteMenuItem = MenuLink({
@@ -65,10 +59,7 @@ export const editSiteMenuItem = MenuRoute({
   route: siteMenuItem.route.add("edit"),
   parent: siteMenuItem,
   tooltip: () => "Change the details for this site",
-  predicate: isOwnerPredicate,
-  order: {
-    priority: siteMenuItem.order.priority
-  }
+  predicate: isOwnerPredicate
 });
 
 export const harvestMenuItem = MenuRoute({
@@ -77,10 +68,7 @@ export const harvestMenuItem = MenuRoute({
   route: siteMenuItem.route.add("harvest"),
   parent: siteMenuItem,
   tooltip: () => "Upload new audio to this site",
-  predicate: isAdminPredicate,
-  order: {
-    priority: siteMenuItem.order.priority
-  }
+  predicate: isAdminPredicate
 });
 
 export const assignSiteMenuItem = MenuLink({
@@ -97,8 +85,5 @@ export const deleteSiteMenuItem = MenuRoute({
   route: siteMenuItem.route.add("delete"),
   parent: siteMenuItem,
   tooltip: () => "Delete this site",
-  predicate: isOwnerPredicate,
-  order: {
-    priority: siteMenuItem.order.priority
-  }
+  predicate: isOwnerPredicate
 });

--- a/src/app/component/statistics/statistics.menus.ts
+++ b/src/app/component/statistics/statistics.menus.ts
@@ -11,5 +11,5 @@ export const statisticsMenuItem = MenuRoute({
   label: "Statistics",
   route: statisticsRoute,
   tooltip: () => "Annotation and audio recording statistics",
-  order: { priority: 10, indentation: 0 }
+  order: { priority: 10 }
 });

--- a/src/app/component/statistics/statistics.menus.ts
+++ b/src/app/component/statistics/statistics.menus.ts
@@ -11,5 +11,5 @@ export const statisticsMenuItem = MenuRoute({
   label: "Statistics",
   route: statisticsRoute,
   tooltip: () => "Annotation and audio recording statistics",
-  order: { priority: 10 }
+  order: 10
 });

--- a/src/app/helpers/page/defaultMenus.ts
+++ b/src/app/helpers/page/defaultMenus.ts
@@ -25,7 +25,7 @@ export const DefaultMenu = {
       label: "My Annotations",
       tooltip: () => "View my recent annotations",
       predicate: user => !!user,
-      order: { priority: 3 },
+      order: 3,
       uri: "REPLACE_ME"
     }),
     projectsMenuItem,
@@ -33,14 +33,14 @@ export const DefaultMenu = {
       icon: ["fas", "server"],
       label: "Audio Analysis",
       tooltip: () => "View audio analysis jobs",
-      order: { priority: 5 },
+      order: 5,
       uri: "/audio_analysis"
     }),
     MenuLink({
       icon: ["fas", "book"],
       label: "Library",
       tooltip: () => "Annotation library",
-      order: { priority: 6 },
+      order: 6,
       uri: "/library"
     }),
     dataRequestMenuItem,
@@ -48,7 +48,7 @@ export const DefaultMenu = {
       icon: ["fas", "envelope"],
       label: "Send Audio",
       tooltip: () => "Send us audio recordings to upload",
-      order: { priority: 8 },
+      order: 8,
       uri: "/data_upload"
     }),
     reportProblemMenuItem,

--- a/src/app/helpers/page/defaultMenus.ts
+++ b/src/app/helpers/page/defaultMenus.ts
@@ -25,7 +25,7 @@ export const DefaultMenu = {
       label: "My Annotations",
       tooltip: () => "View my recent annotations",
       predicate: user => !!user,
-      order: { priority: 3, indentation: 0 },
+      order: { priority: 3 },
       uri: "REPLACE_ME"
     }),
     projectsMenuItem,
@@ -33,14 +33,14 @@ export const DefaultMenu = {
       icon: ["fas", "server"],
       label: "Audio Analysis",
       tooltip: () => "View audio analysis jobs",
-      order: { priority: 5, indentation: 0 },
+      order: { priority: 5 },
       uri: "/audio_analysis"
     }),
     MenuLink({
       icon: ["fas", "book"],
       label: "Library",
       tooltip: () => "Annotation library",
-      order: { priority: 6, indentation: 0 },
+      order: { priority: 6 },
       uri: "/library"
     }),
     dataRequestMenuItem,
@@ -48,7 +48,7 @@ export const DefaultMenu = {
       icon: ["fas", "envelope"],
       label: "Send Audio",
       tooltip: () => "Send us audio recordings to upload",
-      order: { priority: 8, indentation: 0 },
+      order: { priority: 8 },
       uri: "/data_upload"
     }),
     reportProblemMenuItem,

--- a/src/app/interfaces/menusInterfaces.ts
+++ b/src/app/interfaces/menusInterfaces.ts
@@ -53,7 +53,7 @@ export interface Order {
    * Priority of link
    * The lower the value, the greater the importance.
    */
-  priority: number;
+  priority?: number;
 
   /**
    * Indentation of link. Value is calculated by SecondaryMenuComponent

--- a/src/app/interfaces/menusInterfaces.ts
+++ b/src/app/interfaces/menusInterfaces.ts
@@ -56,9 +56,9 @@ export interface Order {
   priority: number;
 
   /**
-   * Indentation of link
+   * Indentation of link. Value is calculated by SecondaryMenuComponent
    */
-  indentation: number;
+  indentation?: number;
 }
 
 /**

--- a/src/app/interfaces/menusInterfaces.ts
+++ b/src/app/interfaces/menusInterfaces.ts
@@ -46,22 +46,6 @@ export interface Category extends LabelAndIcon {
 }
 
 /**
- * Defines order and indentation for `MenuItems`
- */
-export interface Order {
-  /**
-   * Priority of link
-   * The lower the value, the greater the importance.
-   */
-  priority?: number;
-
-  /**
-   * Indentation of link. Value is calculated by SecondaryMenuComponent
-   */
-  indentation?: number;
-}
-
-/**
  * Literal string choice type (like an enum) used for the `kind`
  * property in things derived from MenuItems.
  */
@@ -91,7 +75,11 @@ export interface MenuItem extends LabelAndIcon {
   /**
    * The order position of this link in comparison to others.
    */
-  order?: Order;
+  order?: number;
+  /**
+   * The indentation of this link
+   */
+  indentation?: number;
 }
 
 /**
@@ -109,7 +97,10 @@ export interface MenuLink extends MenuItem {
 }
 
 export function MenuLink<T extends Omit<MenuLink, "kind">>(item: T): MenuLink {
-  return Object.assign(item, { kind: "MenuLink" as "MenuLink" });
+  return Object.assign(item, {
+    kind: "MenuLink" as "MenuLink",
+    indentation: 0
+  });
 }
 
 /**
@@ -133,7 +124,11 @@ export interface MenuRoute extends MenuItem {
 export function MenuRoute<T extends Omit<MenuRoute, "kind">>(
   item: T
 ): MenuRoute {
-  return Object.assign(item, { kind: "MenuRoute" as "MenuRoute" });
+  return Object.assign(item, {
+    kind: "MenuRoute" as "MenuRoute",
+    indentation: item.parent ? item.parent.indentation + 1 : 0,
+    order: item.parent ? item.parent.order : item.order
+  });
 }
 
 /**
@@ -149,7 +144,10 @@ export interface MenuAction extends MenuItem {
 export function MenuAction<T extends Omit<MenuAction, "kind">>(
   item: T
 ): MenuAction {
-  return Object.assign(item, { kind: "MenuAction" as "MenuAction" });
+  return Object.assign(item, {
+    kind: "MenuAction" as "MenuAction",
+    indentation: 0
+  });
 }
 
 /**


### PR DESCRIPTION
Improved secondary menu indentation system so that indentation does not need to be defined by page components. Components specify their parent, which is then used to calculate its indentation level and organise sub-links.

Edit 1:
Order and indentation can now be calculated for all sub-links automatically. Order for top level links must still be set manually.

Closes #58 