### PR TITLE
Unsubscribe mixin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7418,13 +7418,6 @@
       "integrity": "sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ==",
       "requires": {
         "icu4c-data": "^0.64.2"
-      },
-      "dependencies": {
-        "icu4c-data": {
-          "version": "0.62.2",
-          "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.62.2.tgz",
-          "integrity": "sha512-XeGQzD3LAFprTRJ+IJZky7gUEk330neU8oo+xUT7LH08JFLTC1Eh22LiyrKIJPiZKV3w5Nq/cj8QyFWe18VDtw=="
-        }
       }
     },
     "function-bind": {
@@ -8027,6 +8020,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "icu4c-data": {
+      "version": "0.64.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ=="
     },
     "ieee754": {
       "version": "1.1.13",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,18 +1,18 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { Title } from "@angular/platform-browser";
 import { ActivatedRoute, NavigationEnd, Router } from "@angular/router";
 import { LoadingBarService } from "@ngx-loading-bar/core";
-import { Observable, Subject } from "rxjs";
+import { Observable } from "rxjs";
 import { delay, map, takeUntil, withLatestFrom } from "rxjs/operators";
 import { environment } from "src/environments/environment";
+import { WithUnsubscribe } from "./helpers/unsubscribe/unsubscribe";
 
 @Component({
   selector: "app-root",
   templateUrl: "./app.component.html",
   styleUrls: ["./app.component.scss"]
 })
-export class AppComponent implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+export class AppComponent extends WithUnsubscribe() implements OnInit {
   menuLayout: boolean;
   delayedProgress$: Observable<number>;
 
@@ -21,7 +21,9 @@ export class AppComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private title: Title,
     private loader: LoadingBarService
-  ) {}
+  ) {
+    super();
+  }
 
   ngOnInit() {
     this.title.setTitle(environment.values.brand.name);
@@ -71,10 +73,5 @@ export class AppComponent implements OnInit, OnDestroy {
       },
       err => {}
     );
-  }
-
-  ngOnDestroy(): void {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 }

--- a/src/app/component/home/home.component.ts
+++ b/src/app/component/home/home.component.ts
@@ -1,6 +1,5 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { flatMap, map, takeUntil } from "rxjs/operators";
 import { PageComponent } from "src/app/helpers/page/pageComponent";
 import { Page } from "src/app/helpers/page/pageDecorator";
@@ -24,11 +23,10 @@ import { homeCategory, homeMenuItem } from "./home.menus";
   templateUrl: "./home.component.html",
   styleUrls: ["./home.component.scss"]
 })
-export class HomeComponent extends PageComponent implements OnInit, OnDestroy {
+export class HomeComponent extends PageComponent implements OnInit {
   public page: string;
   public moreProjectsLink = projectsMenuItem;
   public projectList: List<Card> = List([]);
-  private unsubscribe = new Subject();
 
   constructor(
     private projectApi: ProjectsService,
@@ -59,10 +57,5 @@ export class HomeComponent extends PageComponent implements OnInit, OnDestroy {
           this.projectList = List([]);
         }
       );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 }

--- a/src/app/component/profile/pages/my-edit/my-edit.component.ts
+++ b/src/app/component/profile/pages/my-edit/my-edit.component.ts
@@ -1,6 +1,5 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { WithFormCheck } from "src/app/guards/form/form.guard";
 import { PageComponent } from "src/app/helpers/page/pageComponent";
@@ -60,15 +59,13 @@ import { fields } from "./my-edit.json";
   `
 })
 export class MyEditComponent extends WithFormCheck(PageComponent)
-  implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+  implements OnInit {
   error: string;
   errorDetails: ApiErrorDetails;
   loading: boolean;
   ready: boolean;
   schema = { model: { edit: { name: "" } }, fields };
   success: string;
-
   user: User;
 
   constructor(private api: UserService) {
@@ -93,11 +90,6 @@ export class MyEditComponent extends WithFormCheck(PageComponent)
           this.errorDetails = err;
         }
       );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 
   /**

--- a/src/app/component/profile/pages/profile/my-profile.component copy.ts
+++ b/src/app/component/profile/pages/profile/my-profile.component copy.ts
@@ -1,6 +1,5 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { ItemInterface } from "src/app/component/shared/items/item/item.component";
 import { PageComponent } from "src/app/helpers/page/pageComponent";
@@ -41,9 +40,7 @@ export const myProfileMenuItemActions = [
   templateUrl: "./profile.component.html",
   styleUrls: ["./profile.component.scss"]
 })
-export class MyProfileComponent extends PageComponent
-  implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+export class MyProfileComponent extends PageComponent implements OnInit {
   error: ApiErrorDetails;
   imageUrl: string;
   tags: ItemInterface[];
@@ -92,10 +89,5 @@ export class MyProfileComponent extends PageComponent
         uri: () => "BROKEN LINK"
       }
     ];
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 }

--- a/src/app/component/profile/pages/profile/their-profile.component.ts
+++ b/src/app/component/profile/pages/profile/their-profile.component.ts
@@ -1,7 +1,6 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { flatMap, takeUntil } from "rxjs/operators";
 import { ItemInterface } from "src/app/component/shared/items/item/item.component";
 import { PageComponent } from "src/app/helpers/page/pageComponent";
@@ -42,9 +41,7 @@ export const theirProfileMenuItemActions = [
   templateUrl: "./profile.component.html",
   styleUrls: ["./profile.component.scss"]
 })
-export class TheirProfileComponent extends PageComponent
-  implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+export class TheirProfileComponent extends PageComponent implements OnInit {
   error: ApiErrorDetails;
   imageUrl: string;
   tags: ItemInterface[];
@@ -97,10 +94,5 @@ export class TheirProfileComponent extends PageComponent
         uri: () => "BROKEN LINK"
       }
     ];
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 }

--- a/src/app/component/profile/pages/their-edit/their-edit.component.ts
+++ b/src/app/component/profile/pages/their-edit/their-edit.component.ts
@@ -1,7 +1,6 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { flatMap, takeUntil } from "rxjs/operators";
 import { WithFormCheck } from "src/app/guards/form/form.guard";
 import { PageComponent } from "src/app/helpers/page/pageComponent";
@@ -48,8 +47,7 @@ import { fields } from "./their-edit.json";
   `
 })
 export class TheirEditComponent extends WithFormCheck(PageComponent)
