### PR TITLE
Strong route parameter failure

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,6 @@
     "**/.git/objects/**",
     ".vscode",
     ".tsling.json"
-  ]
+  ],
+  "explorer.compactFolders": false
 }

--- a/baw-client.code-workspace
+++ b/baw-client.code-workspace
@@ -38,7 +38,8 @@
       "statusBar.foreground": "#e7e7e7"
     },
     "peacock.color": "#2b7489",
-    "angularKarmaTestExplorer.debugMode": true
+    "angularKarmaTestExplorer.debugMode": true,
+    "explorer.compactFolders": false
   },
   "extensions": {
     "recommendations": [

--- a/src/app/component/projects/pages/new/new.component.ts
+++ b/src/app/component/projects/pages/new/new.component.ts
@@ -2,8 +2,6 @@ import { ChangeDetectorRef, Component, OnDestroy, OnInit } from "@angular/core";
 import { List } from "immutable";
 import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
-import { PermissionsShieldComponent } from "src/app/component/shared/permissions-shield/permissions-shield.component";
-import { WidgetMenuItem } from "src/app/component/shared/widget/widgetItem";
 import { PageComponent } from "src/app/helpers/page/pageComponent";
 import { Page } from "src/app/helpers/page/pageDecorator";
 import { AnyMenuItem } from "src/app/interfaces/menusInterfaces";
@@ -22,7 +20,6 @@ import data from "./new.json";
   category: projectsCategory,
   menus: {
     actions: List<AnyMenuItem>([projectsMenuItem, ...projectsMenuItemActions]),
-    actionsWidget: new WidgetMenuItem(PermissionsShieldComponent, {}),
     links: List()
   },
   self: newProjectMenuItem

--- a/src/app/component/projects/projects.menus.ts
+++ b/src/app/component/projects/projects.menus.ts
@@ -30,6 +30,14 @@ export const projectsMenuItem = MenuRoute({
   order: 4
 });
 
+export const projectMenuItem = MenuRoute({
+  icon: ["fas", "folder-open"],
+  label: "Project",
+  route: projectsRoute.add(":projectId"),
+  tooltip: () => "The current project",
+  parent: projectsMenuItem
+});
+
 export const newProjectMenuItem = MenuRoute({
   icon: defaultNewIcon,
   label: "New project",
@@ -45,14 +53,6 @@ export const requestProjectMenuItem = MenuRoute({
   route: projectsRoute.add("request"),
   tooltip: () => "Request access to a project not listed here",
   predicate: isLoggedInPredicate,
-  parent: projectsMenuItem
-});
-
-export const projectMenuItem = MenuRoute({
-  icon: ["fas", "folder-open"],
-  label: "Project",
-  route: projectsRoute.add(":projectId"),
-  tooltip: () => "The current project",
   parent: projectsMenuItem
 });
 

--- a/src/app/component/shared/permissions-shield/permissions-shield.component.ts
+++ b/src/app/component/shared/permissions-shield/permissions-shield.component.ts
@@ -52,6 +52,8 @@ export class PermissionsShieldComponent
             return this.sitesApi.show(params.projectId, params.siteId);
           } else if (params.projectId) {
             return this.projectsApi.show(params.projectId);
+          } else {
+            throw Error("No parameters found in url");
           }
         }),
         takeUntil(this.unsubscribe)

--- a/src/app/helpers/page/pageRouting.ts
+++ b/src/app/helpers/page/pageRouting.ts
@@ -41,5 +41,5 @@ export function GetRouteConfigForPage(
         component: ActionMenuComponent
       }
     ]
-  });
+  } as Route);
 }

