### PR TITLE
Menu adjustments

### DIFF
--- a/src/app/component/profile/pages/profile/my-profile.component copy.ts
+++ b/src/app/component/profile/pages/profile/my-profile.component copy.ts
@@ -21,28 +21,28 @@ export const myProfileMenuItemActions = [
   MenuLink({
     icon: ["fas", "globe-asia"],
     label: "My Projects",
-    uri: "BROKEN LINK",
+    uri: () => "BROKEN LINK",
     tooltip: user => `Projects ${user.userName} can access`,
     predicate: user => !!user
   }),
   MenuLink({
     icon: ["fas", "map-marker-alt"],
     label: "My Sites",
-    uri: "BROKEN LINK",
+    uri: () => "BROKEN LINK",
     tooltip: user => `Sites ${user.userName} can access`,
     predicate: user => !!user
   }),
   MenuLink({
     icon: ["fas", "bookmark"],
     label: "My Bookmarks",
-    uri: "BROKEN LINK",
+    uri: () => "BROKEN LINK",
     tooltip: user => `Bookmarks created by ${user.userName}`,
     predicate: user => !!user
   }),
   MenuLink({
     icon: ["fas", "bullseye"],
     label: "My Annotations",
-    uri: "BROKEN LINK",
+    uri: () => "BROKEN LINK",
     tooltip: user => `Annotations created by ${user.userName}`,
     predicate: user => !!user
   })
@@ -103,13 +103,13 @@ export class MyProfileComponent extends PageComponent
         icon: ["fas", "tag"],
         name: "Test 1",
         value: 0,
-        uri: "BROKEN LINK"
+        uri: () => "BROKEN LINK"
       },
       {
         icon: ["fas", "tag"],
         name: "Test 2",
         value: 0,
-        uri: "BROKEN LINK"
+        uri: () => "BROKEN LINK"
       }
     ];
   }

--- a/src/app/component/profile/pages/profile/my-profile.component copy.ts
+++ b/src/app/component/profile/pages/profile/my-profile.component copy.ts
@@ -6,46 +6,26 @@ import { ItemInterface } from "src/app/component/shared/items/item/item.componen
 import { PageComponent } from "src/app/helpers/page/pageComponent";
 import { Page } from "src/app/helpers/page/pageDecorator";
 import { ImageSizes } from "src/app/interfaces/apiInterfaces";
-import { AnyMenuItem, MenuLink } from "src/app/interfaces/menusInterfaces";
+import { AnyMenuItem } from "src/app/interfaces/menusInterfaces";
 import { User } from "src/app/models/User";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
 import { UserService } from "src/app/services/baw-api/user.service";
 import {
   editMyAccountMenuItem,
   myAccountCategory,
-  myAccountMenuItem
+  myAccountMenuItem,
+  myAnnotationsMenuItem,
+  myBookmarksMenuItem,
+  myProjectsMenuItem,
+  mySitesMenuItem
 } from "../../profile.menus";
 
 export const myProfileMenuItemActions = [
   editMyAccountMenuItem,
-  MenuLink({
-    icon: ["fas", "globe-asia"],
-    label: "My Projects",
-    uri: () => "BROKEN LINK",
-    tooltip: user => `Projects ${user.userName} can access`,
-    predicate: user => !!user
-  }),
-  MenuLink({
-    icon: ["fas", "map-marker-alt"],
-    label: "My Sites",
-    uri: () => "BROKEN LINK",
-    tooltip: user => `Sites ${user.userName} can access`,
-    predicate: user => !!user
-  }),
-  MenuLink({
-    icon: ["fas", "bookmark"],
-    label: "My Bookmarks",
-    uri: () => "BROKEN LINK",
-    tooltip: user => `Bookmarks created by ${user.userName}`,
-    predicate: user => !!user
-  }),
-  MenuLink({
-    icon: ["fas", "bullseye"],
-    label: "My Annotations",
-    uri: () => "BROKEN LINK",
-    tooltip: user => `Annotations created by ${user.userName}`,
-    predicate: user => !!user
-  })
+  myProjectsMenuItem,
+  mySitesMenuItem,
+  myBookmarksMenuItem,
+  myAnnotationsMenuItem
 ];
 
 @Page({

--- a/src/app/component/profile/pages/profile/their-profile.component.ts
+++ b/src/app/component/profile/pages/profile/their-profile.component.ts
@@ -22,28 +22,28 @@ export const theirProfileMenuItemActions = [
   MenuLink({
     icon: ["fas", "globe-asia"],
     label: "Their Projects",
-    uri: "BROKEN LINK",
+    uri: () => "BROKEN LINK",
     tooltip: () => "Projects they can access",
     predicate: user => !!user
   }),
   MenuLink({
     icon: ["fas", "map-marker-alt"],
     label: "Their Sites",
-    uri: "BROKEN LINK",
+    uri: () => "BROKEN LINK",
     tooltip: () => "Sites they can access",
     predicate: user => !!user
   }),
   MenuLink({
     icon: ["fas", "bookmark"],
     label: "Their Bookmarks",
-    uri: "BROKEN LINK",
+    uri: () => "BROKEN LINK",
     tooltip: () => "Bookmarks created by them",
     predicate: user => !!user
   }),
   MenuLink({
     icon: ["fas", "bullseye"],
     label: "Their Annotations",
-    uri: "BROKEN LINK",
+    uri: () => "BROKEN LINK",
     tooltip: () => "Annotations created by them",
     predicate: user => !!user
   })
@@ -108,13 +108,13 @@ export class TheirProfileComponent extends PageComponent
         icon: ["fas", "tag"],
         name: "Test 1",
         value: 0,
-        uri: "BROKEN LINK"
+        uri: () => "BROKEN LINK"
       },
       {
         icon: ["fas", "tag"],
         name: "Test 2",
         value: 0,
-        uri: "BROKEN LINK"
+        uri: () => "BROKEN LINK"
       }
     ];
   }

--- a/src/app/component/profile/pages/profile/their-profile.component.ts
+++ b/src/app/component/profile/pages/profile/their-profile.component.ts
@@ -7,46 +7,26 @@ import { ItemInterface } from "src/app/component/shared/items/item/item.componen
 import { PageComponent } from "src/app/helpers/page/pageComponent";
 import { Page } from "src/app/helpers/page/pageDecorator";
 import { ImageSizes } from "src/app/interfaces/apiInterfaces";