-  implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+  implements OnInit {
   error: string;
   errorDetails: ApiErrorDetails;
   loading: boolean;
@@ -85,10 +83,6 @@ export class TheirEditComponent extends WithFormCheck(PageComponent)
           this.errorDetails = err;
         }
       );
-  }
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 
   /**

--- a/src/app/component/projects/pages/assign/assign.component.ts
+++ b/src/app/component/projects/pages/assign/assign.component.ts
@@ -1,7 +1,6 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { flatMap, takeUntil } from "rxjs/operators";
 import { PermissionsShieldComponent } from "src/app/component/shared/permissions-shield/permissions-shield.component";
 import { WidgetMenuItem } from "src/app/component/shared/widget/widgetItem";
@@ -37,8 +36,7 @@ import { projectMenuItemActions } from "../details/details.component";
   templateUrl: "./assign.component.html",
   styleUrls: ["./assign.component.scss"]
 })
-export class AssignComponent extends TableTemplate<TableRow>
-  implements OnInit, OnDestroy {
+export class AssignComponent extends TableTemplate<TableRow> implements OnInit {
   // TODO Move this back into the admin dashboard
 
   public totalSites: number;
@@ -47,8 +45,6 @@ export class AssignComponent extends TableTemplate<TableRow>
   public error: ApiErrorDetails;
   public project: Project;
   public sites: Site[];
-
-  private unsubscribe = new Subject();
 
   constructor(
     private route: ActivatedRoute,
@@ -82,11 +78,6 @@ export class AssignComponent extends TableTemplate<TableRow>
           this.error = err;
         }
       );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 
   public onSelect(event) {

--- a/src/app/component/projects/pages/delete/delete.component.ts
+++ b/src/app/component/projects/pages/delete/delete.component.ts
@@ -1,7 +1,6 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { flatMap, takeUntil } from "rxjs/operators";
 import { PermissionsShieldComponent } from "src/app/component/shared/permissions-shield/permissions-shield.component";
 import { WidgetMenuItem } from "src/app/component/shared/widget/widgetItem";
@@ -48,8 +47,7 @@ import { projectMenuItemActions } from "../details/details.component";
   `
 })
 export class DeleteComponent extends WithFormCheck(PageComponent)
-  implements OnInit, OnDestroy {
-  private unsubscribe = new Subject<any>();
+  implements OnInit {
   error: string;
   errorDetails: ApiErrorDetails;
   formLoading: boolean;
@@ -89,11 +87,6 @@ export class DeleteComponent extends WithFormCheck(PageComponent)
           this.loading = false;
         }
       );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next(null);
-    this.unsubscribe.complete();
   }
 
   submit() {

--- a/src/app/component/projects/pages/details/details.component.ts
+++ b/src/app/component/projects/pages/details/details.component.ts
@@ -1,7 +1,6 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { flatMap, takeUntil } from "rxjs/operators";
 import { PermissionsShieldComponent } from "src/app/component/shared/permissions-shield/permissions-shield.component";
 import { WidgetMenuItem } from "src/app/component/shared/widget/widgetItem";
@@ -48,9 +47,7 @@ export const projectMenuItemActions = [
   templateUrl: "./details.component.html",
   styleUrls: ["./details.component.scss"]
 })
-export class DetailsComponent extends PageComponent
-  implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+export class DetailsComponent extends PageComponent implements OnInit {
   project: Project;
   sites: Site[];
   error: ApiErrorDetails;
@@ -102,10 +99,5 @@ export class DetailsComponent extends PageComponent
           }
         }
       );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 }

--- a/src/app/component/projects/pages/edit/edit.component.ts
+++ b/src/app/component/projects/pages/edit/edit.component.ts
@@ -1,7 +1,6 @@
-import { ChangeDetectorRef, Component, OnDestroy, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { flatMap, takeUntil } from "rxjs/operators";
 import { PermissionsShieldComponent } from "src/app/component/shared/permissions-shield/permissions-shield.component";
 import { WidgetMenuItem } from "src/app/component/shared/widget/widgetItem";
@@ -48,8 +47,7 @@ import { fields } from "./edit.json";
   `
 })
 export class EditComponent extends WithFormCheck(PageComponent)
-  implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+  implements OnInit {
   error: string;
   errorDetails: ApiErrorDetails;
   loading: boolean;
@@ -88,11 +86,6 @@ export class EditComponent extends WithFormCheck(PageComponent)
           this.errorDetails = err;
         }
       );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 
   /**

--- a/src/app/component/projects/pages/list/list.component.ts
+++ b/src/app/component/projects/pages/list/list.component.ts
@@ -1,6 +1,5 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { map, takeUntil } from "rxjs/operators";
 import { Card } from "src/app/component/shared/cards/cards.component";
 import { PageComponent } from "src/app/helpers/page/pageComponent";
@@ -46,8 +45,7 @@ export const projectsMenuItemActions = [
     <app-error-handler [error]="error"></app-error-handler>
   `
 })
-export class ListComponent extends PageComponent implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+export class ListComponent extends PageComponent implements OnInit {
   cardList: List<Card>;
   loading: boolean;
   error: ApiErrorDetails;
@@ -77,10 +75,5 @@ export class ListComponent extends PageComponent implements OnInit, OnDestroy {
           this.error = err;
         }
       );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 }

--- a/src/app/component/projects/pages/new/new.component.ts
+++ b/src/app/component/projects/pages/new/new.component.ts
@@ -1,6 +1,5 @@
-import { ChangeDetectorRef, Component, OnDestroy, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, OnInit } from "@angular/core";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { WithFormCheck } from "src/app/guards/form/form.guard";
 import { PageComponent } from "src/app/helpers/page/pageComponent";
@@ -40,8 +39,7 @@ import { fields } from "./new.json";
   `
 })
 export class NewComponent extends WithFormCheck(PageComponent)
-  implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+  implements OnInit {
   error: string;
   loading: boolean;
   schema = { model: {}, fields };
@@ -53,11 +51,6 @@ export class NewComponent extends WithFormCheck(PageComponent)
 
   ngOnInit() {
     this.loading = false;
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 
   /**

--- a/src/app/component/projects/pages/permissions/permissions.component.ts
+++ b/src/app/component/projects/pages/permissions/permissions.component.ts
@@ -1,8 +1,7 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { flatMap, takeUntil } from "rxjs/operators";
 import { theirProfileMenuItem } from "src/app/component/profile/profile.menus";
 import { ISelectableItem } from "src/app/component/shared/items/selectable-items/selectable-items.component";
@@ -36,7 +35,7 @@ import { projectMenuItemActions } from "../details/details.component";
   styleUrls: ["permissions.component.scss"]
 })
 export class PermissionsComponent extends TableTemplate<TableRow>
-  implements OnInit, OnDestroy {
+  implements OnInit {
   public errorDetails: ApiErrorDetails;
   public loading: boolean;
   public project: Project;
@@ -46,8 +45,6 @@ export class PermissionsComponent extends TableTemplate<TableRow>
   public individualOptions: ISelectableItem[];
   public userOptions: ISelectableItem[];
   public visitorOptions: ISelectableItem[];
-
-  private unsubscribe = new Subject();
 
   constructor(private route: ActivatedRoute, private api: ProjectsService) {
     super((val, row) => this.checkMatch(val, row.user));
@@ -99,10 +96,6 @@ export class PermissionsComponent extends TableTemplate<TableRow>
       );
   }
 
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
-  }
   public submit($event: any) {
     console.log($event);
   }

--- a/src/app/component/projects/pages/request/request.component.ts
+++ b/src/app/component/projects/pages/request/request.component.ts
@@ -1,6 +1,5 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { WithFormCheck } from "src/app/guards/form/form.guard";
 import { PageComponent } from "src/app/helpers/page/pageComponent";
@@ -41,8 +40,7 @@ import { fields } from "./request.json";
   `
 })
 export class RequestComponent extends WithFormCheck(PageComponent)
-  implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+  implements OnInit {
   schema = { model: {}, fields };
   error: string;
   errorDetails: ApiErrorDetails;
@@ -72,11 +70,6 @@ export class RequestComponent extends WithFormCheck(PageComponent)
         },
         (err: ApiErrorDetails) => (this.errorDetails = err)
       );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 
   /**

--- a/src/app/component/projects/site-card/site-card.component.ts
+++ b/src/app/component/projects/site-card/site-card.component.ts
@@ -6,7 +6,6 @@ import {
 } from "@angular/core";
 import { Project } from "src/app/models/Project";
 import { Site } from "src/app/models/Site";
-import { siteMenuItem } from "../../sites/sites.menus";
 
 @Component({
   selector: "app-site-card",

--- a/src/app/component/security/pages/login/login.component.ts
+++ b/src/app/component/security/pages/login/login.component.ts
@@ -1,14 +1,7 @@
 import { DOCUMENT, Location } from "@angular/common";
-import {
-  ChangeDetectorRef,
-  Component,
-  Inject,
-  OnDestroy,
-  OnInit
-} from "@angular/core";
+import { ChangeDetectorRef, Component, Inject, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { homeMenuItem } from "src/app/component/home/home.menus";
 import { API_ROOT } from "src/app/helpers/app-initializer/app-initializer";
@@ -57,14 +50,13 @@ import { fields } from "./login.json";
     <app-error-handler [error]="errorDetails"></app-error-handler>
   `
 })
-export class LoginComponent extends PageComponent implements OnInit, OnDestroy {
+export class LoginComponent extends PageComponent implements OnInit {
   public schema = { model: {}, fields };
   public error: string;
   public errorDetails: ApiErrorDetails;
   public loading: boolean;
   private redirectUrl: string;
   private redirectBack: boolean;
-  private unsubscribe = new Subject();
 
   constructor(
     @Inject(API_ROOT) private apiRoot: string,
@@ -116,11 +108,6 @@ export class LoginComponent extends PageComponent implements OnInit, OnDestroy {
       },
       err => {}
     );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 
   /**

--- a/src/app/component/security/pages/register/register.component.ts
+++ b/src/app/component/security/pages/register/register.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
-import { Subject } from "rxjs";
+import { Component, OnInit } from "@angular/core";
 import { PageComponent } from "src/app/helpers/page/pageComponent";
 import { Page } from "src/app/helpers/page/pageDecorator";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
@@ -29,9 +28,7 @@ import { fields } from "./register.json";
     </app-wip>
   `
 })
-export class RegisterComponent extends PageComponent
-  implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+export class RegisterComponent extends PageComponent implements OnInit {
   schema = { model: {}, fields };
   error: string;
   errorDetails: ApiErrorDetails;
@@ -51,11 +48,6 @@ export class RegisterComponent extends PageComponent
       this.loading = false;
       this.error = null;
     }
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 
   submit(model) {

--- a/src/app/component/shared/action-menu/action-menu.component.ts
+++ b/src/app/component/shared/action-menu/action-menu.component.ts
@@ -1,13 +1,13 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { DefaultMenu } from "src/app/helpers/page/defaultMenus";
 import { PageInfo } from "src/app/helpers/page/pageInfo";
 import { AnyMenuItem, LabelAndIcon } from "src/app/interfaces/menusInterfaces";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
 import { WidgetMenuItem } from "../widget/widgetItem";
+import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 
 @Component({
   selector: "app-action-menu",
@@ -21,13 +21,14 @@ import { WidgetMenuItem } from "../widget/widgetItem";
     </app-menu>
   `
 })
-export class ActionMenuComponent implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+export class ActionMenuComponent extends WithUnsubscribe() implements OnInit {
   actionTitle: LabelAndIcon;
   actionLinks: List<AnyMenuItem>;
   actionWidget: WidgetMenuItem;
 
-  constructor(private route: ActivatedRoute) {}
+  constructor(private route: ActivatedRoute) {
+    super();
+  }
 
   ngOnInit() {
     this.route.data.pipe(takeUntil(this.unsubscribe)).subscribe(
@@ -49,10 +50,5 @@ export class ActionMenuComponent implements OnInit, OnDestroy {
       },
       (err: ApiErrorDetails) => console.error("ActionMenuComponent", err)
     );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 }

--- a/src/app/component/shared/action-menu/action-menu.component.ts
+++ b/src/app/component/shared/action-menu/action-menu.component.ts
@@ -4,10 +4,10 @@ import { List } from "immutable";
 import { takeUntil } from "rxjs/operators";
 import { DefaultMenu } from "src/app/helpers/page/defaultMenus";
 import { PageInfo } from "src/app/helpers/page/pageInfo";
+import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 import { AnyMenuItem, LabelAndIcon } from "src/app/interfaces/menusInterfaces";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
 import { WidgetMenuItem } from "../widget/widgetItem";
-import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 
 @Component({
   selector: "app-action-menu",

--- a/src/app/component/shared/cms/cms.component.ts
+++ b/src/app/component/shared/cms/cms.component.ts
@@ -28,7 +28,7 @@ export class CmsComponent implements OnInit, OnDestroy {
   public blob: SafeHtml;
   public error: ApiErrorDetails;
   public loading: boolean;
-  private unsubscribe = new Subject();
+  private unsubscribe = new Subject<void>();
 
   constructor(
     @Inject(CMS_ROOT) private cmsRoot: string,

--- a/src/app/component/shared/cms/cms.component.ts
+++ b/src/app/component/shared/cms/cms.component.ts
@@ -4,14 +4,13 @@ import {
   Component,
   Inject,
   Input,
-  OnDestroy,
   OnInit
 } from "@angular/core";
 import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
-import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { CMS_ROOT } from "src/app/helpers/app-initializer/app-initializer";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
+import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 
 @Component({
   selector: "app-cms",
@@ -23,19 +22,20 @@ import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.servic
     <app-error-handler [error]="error"></app-error-handler>
   `
 })
-export class CmsComponent implements OnInit, OnDestroy {
+export class CmsComponent extends WithUnsubscribe() implements OnInit {
   @Input() page: string;
   public blob: SafeHtml;
   public error: ApiErrorDetails;
   public loading: boolean;
-  private unsubscribe = new Subject<void>();
 
   constructor(
     @Inject(CMS_ROOT) private cmsRoot: string,
     private http: HttpClient,
     private ref: ChangeDetectorRef,
     private sanitizer: DomSanitizer
-  ) {}
+  ) {
+    super();
+  }
 
   ngOnInit() {
     this.loading = true;
@@ -57,10 +57,5 @@ export class CmsComponent implements OnInit, OnDestroy {
           this.ref.detectChanges();
         }
       );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 }

--- a/src/app/component/shared/cms/cms.component.ts
+++ b/src/app/component/shared/cms/cms.component.ts
@@ -9,8 +9,8 @@ import {
 import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
 import { takeUntil } from "rxjs/operators";
 import { CMS_ROOT } from "src/app/helpers/app-initializer/app-initializer";
-import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
 import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
+import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
 
 @Component({
   selector: "app-cms",

--- a/src/app/component/shared/form/form.component.ts
+++ b/src/app/component/shared/form/form.component.ts
@@ -3,16 +3,15 @@ import {
   Component,
   EventEmitter,
   Input,
-  OnDestroy,
   OnInit,
   Output,
   ViewEncapsulation
 } from "@angular/core";
 import { FormGroup } from "@angular/forms";
 import { FormlyFieldConfig } from "@ngx-formly/core";
-import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
+import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 
 @Component({
   selector: "app-form",
@@ -21,7 +20,7 @@ import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.servic
   // tslint:disable-next-line: use-component-view-encapsulation
   encapsulation: ViewEncapsulation.None
 })
-export class FormComponent implements OnInit, OnDestroy {
+export class FormComponent extends WithUnsubscribe() implements OnInit {
   @Input() btnColor:
     | "btn-danger"
     | "btn-success"
@@ -46,12 +45,13 @@ export class FormComponent implements OnInit, OnDestroy {
   // tslint:disable-next-line: no-output-rename
   @Output("onSubmit") submitFunction: EventEmitter<any> = new EventEmitter();
 
-  private unsubscribe = new Subject();
   form: FormGroup;
   fields: FormlyFieldConfig[];
   model: {};
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient) {
+    super();
+  }
 
   ngOnInit() {
     this.form = new FormGroup({});
@@ -78,11 +78,6 @@ export class FormComponent implements OnInit, OnDestroy {
           }
         );
     }
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 
   /**

--- a/src/app/component/shared/form/form.component.ts
+++ b/src/app/component/shared/form/form.component.ts
@@ -10,8 +10,8 @@ import {
 import { FormGroup } from "@angular/forms";
 import { FormlyFieldConfig } from "@ngx-formly/core";
 import { takeUntil } from "rxjs/operators";
-import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
 import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
+import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
 
 @Component({
   selector: "app-form",

--- a/src/app/component/shared/header/header.component.ts
+++ b/src/app/component/shared/header/header.component.ts
@@ -1,7 +1,6 @@
-import { ChangeDetectorRef, Component, OnDestroy, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, OnInit } from "@angular/core";
 import { NavigationEnd, Router } from "@angular/router";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import {
   HeaderDropDownConvertedLink,
@@ -23,14 +22,14 @@ import { homeMenuItem } from "../../home/home.menus";
 import { myAccountMenuItem } from "../../profile/profile.menus";
 import { projectsMenuItem } from "../../projects/projects.menus";
 import { loginMenuItem, registerMenuItem } from "../../security/security.menus";
+import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 
 @Component({
   selector: "app-header",
   templateUrl: "./header.component.html",
   styleUrls: ["./header.component.scss"]
 })
-export class HeaderComponent implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+export class HeaderComponent extends WithUnsubscribe() implements OnInit {
   activeLink: string;
   collapsed: boolean;
   headers: List<NavigableMenuItem | HeaderDropDownConvertedLink>;
@@ -46,7 +45,9 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private securityApi: SecurityService,
     private userApi: UserService,
     private ref: ChangeDetectorRef
-  ) {}
+  ) {
+    super();
+  }
 
   ngOnInit() {
     this.collapsed = true;
@@ -84,11 +85,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
         () => this.updateUser(),
         err => {}
       );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 
   /**

--- a/src/app/component/shared/header/header.component.ts
+++ b/src/app/component/shared/header/header.component.ts
@@ -6,6 +6,7 @@ import {
   HeaderDropDownConvertedLink,
   isHeaderLink
 } from "src/app/helpers/app-initializer/app-initializer";
+import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 import { ImageSizes } from "src/app/interfaces/apiInterfaces";
 import {
   isNavigableMenuItem,
@@ -22,7 +23,6 @@ import { homeMenuItem } from "../../home/home.menus";
 import { myAccountMenuItem } from "../../profile/profile.menus";
 import { projectsMenuItem } from "../../projects/projects.menus";
 import { loginMenuItem, registerMenuItem } from "../../security/security.menus";
-import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 
 @Component({
   selector: "app-header",

--- a/src/app/component/shared/menu/menu.component.ts
+++ b/src/app/component/shared/menu/menu.component.ts
@@ -3,13 +3,11 @@ import {
   Component,
   ComponentFactoryResolver,
   Input,
-  OnDestroy,
   OnInit,
   ViewChild
 } from "@angular/core";
 import { ActivatedRoute, Params } from "@angular/router";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import {
   AnyMenuItem,
   isButton,
@@ -22,6 +20,7 @@ import { SecurityService } from "src/app/services/baw-api/security.service";
 import { WidgetComponent } from "../widget/widget.component";
 import { WidgetDirective } from "../widget/widget.directive";
 import { WidgetMenuItem } from "../widget/widgetItem";
+import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 
 @Component({
   selector: "app-menu",
@@ -29,14 +28,13 @@ import { WidgetMenuItem } from "../widget/widgetItem";
   styleUrls: ["./menu.component.scss"],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class MenuComponent implements OnInit, OnDestroy {
+export class MenuComponent extends WithUnsubscribe() implements OnInit {
   @Input() title?: LabelAndIcon;
   @Input() links: List<AnyMenuItem>;
   @Input() menuType: "action" | "secondary";
   @Input() widget?: WidgetMenuItem;
   @ViewChild(WidgetDirective, { static: true }) menuWidget: WidgetDirective;
 
-  private unsubscribe = new Subject();
   filteredLinks: Set<AnyMenuItem>;
   placement: "left" | "right";
   params: Params;
@@ -52,7 +50,9 @@ export class MenuComponent implements OnInit, OnDestroy {
     private api: SecurityService,
     private route: ActivatedRoute,
     private componentFactoryResolver: ComponentFactoryResolver
-  ) {}
+  ) {
+    super();
+  }
 
   ngOnInit() {
     // Get user details
@@ -80,11 +80,6 @@ export class MenuComponent implements OnInit, OnDestroy {
 
     // Load widget
     this.loadComponent();
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 
   /**

--- a/src/app/component/shared/menu/menu.component.ts
+++ b/src/app/component/shared/menu/menu.component.ts
@@ -8,6 +8,7 @@ import {
 } from "@angular/core";
 import { ActivatedRoute, Params } from "@angular/router";
 import { List } from "immutable";
+import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 import {
   AnyMenuItem,
   isButton,
@@ -20,7 +21,6 @@ import { SecurityService } from "src/app/services/baw-api/security.service";
 import { WidgetComponent } from "../widget/widget.component";
 import { WidgetDirective } from "../widget/widget.directive";
 import { WidgetMenuItem } from "../widget/widgetItem";
-import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 
 @Component({
   selector: "app-menu",

--- a/src/app/component/shared/permissions-shield/permissions-shield.component.ts
+++ b/src/app/component/shared/permissions-shield/permissions-shield.component.ts
@@ -1,13 +1,13 @@
 import { ChangeDetectorRef, Component, Input, OnInit } from "@angular/core";
 import { ActivatedRoute, Params } from "@angular/router";
 import { flatMap, takeUntil } from "rxjs/operators";
+import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 import { Project } from "src/app/models/Project";
 import { Site } from "src/app/models/Site";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
 import { ProjectsService } from "src/app/services/baw-api/projects.service";
 import { SitesService } from "src/app/services/baw-api/sites.service";
 import { WidgetComponent } from "../widget/widget.component";
-import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 
 @Component({
   selector: "app-permissions-shield",

--- a/src/app/component/shared/permissions-shield/permissions-shield.component.ts
+++ b/src/app/component/shared/permissions-shield/permissions-shield.component.ts
@@ -1,12 +1,5 @@
-import {
-  ChangeDetectorRef,
-  Component,
-  Input,
-  OnDestroy,
-  OnInit
-} from "@angular/core";
+import { ChangeDetectorRef, Component, Input, OnInit } from "@angular/core";
 import { ActivatedRoute, Params } from "@angular/router";
-import { Subject } from "rxjs";
 import { flatMap, takeUntil } from "rxjs/operators";
 import { Project } from "src/app/models/Project";
 import { Site } from "src/app/models/Site";
@@ -14,6 +7,7 @@ import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.servic
 import { ProjectsService } from "src/app/services/baw-api/projects.service";
 import { SitesService } from "src/app/services/baw-api/sites.service";
 import { WidgetComponent } from "../widget/widget.component";
+import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 
 @Component({
   selector: "app-permissions-shield",
@@ -26,9 +20,8 @@ import { WidgetComponent } from "../widget/widget.component";
   `,
   styleUrls: ["./permissions-shield.component.scss"]
 })
-export class PermissionsShieldComponent
-  implements OnInit, OnDestroy, WidgetComponent {
-  private unsubscribe = new Subject();
+export class PermissionsShieldComponent extends WithUnsubscribe()
+  implements OnInit, WidgetComponent {
   @Input() data: any;
 
   error: boolean;
@@ -40,7 +33,9 @@ export class PermissionsShieldComponent
     private projectsApi: ProjectsService,
     private sitesApi: SitesService,
     private ref: ChangeDetectorRef
-  ) {}
+  ) {
+    super();
+  }
 
   ngOnInit() {
     this.ready = false;
@@ -68,10 +63,5 @@ export class PermissionsShieldComponent
           console.error("PermissionsShieldComponent: ", err);
         }
       );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 }

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.ts
@@ -15,6 +15,7 @@ import {
   NavigableMenuItem
 } from "src/app/interfaces/menusInterfaces";
 import { WidgetMenuItem } from "../widget/widgetItem";
+import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 
 @Component({
   selector: "app-secondary-menu",
@@ -28,12 +29,14 @@ import { WidgetMenuItem } from "../widget/widgetItem";
   `,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SecondaryMenuComponent implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+export class SecondaryMenuComponent extends WithUnsubscribe()
+  implements OnInit, OnDestroy {
   contextLinks: List<NavigableMenuItem>;
   linksWidget: WidgetMenuItem;
 
-  constructor(private route: ActivatedRoute) {}
+  constructor(private route: ActivatedRoute) {
+    super();
+  }
 
   ngOnInit() {
     this.route.data.pipe(takeUntil(this.unsubscribe)).subscribe(
@@ -75,10 +78,5 @@ export class SecondaryMenuComponent implements OnInit, OnDestroy {
       },
       err => {}
     );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 }

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.ts
@@ -1,9 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  OnDestroy,
-  OnInit
-} from "@angular/core";
+import { ChangeDetectionStrategy, Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { List } from "immutable";
 import { takeUntil } from "rxjs/operators";
@@ -29,7 +24,7 @@ import { WidgetMenuItem } from "../widget/widgetItem";
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SecondaryMenuComponent extends WithUnsubscribe()
-  implements OnInit, OnDestroy {
+  implements OnInit {
   contextLinks: List<NavigableMenuItem>;
   linksWidget: WidgetMenuItem;
 

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.ts
@@ -5,17 +5,16 @@ import {
   OnInit
 } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
-import { fromJS, List } from "immutable";
-import { Subject } from "rxjs";
+import { List } from "immutable";
 import { takeUntil } from "rxjs/operators";
 import { DefaultMenu } from "src/app/helpers/page/defaultMenus";
 import { PageInfo } from "src/app/helpers/page/pageInfo";
+import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 import {
   MenuRoute,
   NavigableMenuItem
 } from "src/app/interfaces/menusInterfaces";
 import { WidgetMenuItem } from "../widget/widgetItem";
-import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 
 @Component({
   selector: "app-secondary-menu",

--- a/src/app/component/shared/user-badges/user-badges.component.ts
+++ b/src/app/component/shared/user-badges/user-badges.component.ts
@@ -4,7 +4,6 @@ import {
   Component,
   Input,
   OnChanges,
-  OnDestroy,
   OnInit
 } from "@angular/core";
 import { List } from "immutable";
@@ -50,7 +49,7 @@ import { Badge } from "./user-badge/user-badge.component";
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class UserBadgesComponent extends WithUnsubscribe()
-  implements OnInit, OnChanges, OnDestroy {
+  implements OnInit, OnChanges {
   @Input() model: Site | Project;
 
   created: any;

--- a/src/app/component/shared/user-badges/user-badges.component.ts
+++ b/src/app/component/shared/user-badges/user-badges.component.ts
@@ -8,8 +8,8 @@ import {
   OnInit
 } from "@angular/core";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
+import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 import {
   DateTimeTimezone,
   defaultDateTimeTimezone,
@@ -21,7 +21,6 @@ import { User } from "src/app/models/User";
 import { AccountService } from "src/app/services/baw-api/account.service";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
 import { Badge } from "./user-badge/user-badge.component";
-import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 
 @Component({
   selector: "app-user-badges",

--- a/src/app/component/shared/user-badges/user-badges.component.ts
+++ b/src/app/component/shared/user-badges/user-badges.component.ts
@@ -21,6 +21,7 @@ import { User } from "src/app/models/User";
 import { AccountService } from "src/app/services/baw-api/account.service";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
 import { Badge } from "./user-badge/user-badge.component";
+import { WithUnsubscribe } from "src/app/helpers/unsubscribe/unsubscribe";
 
 @Component({
   selector: "app-user-badges",
@@ -49,15 +50,17 @@ import { Badge } from "./user-badge/user-badge.component";
   styleUrls: ["./user-badges.component.scss"],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class UserBadgesComponent implements OnInit, OnChanges, OnDestroy {
+export class UserBadgesComponent extends WithUnsubscribe()
+  implements OnInit, OnChanges, OnDestroy {
   @Input() model: Site | Project;
 
-  private unsubscribe = new Subject();
   created: any;
   updated: any;
   owned: any;
 
-  constructor(private api: AccountService, private ref: ChangeDetectorRef) {}
+  constructor(private api: AccountService, private ref: ChangeDetectorRef) {
+    super();
+  }
 
   ngOnInit() {
     this.generateBadges();
@@ -65,11 +68,6 @@ export class UserBadgesComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnChanges() {
     this.generateBadges();
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 
   generateBadges() {

--- a/src/app/component/sites/pages/delete/delete.component.ts
+++ b/src/app/component/sites/pages/delete/delete.component.ts
@@ -1,7 +1,6 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { flatMap, takeUntil } from "rxjs/operators";
 import { projectMenuItem } from "src/app/component/projects/projects.menus";
 import { PermissionsShieldComponent } from "src/app/component/shared/permissions-shield/permissions-shield.component";
@@ -47,8 +46,7 @@ import { siteMenuItemActions } from "../details/details.component";
   `
 })
 export class DeleteComponent extends WithFormCheck(PageComponent)
-  implements OnInit, OnDestroy {
-  private unsubscribe = new Subject<any>();
+  implements OnInit {
   error: string;
   errorDetails: ApiErrorDetails;
   formLoading: boolean;
@@ -90,11 +88,6 @@ export class DeleteComponent extends WithFormCheck(PageComponent)
           this.loading = false;
         }
       );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next(null);
-    this.unsubscribe.complete();
   }
 
   submit() {

--- a/src/app/component/sites/pages/details/details.component.ts
+++ b/src/app/component/sites/pages/details/details.component.ts
@@ -1,7 +1,6 @@
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { flatMap, takeUntil } from "rxjs/operators";
 import { PermissionsShieldComponent } from "src/app/component/shared/permissions-shield/permissions-shield.component";
 import { WidgetMenuItem } from "src/app/component/shared/widget/widgetItem";
@@ -47,9 +46,7 @@ export const siteMenuItemActions = [
   templateUrl: "./details.component.html",
   styleUrls: ["./details.component.scss"]
 })
-export class DetailsComponent extends PageComponent
-  implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+export class DetailsComponent extends PageComponent implements OnInit {
   endDate: DateTimeTimezone;
   loadingProgress = 0;
   project: Project;
@@ -158,10 +155,5 @@ export class DetailsComponent extends PageComponent
 
     this.startDate = startDate;
     this.endDate = endDate;
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 }

--- a/src/app/component/sites/pages/edit/edit.component.ts
+++ b/src/app/component/sites/pages/edit/edit.component.ts
@@ -1,7 +1,6 @@
-import { ChangeDetectorRef, Component, OnDestroy, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { flatMap, takeUntil } from "rxjs/operators";
 import { flattenFields } from "src/app/component/shared/form/form.component";
 import { PermissionsShieldComponent } from "src/app/component/shared/permissions-shield/permissions-shield.component";
@@ -49,8 +48,7 @@ import { fields } from "./edit.json";
   `
 })
 export class EditComponent extends WithFormCheck(PageComponent)
-  implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+  implements OnInit {
   error: string;
   errorDetails: ApiErrorDetails;
   loading: boolean;
@@ -93,11 +91,6 @@ export class EditComponent extends WithFormCheck(PageComponent)
           this.ready = false;
         }
       );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 
   /**

--- a/src/app/component/sites/pages/new/new.component.ts
+++ b/src/app/component/sites/pages/new/new.component.ts
@@ -1,7 +1,6 @@
-import { ChangeDetectorRef, Component, OnDestroy, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { List } from "immutable";
-import { Subject } from "rxjs";
 import { flatMap, takeUntil } from "rxjs/operators";
 import { projectMenuItemActions } from "src/app/component/projects/pages/details/details.component";
 import { projectMenuItem } from "src/app/component/projects/projects.menus";
@@ -43,8 +42,7 @@ import { fields } from "./new.json";
   `
 })
 export class NewComponent extends WithFormCheck(PageComponent)
-  implements OnInit, OnDestroy {
-  private unsubscribe = new Subject();
+  implements OnInit {
   error: string;
   errorDetails: ApiErrorDetails;
   loading: boolean;
@@ -83,11 +81,6 @@ export class NewComponent extends WithFormCheck(PageComponent)
           this.ready = false;
         }
       );
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
   }
 
   /**

--- a/src/app/helpers/page/pageComponent.ts
+++ b/src/app/helpers/page/pageComponent.ts
@@ -1,9 +1,9 @@
-import { Type } from "@angular/core";
+import { OnDestroy, Type } from "@angular/core";
+import { Subject } from "rxjs";
 import { PageInfo } from "./pageInfo";
 
 export interface PageComponentStatic
-  extends
-    Type<PageComponentInterface>,
+  extends Type<PageComponentInterface>,
     Type<any> {
   readonly pageInfo: PageInfo;
 }
@@ -17,7 +17,14 @@ export interface PageComponentInterface {
 // See https://github.com/Microsoft/TypeScript/issues/4881
 // If they did, then we wouldn't need this shim, which
 // currently needs to be extended from in every component!
-export class PageComponent implements PageComponentInterface {
+export class PageComponent implements PageComponentInterface, OnDestroy {
+  protected unsubscribe = new Subject<void>();
+
+  ngOnDestroy() {
+    this.unsubscribe.next();
+    this.unsubscribe.complete();
+  }
+
   static get pageInfo(): PageInfo {
     return null;
   }
@@ -30,7 +37,7 @@ export class PageComponent implements PageComponentInterface {
  * Get the page info interface of an angular component
  * @param component Angular component
  */