--- a/src/app/interfaces/strongRoute.spec.ts
+++ b/src/app/interfaces/strongRoute.spec.ts
@@ -1,0 +1,58 @@
+describe("StrongRoute", () => {
+  describe("Base StrongRoute", () => {
+    it("should create base route", () => {});
+    it("should add route", () => {});
+    it("should add multiple routes", () => {});
+    it("should add parameter route", () => {});
+    it("should add mixed routes", () => {});
+  });
+
+  describe("Child StrongRoute", () => {
+    it("should add route", () => {});
+    it("should add multiple routes", () => {});
+    it("should add parameter route", () => {});
+    it("should add mixed routes", () => {});
+  });
+
+  describe("Sorting", () => {
+    it("should order '\"\"' routes first", () => {});
+    it("should order parameter route last", () => {});
+  });
+
+  describe("Formatting", () => {
+    it("should format base route", () => {});
+    it("should format child route", () => {});
+    it("should format parameter route", () => {});
+    it("should format child parameter route", () => {});
+  });
+
+  describe("Compile Routes", () => {
+    it("should compile base route with route", () => {});
+    it("should compile base route with parameter route", () => {});
+    it("should compile base route with mixed routes", () => {});
+    it("should compile child StrongRoute with route", () => {});
+    it("should compile child StrongRoute with parameter route", () => {});
+    it("should compile child StrongRoute with mixed routes", () => {});
+  });
+
+  describe("toString", () => {
+    it("should handle base StrongRoute", () => {});
+    it("should handle child StrongRoute", () => {});
+    it("should handle grandchild StrongRoute", () => {});
+    it("should handle parameter StrongRoute", () => {});
+  });
+
+  describe("toRoute", () => {
+    it("should handle base StrongRoute", () => {});
+    it("should handle child StrongRoute", () => {});
+    it("should handle grandchild StrongRoute", () => {});
+    it("should handle parameter StrongRoute", () => {});
+  });
+
+  describe("routeConfig", () => {
+    it("should handle base StrongRoute", () => {});
+    it("should handle child StrongRoute", () => {});
+    it("should handle grandchild StrongRoute", () => {});
+    it("should handle parameter StrongRoute", () => {});
+  });
+});

--- a/src/app/interfaces/strongRoute.spec.ts
+++ b/src/app/interfaces/strongRoute.spec.ts
@@ -1,3 +1,5 @@
+import { Type } from "@angular/core";
+import { Route, Routes } from "@angular/router";
 import { StrongRoute } from "./strongRoute";
 
 describe("StrongRoute", () => {
@@ -73,78 +75,297 @@ describe("StrongRoute", () => {
     });
   });
 
