### PR TITLE
ngx-datatable defaults

### DIFF
--- a/src/app/app.helper.ts
+++ b/src/app/app.helper.ts
@@ -27,6 +27,7 @@ import {
 import { SecurityService } from "./services/baw-api/security.service";
 import {
   shallowSiteResolvers,
+  ShallowSitesService,
   siteResolvers,
   SitesService
 } from "./services/baw-api/sites.service";
@@ -110,6 +111,7 @@ export const providers = [
   ProjectsService,
   SecurityService,
   SitesService,
+  ShallowSitesService,
   UserService,
   ...accountResolvers,
   ...projectResolvers,

--- a/src/app/component/projects/pages/assign/assign.component.html
+++ b/src/app/component/projects/pages/assign/assign.component.html
@@ -12,15 +12,10 @@
 
     <ngx-datatable
       #table
-      [class]="tableClass"
+      bawDatatableDefaults
       [columnMode]="ColumnMode.force"
       [columns]="columns"
-      [footerHeight]="footerHeight"
-      [headerHeight]="headerHeight"
-      [limit]="defaultTableLimit"
-      [rowHeight]="'auto'"
       [rows]="rows"
-      [scrollbarH]="true"
       [selectAllRowsOnPage]="false"
       [selected]="selected"
       [selectionType]="SelectionType.checkbox"

--- a/src/app/component/projects/pages/permissions/permissions.component.html
+++ b/src/app/component/projects/pages/permissions/permissions.component.html
@@ -84,16 +84,11 @@
 
     <ngx-datatable
       #table
+      bawDatatableDefaults
       [class]="tableClass"
       [rows]="rows"
       [columns]="columns"
       [columnMode]="ColumnMode.force"
-      [limit]="defaultTableLimit"
-      [rowHeight]="'auto'"
-      [headerHeight]="headerHeight"
-      [footerHeight]="footerHeight"
-      [reorderable]="false"
-      [scrollbarH]="true"
     >
       <!-- User Template -->
       <ngx-datatable-column name="User">

--- a/src/app/component/shared/cms/cms.component.spec.ts
+++ b/src/app/component/shared/cms/cms.component.spec.ts
@@ -174,11 +174,11 @@ describe("CmsComponent", () => {
 
     const header = fixture.nativeElement.querySelector("h1");
     expect(header).toBeTruthy();
-    expect(header.innerText).toBe("Response");
+    expect(header.innerText.trim()).toBe("Response");
 
     const body = fixture.nativeElement.querySelector("p");
     expect(body).toBeTruthy();
-    expect(body.innerText).toBe("Example HTML response from API");
+    expect(body.innerText.trim()).toBe("Example HTML response from API");
   });
 
   it("should display 'not found' on page not found", () => {
@@ -192,7 +192,7 @@ describe("CmsComponent", () => {
 
     const header = fixture.nativeElement.querySelector("h1");
     expect(header).toBeTruthy();
-    expect(header.innerText).toBe("Not Found");
+    expect(header.innerText.trim()).toBe("Not Found");
   });
 
   it("should display 'unauthorized' on unauthorized", () => {
@@ -206,6 +206,6 @@ describe("CmsComponent", () => {
 
     const header = fixture.nativeElement.querySelector("h1");
     expect(header).toBeTruthy();
-    expect(header.innerText).toBe("Unauthorized Access");
+    expect(header.innerText.trim()).toBe("Unauthorized Access");
   });
 });

--- a/src/app/component/shared/shared.components.ts
+++ b/src/app/component/shared/shared.components.ts
@@ -9,6 +9,7 @@ import { FormlyModule } from "@ngx-formly/core";
 import { LoadingBarHttpClientModule } from "@ngx-loading-bar/http-client";
 import { NgxDatatableModule } from "@swimlane/ngx-datatable";
 import { ToastrModule } from "ngx-toastr";
+import { DirectivesModule } from "src/app/directives/directives.module";
 import { ActionMenuComponent } from "./action-menu/action-menu.component";
 import { CardsModule } from "./cards/cards.module";
 import { CmsComponent } from "./cms/cms.component";
@@ -58,6 +59,7 @@ export const sharedModules = [
   NgxDatatableModule,
   ToastrModule,
 
+  DirectivesModule,
   CardsModule,
   HeaderModule,
   ItemsModule,

--- a/src/app/directives/datatable/datatable.directive.spec.ts
+++ b/src/app/directives/datatable/datatable.directive.spec.ts
@@ -1,0 +1,115 @@
+import { Component, DebugElement } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+import { SharedModule } from "src/app/component/shared/shared.module";
+import { DatatableDirective } from "./datatable.directive";
+
+describe("DatatableDirective", () => {
+  let fixture: ComponentFixture<any>;
+  let datatable: DebugElement;
+
+  function configureTestingModule(overrideDefaults?: {
+    footerHeight?: number;
+    headerHeight?: number;
+  }) {
+    const template = `
+      <ngx-datatable
+        #table
+        bawDatatableDefaults
+        [rows]="rows"
+        [columns]="columns"
+        ${
+          overrideDefaults
+            ? Object.keys(overrideDefaults)
+                .map(key => {
+                  return "[" + key + "]='" + overrideDefaults[key] + "'";
+                })
+                .toString()
+                .replace(",", " ")
+            : ""
+        }
+      >
+      </ngx-datatable>
+    `;
+
+    @Component({
+      template
+    })
+    class MockComponent {
+      rows = [{ id: 1 }];
+      columns = [{ prop: "id" }];
+      headerHeight = overrideDefaults?.headerHeight;
+      footerHeight = overrideDefaults?.footerHeight;
+    }
+
+    TestBed.configureTestingModule({
+      declarations: [MockComponent, DatatableDirective],
+      imports: [SharedModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MockComponent);
+    fixture.detectChanges();
+
+    datatable = fixture.debugElement.query(By.css("ngx-datatable"));
+  }
+
+  function assertAttribute(
+    selector: string,
+    attribute: string,
+    expectedValue: string
+  ) {
+    const target = datatable.query(By.css(selector));
+    expect(target).toBeTruthy();
+    expect(target.attributes["ng-reflect-" + attribute]).toBeTruthy();
+    expect(target.attributes["ng-reflect-" + attribute]).toBe(expectedValue);
+  }
+
+  describe("Defaults", () => {
+    beforeEach(() => {
+      configureTestingModule();
+    });
+
+    it("should set class", () => {
+      expect(Object.keys(datatable.classes)).toContain("bootstrap");
+    });
+
+    it("should set footer height", () => {
+      assertAttribute("datatable-footer", "footer-height", "50");
+    });
+
+    it("should set header height", () => {
+      assertAttribute("datatable-header", "header-height", "50");
+    });
+
+    it("should set limit", () => {
+      assertAttribute("datatable-body", "page-size", "25");
+    });
+
+    it("should set row height", () => {
+      assertAttribute("datatable-body", "row-height", "auto");
+    });
+
+    it("should set horizontal scroll bar", () => {
+      assertAttribute("datatable-scroller", "scrollbar-h", "true");
+    });
+
+    it("should set not reorderable", () => {
+      assertAttribute("datatable-header", "reorderable", "false");
+    });
+  });
+
+  describe("Overrides", () => {
+    it("should override default value", () => {
+      configureTestingModule({ footerHeight: 150 });
+
+      assertAttribute("datatable-footer", "footer-height", "150");
+    });
+
+    it("should override multiple default values", () => {
+      configureTestingModule({ footerHeight: 150, headerHeight: 150 });
+
+      assertAttribute("datatable-footer", "footer-height", "150");
+      assertAttribute("datatable-header", "header-height", "150");
+    });
+  });
+});

--- a/src/app/directives/datatable/datatable.directive.ts
+++ b/src/app/directives/datatable/datatable.directive.ts
@@ -1,0 +1,32 @@
+import { Directive, ElementRef, Host, Input, OnInit } from "@angular/core";
+import { DatatableComponent } from "@swimlane/ngx-datatable";
+
+@Directive({
+  selector: "[bawDatatableDefaults]"
+})
+export class DatatableDirective implements OnInit {
+  @Input() footerHeight = 50;
+  @Input() headerHeight = 50;
+  @Input() limit = 25;
+  @Input() rowHeight: ((row: any) => number) | number | "auto" = "auto";
+  @Input() scrollbarH = true;
+  @Input() reorderable = false;
+
+  constructor(
+    @Host() private datatable: DatatableComponent,
+    private datatableRef: ElementRef
+  ) {}
+
+  ngOnInit(): void {
+    // Set class
+    this.datatableRef.nativeElement.classList.add("bootstrap");
+
+    // Set overrides
+    this.datatable.footerHeight = this.footerHeight;
+    this.datatable.headerHeight = this.headerHeight;
+    this.datatable.limit = this.limit;
+    this.datatable.rowHeight = this.rowHeight;
+    this.datatable.scrollbarH = this.scrollbarH;
+    this.datatable.reorderable = this.reorderable;
+  }
+}

--- a/src/app/directives/directives.module.ts
+++ b/src/app/directives/directives.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from "@angular/core";
+import { DatatableDirective } from "./datatable/datatable.directive";
+
+const directives = [DatatableDirective];
+
+@NgModule({
+  declarations: directives,
+  exports: directives
+})
+export class DirectivesModule {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,
-    "strictInjectionParameters": true
+    "strictInjectionParameters": true,
+    "disableTypeScriptVersionCheck": true
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -12,7 +12,7 @@
     "component-class-suffix": true,
     "contextual-lifecycle": true,
     "directive-class-suffix": true,
-    "directive-selector": [true, "attribute", "app", "camelCase"],
+    "directive-selector": [true, "attribute", ["app", "baw"], "camelCase"],
     "component-selector": [true, "element", "app", "kebab-case"],
     "import-blacklist": [true, "rxjs/Rx"],
     "interface-name": false,


### PR DESCRIPTION
# Datatable Defaults

Created a directive for `<ngx-datatable>` components which loads the table with set defaults.

## Changes

- Created `src/app/directives/datatable/datatable.directive.ts
- To enable defaults the following must be added to a `<ngx-datatable>`

```typescript
<ngx-datatable appDatatable>
</ngx-datatable>
```

- To override defaults, you can do the following:

```typescript
<ngx-datatable
      appDatatable
      [footerHeight]="150">
</ngx-datatable>
```

- Fixed failing unit tests on edge browser
  - `.innerText` had some extra whitespace causing the CMS tests to fail
- Fixed the following bug:
  - `ERROR Error: "[Front for longstractor/server0.conn5.child1/longstractor3430]"`
  - This appears to be caused by resolvers failing, and looking into the error doesn't help much online hence why I'm documenting the method used to find the solution
  - Following the advice [here](https://stackoverflow.com/questions/59930000/angular-agmmaps-cant-use-polylinemanager-with-error-front-for-longstractor), I enabled tracing on the router module. From this I was able to determine the `ShallowSitesService` resolvers were failing because it was not properly imported. Another similar issue that caused this error was an import using `.js` at the end of the import path.

## Closes

Closes #100 