-export function getPageInfo(component: Type<any>): (PageInfo | null) {
+export function getPageInfo(component: Type<any>): PageInfo | null {
   const pageComponent = component as PageComponentStatic;
   return pageComponent ? pageComponent.pageInfo : null;
 }

--- a/src/app/helpers/page/pageComponent.ts
+++ b/src/app/helpers/page/pageComponent.ts
@@ -1,6 +1,6 @@
 import { Type } from "@angular/core";
-import { PageInfo } from "./pageInfo";
 import { WithUnsubscribe } from "../unsubscribe/unsubscribe";
+import { PageInfo } from "./pageInfo";
 
 export interface PageComponentStatic
   extends Type<PageComponentInterface>,

--- a/src/app/helpers/page/pageComponent.ts
+++ b/src/app/helpers/page/pageComponent.ts
@@ -1,6 +1,6 @@
-import { OnDestroy, Type } from "@angular/core";
-import { Subject } from "rxjs";
+import { Type } from "@angular/core";
 import { PageInfo } from "./pageInfo";
+import { WithUnsubscribe } from "../unsubscribe/unsubscribe";
 
 export interface PageComponentStatic
   extends Type<PageComponentInterface>,
@@ -17,14 +17,8 @@ export interface PageComponentInterface {
 // See https://github.com/Microsoft/TypeScript/issues/4881
 // If they did, then we wouldn't need this shim, which
 // currently needs to be extended from in every component!
-export class PageComponent implements PageComponentInterface, OnDestroy {
-  protected unsubscribe = new Subject<void>();
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
-  }
-
+export class PageComponent extends WithUnsubscribe()
+  implements PageComponentInterface {
   static get pageInfo(): PageInfo {
     return null;
   }

--- a/src/app/helpers/page/pageInfo.ts
+++ b/src/app/helpers/page/pageInfo.ts
@@ -21,11 +21,12 @@ export interface PageInfoInterface extends Data {
  * Page info class
  */
 export class PageInfo implements PageInfoInterface {
-  self: MenuRoute;
-  component: Type<any>;
-  category: Category;
-  menus: Menus;
-  fullscreen: boolean;
+  public self: MenuRoute;
+  public component: Type<any>;
+  public category: Category;
+  public menus: Menus;
+  public fullscreen: boolean;
+
   constructor(target: Type<any>, args: PageInfoInterface) {
     if (!args.self) {
       throw new Error("A page info must be provided with an `self` MenuRoute");

--- a/src/app/helpers/tableTemplate/tableTemplate.spec.ts
+++ b/src/app/helpers/tableTemplate/tableTemplate.spec.ts
@@ -18,11 +18,11 @@ import { TableTemplate } from "./tableTemplate";
     </ngx-datatable>
   `
 })
-class MockComponent extends TableTemplate<any> {
+class MockComponent extends TableTemplate<{ id: number | string }> {
+  public columns = [{ prop: "id" }];
+
   constructor() {
     super(() => true);
-
-    this.columns = [{ prop: "id" }];
   }
 
   protected createRows() {

--- a/src/app/helpers/tableTemplate/tableTemplate.spec.ts
+++ b/src/app/helpers/tableTemplate/tableTemplate.spec.ts
@@ -1,5 +1,6 @@
-import { Component } from "@angular/core";
+import { Component, ViewChild } from "@angular/core";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { DatatableComponent } from "@swimlane/ngx-datatable";
 import { SharedModule } from "src/app/component/shared/shared.module";
 import { TableTemplate } from "./tableTemplate";
 
@@ -19,6 +20,13 @@ import { TableTemplate } from "./tableTemplate";
   `
 })
 class MockComponent extends TableTemplate<{ id: number | string }> {
+  // TODO Check if this bug has been fixed
+  // Unsure why but this line is required on in unit tests
+  // Specifically: a unit test which is run with another .spec.ts file
+  // in the pool of tests. If this test suite is run in isolation it
+  // will pass without this line.
+  @ViewChild(DatatableComponent) table: DatatableComponent;
+
   public columns = [{ prop: "id" }];
 
   constructor() {

--- a/src/app/helpers/unsubscribe/unsubscribe.spec.ts
+++ b/src/app/helpers/unsubscribe/unsubscribe.spec.ts
@@ -1,7 +1,56 @@
+import { WithUnsubscribe } from "./unsubscribe";
+import { Subject } from "rxjs";
+
 describe("WithUnsubscribe", () => {
-  it("should accept empty base class", () => {});
-  it("should accept PageComponent base class", () => {});
-  it("should provide unsubscribe observable", () => {});
-  it("should call next() when ngOnDestroy is called", () => {});
-  it("should call complete() when ngOnDestroy is called", () => {});
+  it("should accept empty base class", () => {
+    class MockClass extends WithUnsubscribe() {
+      public test = "MockClass";
+    }
+
+    const mockClass = new MockClass();
+
+    expect(mockClass).toBeTruthy();
+    expect(mockClass.test).toBe("MockClass");
+  });
+
+  it("should accept custom class base class", () => {
+    class MockBaseClass {
+      public base = "MockBaseClass";
+    }
+    class MockClass extends WithUnsubscribe(MockBaseClass) {
+      public test = "Custom Test";
+    }
+
+    const mockClass = new MockClass();
+
+    expect(mockClass).toBeTruthy();
+    expect(mockClass.base).toBe("MockBaseClass");
+    expect(mockClass.test).toBe("Custom Test");
+  });
+
+  it("should provide unsubscribe observable", () => {
+    class MockClass extends WithUnsubscribe() {}
+    const mockClass = new MockClass();
+
+    expect(mockClass["unsubscribe"]).toBeTruthy();
+    expect(mockClass["unsubscribe"] instanceof Subject).toBeTrue();
+  });
+
+  it("should call next() when ngOnDestroy is called", () => {
+    class MockClass extends WithUnsubscribe() {}
+    const mockClass = new MockClass();
+    const spy = spyOn(mockClass["unsubscribe"], "next").and.callThrough();
+
+    mockClass.ngOnDestroy();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("should call complete() when ngOnDestroy is called", () => {
+    class MockClass extends WithUnsubscribe() {}
+    const mockClass = new MockClass();
+    const spy = spyOn(mockClass["unsubscribe"], "complete").and.callThrough();
+
+    mockClass.ngOnDestroy();
+    expect(spy).toHaveBeenCalled();
+  });
 });

--- a/src/app/helpers/unsubscribe/unsubscribe.spec.ts
+++ b/src/app/helpers/unsubscribe/unsubscribe.spec.ts
@@ -1,0 +1,7 @@
+describe("WithUnsubscribe", () => {
+  it("should accept empty base class", () => {});
+  it("should accept PageComponent base class", () => {});
+  it("should provide unsubscribe observable", () => {});
+  it("should call next() when ngOnDestroy is called", () => {});
+  it("should call complete() when ngOnDestroy is called", () => {});
+});

--- a/src/app/helpers/unsubscribe/unsubscribe.spec.ts
+++ b/src/app/helpers/unsubscribe/unsubscribe.spec.ts
@@ -1,5 +1,5 @@
-import { WithUnsubscribe } from "./unsubscribe";
 import { Subject } from "rxjs";
+import { WithUnsubscribe } from "./unsubscribe";
 
 describe("WithUnsubscribe", () => {
   it("should accept empty base class", () => {

--- a/src/app/helpers/unsubscribe/unsubscribe.ts
+++ b/src/app/helpers/unsubscribe/unsubscribe.ts
@@ -1,4 +1,4 @@
-import { Type, OnDestroy } from "@angular/core";
+import { OnDestroy, Type } from "@angular/core";
 import { Subject } from "rxjs";
 
 export function WithUnsubscribe<T extends Type<{}>>(Base: T = class {} as any) {

--- a/src/app/helpers/unsubscribe/unsubscribe.ts
+++ b/src/app/helpers/unsubscribe/unsubscribe.ts
@@ -1,0 +1,13 @@
+import { Type, OnDestroy } from "@angular/core";
+import { Subject } from "rxjs";
+
+export function WithUnsubscribe<T extends Type<{}>>(Base: T = class {} as any) {
+  return class extends Base implements OnDestroy {
+    protected unsubscribe = new Subject<void>();
+
+    ngOnDestroy() {
+      this.unsubscribe.next();
+      this.unsubscribe.complete();
+    }
+  };
+}

--- a/tslint.json
+++ b/tslint.json
@@ -61,7 +61,6 @@
     "rxjs-no-create": true,
     "rxjs-no-ignored-error": true,
     "rxjs-no-nested-subscribe": true,
-    "rxjs-prefer-angular-takeuntil": true,
     "template-banana-in-box": true,
     "template-no-negated-async": true,
     "triple-equals": true,


### PR DESCRIPTION
# Unsubscribe observable mixin

Created an unsubscribe mixin to reduce the amount of boilerplate required with creating an observable which cancels observable withing the component.

**Note:** This does not automatically cleanup any observables within the component, only provides a variable `unsubscribe` which you place inside the subscription pipe as so: `.pipe(takeUntil(this.unsubscribe))`

## Changes

- Created `WithUnsubscribe` mixin
- Updated `PageComponent` to extend `WithUnsubscribe` mixin
- Updated non `PageComponent` components to extend `WithUnsubscribe` mixin

## Closes

Closes #120 