-  xdescribe("Formatting", () => {
-    it("should format base route", () => {});
-    it("should format child route", () => {});
-    it("should format parameter route", () => {});
-    it("should format child parameter route", () => {});
+  describe("Formatting", () => {
+    let strongRoute: StrongRoute;
+
+    beforeEach(() => {
+      strongRoute = StrongRoute.Base;
+    });
+
+    it("should format base route", () => {
+      expect(strongRoute.format(undefined)).toBe("");
+    });
+
+    it("should format single parameter route", () => {
+      const paramRoute = strongRoute.add(":id");
+      expect(paramRoute.format({ id: 1 })).toBe("/1");
+    });
+
+    it("should format multiple parameter routes", () => {
+      const paramRoute = strongRoute.add(":siteId").add(":projectId");
+      expect(paramRoute.format({ siteId: 1, projectId: 5 })).toBe("/1/5");
+    });
+
+    it("should format mix routes", () => {
+      const paramRoute = strongRoute
+        .add("home")
+        .add(":id")
+        .add("house");
+      expect(paramRoute.format({ id: 1 })).toBe("/home/1/house");
+    });
   });
 
-  xdescribe("Compile Routes", () => {
-    it("should compile base route with route", () => {});
-    it("should compile base route with parameter route", () => {});
-    it("should compile base route with mixed routes", () => {});
-    it("should compile child StrongRoute with route", () => {});
-    it("should compile child StrongRoute with parameter route", () => {});
-    it("should compile child StrongRoute with mixed routes", () => {});
-    it("should order '\"\"' routes first", () => {});
-    it("should order parameter route last", () => {});
+  describe("Compile Routes", () => {
+    let strongRoute: StrongRoute;
+
+    class MockComponent {}
+
+    function callback(component: Type<any>, config: Partial<Route>) {
+      Object.assign(config, {
+        children: [
+          {
+            path: "",
+            pathMatch: "full",
+            component
+          }
+        ]
+      } as Route);
+    }
+
+    beforeEach(() => {
+      strongRoute = StrongRoute.Base;
+    });
+
+    it("should compile base route", () => {
+      const routes: Routes = [];
+      strongRoute.pageComponent = MockComponent;
+      const compiledRoutes = strongRoute.compileRoutes(callback);
+      expect(compiledRoutes).toEqual(routes);
+    });
+
+    it("should compile StrongRoute with route", () => {
+      const routes: Routes = [
+        {
+          path: "home",
+          children: [
+            {
+              path: "",
+              pathMatch: "full",
+              component: MockComponent
+            }
+          ]
+        }
+      ];
+      const homeRoute = strongRoute.add("home");
+      homeRoute.pageComponent = MockComponent;
+      const compiledRoutes = homeRoute.compileRoutes(callback);
+
+      expect(compiledRoutes).toEqual(routes);
+    });
+
+    it("should compile StrongRoute with parameter route", () => {
+      const routes: Routes = [
+        {
+          path: ":id",
+          children: [
+            {
+              path: "",
+              pathMatch: "full",
+              component: MockComponent
+            }
+          ]
+        }
+      ];
+      const paramRoute = strongRoute.add(":id");
+      paramRoute.pageComponent = MockComponent;
+      const compiledRoutes = paramRoute.compileRoutes(callback);
+
+      expect(compiledRoutes).toEqual(routes);
+    });
+
+    it("should compile StrongRoute with mixed routes", () => {
+      const routes: Routes = [
+        {
+          path: "home",
+          children: [
+            {
+              path: "",
+              pathMatch: "full",
+              component: undefined
+            },
+            {
+              path: ":id",
+              children: [
+                {
+                  path: "",
+                  pathMatch: "full",
+                  component: undefined
+                },
+                {
+                  path: "house",
+                  children: [
+                    {
+                      path: "",
+                      pathMatch: "full",
+                      component: MockComponent
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ];
+      const paramRoute = strongRoute
+        .add("home")
+        .add(":id")
+        .add("house");
+      paramRoute.pageComponent = MockComponent;
+      const compiledRoutes = paramRoute.compileRoutes(callback);
+
+      expect(compiledRoutes).toEqual(routes);
+    });
+
+    it("should order child StrongRoute routes", () => {
+      const routes: Routes = [
+        {
+          path: "home",
+          children: [
+            {
+              path: "",
+              pathMatch: "full",
+              component: undefined
+            },
+            {
+              path: "house",
+              children: [
+                {
+                  path: "",
+                  pathMatch: "full",
+                  component: undefined
+                }
+              ]
+            },
+            {
+              path: ":id",
+              children: [
+                {
+                  path: "",
+                  pathMatch: "full",
+                  component: undefined
+                }
+              ]
+            }
+          ]
+        }
+      ];
+      const homeRoute = strongRoute.add("home");
+      homeRoute.add(":id");
+      homeRoute.add("house");
+      const compiledRoutes = homeRoute.compileRoutes(callback);
+
+      expect(compiledRoutes).toEqual(routes);
+    });
+
+    it("should order base StrongRoute routes", () => {
+      const routes: Routes = [
+        {
+          path: "home",
+          children: [
+            {
+              path: "",
+              pathMatch: "full",
+              component: undefined
+            }
+          ]
+        },
+        {
+          path: "house",
+          children: [
+            {
+              path: "",
+              pathMatch: "full",
+              component: undefined
+            }
+          ]
+        },
+        {
+          path: ":id",
+          children: [
+            {
+              path: "",
+              pathMatch: "full",
+              component: undefined
+            }
+          ]
+        }
+      ];
+
+      strongRoute.add("home");
+      strongRoute.add(":id");
+      strongRoute.add("house");
+      const compiledRoutes = strongRoute.compileRoutes(callback);
+
+      expect(compiledRoutes).toEqual(routes);
+    });
   });
 
   describe("toString", () => {
+    let strongRoute: StrongRoute;
+
+    beforeEach(() => {
+      strongRoute = StrongRoute.Base;
+    });
+
     it("should handle base StrongRoute", () => {
-      const strongRoute = StrongRoute.Base;
       expect(strongRoute.toString()).toBe("");
     });
 
     it("should handle child route", () => {
-      const childRoute = StrongRoute.Base.add("home");
+      const childRoute = strongRoute.add("home");
       expect(childRoute.toString()).toBe("/home");
     });
 
     it("should handle grandchild route", () => {
-      const grandChildRoute = StrongRoute.Base.add("home").add("house");
+      const grandChildRoute = strongRoute.add("home").add("house");
       expect(grandChildRoute.toString()).toBe("/home/house");
     });
 
     it("should handle mixed routes", () => {
-      const grandChildRoute = StrongRoute.Base.add("home")
+      const grandChildRoute = strongRoute
+        .add("home")
         .add(":id")
         .add("house");
       expect(grandChildRoute.toString()).toBe("/home/:id/house");
     });
 
     it("should handle parameter route", () => {
-      const childRoute = StrongRoute.Base.add(":id");
+      const childRoute = strongRoute.add(":id");
       expect(childRoute.toString()).toBe("/:id");
     });
   });
 
   describe("toRoute", () => {
+    let strongRoute: StrongRoute;
+
+    beforeEach(() => {
+      strongRoute = StrongRoute.Base;
+    });
+
     it("should handle base StrongRoute", () => {
-      const strongRoute = StrongRoute.Base;
       expect(strongRoute.toRoute()).toEqual([""]);
     });
 
     it("should handle child route", () => {
-      const childRoute = StrongRoute.Base.add("home");
+      const childRoute = strongRoute.add("home");
       expect(childRoute.toRoute()).toEqual(["home"]);
     });
 
     it("should handle grandchild route", () => {
-      const grandChildRoute = StrongRoute.Base.add("home").add("house");
+      const grandChildRoute = strongRoute.add("home").add("house");
       expect(grandChildRoute.toRoute()).toEqual(["home", "house"]);
     });
 
     it("should handle mixed routes", () => {
-      const grandChildRoute = StrongRoute.Base.add("home")
+      const grandChildRoute = strongRoute
+        .add("home")
         .add(":id")
         .add("house");
       expect(grandChildRoute.toRoute()).toEqual(["home", ":id", "house"]);
     });
 
     it("should handle parameter route", () => {
-      const childRoute = StrongRoute.Base.add(":id");
+      const childRoute = strongRoute.add(":id");
       expect(childRoute.toRoute()).toEqual([":id"]);
     });
   });

--- a/src/app/interfaces/strongRoute.spec.ts
+++ b/src/app/interfaces/strongRoute.spec.ts
@@ -3,75 +3,77 @@ import { Route, Routes } from "@angular/router";
 import { StrongRoute } from "./strongRoute";
 
 describe("StrongRoute", () => {
+  function assertChildren(route: StrongRoute, children: StrongRoute[]) {
+    expect(route.children).toEqual(children);
+  }
+
   describe("Base StrongRoute", () => {
-    let strongRoute: StrongRoute;
+    let baseRoute: StrongRoute;
 
     beforeEach(() => {
-      strongRoute = StrongRoute.Base;
+      baseRoute = StrongRoute.Base;
     });
 
     it("should create base route", () => {
-      expect(strongRoute).toBeTruthy();
+      expect(baseRoute).toBeTruthy();
+      assertChildren(baseRoute, []);
     });
 
     it("should add route", () => {
-      const homeRoute = strongRoute.add("home");
-      expect(homeRoute).toBeTruthy();
+      const homeRoute = baseRoute.add("home");
+      assertChildren(baseRoute, [homeRoute]);
     });
 
     it("should add multiple routes", () => {
-      const homeRoute = strongRoute.add("home");
-      const houseRoute = strongRoute.add("house");
-      expect(homeRoute).toBeTruthy();
-      expect(houseRoute).toBeTruthy();
+      const homeRoute = baseRoute.add("home");
+      const houseRoute = baseRoute.add("house");
+      assertChildren(baseRoute, [homeRoute, houseRoute]);
     });
 
     it("should add parameter route", () => {
-      const paramRoute = strongRoute.add(":id");
-      expect(paramRoute).toBeTruthy();
+      const paramRoute = baseRoute.add(":id");
+      assertChildren(baseRoute, [paramRoute]);
     });
 
     it("should add mixed routes", () => {
-      const homeRoute = strongRoute.add("home");
-      const paramRoute = strongRoute.add(":id");
-      expect(homeRoute).toBeTruthy();
-      expect(paramRoute).toBeTruthy();
+      const homeRoute = baseRoute.add("home");
+      const paramRoute = baseRoute.add(":id");
+      assertChildren(baseRoute, [homeRoute, paramRoute]);
     });
   });
 
   describe("Child StrongRoute", () => {
-    let childStrongRoute: StrongRoute;
+    let parentRoute: StrongRoute;
 
     beforeEach(() => {
-      childStrongRoute = StrongRoute.Base.add("parent");
+      parentRoute = StrongRoute.Base.add("parent");
     });
 
     it("should create base route", () => {
-      expect(childStrongRoute).toBeTruthy();
+      expect(parentRoute).toBeTruthy();
+      assertChildren(parentRoute, []);
     });
 
     it("should add route", () => {
-      const homeRoute = childStrongRoute.add("home");
-      expect(homeRoute).toBeTruthy();
+      const homeRoute = parentRoute.add("home");
+      assertChildren(parentRoute, [homeRoute]);
     });
 
     it("should add multiple routes", () => {
-      const homeRoute = childStrongRoute.add("home");
-      const houseRoute = childStrongRoute.add("house");
-      expect(homeRoute).toBeTruthy();
-      expect(houseRoute).toBeTruthy();
+      const homeRoute = parentRoute.add("home");
+      const houseRoute = parentRoute.add("house");
+      assertChildren(parentRoute, [homeRoute, houseRoute]);
     });
 
     it("should add parameter route", () => {
-      const paramRoute = childStrongRoute.add(":id");
-      expect(paramRoute).toBeTruthy();
+      const paramRoute = parentRoute.add(":id");
+      assertChildren(parentRoute, [paramRoute]);
     });
 
     it("should add mixed routes", () => {
-      const homeRoute = childStrongRoute.add("home");
-      const paramRoute = childStrongRoute.add(":id");
-      expect(homeRoute).toBeTruthy();
-      expect(paramRoute).toBeTruthy();
+      const homeRoute = parentRoute.add("home");
+      const paramRoute = parentRoute.add(":id");
+      assertChildren(parentRoute, [homeRoute, paramRoute]);
     });
   });
 
@@ -340,10 +342,6 @@ describe("StrongRoute", () => {
 
     beforeEach(() => {
       strongRoute = StrongRoute.Base;
-    });
-
-    it("should handle base StrongRoute", () => {
-      expect(strongRoute.toRoute()).toEqual([""]);
     });
 
     it("should handle child route", () => {

--- a/src/app/interfaces/strongRoute.spec.ts
+++ b/src/app/interfaces/strongRoute.spec.ts
@@ -1,56 +1,156 @@
+import { StrongRoute } from "./strongRoute";
+
 describe("StrongRoute", () => {
   describe("Base StrongRoute", () => {
-    it("should create base route", () => {});
-    it("should add route", () => {});
-    it("should add multiple routes", () => {});
-    it("should add parameter route", () => {});
-    it("should add mixed routes", () => {});
+    let strongRoute: StrongRoute;
+
+    beforeEach(() => {
+      strongRoute = StrongRoute.Base;
+    });
+
+    it("should create base route", () => {
+      expect(strongRoute).toBeTruthy();
+    });
+
+    it("should add route", () => {
+      const homeRoute = strongRoute.add("home");
+      expect(homeRoute).toBeTruthy();
+    });
+
+    it("should add multiple routes", () => {
+      const homeRoute = strongRoute.add("home");
+      const houseRoute = strongRoute.add("house");
+      expect(homeRoute).toBeTruthy();
+      expect(houseRoute).toBeTruthy();
+    });
+
+    it("should add parameter route", () => {
+      const paramRoute = strongRoute.add(":id");
+      expect(paramRoute).toBeTruthy();
+    });
+
+    it("should add mixed routes", () => {
+      const homeRoute = strongRoute.add("home");
+      const paramRoute = strongRoute.add(":id");
+      expect(homeRoute).toBeTruthy();
+      expect(paramRoute).toBeTruthy();
+    });
   });
 
   describe("Child StrongRoute", () => {
-    it("should add route", () => {});
-    it("should add multiple routes", () => {});
-    it("should add parameter route", () => {});
-    it("should add mixed routes", () => {});
+    let childStrongRoute: StrongRoute;
+
+    beforeEach(() => {
+      childStrongRoute = StrongRoute.Base.add("parent");
+    });
+
+    it("should create base route", () => {
+      expect(childStrongRoute).toBeTruthy();
+    });
+
+    it("should add route", () => {
+      const homeRoute = childStrongRoute.add("home");
+      expect(homeRoute).toBeTruthy();
+    });
+
+    it("should add multiple routes", () => {
+      const homeRoute = childStrongRoute.add("home");
+      const houseRoute = childStrongRoute.add("house");
+      expect(homeRoute).toBeTruthy();
+      expect(houseRoute).toBeTruthy();
+    });
+
+    it("should add parameter route", () => {
+      const paramRoute = childStrongRoute.add(":id");
+      expect(paramRoute).toBeTruthy();
+    });
+
+    it("should add mixed routes", () => {
+      const homeRoute = childStrongRoute.add("home");
+      const paramRoute = childStrongRoute.add(":id");
+      expect(homeRoute).toBeTruthy();
+      expect(paramRoute).toBeTruthy();
+    });
   });
 
-  describe("Sorting", () => {
-    it("should order '\"\"' routes first", () => {});
-    it("should order parameter route last", () => {});
-  });
-
-  describe("Formatting", () => {
+  xdescribe("Formatting", () => {
     it("should format base route", () => {});
     it("should format child route", () => {});
     it("should format parameter route", () => {});
     it("should format child parameter route", () => {});
   });
 
-  describe("Compile Routes", () => {
+  xdescribe("Compile Routes", () => {
     it("should compile base route with route", () => {});
     it("should compile base route with parameter route", () => {});
     it("should compile base route with mixed routes", () => {});
     it("should compile child StrongRoute with route", () => {});
     it("should compile child StrongRoute with parameter route", () => {});
     it("should compile child StrongRoute with mixed routes", () => {});
+    it("should order '\"\"' routes first", () => {});
+    it("should order parameter route last", () => {});
   });
 
   describe("toString", () => {
-    it("should handle base StrongRoute", () => {});
-    it("should handle child StrongRoute", () => {});
-    it("should handle grandchild StrongRoute", () => {});
-    it("should handle parameter StrongRoute", () => {});
+    it("should handle base StrongRoute", () => {
+      const strongRoute = StrongRoute.Base;
+      expect(strongRoute.toString()).toBe("");
+    });
+
+    it("should handle child route", () => {
+      const childRoute = StrongRoute.Base.add("home");
+      expect(childRoute.toString()).toBe("/home");
+    });
+
+    it("should handle grandchild route", () => {
+      const grandChildRoute = StrongRoute.Base.add("home").add("house");
+      expect(grandChildRoute.toString()).toBe("/home/house");
+    });
+
+    it("should handle mixed routes", () => {
+      const grandChildRoute = StrongRoute.Base.add("home")
+        .add(":id")
+        .add("house");
+      expect(grandChildRoute.toString()).toBe("/home/:id/house");
+    });
+
+    it("should handle parameter route", () => {
+      const childRoute = StrongRoute.Base.add(":id");
+      expect(childRoute.toString()).toBe("/:id");
+    });
   });
 
   describe("toRoute", () => {
-    it("should handle base StrongRoute", () => {});
-    it("should handle child StrongRoute", () => {});
-    it("should handle grandchild StrongRoute", () => {});
-    it("should handle parameter StrongRoute", () => {});
+    it("should handle base StrongRoute", () => {
+      const strongRoute = StrongRoute.Base;
+      expect(strongRoute.toRoute()).toEqual([""]);
+    });
+
+    it("should handle child route", () => {
+      const childRoute = StrongRoute.Base.add("home");
+      expect(childRoute.toRoute()).toEqual(["home"]);
+    });
+
+    it("should handle grandchild route", () => {
+      const grandChildRoute = StrongRoute.Base.add("home").add("house");
+      expect(grandChildRoute.toRoute()).toEqual(["home", "house"]);
+    });
+
+    it("should handle mixed routes", () => {
+      const grandChildRoute = StrongRoute.Base.add("home")
+        .add(":id")
+        .add("house");
+      expect(grandChildRoute.toRoute()).toEqual(["home", ":id", "house"]);
+    });
+
+    it("should handle parameter route", () => {
+      const childRoute = StrongRoute.Base.add(":id");
+      expect(childRoute.toRoute()).toEqual([":id"]);
+    });
   });
 
-  describe("routeConfig", () => {
-    it("should handle base StrongRoute", () => {});
+  // Currently this doesn't appear to be in use
+  xdescribe("routeConfig", () => {
     it("should handle child StrongRoute", () => {});
     it("should handle grandchild StrongRoute", () => {});
     it("should handle parameter StrongRoute", () => {});

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -158,7 +158,8 @@ export class StrongRoute {
    * Router representation of the route
    */
   toRoute(): string[] {
-    return this.full.map(x => x.name).filter(x => !!x);
+    const output = this.full.map(x => x.name);
+    return output.length > 1 ? output.filter(x => !!x) : [""];
   }
 
   /**

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -118,14 +118,17 @@ export class StrongRoute {
     const rootRoute = this.root;
 
     const sortRoutes = (a: Route, b: Route): -1 | 0 | 1 => {
+      const aParamRoute = a.path.startsWith(":");
+      const bParamRoute = b.path.startsWith(":");
+
       // If one of the routes is a parameter route
-      if (a.path.charAt(0) === ":" || b.path.startsWith(":")) {
+      if (aParamRoute || bParamRoute) {
         // If both are parameter routes, they are equal
-        if (a.path.charAt(0) === ":" && b.path.startsWith(":")) {
+        if (aParamRoute && bParamRoute) {
           return 0;
         }
         // Else give priority to the non-parameter route
-        return a.path.charAt(0) === ":" ? 1 : -1;
+        return aParamRoute ? 1 : -1;
       }
 
       return 0;
@@ -159,8 +162,7 @@ export class StrongRoute {
    * Router representation of the route
    */
   toRoute(): string[] {
-    const output = this.full.map(x => x.name);
-    return output.length > 1 ? output.filter(x => !!x) : [""];
+    return this.full.slice(1).map(x => x.name);
   }
 
   /**

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -12,17 +12,16 @@ export type RouteConfigCallback = (
  * dynamically create routes for the various page components.
  */
 export class StrongRoute {
+  public pageComponent: Type<any> | null;
+  public readonly root: any;
+  public readonly parent: StrongRoute;
+  public readonly name: string;
+  public readonly isParameter: boolean;
+  public readonly fullRoute: string;
+  public readonly children: StrongRoute[] = [];
   private readonly parameters: StrongRoute[];
   private readonly full: StrongRoute[];
-
   private readonly config: Partial<Route>;
-  readonly root: any;
-  readonly parent: StrongRoute;
-  readonly name: string;
-  readonly isParameter: boolean;
-  readonly fullRoute: string;
-  readonly children: StrongRoute[] = [];
-  pageComponent: Type<any> | null;
 
   /**
    * Constructor
@@ -144,7 +143,9 @@ export class StrongRoute {
       return thisRoute;
     };
 
-    return rootRoute.children.map(recursiveAdd).sort(sortRoutes);
+    const output = rootRoute.children.map(recursiveAdd).sort(sortRoutes);
+
+    return output instanceof Array ? output : [output];
   }
 
   /**

--- a/src/test.ts
+++ b/src/test.ts
@@ -16,6 +16,6 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 // Then we find all the tests.
-const context = require.context("./", true, /\.spec\.ts$/);
+const context = require.context("./", true, /strongRoute\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);

--- a/src/test.ts
+++ b/src/test.ts
@@ -16,6 +16,6 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 // Then we find all the tests.
-const context = require.context("./", true, /strongRoute\.spec\.ts$/);
+const context = require.context("./", true, /\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);


### PR DESCRIPTION
# Fixing Bug in Strong Route

PR fixes bug where the order in which routes are added to the StrongRoute class can cause them to fail. Specifically any routes declared after a parameter route (eg `/:id`) would fail to load. 

## Changes

- Added StrongRoute unit tests
- Added sorting to StrongRoute paths

## Issues

- `routeConfig` function unit tests not written as the function is not used
- Noticed that StrongRoute children will also add their parent routes to the router. This may cause an issue later in development, however for now it has no adverse affects

## Closes

Closes #12 