-import { AnyMenuItem, MenuLink } from "src/app/interfaces/menusInterfaces";
+import { AnyMenuItem } from "src/app/interfaces/menusInterfaces";
 import { User } from "src/app/models/User";
 import { AccountService } from "src/app/services/baw-api/account.service";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
 import {
+  theirAnnotationsMenuItem,
+  theirBookmarksMenuItem,
   theirEditProfileMenuItem,
   theirProfileCategory,
-  theirProfileMenuItem
+  theirProfileMenuItem,
+  theirProjectsMenuItem,
+  theirSitesMenuItem
 } from "../../profile.menus";
 
 export const theirProfileMenuItemActions = [
   theirEditProfileMenuItem,
-  MenuLink({
-    icon: ["fas", "globe-asia"],
-    label: "Their Projects",
-    uri: () => "BROKEN LINK",
-    tooltip: () => "Projects they can access",
-    predicate: user => !!user
-  }),
-  MenuLink({
-    icon: ["fas", "map-marker-alt"],
-    label: "Their Sites",
-    uri: () => "BROKEN LINK",
-    tooltip: () => "Sites they can access",
-    predicate: user => !!user
-  }),
-  MenuLink({
-    icon: ["fas", "bookmark"],
-    label: "Their Bookmarks",
-    uri: () => "BROKEN LINK",
-    tooltip: () => "Bookmarks created by them",
-    predicate: user => !!user
-  }),
-  MenuLink({
-    icon: ["fas", "bullseye"],
-    label: "Their Annotations",
-    uri: () => "BROKEN LINK",
-    tooltip: () => "Annotations created by them",
-    predicate: user => !!user
-  })
+  theirProjectsMenuItem,
+  theirSitesMenuItem,
+  theirBookmarksMenuItem,
+  theirAnnotationsMenuItem
 ];
 
 @Page({

--- a/src/app/component/profile/profile.menus.ts
+++ b/src/app/component/profile/profile.menus.ts
@@ -3,7 +3,11 @@ import {
   isAdminPredicate,
   isLoggedInPredicate
 } from "src/app/app.menus";
-import { Category, MenuRoute } from "src/app/interfaces/menusInterfaces";
+import {
+  Category,
+  MenuLink,
+  MenuRoute
+} from "src/app/interfaces/menusInterfaces";
 import { StrongRoute } from "src/app/interfaces/strongRoute";
 
 export const myAccountRoute = StrongRoute.Base.add("my_account");
@@ -35,6 +39,39 @@ export const editMyAccountMenuItem = MenuRoute({
   predicate: isLoggedInPredicate
 });
 
+export const myProjectsMenuItem = MenuLink({
+  icon: ["fas", "globe-asia"],
+  label: "My Projects",
+  uri: () => "BROKEN LINK",
+  tooltip: user => `Projects ${user.userName} can access`,
+  predicate: user => !!user
+});
+
+export const mySitesMenuItem = MenuLink({
+  icon: ["fas", "map-marker-alt"],
+  label: "My Sites",
+  uri: () => "BROKEN LINK",
+  tooltip: user => `Sites ${user.userName} can access`,
+  predicate: user => !!user
+});
+
+export const myBookmarksMenuItem = MenuLink({
+  icon: ["fas", "bookmark"],
+  label: "My Bookmarks",
+  uri: () => "BROKEN LINK",
+  tooltip: user => `Bookmarks created by ${user.userName}`,
+  predicate: user => !!user
+});
+
+export const myAnnotationsMenuItem = MenuLink({
+  icon: ["fas", "border-all"],
+  label: "My Annotations",
+  tooltip: user => `Annotations created by ${user.userName}`,
+  predicate: user => !!user,
+  order: 3,
+  uri: () => "REPLACE_ME"
+});
+
 /**
  * Their Profile Menus
  */
@@ -62,4 +99,36 @@ export const theirEditProfileMenuItem = MenuRoute({
   parent: theirProfileMenuItem,
   tooltip: () => "Change the details for this profile",
   predicate: isAdminPredicate
+});
+
+export const theirProjectsMenuItem = MenuLink({
+  icon: ["fas", "globe-asia"],
+  label: "Their Projects",
+  uri: () => "BROKEN LINK",
+  tooltip: () => "Projects they can access",
+  predicate: user => !!user
+});
+
+export const theirSitesMenuItem = MenuLink({
+  icon: ["fas", "map-marker-alt"],
+  label: "Their Sites",
+  uri: () => "BROKEN LINK",
+  tooltip: () => "Sites they can access",
+  predicate: user => !!user
+});
+
+export const theirBookmarksMenuItem = MenuLink({
+  icon: ["fas", "bookmark"],
+  label: "Their Bookmarks",
+  uri: () => "BROKEN LINK",
+  tooltip: () => "Bookmarks created by them",
+  predicate: user => !!user
+});
+
+export const theirAnnotationsMenuItem = MenuLink({
+  icon: ["fas", "bullseye"],
+  label: "Their Annotations",
+  uri: () => "BROKEN LINK",
+  tooltip: () => "Annotations created by them",
+  predicate: user => !!user
 });

--- a/src/app/component/projects/pages/details/details.component.ts
+++ b/src/app/component/projects/pages/details/details.component.ts
@@ -21,7 +21,8 @@ import {
   editProjectPermissionsMenuItem,
   exploreAudioProjectMenuItem,
   projectCategory,
-  projectMenuItem
+  projectMenuItem,
+  projectsMenuItem
 } from "../../projects.menus";
 
 export const projectMenuItemActions = [
@@ -36,7 +37,7 @@ export const projectMenuItemActions = [
 @Page({
   category: projectCategory,
   menus: {
-    actions: List<AnyMenuItem>(projectMenuItemActions),
+    actions: List<AnyMenuItem>([projectsMenuItem, ...projectMenuItemActions]),
     actionsWidget: new WidgetMenuItem(PermissionsShieldComponent, {}),
     links: List()
   },

--- a/src/app/component/projects/pages/details/details.component.ts
+++ b/src/app/component/projects/pages/details/details.component.ts
@@ -6,6 +6,7 @@ import { flatMap, takeUntil } from "rxjs/operators";
 import { PermissionsShieldComponent } from "src/app/component/shared/permissions-shield/permissions-shield.component";
 import { WidgetMenuItem } from "src/app/component/shared/widget/widgetItem";
 import { newSiteMenuItem } from "src/app/component/sites/sites.menus";
+import { exploreAudioMenuItem } from "src/app/helpers/page/externalMenus";
 import { PageComponent } from "src/app/helpers/page/pageComponent";
 import { Page } from "src/app/helpers/page/pageDecorator";
 import { AnyMenuItem } from "src/app/interfaces/menusInterfaces";
@@ -19,14 +20,13 @@ import {
   deleteProjectMenuItem,
   editProjectMenuItem,
   editProjectPermissionsMenuItem,
-  exploreAudioProjectMenuItem,
   projectCategory,
   projectMenuItem,
   projectsMenuItem
 } from "../../projects.menus";
 
 export const projectMenuItemActions = [
-  exploreAudioProjectMenuItem,
+  exploreAudioMenuItem,
   editProjectMenuItem,
   editProjectPermissionsMenuItem,
   newSiteMenuItem,

--- a/src/app/component/projects/projects.menus.ts
+++ b/src/app/component/projects/projects.menus.ts
@@ -7,11 +7,7 @@ import {
   isLoggedInPredicate,
   isOwnerPredicate
 } from "src/app/app.menus";
-import {
-  Category,
-  MenuLink,
-  MenuRoute
-} from "src/app/interfaces/menusInterfaces";
+import { Category, MenuRoute } from "src/app/interfaces/menusInterfaces";
 import { StrongRoute } from "src/app/interfaces/strongRoute";
 
 export const projectsRoute = StrongRoute.Base.add("projects");
@@ -69,13 +65,6 @@ export const editProjectMenuItem = MenuRoute({
   parent: projectMenuItem,
   tooltip: () => "Change the details for this project",
   predicate: isOwnerPredicate
-});
-
-export const exploreAudioProjectMenuItem = MenuLink({
-  uri: params => `/visualize?projectId=${params.projectId}`,
-  icon: ["fas", "map"],
-  label: "Explore audio",
-  tooltip: () => "Explore audio"
 });
 
 export const editProjectPermissionsMenuItem = MenuRoute({

--- a/src/app/component/projects/projects.menus.ts
+++ b/src/app/component/projects/projects.menus.ts
@@ -72,7 +72,7 @@ export const editProjectMenuItem = MenuRoute({
 });
 
 export const exploreAudioProjectMenuItem = MenuLink({
-  uri: (bawUrl, params) => `${bawUrl}/visualize?projectId=${params.projectId}`,
+  uri: params => `/visualize?projectId=${params.projectId}`,
   icon: ["fas", "map"],
   label: "Explore audio",
   tooltip: () => "Explore audio"

--- a/src/app/component/projects/projects.menus.ts
+++ b/src/app/component/projects/projects.menus.ts
@@ -72,7 +72,7 @@ export const editProjectMenuItem = MenuRoute({
 });
 
 export const exploreAudioProjectMenuItem = MenuLink({
-  uri: "REPLACE_ME",
+  uri: (bawUrl, params) => `${bawUrl}/visualize?projectId=${params.projectId}`,
   icon: ["fas", "map"],
   label: "Explore audio",
   tooltip: () => "Explore audio"

--- a/src/app/component/shared/action-menu/action-menu.component.spec.ts
+++ b/src/app/component/shared/action-menu/action-menu.component.spec.ts
@@ -5,6 +5,7 @@ import { RouterTestingModule } from "@angular/router/testing";
 import { List } from "immutable";
 import { BehaviorSubject } from "rxjs";
 import { PageInfoInterface } from "src/app/helpers/page/pageInfo";
+import { assertIcon, assertTooltip } from "src/app/helpers/tests/helpers";
 import {
   AnyMenuItem,
   Category,
@@ -35,15 +36,6 @@ describe("ActionMenuComponent", () => {
     route: defaultRoute
   } as Category;
 
-  function assertIcon(target: HTMLElement, prop: string) {
-    const icon: HTMLElement = target.querySelector("fa-icon");
-    expect(icon).toBeTruthy("Icon is missing");
-    expect(icon.attributes.getNamedItem("ng-reflect-icon")).toBeTruthy(
-      "Icon missing [icon]"
-    );
-    expect(icon.attributes.getNamedItem("ng-reflect-icon").value).toBe(prop);
-  }
-
   function assertTitle(target: HTMLElement, header: string) {
     expect(target).toBeTruthy("Title is missing");
     expect(target.innerText.trim()).toBe(header);
@@ -55,16 +47,6 @@ describe("ActionMenuComponent", () => {
     expect(label.innerText.trim()).toBe(labelText);
   }
 
-  function assertTooltip(target: HTMLElement, tooltip: string) {
-    expect(target).toBeTruthy("Tooltip is missing");
-    expect(target.attributes.getNamedItem("ng-reflect-tooltip")).toBeTruthy(
-      "Tooltip missing [tooltip]"
-    );
-    expect(
-      target.attributes.getNamedItem("ng-reflect-tooltip").value.trim()
-    ).toBe(tooltip);
-  }
-
   function findLinks(
     selector: "internal-link" | "external-link" | "button"
   ): HTMLElement[] {
@@ -73,8 +55,10 @@ describe("ActionMenuComponent", () => {
 
   function createTestBed(params: any, data: PageInfoInterface) {
     class MockActivatedRoute {
-      public params = new BehaviorSubject<any>(params);
       public data = new BehaviorSubject<PageInfoInterface>(data);
+      public snapshot = {
+        params
+      };
     }
 
     TestBed.configureTestingModule({

--- a/src/app/component/shared/action-menu/action-menu.component.spec.ts
+++ b/src/app/component/shared/action-menu/action-menu.component.spec.ts
@@ -269,7 +269,7 @@ describe("ActionMenuComponent", () => {
               label: "Custom Label",
               icon: ["fas", "tag"],
               tooltip: () => "Custom Tooltip",
-              uri: "http://brokenlink/"
+              uri: () => "http://brokenlink/"
             }),
             MenuAction({
               label: "Custom Label",
@@ -373,7 +373,7 @@ describe("ActionMenuComponent", () => {
               label: "Custom Label",
               icon: ["fas", "tag"],
               tooltip: () => "Custom Tooltip",
-              uri: "http://brokenlink/"
+              uri: () => "http://brokenlink/"
             })
           ]),
           links: List<NavigableMenuItem>([])
@@ -403,13 +403,13 @@ describe("ActionMenuComponent", () => {
               label: "Custom Label 1",
               icon: ["fas", "tag"],
               tooltip: () => "Custom Tooltip 1",
-              uri: "http://brokenlink/1"
+              uri: () => "http://brokenlink/1"
             }),
             MenuLink({
               label: "Custom Label 2",
               icon: ["fas", "tags"],
               tooltip: () => "Custom Tooltip 2",
-              uri: "http://brokenlink/2"
+              uri: () => "http://brokenlink/2"
             })
           ]),
           links: List<NavigableMenuItem>([])

--- a/src/app/component/shared/header/header-dropdown/header-dropdown.component.spec.ts
+++ b/src/app/component/shared/header/header-dropdown/header-dropdown.component.spec.ts
@@ -26,7 +26,7 @@ describe("HeaderDropdownComponent", () => {
       items: [
         MenuLink({
           label: "label",
-          uri: "uri",
+          uri: () => "uri",
           icon: ["fas", "home"],
           tooltip: () => "tooltip"
         })
@@ -42,7 +42,7 @@ describe("HeaderDropdownComponent", () => {
       items: [
         MenuLink({
           label: "label",
-          uri: "uri",
+          uri: () => "uri",
           icon: ["fas", "home"],
           tooltip: () => "tooltip"
         })
@@ -61,7 +61,7 @@ describe("HeaderDropdownComponent", () => {
       items: [
         MenuLink({
           label: "label",
-          uri: "uri",
+          uri: () => "uri",
           icon: ["fas", "home"],
           tooltip: () => "tooltip"
         })
@@ -83,7 +83,7 @@ describe("HeaderDropdownComponent", () => {
       items: [
         MenuLink({
           label: "label",
-          uri: "uri",
+          uri: () => "uri",
           icon: ["fas", "home"],
           tooltip: () => "tooltip"
         })
@@ -175,7 +175,7 @@ describe("HeaderDropdownComponent", () => {
           label: "Custom Label",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          uri: "http://brokenlink/"
+          uri: () => "http://brokenlink/"
         })
       ]
     };
@@ -195,13 +195,13 @@ describe("HeaderDropdownComponent", () => {
           label: "Custom Label 1",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          uri: "http://brokenlink/1"
+          uri: () => "http://brokenlink/1"
         }),
         MenuLink({
           label: "Custom Label 2",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          uri: "http://brokenlink/2"
+          uri: () => "http://brokenlink/2"
         })
       ]
     };
@@ -223,7 +223,7 @@ describe("HeaderDropdownComponent", () => {
           label: "Custom Label 1",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          uri: "http://brokenlink/1"
+          uri: () => "http://brokenlink/1"
         }),
         MenuRoute({
           label: "Custom Label 2",

--- a/src/app/component/shared/header/header-dropdown/header-dropdown.component.ts
+++ b/src/app/component/shared/header/header-dropdown/header-dropdown.component.ts
@@ -4,10 +4,11 @@ import {
   Input,
   OnInit
 } from "@angular/core";
+import { ActivatedRoute, Params } from "@angular/router";
 import {
+  getRoute,
   isExternalLink,
-  isInternalRoute,
-  NavigableMenuItem
+  isInternalRoute
 } from "src/app/interfaces/menusInterfaces";
 import { HeaderDropDownConvertedLink } from "src/app/services/app-config/app-config.service";
 
@@ -29,13 +30,13 @@ import { HeaderDropDownConvertedLink } from "src/app/services/app-config/app-con
             <a
               ngbDropdownItem
               routerLinkActive="active"
-              [routerLink]="getRoute(link)"
+              [routerLink]="getRoute(link, params)"
             >
               {{ link.label }}
             </a>
           </ng-container>
           <ng-container *ngIf="isExternalLink(link)">
-            <a ngbDropdownItem [href]="getRoute(link)">
+            <a ngbDropdownItem [href]="getRoute(link, params)">
               {{ link.label }}
             </a>
           </ng-container>
@@ -48,23 +49,15 @@ import { HeaderDropDownConvertedLink } from "src/app/services/app-config/app-con
 export class HeaderDropdownComponent implements OnInit {
   @Input() active: boolean;
   @Input() links: HeaderDropDownConvertedLink;
+  public params: Params;
 
   isInternalRoute = isInternalRoute;
   isExternalLink = isExternalLink;
+  getRoute = getRoute;
 
-  constructor() {}
+  constructor(private route: ActivatedRoute) {
+    this.params = this.route.snapshot.params;
+  }
 
   ngOnInit() {}
-
-  /**
-   * Get link route. This is only required because typescript is unable to
-   * properly type-check links in template
-   */
-  public getRoute(link: NavigableMenuItem): string {
-    if (isInternalRoute(link)) {
-      return link.route.toString();
-    } else {
-      return link.uri(undefined);
-    }
-  }
 }

--- a/src/app/component/shared/header/header-dropdown/header-dropdown.component.ts
+++ b/src/app/component/shared/header/header-dropdown/header-dropdown.component.ts
@@ -6,7 +6,8 @@ import {
 } from "@angular/core";
 import {
   isExternalLink,
-  isInternalRoute
+  isInternalRoute,
+  NavigableMenuItem
 } from "src/app/interfaces/menusInterfaces";
 import { HeaderDropDownConvertedLink } from "src/app/services/app-config/app-config.service";
 
@@ -28,13 +29,13 @@ import { HeaderDropDownConvertedLink } from "src/app/services/app-config/app-con
             <a
               ngbDropdownItem
               routerLinkActive="active"
-              [routerLink]="link.route.toString()"
+              [routerLink]="getRoute(link)"
             >
               {{ link.label }}
             </a>
           </ng-container>
           <ng-container *ngIf="isExternalLink(link)">
-            <a ngbDropdownItem [href]="link.uri">
+            <a ngbDropdownItem [href]="getRoute(link)">
               {{ link.label }}
             </a>
           </ng-container>
@@ -54,4 +55,16 @@ export class HeaderDropdownComponent implements OnInit {
   constructor() {}
 
   ngOnInit() {}
+
+  /**
+   * Get link route. This is only required because typescript is unable to
+   * properly type-check links in template
+   */
+  public getRoute(link: NavigableMenuItem): string {
+    if (isInternalRoute(link)) {
+      return link.route.toString();
+    } else {
+      return link.uri(undefined);
+    }
+  }
 }

--- a/src/app/component/shared/header/header-item/header-item.component.spec.ts
+++ b/src/app/component/shared/header/header-item/header-item.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { assertRoute } from "src/app/helpers/tests/helpers";
 import { MenuLink, MenuRoute } from "src/app/interfaces/menusInterfaces";
 import { StrongRoute } from "src/app/interfaces/strongRoute";
 import { HeaderItemComponent } from "./header-item.component";
@@ -49,10 +50,7 @@ describe("HeaderItemComponent", () => {
     fixture.detectChanges();
 
     const link = fixture.nativeElement.querySelector("a");
-    expect(link.attributes.getNamedItem("ng-reflect-router-link")).toBeTruthy();
-    expect(link.attributes.getNamedItem("ng-reflect-router-link").value).toBe(
-      "/home"
-    );
+    assertRoute(link, "/home");
   });
 
   it("internal link should have router link active attribute", () => {

--- a/src/app/component/shared/header/header-item/header-item.component.spec.ts
+++ b/src/app/component/shared/header/header-item/header-item.component.spec.ts
@@ -78,7 +78,7 @@ describe("HeaderItemComponent", () => {
       label: "Custom Label",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
-      uri: "http://brokenlink/"
+      uri: () => "http://brokenlink/"
     });
     fixture.detectChanges();
 

--- a/src/app/component/shared/header/header-item/header-item.component.ts
+++ b/src/app/component/shared/header/header-item/header-item.component.ts
@@ -4,8 +4,9 @@ import {
   Input,
   OnInit
 } from "@angular/core";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, Params } from "@angular/router";
 import {
+  getRoute,
   isExternalLink,
   isInternalRoute,
   NavigableMenuItem
@@ -19,13 +20,13 @@ import {
         <a
           class="nav-link"
           routerLinkActive="active"
-          [routerLink]="getRoute(link)"
+          [routerLink]="getRoute(link, params)"
         >
           {{ link.label }}
         </a>
       </ng-container>
       <ng-container *ngIf="isExternalLink(link)">
-        <a class="nav-link" [href]="getRoute(link)">
+        <a class="nav-link" [href]="getRoute(link, params)">
           {{ link.label }}
         </a>
       </ng-container>
@@ -35,25 +36,15 @@ import {
 })
 export class HeaderItemComponent implements OnInit {
   @Input() link: NavigableMenuItem;
+  public params: Params;
 
   isInternalRoute = isInternalRoute;
   isExternalLink = isExternalLink;
+  getRoute = getRoute;
 
-  constructor(private route: ActivatedRoute) {}
+  constructor(private route: ActivatedRoute) {
+    this.params = this.route.snapshot.params;
+  }
 
   ngOnInit() {}
-
-  /**
-   * Get link route. This is only required because typescript is unable to
-   * properly type-check links in template
-   */
-  public getRoute(link: NavigableMenuItem): string {
-    if (isInternalRoute(link)) {
-      return link.route.toString();
-    } else {
-      const params = this.route.snapshot.params;
-
-      return link.uri(params);
-    }
-  }
 }

--- a/src/app/component/shared/header/header-item/header-item.component.ts
+++ b/src/app/component/shared/header/header-item/header-item.component.ts
@@ -4,6 +4,7 @@ import {
   Input,
   OnInit
 } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
 import {
   isExternalLink,
   isInternalRoute,
@@ -18,13 +19,13 @@ import {
         <a
           class="nav-link"
           routerLinkActive="active"
-          [routerLink]="link.route.toString()"
+          [routerLink]="getRoute(link)"
         >
           {{ link.label }}
         </a>
       </ng-container>
       <ng-container *ngIf="isExternalLink(link)">
-        <a class="nav-link" [href]="link.uri">
+        <a class="nav-link" [href]="getRoute(link)">
           {{ link.label }}
         </a>
       </ng-container>
@@ -38,7 +39,21 @@ export class HeaderItemComponent implements OnInit {
   isInternalRoute = isInternalRoute;
   isExternalLink = isExternalLink;
 
-  constructor() {}
+  constructor(private route: ActivatedRoute) {}
 
   ngOnInit() {}
+
+  /**
+   * Get link route. This is only required because typescript is unable to
+   * properly type-check links in template
+   */
+  public getRoute(link: NavigableMenuItem): string {
+    if (isInternalRoute(link)) {
+      return link.route.toString();
+    } else {
+      const params = this.route.snapshot.params;
+
+      return link.uri(params);
+    }
+  }
 }

--- a/src/app/component/shared/header/header.component.ts
+++ b/src/app/component/shared/header/header.component.ts
@@ -182,7 +182,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
       label: item.title,
       icon: ["fas", "home"],
       tooltip: () => "UPDATE ME",
-      uri: item.url
+      uri: () => item.url
     });
   }
 }

--- a/src/app/component/shared/items/item/item.component.spec.ts
+++ b/src/app/component/shared/items/item/item.component.spec.ts
@@ -21,7 +21,7 @@ describe("ItemComponent", () => {
     component = fixture.componentInstance;
   });
 
-  it("should create", () => {
+  it("should handle no uri", () => {
     component.icon = ["fas", "home"] as IconProp;
     component.name = "Test";
     component.value = 0;
@@ -134,7 +134,7 @@ describe("ItemComponent", () => {
     component.icon = ["fas", "home"] as IconProp;
     component.name = "Test";
     component.value = "unknown";
-    component.uri = "http://broken_link/";
+    component.uri = () => "http://broken_link/";
 
     fixture.detectChanges();
     const anchor = fixture.nativeElement.querySelector("a");

--- a/src/app/component/shared/items/item/item.component.ts
+++ b/src/app/component/shared/items/item/item.component.ts
@@ -8,7 +8,6 @@ import { ActivatedRoute } from "@angular/router";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { Href } from "src/app/interfaces/menusInterfaces";
 import { StrongRoute } from "src/app/interfaces/strongRoute";
-import { AppConfigService } from "src/app/services/app-config/app-config.service";
 
 @Component({
   selector: "app-items-item",
@@ -55,21 +54,21 @@ export class ItemComponent implements OnInit {
   link: string;
   internalLink: boolean;
 
-  constructor(
-    private config: AppConfigService,
-    private route: ActivatedRoute
-  ) {}
+  constructor(private route: ActivatedRoute) {}
 
   ngOnInit() {
+    if (!this.uri) {
+      return;
+    }
+
     if (typeof this.uri === "object") {
       this.internalLink = true;
       this.link = this.uri.toString();
     } else {
       const params = this.route.snapshot.params;
-      const bawUrl = this.config.getConfig().environment.apiRoot;
 
       this.internalLink = false;
-      this.link = this.uri(bawUrl, params);
+      this.link = this.uri(params);
     }
   }
 }

--- a/src/app/component/shared/items/item/item.component.ts
+++ b/src/app/component/shared/items/item/item.component.ts
@@ -4,9 +4,11 @@ import {
   Input,
   OnInit
 } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { Href } from "src/app/interfaces/menusInterfaces";
 import { StrongRoute } from "src/app/interfaces/strongRoute";
+import { AppConfigService } from "src/app/services/app-config/app-config.service";
 
 @Component({
   selector: "app-items-item",
@@ -53,15 +55,21 @@ export class ItemComponent implements OnInit {
   link: string;
   internalLink: boolean;
 
-  constructor() {}
+  constructor(
+    private config: AppConfigService,
+    private route: ActivatedRoute
+  ) {}
 
   ngOnInit() {
     if (typeof this.uri === "object") {
       this.internalLink = true;
       this.link = this.uri.toString();
     } else {
+      const params = this.route.snapshot.params;
+      const bawUrl = this.config.getConfig().environment.apiRoot;
+
       this.internalLink = false;
-      this.link = this.uri;
+      this.link = this.uri(bawUrl, params);
     }
   }
 }

--- a/src/app/component/shared/items/items/items.component.spec.ts
+++ b/src/app/component/shared/items/items/items.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
 import { SharedModule } from "../../shared.module";
 import { ItemComponent, ItemInterface } from "../item/item.component";
 import { ItemsComponent } from "./items.component";
@@ -22,7 +23,7 @@ describe("ItemsComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [SharedModule],
+      imports: [SharedModule, RouterTestingModule],
       declarations: [ItemsComponent, ItemComponent]
     }).compileComponents();
   }));

--- a/src/app/component/shared/menu/external-link/external-link.component.spec.ts
+++ b/src/app/component/shared/menu/external-link/external-link.component.spec.ts
@@ -25,7 +25,7 @@ describe("MenuExternalLinkComponent", () => {
     component.link = MenuLink({
       icon: ["fas", "home"],
       label: "home",
-      uri: "http://link/",
+      uri: () => "http://link/",
       tooltip: () => "custom tooltip"
     });
     component.tooltip = "custom tooltip";
@@ -40,7 +40,7 @@ describe("MenuExternalLinkComponent", () => {
     component.link = MenuLink({
       icon: ["fas", "home"],
       label: "home",
-      uri: "http://link/",
+      uri: () => "http://link/",
       tooltip: () => "custom tooltip"
     });
     component.tooltip = "custom tooltip";
@@ -61,7 +61,7 @@ describe("MenuExternalLinkComponent", () => {
     component.link = MenuLink({
       icon: ["fas", "home"],
       label: "custom label",
-      uri: "http://link/",
+      uri: () => "http://link/",
       tooltip: () => "custom tooltip"
     });
     component.tooltip = "custom tooltip";
@@ -79,7 +79,7 @@ describe("MenuExternalLinkComponent", () => {
     component.link = MenuLink({
       icon: ["fas", "home"],
       label: "home",
-      uri: "http://link/",
+      uri: () => "http://link/",
       tooltip: () => "custom tooltip"
     });
     component.tooltip = "custom tooltip";
@@ -100,7 +100,7 @@ describe("MenuExternalLinkComponent", () => {
     component.link = MenuLink({
       icon: ["fas", "home"],
       label: "home",
-      uri: "http://link/",
+      uri: () => "http://link/",
       tooltip: () => "tooltip"
     });
     component.tooltip = "custom tooltip";
@@ -121,7 +121,7 @@ describe("MenuExternalLinkComponent", () => {
     component.link = MenuLink({
       icon: ["fas", "home"],
       label: "home",
-      uri: "http://link/",
+      uri: () => "http://link/",
       tooltip: () => "tooltip"
     });
     component.tooltip = "custom tooltip";
@@ -138,7 +138,7 @@ describe("MenuExternalLinkComponent", () => {
     component.link = MenuLink({
       icon: ["fas", "home"],
       label: "home",
-      uri: "http://link/",
+      uri: () => "http://link/",
       tooltip: () => "tooltip"
     });
     component.tooltip = "custom tooltip";
@@ -156,7 +156,7 @@ describe("MenuExternalLinkComponent", () => {
     component.link = MenuLink({
       icon: ["fas", "home"],
       label: "home",
-      uri: "http://link/",
+      uri: () => "http://link/",
       tooltip: () => "custom tooltip"
     });
     component.tooltip = "custom tooltip";
@@ -177,7 +177,7 @@ describe("MenuExternalLinkComponent", () => {
     component.link = MenuLink({
       icon: ["fas", "home"],
       label: "home",
-      uri: "http://link/",
+      uri: () => "http://link/",
       tooltip: () => "custom tooltip"
     });
     component.tooltip = "custom tooltip";
@@ -198,7 +198,7 @@ describe("MenuExternalLinkComponent", () => {
     component.link = MenuLink({
       icon: ["fas", "home"],
       label: "home",
-      uri: "http://brokenlink/",
+      uri: () => "http://brokenlink/",
       tooltip: () => "custom tooltip"
     });
     component.tooltip = "custom tooltip";
@@ -208,22 +208,5 @@ describe("MenuExternalLinkComponent", () => {
     const link = fixture.nativeElement.querySelector("a");
     expect(link).toBeTruthy();
     expect(link.href).toBe("http://brokenlink/");
-  });
-
-  it("should convert links to AngularJS server", () => {
-    component.id = "id";
-    component.link = MenuLink({
-      icon: ["fas", "home"],
-      label: "home",
-      uri: "/brokenlink/",
-      tooltip: () => "custom tooltip"
-    });
-    component.tooltip = "custom tooltip";
-    component.placement = "left";
-    fixture.detectChanges();
-
-    const link = fixture.nativeElement.querySelector("a");
-    expect(link).toBeTruthy();
-    expect(link.href).toBe("http://apiroot/brokenlink/");
   });
 });

--- a/src/app/component/shared/menu/external-link/external-link.component.spec.ts
+++ b/src/app/component/shared/menu/external-link/external-link.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { assertIcon, assertTooltip } from "src/app/helpers/tests/helpers";
 import { MenuLink } from "src/app/interfaces/menusInterfaces";
+import { AppConfigService } from "src/app/services/app-config/app-config.service";
 import { testAppInitializer } from "src/app/test.helper";
 import { SharedModule } from "../../shared.module";
 import { MenuExternalLinkComponent } from "./external-link.component";
@@ -8,6 +10,7 @@ import { MenuExternalLinkComponent } from "./external-link.component";
 describe("MenuExternalLinkComponent", () => {
   let component: MenuExternalLinkComponent;
   let fixture: ComponentFixture<MenuExternalLinkComponent>;
+  let config: AppConfigService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -17,6 +20,7 @@ describe("MenuExternalLinkComponent", () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(MenuExternalLinkComponent);
+    config = TestBed.inject(AppConfigService);
     component = fixture.componentInstance;
   });
 
@@ -29,6 +33,7 @@ describe("MenuExternalLinkComponent", () => {
       tooltip: () => "custom tooltip"
     });
     component.tooltip = "custom tooltip";
+    component.uri = "http://link/";
     component.placement = "left";
     fixture.detectChanges();
 
@@ -44,16 +49,11 @@ describe("MenuExternalLinkComponent", () => {
       tooltip: () => "custom tooltip"
     });
     component.tooltip = "custom tooltip";
+    component.uri = "http://link/";
     component.placement = "left";
     fixture.detectChanges();
 
-    const icon = fixture.nativeElement.querySelector("fa-icon");
-
-    expect(icon).toBeTruthy("Should contain <fa-icon> element");
-    expect(icon.attributes.getNamedItem("ng-reflect-icon")).toBeTruthy();
-    expect(icon.attributes.getNamedItem("ng-reflect-icon").value).toBe(
-      "fas,home"
-    );
+    assertIcon(fixture.nativeElement, "fas,home");
   });
 
   it("should have label", () => {
@@ -65,6 +65,7 @@ describe("MenuExternalLinkComponent", () => {
       tooltip: () => "custom tooltip"
     });
     component.tooltip = "custom tooltip";
+    component.uri = "http://link/";
     component.placement = "left";
     fixture.detectChanges();
 
@@ -83,16 +84,12 @@ describe("MenuExternalLinkComponent", () => {
       tooltip: () => "custom tooltip"
     });
     component.tooltip = "custom tooltip";
+    component.uri = "http://link/";
     component.placement = "left";
     fixture.detectChanges();
 
     const link = fixture.nativeElement.querySelector("a");
-
-    expect(link).toBeTruthy("Anchor should have [ngbTooltip] directive");
-    expect(link.attributes.getNamedItem("ng-reflect-ngb-tooltip")).toBeTruthy();
-    expect(link.attributes.getNamedItem("ng-reflect-ngb-tooltip").value).toBe(
-      "custom tooltip"
-    );
+    assertTooltip(link, "custom tooltip");
   });
 
   it("should not use link tooltip", () => {
@@ -104,51 +101,12 @@ describe("MenuExternalLinkComponent", () => {
       tooltip: () => "tooltip"
     });
     component.tooltip = "custom tooltip";
+    component.uri = "http://link/";
     component.placement = "left";
     fixture.detectChanges();
 
     const link = fixture.nativeElement.querySelector("a");
-
-    expect(link).toBeTruthy("Anchor should have [ngbTooltip] directive");
-    expect(link.attributes.getNamedItem("ng-reflect-ngb-tooltip")).toBeTruthy();
-    expect(link.attributes.getNamedItem("ng-reflect-ngb-tooltip").value).toBe(
-      "custom tooltip"
-    );
-  });
-
-  it("should have id for disabled access tooltip", () => {
-    component.id = "id1000";
-    component.link = MenuLink({
-      icon: ["fas", "home"],
-      label: "home",
-      uri: () => "http://link/",
-      tooltip: () => "tooltip"
-    });
-    component.tooltip = "custom tooltip";
-    component.placement = "left";
-    fixture.detectChanges();
-
-    const tooltip = fixture.nativeElement.querySelector("span.d-none");
-    expect(tooltip).toBeTruthy("Tooltip should exist");
-    expect(tooltip.id).toBe("id1000");
-  });
-
-  it("should have disabled access tooltip", () => {
-    component.id = "id";
-    component.link = MenuLink({
-      icon: ["fas", "home"],
-      label: "home",
-      uri: () => "http://link/",
-      tooltip: () => "tooltip"
-    });
-    component.tooltip = "custom tooltip";
-    component.placement = "left";
-    fixture.detectChanges();
-
-    const tooltip = fixture.nativeElement.querySelector("span.d-none");
-
-    expect(tooltip).toBeTruthy("Tooltip should exist");
-    expect(tooltip.innerText.trim()).toBe("custom tooltip");
+    assertTooltip(link, "custom tooltip");
   });
 
   it("should handle left placement of tooltip", () => {
@@ -160,6 +118,7 @@ describe("MenuExternalLinkComponent", () => {
       tooltip: () => "custom tooltip"
     });
     component.tooltip = "custom tooltip";
+    component.uri = "http://link/";
     component.placement = "left";
     fixture.detectChanges();
 
@@ -181,6 +140,7 @@ describe("MenuExternalLinkComponent", () => {
       tooltip: () => "custom tooltip"
     });
     component.tooltip = "custom tooltip";
+    component.uri = "http://link/";
     component.placement = "right";
     fixture.detectChanges();
 
@@ -193,6 +153,24 @@ describe("MenuExternalLinkComponent", () => {
     );
   });
 
+  it("should not use link uri", () => {
+    component.id = "id";
+    component.link = MenuLink({
+      icon: ["fas", "home"],
+      label: "home",
+      uri: () => "http://brokenlink/",
+      tooltip: () => "custom tooltip"
+    });
+    component.tooltip = "custom tooltip";
+    component.uri = "http://differentlink/";
+    component.placement = "left";
+    fixture.detectChanges();
+
+    const link = fixture.nativeElement.querySelector("a");
+    expect(link).toBeTruthy();
+    expect(link.href).toBe("http://differentlink/");
+  });
+
   it("should link to external website", () => {
     component.id = "id";
     component.link = MenuLink({
@@ -202,11 +180,32 @@ describe("MenuExternalLinkComponent", () => {
       tooltip: () => "custom tooltip"
     });
     component.tooltip = "custom tooltip";
+    component.uri = "http://brokenlink/";
     component.placement = "left";
     fixture.detectChanges();
 
     const link = fixture.nativeElement.querySelector("a");
     expect(link).toBeTruthy();
     expect(link.href).toBe("http://brokenlink/");
+  });
+
+  it("should convert links to AngularJS server", () => {
+    component.id = "id";
+    component.link = MenuLink({
+      icon: ["fas", "home"],
+      label: "home",
+      uri: () => "/brokenlink/",
+      tooltip: () => "custom tooltip"
+    });
+    component.tooltip = "custom tooltip";
+    component.uri = "/brokenlink/";
+    component.placement = "left";
+    fixture.detectChanges();
+
+    const link = fixture.nativeElement.querySelector("a");
+    expect(link).toBeTruthy();
+    expect(link.href).toBe(
+      config.getConfig().environment.apiRoot + "/brokenlink/"
+    );
   });
 });

--- a/src/app/component/shared/menu/external-link/external-link.component.ts
+++ b/src/app/component/shared/menu/external-link/external-link.component.ts
@@ -5,6 +5,7 @@ import {
   OnInit
 } from "@angular/core";
 import { MenuLink } from "src/app/interfaces/menusInterfaces";
+import { AppConfigService } from "src/app/services/app-config/app-config.service";
 
 @Component({
   selector: "app-menu-external-link",
@@ -32,7 +33,11 @@ export class MenuExternalLinkComponent implements OnInit {
   @Input() tooltip: string;
   @Input() uri: string;
 
-  constructor() {}
+  constructor(private config: AppConfigService) {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    if (this.uri.charAt(0) === "/") {
+      this.uri = this.config.getConfig().environment.apiRoot + this.uri;
+    }
+  }
 }

--- a/src/app/component/shared/menu/external-link/external-link.component.ts
+++ b/src/app/component/shared/menu/external-link/external-link.component.ts
@@ -5,14 +5,13 @@ import {
   OnInit
 } from "@angular/core";
 import { MenuLink } from "src/app/interfaces/menusInterfaces";
-import { AppConfigService } from "src/app/services/app-config/app-config.service";
 
 @Component({
   selector: "app-menu-external-link",
   template: `
     <a
       class="nav-link"
-      href="{{ link.uri }}"
+      href="{{ uri }}"
       placement="{{ placement }}"
       ngbTooltip="{{ tooltip }}"
     >
@@ -31,13 +30,9 @@ export class MenuExternalLinkComponent implements OnInit {
   @Input() link: MenuLink;
   @Input() placement: "left" | "right";
   @Input() tooltip: string;
+  @Input() uri: string;
 
-  constructor(private config: AppConfigService) {}
+  constructor() {}
 
-  ngOnInit() {
-    if (this.link.uri.charAt(0) === "/") {
-      this.link.uri =
-        this.config.getConfig().environment.apiRoot + this.link.uri;
-    }
-  }
+  ngOnInit() {}
 }

--- a/src/app/component/shared/menu/internal-link/internal-link.component.spec.ts
+++ b/src/app/component/shared/menu/internal-link/internal-link.component.spec.ts
@@ -1,5 +1,10 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import {
+  assertIcon,
+  assertRoute,
+  assertTooltip
+} from "src/app/helpers/tests/helpers";
 import { MenuRoute } from "src/app/interfaces/menusInterfaces";
 import { StrongRoute } from "src/app/interfaces/strongRoute";
 import { SharedModule } from "../../shared.module";
@@ -28,7 +33,7 @@ describe("MenuInternalLinkComponent", () => {
       tooltip: () => "tooltip"
     });
     component.tooltip = "custom tooltip";
-    component.linkParams = {};
+    component.route = "/home";
     component.placement = "left";
     fixture.detectChanges();
 
@@ -44,17 +49,11 @@ describe("MenuInternalLinkComponent", () => {
       tooltip: () => "tooltip"
     });
     component.tooltip = "custom tooltip";
-    component.linkParams = {};
+    component.route = "/home";
     component.placement = "left";
     fixture.detectChanges();
 
-    const icon = fixture.nativeElement.querySelector("fa-icon");
-
-    expect(icon).toBeTruthy("Should contain <fa-icon> element");
-    expect(icon.attributes.getNamedItem("ng-reflect-icon")).toBeTruthy();
-    expect(icon.attributes.getNamedItem("ng-reflect-icon").value).toBe(
-      "fas,home"
-    );
+    assertIcon(fixture.nativeElement, "fas,home");
   });
 
   it("should have label", () => {
@@ -66,7 +65,7 @@ describe("MenuInternalLinkComponent", () => {
       tooltip: () => "tooltip"
     });
     component.tooltip = "custom tooltip";
-    component.linkParams = {};
+    component.route = "/home";
     component.placement = "left";
     fixture.detectChanges();
 
@@ -85,17 +84,12 @@ describe("MenuInternalLinkComponent", () => {
       tooltip: () => "custom tooltip"
     });
     component.tooltip = "custom tooltip";
-    component.linkParams = {};
+    component.route = "/home";
     component.placement = "left";
     fixture.detectChanges();
 
     const link = fixture.nativeElement.querySelector("a");
-
-    expect(link).toBeTruthy("Anchor should have [ngbTooltip] directive");
-    expect(link.attributes.getNamedItem("ng-reflect-ngb-tooltip")).toBeTruthy();
-    expect(link.attributes.getNamedItem("ng-reflect-ngb-tooltip").value).toBe(
-      "custom tooltip"
-    );
+    assertTooltip(link, "custom tooltip");
   });
 
   it("should not use link tooltip", () => {
@@ -107,54 +101,12 @@ describe("MenuInternalLinkComponent", () => {
       tooltip: () => "tooltip"
     });
     component.tooltip = "custom tooltip";
-    component.linkParams = {};
+    component.route = "/home";
     component.placement = "left";
     fixture.detectChanges();
 
     const link = fixture.nativeElement.querySelector("a");
-
-    expect(link).toBeTruthy("Anchor should have [ngbTooltip] directive");
-    expect(link.attributes.getNamedItem("ng-reflect-ngb-tooltip")).toBeTruthy();
-    expect(link.attributes.getNamedItem("ng-reflect-ngb-tooltip").value).toBe(
-      "custom tooltip"
-    );
-  });
-
-  it("should have id for disabled access tooltip", () => {
-    component.id = "id1000";
-    component.link = MenuRoute({
-      icon: ["fas", "home"],
-      label: "home",
-      route: StrongRoute.Base.add("home"),
-      tooltip: () => "tooltip"
-    });
-    component.tooltip = "custom tooltip";
-    component.linkParams = {};
-    component.placement = "left";
-    fixture.detectChanges();
-
-    const tooltip = fixture.nativeElement.querySelector("span.d-none");
-    expect(tooltip).toBeTruthy("Tooltip should exist");
-    expect(tooltip.id).toBe("id1000");
-  });
-
-  it("should have disabled access tooltip", () => {
-    component.id = "id";
-    component.link = MenuRoute({
-      icon: ["fas", "home"],
-      label: "home",
-      route: StrongRoute.Base.add("home"),
-      tooltip: () => "custom tooltip"
-    });
-    component.tooltip = "custom tooltip";
-    component.linkParams = {};
-    component.placement = "left";
-    fixture.detectChanges();
-
-    const tooltip = fixture.nativeElement.querySelector("span.d-none");
-
-    expect(tooltip).toBeTruthy("Tooltip should exist");
-    expect(tooltip.innerText.trim()).toBe("custom tooltip");
+    assertTooltip(link, "custom tooltip");
   });
 
   it("should handle left placement of tooltip", () => {
@@ -166,7 +118,7 @@ describe("MenuInternalLinkComponent", () => {
       tooltip: () => "tooltip"
     });
     component.tooltip = "custom tooltip";
-    component.linkParams = {};
+    component.route = "/home";
     component.placement = "left";
     fixture.detectChanges();
 
@@ -188,7 +140,7 @@ describe("MenuInternalLinkComponent", () => {
       tooltip: () => "tooltip"
     });
     component.tooltip = "custom tooltip";
-    component.linkParams = {};
+    component.route = "/home";
     component.placement = "right";
     fixture.detectChanges();
 
@@ -210,37 +162,29 @@ describe("MenuInternalLinkComponent", () => {
       tooltip: () => "tooltip"
     });
     component.tooltip = "custom tooltip";
-    component.linkParams = {};
+    component.route = "/brokenlink";
     component.placement = "right";
     fixture.detectChanges();
 
     const link = fixture.nativeElement.querySelector("a");
-    expect(link.attributes.getNamedItem("ng-reflect-router-link")).toBeTruthy();
-    expect(link.attributes.getNamedItem("ng-reflect-router-link").value).toBe(
-      "/brokenlink"
-    );
+    assertRoute(link, "/brokenlink");
   });
 
-  it("should create routerLink with attributes", () => {
-    const baseRoute = StrongRoute.Base.add("brokenlink");
-
+  it("should not use link route", () => {
     component.id = "id";
     component.link = MenuRoute({
       icon: ["fas", "home"],
       label: "home",
-      route: baseRoute.add(":attribute"),
+      route: StrongRoute.Base.add("home"),
       tooltip: () => "tooltip"
     });
     component.tooltip = "custom tooltip";
-    component.linkParams = { attribute: "10" };
-    component.placement = "right";
+    component.route = "/house";
+    component.placement = "left";
     fixture.detectChanges();
 
     const link = fixture.nativeElement.querySelector("a");
-    expect(link.attributes.getNamedItem("ng-reflect-router-link")).toBeTruthy();
-    expect(link.attributes.getNamedItem("ng-reflect-router-link").value).toBe(
-      "/brokenlink/10"
-    );
+    assertRoute(link, "/house");
   });
 
   it("should not highlight link when not active", () => {
@@ -252,7 +196,7 @@ describe("MenuInternalLinkComponent", () => {
       tooltip: () => "tooltip"
     });
     component.tooltip = "custom tooltip";
-    component.linkParams = {};
+    component.route = "/brokenlink";
     component.placement = "right";
     fixture.detectChanges();
 
@@ -269,7 +213,7 @@ describe("MenuInternalLinkComponent", () => {
       tooltip: () => "tooltip"
     });
     component.tooltip = "custom tooltip";
-    component.linkParams = {};
+    component.route = "/context.html";
     component.placement = "right";
     fixture.detectChanges();
 

--- a/src/app/component/shared/menu/internal-link/internal-link.component.ts
+++ b/src/app/component/shared/menu/internal-link/internal-link.component.ts
@@ -4,7 +4,6 @@ import {
   Input,
   OnInit
 } from "@angular/core";
-import { Params } from "@angular/router";
 import { MenuRoute } from "src/app/interfaces/menusInterfaces";
 
 @Component({
@@ -13,7 +12,7 @@ import { MenuRoute } from "src/app/interfaces/menusInterfaces";
     <a
       class="nav-link"
       [ngClass]="{ active: active }"
-      [routerLink]="linkRoute"
+      [routerLink]="route"
       [placement]="placement"
       [ngbTooltip]="tooltip"
     >
@@ -30,16 +29,14 @@ import { MenuRoute } from "src/app/interfaces/menusInterfaces";
 export class MenuInternalLinkComponent implements OnInit {
   @Input() id: string;
   @Input() link: MenuRoute;
-  @Input() linkParams: Params;
+  @Input() route: string;
   @Input() placement: "left" | "right";
   @Input() tooltip: string;
-  linkRoute: string;
   active: boolean;
 
   constructor() {}
 
   ngOnInit() {
-    this.linkRoute = this.link.route.format(this.linkParams);
-    this.active = this.linkRoute === window.location.pathname;
+    this.active = this.route === window.location.pathname;
   }
 }

--- a/src/app/component/shared/menu/menu.component.html
+++ b/src/app/component/shared/menu/menu.component.html
@@ -31,9 +31,9 @@
           <app-menu-internal-link
             [id]="menuType + '-tooltip-' + i"
             [link]="link"
-            [linkParams]="routerParams"
             [placement]="placement"
             [tooltip]="link.tooltip(user)"
+            [route]="link.route.format(params)"
           >
           </app-menu-internal-link>
         </ng-container>
@@ -43,6 +43,7 @@
             [link]="link"
             [placement]="placement"
             [tooltip]="link.tooltip(user)"
+            [uri]="link.uri(bawUrl, params)"
           >
           </app-menu-external-link>
         </ng-container>

--- a/src/app/component/shared/menu/menu.component.html
+++ b/src/app/component/shared/menu/menu.component.html
@@ -43,7 +43,7 @@
             [link]="link"
             [placement]="placement"
             [tooltip]="link.tooltip(user)"
-            [uri]="link.uri(bawUrl, params)"
+            [uri]="link.uri(params)"
           >
           </app-menu-external-link>
         </ng-container>

--- a/src/app/component/shared/menu/menu.component.spec.ts
+++ b/src/app/component/shared/menu/menu.component.spec.ts
@@ -4,7 +4,6 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { List } from "immutable";
-import { BehaviorSubject } from "rxjs";
 import { isGuestPredicate, isLoggedInPredicate } from "src/app/app.menus";
 import { assertIcon, assertTooltip } from "src/app/helpers/tests/helpers";
 import {
@@ -610,6 +609,22 @@ describe("MenuComponent", () => {
 
       const link = findLinks(linkSelector)[0];
       assertHref(link, "http://brokenlink/");
+    });
+
+    it("should create link href with router params", () => {
+      component.menuType = "action";
+      component.links = List<AnyMenuItem>([
+        MenuLink({
+          label: "label",
+          icon: ["fas", "home"],
+          tooltip: () => "tooltip",
+          uri: params => "http://brokenlink/" + params.attribute
+        })
+      ]);
+      fixture.detectChanges();
+
+      const link = findLinks(linkSelector)[0];
+      assertHref(link, "http://brokenlink/10");
     });
 
     it("should not filter links without predicate", () => {

--- a/src/app/component/shared/menu/menu.component.spec.ts
+++ b/src/app/component/shared/menu/menu.component.spec.ts
@@ -6,6 +6,7 @@ import { RouterTestingModule } from "@angular/router/testing";
 import { List } from "immutable";
 import { BehaviorSubject } from "rxjs";
 import { isGuestPredicate, isLoggedInPredicate } from "src/app/app.menus";
+import { assertIcon, assertTooltip } from "src/app/helpers/tests/helpers";
 import {
   AnyMenuItem,
   MenuAction,
@@ -35,14 +36,9 @@ describe("MenuComponent", () => {
   });
 
   class MockActivatedRoute {
-    public params = new BehaviorSubject<any>({ attribute: 10 });
-  }
-
-  function assertIcon(target: HTMLElement, prop: string) {
-    const icon: HTMLElement = target.querySelector("fa-icon");
-    expect(icon).toBeTruthy();
-    expect(icon.attributes.getNamedItem("ng-reflect-icon")).toBeTruthy();
-    expect(icon.attributes.getNamedItem("ng-reflect-icon").value).toBe(prop);
+    public snapshot = {
+      params: { attribute: 10 }
+    };
   }
 
   function assertTitle(target: HTMLElement, header: string) {
@@ -54,14 +50,6 @@ describe("MenuComponent", () => {
     const label: HTMLElement = target.querySelector("#label");
     expect(label).toBeTruthy();
     expect(label.innerText.trim()).toBe(labelText);
-  }
-
-  function assertTooltip(target: HTMLElement, tooltip: string) {
-    expect(target).toBeTruthy();
-    expect(target.attributes.getNamedItem("ng-reflect-tooltip")).toBeTruthy();
-    expect(
-      target.attributes.getNamedItem("ng-reflect-tooltip").value.trim()
-    ).toBe(tooltip);
   }
 
   function findLinks(

--- a/src/app/component/shared/menu/menu.component.spec.ts
+++ b/src/app/component/shared/menu/menu.component.spec.ts
@@ -177,7 +177,7 @@ describe("MenuComponent", () => {
         label: "label",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
-        uri: "http://brokenlink/"
+        uri: () => "http://brokenlink/"
       }),
       MenuAction({
         label: "label",
@@ -206,7 +206,7 @@ describe("MenuComponent", () => {
         label: "label",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
-        uri: "http://brokenlink/"
+        uri: () => "http://brokenlink/"
       }),
       MenuAction({
         label: "label",
@@ -493,7 +493,7 @@ describe("MenuComponent", () => {
           label: "label",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          uri: "http://brokenlink/"
+          uri: () => "http://brokenlink/"
         })
       ]);
       fixture.detectChanges();
@@ -510,7 +510,7 @@ describe("MenuComponent", () => {
           label: "label",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          uri: "http://brokenlink/"
+          uri: () => "http://brokenlink/"
         })
       ]);
       fixture.detectChanges();
@@ -527,13 +527,13 @@ describe("MenuComponent", () => {
           label: "label 1",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          uri: "http://brokenlink/"
+          uri: () => "http://brokenlink/"
         }),
         MenuLink({
           label: "label 2",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          uri: "http://brokenlink/"
+          uri: () => "http://brokenlink/"
         })
       ]);
       fixture.detectChanges();
@@ -550,7 +550,7 @@ describe("MenuComponent", () => {
           label: "Custom Label",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          uri: "http://brokenlink/"
+          uri: () => "http://brokenlink/"
         })
       ]);
       fixture.detectChanges();
@@ -566,7 +566,7 @@ describe("MenuComponent", () => {
           label: "label",
           icon: ["fas", "exclamation-triangle"],
           tooltip: () => "tooltip",
-          uri: "http://brokenlink/"
+          uri: () => "http://brokenlink/"
         })
       ]);
       fixture.detectChanges();
@@ -582,7 +582,7 @@ describe("MenuComponent", () => {
           label: "label",
           icon: ["fas", "home"],
           tooltip: () => "Custom Tooltip",
-          uri: "http://brokenlink/"
+          uri: () => "http://brokenlink/"
         })
       ]);
       fixture.detectChanges();
@@ -599,7 +599,7 @@ describe("MenuComponent", () => {
           label: "label",
           icon: ["fas", "home"],
           tooltip: user => `${user.userName} tooltip`,
-          uri: "http://brokenlink/"
+          uri: () => "http://brokenlink/"
         })
       ]);
       fixture.detectChanges();
@@ -615,7 +615,7 @@ describe("MenuComponent", () => {
           label: "label",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          uri: "http://brokenlink/"
+          uri: () => "http://brokenlink/"
         })
       ]);
       fixture.detectChanges();
@@ -632,7 +632,7 @@ describe("MenuComponent", () => {
           label: "label",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          uri: "http://brokenlink/"
+          uri: () => "http://brokenlink/"
         })
       ]);
       fixture.detectChanges();
@@ -648,14 +648,14 @@ describe("MenuComponent", () => {
           label: "label 1",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          uri: "http://brokenlink/",
+          uri: () => "http://brokenlink/",
           predicate: isGuestPredicate
         }),
         MenuLink({
           label: "label 2",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          uri: "http://brokenlink/",
+          uri: () => "http://brokenlink/",
           predicate: isLoggedInPredicate
         })
       ]);
@@ -674,14 +674,14 @@ describe("MenuComponent", () => {
           label: "label 1",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          uri: "http://brokenlink/",
+          uri: () => "http://brokenlink/",
           predicate: isGuestPredicate
         }),
         MenuLink({
           label: "label 2",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          uri: "http://brokenlink/",
+          uri: () => "http://brokenlink/",
           predicate: isLoggedInPredicate
         })
       ]);
@@ -697,7 +697,7 @@ describe("MenuComponent", () => {
         label: "label",
         icon: ["fas", "home"],
         tooltip: () => "tooltip",
-        uri: "http://brokenlink/"
+        uri: () => "http://brokenlink/"
       });
       component.menuType = "action";
       component.links = List<AnyMenuItem>([menuLink, menuLink]);

--- a/src/app/component/shared/menu/menu.component.ts
+++ b/src/app/component/shared/menu/menu.component.ts
@@ -63,13 +63,14 @@ export class MenuComponent implements OnInit, OnDestroy {
     this.placement = this.menuType === "action" ? "left" : "right";
 
     // Filter links
-    this.filteredLinks = new Set(this
-      ?.links
-      ?.filter((link) => {
+    this.filteredLinks = new Set(
+      this?.links
+        ?.filter(link => {
           // If link has predicate function, test if returns true
           return link.predicate ? link.predicate(this?.user) : true;
-      })
-      ?.sort(this.compare));
+        })
+        ?.sort(this.compare)
+    );
 
     // Retrieve router parameters to override link attributes
     this.route.params.pipe(takeUntil(this.unsubscribe)).subscribe(
@@ -103,12 +104,12 @@ export class MenuComponent implements OnInit, OnDestroy {
    * @param link Link to calculate padding for
    */
   calculateIndentation(link: AnyMenuItem) {
-      // Only the secondary menu implements this option
-      if (this.menuType !== "secondary" || !link.indentation) {
-        return 0;
-      }
+    // Only the secondary menu implements this option
+    if (this.menuType !== "secondary" || !link.indentation) {
+      return 0;
+    }
 
-      return link.indentation;
+    return link.indentation;
   }
 
   /**
@@ -152,6 +153,6 @@ export class MenuComponent implements OnInit, OnDestroy {
     }
 
     // Return the menu item with the lower order value
-    return (a?.order || 0) < (b?.order || 0) ? -1 : 1;
+    return (a?.order || Infinity) < (b?.order || Infinity) ? -1 : 1;
   }
 }

--- a/src/app/component/shared/menu/menu.component.ts
+++ b/src/app/component/shared/menu/menu.component.ts
@@ -7,7 +7,7 @@ import {
   OnInit,
   ViewChild
 } from "@angular/core";
-import { ActivatedRoute, Params } from "@angular/router";
+import { ActivatedRoute, ParamMap, Params } from "@angular/router";
 import { List } from "immutable";
 import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
@@ -19,6 +19,7 @@ import {
   LabelAndIcon
 } from "src/app/interfaces/menusInterfaces";
 import { SessionUser } from "src/app/models/User";
+import { AppConfigService } from "src/app/services/app-config/app-config.service";
 import { SecurityService } from "src/app/services/baw-api/security.service";
 import { WidgetComponent } from "../widget/widget.component";
 import { WidgetDirective } from "../widget/widget.directive";
@@ -40,7 +41,8 @@ export class MenuComponent implements OnInit, OnDestroy {
   private unsubscribe = new Subject();
   filteredLinks: Set<AnyMenuItem>;
   placement: "left" | "right";
-  routerParams: Params;
+  params: Params;
+  bawUrl: string;
   url: string;
   user: SessionUser;
   loading: boolean;
@@ -51,13 +53,12 @@ export class MenuComponent implements OnInit, OnDestroy {
 
   constructor(
     private api: SecurityService,
+    private config: AppConfigService,
     private route: ActivatedRoute,
     private componentFactoryResolver: ComponentFactoryResolver
   ) {}
 
   ngOnInit() {
-    this.loading = true;
-
     // Get user details
     this.user = this.api.getSessionUser();
     this.placement = this.menuType === "action" ? "left" : "right";
@@ -73,15 +74,8 @@ export class MenuComponent implements OnInit, OnDestroy {
     );
 
     // Retrieve router parameters to override link attributes
-    this.route.params.pipe(takeUntil(this.unsubscribe)).subscribe(
-      params => {
-        this.routerParams = params;
-        this.loading = false;
-      },
-      err => {
-        console.error("MenuComponent: ", err);
-      }
-    );
+    this.params = this.route.snapshot.params;
+    this.bawUrl = this.config.getConfig().environment.apiRoot;
 
     // Load widget
     this.loadComponent();

--- a/src/app/component/shared/menu/menu.component.ts
+++ b/src/app/component/shared/menu/menu.component.ts
@@ -7,10 +7,9 @@ import {
   OnInit,
   ViewChild
 } from "@angular/core";
-import { ActivatedRoute, ParamMap, Params } from "@angular/router";
+import { ActivatedRoute, Params } from "@angular/router";
 import { List } from "immutable";
 import { Subject } from "rxjs";
-import { takeUntil } from "rxjs/operators";
 import {
   AnyMenuItem,
   isButton,
@@ -19,7 +18,6 @@ import {
   LabelAndIcon
 } from "src/app/interfaces/menusInterfaces";
 import { SessionUser } from "src/app/models/User";
-import { AppConfigService } from "src/app/services/app-config/app-config.service";
 import { SecurityService } from "src/app/services/baw-api/security.service";
 import { WidgetComponent } from "../widget/widget.component";
 import { WidgetDirective } from "../widget/widget.directive";
@@ -42,7 +40,6 @@ export class MenuComponent implements OnInit, OnDestroy {
   filteredLinks: Set<AnyMenuItem>;
   placement: "left" | "right";
   params: Params;
-  bawUrl: string;
   url: string;
   user: SessionUser;
   loading: boolean;
@@ -53,7 +50,6 @@ export class MenuComponent implements OnInit, OnDestroy {
 
   constructor(
     private api: SecurityService,
-    private config: AppConfigService,
     private route: ActivatedRoute,
     private componentFactoryResolver: ComponentFactoryResolver
   ) {}
@@ -75,7 +71,6 @@ export class MenuComponent implements OnInit, OnDestroy {
 
     // Retrieve router parameters to override link attributes
     this.params = this.route.snapshot.params;
-    this.bawUrl = this.config.getConfig().environment.apiRoot;
 
     // Load widget
     this.loadComponent();

--- a/src/app/component/shared/menu/menu.component.ts
+++ b/src/app/component/shared/menu/menu.component.ts
@@ -63,8 +63,14 @@ export class MenuComponent implements OnInit, OnDestroy {
     this.filteredLinks = new Set(
       this?.links
         ?.filter(link => {
+          if (!link.predicate || link.active) {
+            // Clear any modifications to link by secondary menu
+            link.active = false;
+            return true;
+          }
+
           // If link has predicate function, test if returns true
-          return link.predicate ? link.predicate(this?.user) : true;
+          return link.predicate(this?.user);
         })
         ?.sort(this.compare)
     );

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
@@ -193,7 +193,7 @@ describe("SecondaryMenuComponent", () => {
               label: "Custom Label",
               icon: ["fas", "tag"],
               tooltip: () => "Custom Tooltip",
-              uri: "http://brokenlink/"
+              uri: () => "http://brokenlink/"
             })
           ])
         }
@@ -412,7 +412,7 @@ describe("SecondaryMenuComponent", () => {
               label: "Custom Label",
               icon: ["fas", "tag"],
               tooltip: () => "Custom Tooltip",
-              uri: "http://brokenlink/"
+              uri: () => "http://brokenlink/"
             })
           ])
         }
@@ -442,13 +442,13 @@ describe("SecondaryMenuComponent", () => {
               label: "Custom Label 1",
               icon: ["fas", "tag"],
               tooltip: () => "Custom Tooltip 1",
-              uri: "http://brokenlink/1"
+              uri: () => "http://brokenlink/1"
             }),
             MenuLink({
               label: "Custom Label 2",
               icon: ["fas", "tags"],
               tooltip: () => "Custom Tooltip 2",
-              uri: "http://brokenlink/2"
+              uri: () => "http://brokenlink/2"
             })
           ])
         }

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
@@ -6,6 +6,7 @@ import { fromJS, List } from "immutable";
 import { BehaviorSubject } from "rxjs";
 import { DefaultMenu } from "src/app/helpers/page/defaultMenus";
 import { PageInfo, PageInfoInterface } from "src/app/helpers/page/pageInfo";
+import { assertIcon, assertTooltip } from "src/app/helpers/tests/helpers";
 import {
   AnyMenuItem,
   Category,
@@ -38,15 +39,6 @@ describe("SecondaryMenuComponent", () => {
     route: defaultRoute
   } as Category;
 
-  function assertIcon(target: HTMLElement, prop: string) {
-    const icon: HTMLElement = target.querySelector("fa-icon");
-    expect(icon).toBeTruthy("Icon is missing");
-    expect(icon.attributes.getNamedItem("ng-reflect-icon")).toBeTruthy(
-      "Icon missing [icon]"
-    );
-    expect(icon.attributes.getNamedItem("ng-reflect-icon").value).toBe(prop);
-  }
-
   function assertTitle(target: HTMLElement, header: string) {
     expect(target).toBeTruthy("Title is missing");
     expect(target.innerText.trim()).toBe(header);
@@ -58,16 +50,6 @@ describe("SecondaryMenuComponent", () => {
     expect(label.innerText.trim()).toBe(labelText);
   }
 
-  function assertTooltip(target: HTMLElement, tooltip: string) {
-    expect(target).toBeTruthy("Tooltip is missing");
-    expect(target.attributes.getNamedItem("ng-reflect-tooltip")).toBeTruthy(
-      "Tooltip missing [tooltip]"
-    );
-    expect(
-      target.attributes.getNamedItem("ng-reflect-tooltip").value.trim()
-    ).toBe(tooltip);
-  }
-
   function findLinks(
     selector: "internal-link" | "external-link" | "button"
   ): HTMLElement[] {
@@ -76,10 +58,11 @@ describe("SecondaryMenuComponent", () => {
 
   function createTestBed(params: any, data: PageInfoInterface) {
     class MockActivatedRoute {
-      public params = new BehaviorSubject<any>(params);
       public data = new BehaviorSubject<PageInfoInterface>(data);
+      public snapshot = {
+        params
+      };
     }
-
     TestBed.configureTestingModule({
       imports: [RouterTestingModule, HttpClientModule, SharedModule],
       declarations: [SecondaryMenuComponent],

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
@@ -349,6 +349,9 @@ describe("SecondaryMenuComponent", () => {
       assertIcon(links[1], "fas,exclamation-triangle");
       assertTooltip(links[1], "Custom Tooltip 2");
     });
+
+    // TODO
+    xit("should hide duplicate if self link exists in default menu", () => {});
   });
 
   describe("internal links", () => {

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
@@ -349,9 +349,6 @@ describe("SecondaryMenuComponent", () => {
       assertIcon(links[1], "fas,exclamation-triangle");
       assertTooltip(links[1], "Custom Tooltip 2");
     });
-
-    // TODO
-    xit("should hide duplicate if self link exists in default menu", () => {});
   });
 
   describe("internal links", () => {
@@ -526,7 +523,7 @@ describe("SecondaryMenuComponent", () => {
 
       const links = findLinks("internal-link");
 
-      expect(findLinks("internal-link").length).toBe(2);
+      expect(findLinks("internal-link").length).toBe(1 + selfLinkCount);
       expect(findLinks("external-link").length).toBe(0);
 
       assertLabel(links[0], "Home");
@@ -567,7 +564,54 @@ describe("SecondaryMenuComponent", () => {
 
       const links = findLinks("internal-link");
 
-      expect(findLinks("internal-link").length).toBe(3);
+      expect(findLinks("internal-link").length).toBe(2 + selfLinkCount);
+      expect(findLinks("external-link").length).toBe(0);
+
+      assertLabel(links[0], "Home");
+      assertTooltip(links[0], "Home page");
+      assertIcon(links[0], "fas,home");
+
+      assertLabel(links[1], "Projects");
+      assertTooltip(links[1], "View projects I have access to");
+      assertIcon(links[1], "fas,globe-asia");
+    });
+
+    it("should hide duplicate if self link exists in default menu", () => {
+      const homeRoute = StrongRoute.Base.add("");
+      const projectsRoute = StrongRoute.Base.add("projects");
+
+      const selfRoute = MenuRoute({
+        icon: ["fas", "globe-asia"],
+        label: "Projects",
+        route: projectsRoute,
+        tooltip: () => "View projects I have access to",
+        order: 4
+      });
+
+      DefaultMenu.contextLinks = List<NavigableMenuItem>([
+        MenuRoute({
+          icon: ["fas", "home"],
+          label: "Home",
+          route: homeRoute,
+          tooltip: () => "Home page",
+          order: 1
+        }),
+        selfRoute
+      ]);
+
+      createTestBed({}, {
+        self: selfRoute,
+        menus: {
+          actions: List<AnyMenuItem>([]),
+          links: List<NavigableMenuItem>([])
+        }
+      } as PageInfoInterface);
+
+      fixture.detectChanges();
+
+      const links = findLinks("internal-link");
+
+      expect(findLinks("internal-link").length).toBe(2);
       expect(findLinks("external-link").length).toBe(0);
 
       assertLabel(links[0], "Home");

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
@@ -352,9 +352,10 @@ describe("SecondaryMenuComponent", () => {
       expect(findLinks("external-link").length).toBe(0);
       expect(findLinks("button").length).toBe(0);
 
-      assertLabel(links[0], "Custom Label");
-      assertTooltip(links[0], "Custom Tooltip");
-      assertIcon(links[0], "fas,tag");
+      // Links offset by one because order is infinite so they are placed after self link
+      assertLabel(links[1], "Custom Label");
+      assertTooltip(links[1], "Custom Tooltip");
+      assertIcon(links[1], "fas,tag");
     });
 
     it("should handle multiple links", () => {
@@ -388,13 +389,14 @@ describe("SecondaryMenuComponent", () => {
       expect(findLinks("external-link").length).toBe(0);
       expect(findLinks("button").length).toBe(0);
 
-      assertLabel(links[0], "Custom Label 1");
-      assertTooltip(links[0], "Custom Tooltip 1");
-      assertIcon(links[0], "fas,tag");
+      // Links offset by one because order is infinite so they are placed after self link
+      assertLabel(links[1], "Custom Label 1");
+      assertTooltip(links[1], "Custom Tooltip 1");
+      assertIcon(links[1], "fas,tag");
 
-      assertLabel(links[1], "Custom Label 2");
-      assertTooltip(links[1], "Custom Tooltip 2");
-      assertIcon(links[1], "fas,tags");
+      assertLabel(links[2], "Custom Label 2");
+      assertTooltip(links[2], "Custom Tooltip 2");
+      assertIcon(links[2], "fas,tags");
     });
   });
 

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
@@ -307,6 +307,48 @@ describe("SecondaryMenuComponent", () => {
       assertIcon(links[2], "fas,exclamation-triangle");
       assertTooltip(links[2], "Custom Tooltip 3");
     });
+
+    it("should not hide self link if predicate fails", () => {
+      const parentRoute = StrongRoute.Base.add("home");
+      const childRoute = parentRoute.add("house");
+      const parentLink = MenuRoute({
+        label: "Parent Label",
+        icon: ["fas", "question"],
+        order: 999,
+        tooltip: () => "Custom Tooltip 1",
+        route: parentRoute,
+        predicate: () => false
+      });
+
+      createTestBed({}, {
+        self: MenuRoute({
+          label: "Child Label",
+          icon: ["fas", "exclamation-triangle"],
+          tooltip: () => "Custom Tooltip 2",
+          order: 999,
+          parent: parentLink,
+          route: childRoute,
+          predicate: () => false
+        }),
+        category: defaultCategory,
+        menus: {
+          actions: List<AnyMenuItem>([]),
+          links: List<NavigableMenuItem>([])
+        }
+      } as PageInfoInterface);
+
+      fixture.detectChanges();
+
+      const links = findLinks("internal-link");
+
+      assertLabel(links[0], "Parent Label");
+      assertIcon(links[0], "fas,question");
+      assertTooltip(links[0], "Custom Tooltip 1");
+
+      assertLabel(links[1], "Child Label");
+      assertIcon(links[1], "fas,exclamation-triangle");
+      assertTooltip(links[1], "Custom Tooltip 2");
+    });
   });
 
   describe("internal links", () => {

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.ts
@@ -5,7 +5,7 @@ import {
   OnInit
 } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
-import { List } from "immutable";
+import { fromJS, List } from "immutable";
 import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { DefaultMenu } from "src/app/helpers/page/defaultMenus";
@@ -36,19 +36,23 @@ export class SecondaryMenuComponent implements OnInit, OnDestroy {
   constructor(private route: ActivatedRoute) {}
 
   ngOnInit() {
+    const clearPredicate = undefined;
+
     this.route.data.pipe(takeUntil(this.unsubscribe)).subscribe(
       (page: PageInfo) => {
         // get default links
         const defaultLinks = DefaultMenu.contextLinks;
 
         // and current page
-        const current = page.self;
+        const current = fromJS(page.self).toJS(); // De-reference
+        current.predicate = clearPredicate;
 
         // and parent pages
         const parentMenuRoutes: MenuRoute[] = [];
         let menuRoute = current;
         while (menuRoute.parent) {
-          menuRoute = menuRoute.parent;
+          menuRoute = fromJS(menuRoute.parent).toJS(); // De-reference
+          menuRoute.predicate = clearPredicate;
           parentMenuRoutes.push(menuRoute);
         }
 

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.ts
@@ -36,23 +36,22 @@ export class SecondaryMenuComponent implements OnInit, OnDestroy {
   constructor(private route: ActivatedRoute) {}
 
   ngOnInit() {
-    const clearPredicate = undefined;
-
     this.route.data.pipe(takeUntil(this.unsubscribe)).subscribe(
       (page: PageInfo) => {
         // get default links
         const defaultLinks = DefaultMenu.contextLinks;
 
         // and current page
-        const current = fromJS(page.self).toJS(); // De-reference
-        current.predicate = clearPredicate;
+        const current = page.self;
+        current.active = true; // Ignore predicate
 
         // and parent pages
         const parentMenuRoutes: MenuRoute[] = [];
         let menuRoute = current;
         while (menuRoute.parent) {
-          menuRoute = fromJS(menuRoute.parent).toJS(); // De-reference
-          menuRoute.predicate = clearPredicate;
+          menuRoute = menuRoute.parent;
+          menuRoute.active = true; // Ignore predicate
+
           parentMenuRoutes.push(menuRoute);
         }
 

--- a/src/app/component/sites/pages/details/details.component.ts
+++ b/src/app/component/sites/pages/details/details.component.ts
@@ -5,6 +5,7 @@ import { Subject } from "rxjs";
 import { flatMap, takeUntil } from "rxjs/operators";
 import { PermissionsShieldComponent } from "src/app/component/shared/permissions-shield/permissions-shield.component";
 import { WidgetMenuItem } from "src/app/component/shared/widget/widgetItem";
+import { exploreAudioMenuItem } from "src/app/helpers/page/externalMenus";
 import { PageComponent } from "src/app/helpers/page/pageComponent";
 import { Page } from "src/app/helpers/page/pageDecorator";
 import { DateTimeTimezone } from "src/app/interfaces/apiInterfaces";
@@ -19,14 +20,13 @@ import {
   annotationsMenuItem,
   deleteSiteMenuItem,
   editSiteMenuItem,
-  exploreAudioSiteMenuItem,
   harvestMenuItem,
   siteMenuItem,
   sitesCategory
 } from "../../sites.menus";
 
 export const siteMenuItemActions = [
-  exploreAudioSiteMenuItem,
+  exploreAudioMenuItem,
   annotationsMenuItem,
   editSiteMenuItem,
   harvestMenuItem,

--- a/src/app/component/sites/sites.menus.ts
+++ b/src/app/component/sites/sites.menus.ts
@@ -39,7 +39,7 @@ export const siteMenuItem = MenuRoute({
 });
 
 export const exploreAudioSiteMenuItem = MenuLink({
-  uri: (bawUrl, params) => `${bawUrl}/visualize?siteId=${params.siteId}`,
+  uri: params => `/visualize?siteId=${params.siteId}`,
   icon: ["fas", "map"],
   label: "Explore audio",
   tooltip: () => "Explore audio"

--- a/src/app/component/sites/sites.menus.ts
+++ b/src/app/component/sites/sites.menus.ts
@@ -39,14 +39,14 @@ export const siteMenuItem = MenuRoute({
 });
 
 export const exploreAudioSiteMenuItem = MenuLink({
-  uri: "REPLACE_ME",
+  uri: (bawUrl, params) => `${bawUrl}/visualize?siteId=${params.siteId}`,
   icon: ["fas", "map"],
   label: "Explore audio",
   tooltip: () => "Explore audio"
 });
 
 export const annotationsMenuItem = MenuLink({
-  uri: "REPLACE_ME",
+  uri: () => "REPLACE_ME",
   icon: ["fas", "table"],
   label: "Download annotations",
   tooltip: () => "Download annotations for this site",

--- a/src/app/component/sites/sites.menus.ts
+++ b/src/app/component/sites/sites.menus.ts
@@ -38,16 +38,9 @@ export const siteMenuItem = MenuRoute({
   parent: projectMenuItem
 });
 
-export const exploreAudioSiteMenuItem = MenuLink({
-  uri: params => `/visualize?siteId=${params.siteId}`,
-  icon: ["fas", "map"],
-  label: "Explore audio",
-  tooltip: () => "Explore audio"
-});
-
 export const annotationsMenuItem = MenuLink({
   uri: () => "REPLACE_ME",
-  icon: ["fas", "table"],
+  icon: ["fas", "border-all"],
   label: "Download annotations",
   tooltip: () => "Download annotations for this site",
   predicate: isLoggedInPredicate

--- a/src/app/component/statistics/pages/statistics.component.spec.ts
+++ b/src/app/component/statistics/pages/statistics.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
 import { SharedModule } from "../../shared/shared.module";
 import { StatisticsComponent } from "./statistics.component";
 
@@ -8,7 +9,7 @@ describe("StatisticsComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [SharedModule],
+      imports: [SharedModule, RouterTestingModule],
       declarations: [StatisticsComponent]
     }).compileComponents();
   }));

--- a/src/app/helpers/page/defaultMenus.ts
+++ b/src/app/helpers/page/defaultMenus.ts
@@ -26,7 +26,7 @@ export const DefaultMenu = {
       tooltip: () => "View my recent annotations",
       predicate: user => !!user,
       order: 3,
-      uri: "REPLACE_ME"
+      uri: () => "REPLACE_ME"
     }),
     projectsMenuItem,
     MenuLink({
@@ -34,14 +34,14 @@ export const DefaultMenu = {
       label: "Audio Analysis",
       tooltip: () => "View audio analysis jobs",
       order: 5,
-      uri: "/audio_analysis"
+      uri: (bawUrl, _) => bawUrl + "/audio_analysis"
     }),
     MenuLink({
       icon: ["fas", "book"],
       label: "Library",
       tooltip: () => "Annotation library",
       order: 6,
-      uri: "/library"
+      uri: (bawUrl, _) => bawUrl + "/library"
     }),
     dataRequestMenuItem,
     MenuLink({
@@ -49,7 +49,7 @@ export const DefaultMenu = {
       label: "Send Audio",
       tooltip: () => "Send us audio recordings to upload",
       order: 8,
-      uri: "/data_upload"
+      uri: () => "REPLACE_ME"
     }),
     reportProblemMenuItem,
     statisticsMenuItem

--- a/src/app/helpers/page/defaultMenus.ts
+++ b/src/app/helpers/page/defaultMenus.ts
@@ -34,14 +34,14 @@ export const DefaultMenu = {
       label: "Audio Analysis",
       tooltip: () => "View audio analysis jobs",
       order: 5,
-      uri: (bawUrl, _) => bawUrl + "/audio_analysis"
+      uri: () => "/audio_analysis"
     }),
     MenuLink({
       icon: ["fas", "book"],
       label: "Library",
       tooltip: () => "Annotation library",
       order: 6,
-      uri: (bawUrl, _) => bawUrl + "/library"
+      uri: () => "/library"
     }),
     dataRequestMenuItem,
     MenuLink({

--- a/src/app/helpers/page/defaultMenus.ts
+++ b/src/app/helpers/page/defaultMenus.ts
@@ -1,7 +1,10 @@
 import { List } from "immutable";
 import { dataRequestMenuItem } from "src/app/component/data-request/data-request.menus";
 import { homeCategory, homeMenuItem } from "src/app/component/home/home.menus";
-import { myAccountMenuItem } from "src/app/component/profile/profile.menus";
+import {
+  myAccountMenuItem,
+  myAnnotationsMenuItem
+} from "src/app/component/profile/profile.menus";
 import { projectsMenuItem } from "src/app/component/projects/projects.menus";
 import { reportProblemMenuItem } from "src/app/component/report-problem/report-problem.menus";
 import {
@@ -13,6 +16,7 @@ import {
   MenuLink,
   NavigableMenuItem
 } from "src/app/interfaces/menusInterfaces";
+import { audioAnalysisMenuItem, libraryMenuItem } from "./externalMenus";
 
 export const DefaultMenu = {
   contextLinks: List<NavigableMenuItem>([
@@ -20,30 +24,12 @@ export const DefaultMenu = {
     loginMenuItem,
     registerMenuItem,
     myAccountMenuItem,
-    MenuLink({
-      icon: ["fas", "border-all"],
-      label: "My Annotations",
-      tooltip: () => "View my recent annotations",
-      predicate: user => !!user,
-      order: 3,
-      uri: () => "REPLACE_ME"
-    }),
+    myAnnotationsMenuItem,
     projectsMenuItem,
-    MenuLink({
-      icon: ["fas", "server"],
-      label: "Audio Analysis",
-      tooltip: () => "View audio analysis jobs",
-      order: 5,
-      uri: () => "/audio_analysis"
-    }),
-    MenuLink({
-      icon: ["fas", "book"],
-      label: "Library",
-      tooltip: () => "Annotation library",
-      order: 6,
-      uri: () => "/library"
-    }),
+    audioAnalysisMenuItem,
+    libraryMenuItem,
     dataRequestMenuItem,
+    // This will be replaced by the send-audio branch
     MenuLink({
       icon: ["fas", "envelope"],
       label: "Send Audio",

--- a/src/app/helpers/page/externalMenus.ts
+++ b/src/app/helpers/page/externalMenus.ts
@@ -1,0 +1,46 @@
+import { Params } from "@angular/router";
+import { MenuLink } from "src/app/interfaces/menusInterfaces";
+import { stringTemplate } from "../stringTemplate/stringTemplate";
+
+export const audioAnalysisMenuItem = MenuLink({
+  icon: ["fas", "server"],
+  label: "Audio Analysis",
+  tooltip: () => "View audio analysis jobs",
+  order: 5,
+  uri: () => "/audio_analysis"
+});
+
+export const libraryMenuItem = MenuLink({
+  icon: ["fas", "book"],
+  label: "Library",
+  tooltip: () => "Annotation library",
+  order: 6,
+  uri: () => "/library"
+});
+
+export const exploreAudioMenuItem = MenuLink({
+  uri: params => visualizeUri(params),
+  icon: ["fas", "map"],
+  label: "Explore audio",
+  tooltip: () => "Explore audio"
+});
+
+function ids(params: Params): string {
+  if (!params) {
+    return "";
+  }
+
+  const siteId = params.siteId;
+  if (siteId) {
+    return `siteId=${siteId}`;
+  }
+
+  const projectId = params.projectId;
+  if (projectId) {
+    return `projectId=${projectId}`;
+  }
+
+  return "";
+}
+
+const visualizeUri = stringTemplate`/visualize?${ids}`;

--- a/src/app/helpers/tests/helpers.ts
+++ b/src/app/helpers/tests/helpers.ts
@@ -1,0 +1,31 @@
+export function assertIcon(target: HTMLElement, prop: string) {
+  const icon: HTMLElement = target.querySelector("fa-icon");
+  expect(icon).toBeTruthy("No icon detected");
+  expect(icon.attributes.getNamedItem("ng-reflect-icon")).toBeTruthy();
+  expect(icon.attributes.getNamedItem("ng-reflect-icon").value.trim()).toBe(
+    prop
+  );
+}
+
+export function assertTooltip(target: HTMLElement, tooltip: string) {
+  expect(target).toBeTruthy("No tooltip detected");
+
+  let attr = target.attributes.getNamedItem("ng-reflect-ngb-tooltip");
+
+  if (!attr) {
+    attr = target.attributes.getNamedItem("ng-reflect-tooltip");
+  }
+
+  expect(attr).toBeTruthy();
+  expect(attr.value.trim()).toBe(tooltip);
+
+  // TODO Add accessability expectations
+}
+
+export function assertRoute(target: HTMLElement, route: string) {
+  expect(target).toBeTruthy("No route detected");
+  expect(target.attributes.getNamedItem("ng-reflect-router-link")).toBeTruthy();
+  expect(
+    target.attributes.getNamedItem("ng-reflect-router-link").value.trim()
+  ).toBe(route);
+}

--- a/src/app/interfaces/menusInterfaces.ts
+++ b/src/app/interfaces/menusInterfaces.ts
@@ -187,6 +187,16 @@ export function isExternalLink(menuItem: AnyMenuItem): menuItem is MenuLink {
 }
 
 /**
+ * Get link route. This is only required because typescript is unable to
+ * properly type-check links in template.
+ * @param link Menu item
+ * @returns Either full route, or uri
+ */
+export function getRoute(link: NavigableMenuItem, params?: Params): string {
+  return isInternalRoute(link) ? link.route.toString() : link.uri(params);
+}
+
+/**
  * Determines if an object is part of the Navigable interface
  * @param menuItem Menu item
  */

--- a/src/app/interfaces/menusInterfaces.ts
+++ b/src/app/interfaces/menusInterfaces.ts
@@ -80,6 +80,11 @@ export interface MenuItem extends LabelAndIcon {
    * The indentation of this link
    */
   indentation?: number;
+  /**
+   * Tracks whether this link, or one of its children is currently actively being displayed.
+   * It allows the link to skip its predicate temporarily.
+   */
+  active?: boolean;
 }
 
 /**
@@ -99,6 +104,7 @@ export interface MenuLink extends MenuItem {
 export function MenuLink<T extends Omit<MenuLink, "kind">>(item: T): MenuLink {
   return Object.assign(item, {
     kind: "MenuLink" as "MenuLink",
+    active: false,
     indentation: 0
   });
 }
@@ -126,6 +132,7 @@ export function MenuRoute<T extends Omit<MenuRoute, "kind">>(
 ): MenuRoute {
   return Object.assign(item, {
     kind: "MenuRoute" as "MenuRoute",
+    active: false,
     indentation: item.parent ? item.parent.indentation + 1 : 0,
     order: item.parent ? item.parent.order : item.order
   });
@@ -146,6 +153,7 @@ export function MenuAction<T extends Omit<MenuAction, "kind">>(
 ): MenuAction {
   return Object.assign(item, {
     kind: "MenuAction" as "MenuAction",
+    active: false,
     indentation: 0
   });
 }

--- a/src/app/interfaces/menusInterfaces.ts
+++ b/src/app/interfaces/menusInterfaces.ts
@@ -13,7 +13,7 @@ export type RouteFragment = string;
 /**
  * External URL
  */
-export type Href = (bawUrl: string, params: Params) => string;
+export type Href = (params: Params) => string;
 
 /**
  * Fontawesome icon. Eg. ['fas', 'home']. All icons used must be imported in app.module.ts.

--- a/src/app/interfaces/menusInterfaces.ts
+++ b/src/app/interfaces/menusInterfaces.ts
@@ -13,7 +13,7 @@ export type RouteFragment = string;
 /**
  * External URL
  */
-export type Href = string;
+export type Href = (bawUrl: string, params: Params) => string;
 
 /**
  * Fontawesome icon. Eg. ['fas', 'home']. All icons used must be imported in app.module.ts.


### PR DESCRIPTION
# Adjustments to Menu System

Minor adjustments to menu system to remove small bugs.

## Changes

- Set links with no order to a value of `Infinity` so they appear on the bottom of the list
- Updated `MenuLink` items to accept a `param` value from the router. This allows links to direct to the ecosounds website
- Updated secondary menu links so that current breadcrumbs are visible regardless of predicate
- Minor changes to unit tests

## Closes

Closes #98 

## Visual Changes

Breadcrumbs appear in the below image, even though the user is not logged in and shouldn't be able to view the final link.

![image](https://user-images.githubusercontent.com/3955116/75007476-035bf180-54c1-11ea-9232-df097baeccbd.png)