### PR TITLE
Enhance category resolvers

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -18,6 +18,7 @@ import { AppComponent } from "./app.component";
 import { appLibraryImports } from "./app.module";
 import { homeMenuItem } from "./component/home/home.menus";
 import { projectsMenuItem } from "./component/projects/projects.menus";
+import { SharedModule } from "./component/shared/shared.module";
 import { Project } from "./models/Project";
 import { AppConfigService } from "./services/app-config/app-config.service";
 import { ProjectsService } from "./services/baw-api/projects.service";
@@ -41,7 +42,8 @@ describe("AppComponent", () => {
           projectsMenuItem.route.routeConfig
         ]),
         HttpClientTestingModule,
-        LoadingBarHttpClientModule
+        LoadingBarHttpClientModule,
+        SharedModule
       ],
       declarations: [AppComponent],
       providers: [...testBawServices]

--- a/src/app/component/about/about.menus.ts
+++ b/src/app/component/about/about.menus.ts
@@ -3,11 +3,11 @@ import { StrongRoute } from "src/app/interfaces/strongRoute";
 
 export const aboutRoute = StrongRoute.Base.add("about");
 
-export const aboutCategory: Category = {
+export const aboutCategory = Category({
   icon: ["fas", "info-circle"],
   label: "About",
   route: aboutRoute
-};
+});
 
 export const contactUsMenuItem = MenuRoute({
   icon: ["fas", "question-circle"],

--- a/src/app/component/admin/admin.menus.ts
+++ b/src/app/component/admin/admin.menus.ts
@@ -12,11 +12,6 @@ import { StrongRoute } from "src/app/interfaces/strongRoute";
 import { sitesCategory } from "../sites/sites.menus";
 
 export const adminRoute = StrongRoute.Base.add("admin");
-export const adminCategory: Category = {
-  icon: ["fas", "cog"],
-  label: "Admin",
-  route: adminRoute
-};
 
 export const adminDashboardMenuItem = MenuRoute({
   icon: ["fas", "toolbox"],
@@ -24,6 +19,12 @@ export const adminDashboardMenuItem = MenuRoute({
   route: adminRoute,
   tooltip: () => "Administrator dashboard",
   predicate: isAdminPredicate
+});
+
+export const adminCategory = Category({
+  icon: ["fas", "cog"],
+  label: "Admin",
+  route: adminRoute
 });
 
 export const adminUserListMenuItem = MenuRoute({
@@ -41,71 +42,6 @@ export const adminOrphanSitesMenuItem = MenuRoute({
   route: adminRoute.add("sites"),
   tooltip: () => "Manage orphaned sites",
   parent: adminDashboardMenuItem,
-  predicate: isAdminPredicate
-});
-
-/*
-  Admin Scripts
-*/
-
-export const adminScriptsCategory: Category = {
-  icon: ["fas", "scroll"],
-  label: "Scripts",
-  route: adminRoute.add("scripts"),
-  parent: adminCategory
-};
-
-export const adminScriptsMenuItem = MenuRoute({
-  icon: ["fas", "scroll"],
-  label: "Scripts",
-  route: adminScriptsCategory.route,
-  tooltip: () => "Manage custom scripts",
-  parent: adminDashboardMenuItem,
-  predicate: isAdminPredicate
-});
-
-export const adminNewScriptsMenuItem = MenuRoute({
-  icon: defaultNewIcon,
-  label: "New Script",
-  route: adminScriptsMenuItem.route.add("new"),
-  tooltip: () => "Create a new script",
-  parent: adminScriptsMenuItem,
-  predicate: isAdminPredicate
-});
-
-export const adminTagsMenuItem = MenuRoute({
-  icon: ["fas", "tag"],
-  label: "Tags",
-  route: adminRoute.add("tags"),
-  tooltip: () => "Manage tags",
-  parent: adminDashboardMenuItem,
-  predicate: isAdminPredicate
-});
-
-export const adminNewTagMenuItem = MenuRoute({
-  icon: defaultNewIcon,
-  label: "New Tag",
-  route: adminTagsMenuItem.route.add("new"),
-  tooltip: () => "Create a new tag",
-  parent: adminTagsMenuItem,
-  predicate: isAdminPredicate
-});
-
-export const adminTagGroupsMenuItem = MenuRoute({
-  icon: ["fas", "tags"],
-  label: "Tag Group",
-  route: adminRoute.add("tags"),
-  tooltip: () => "Manage tags",
-  parent: adminDashboardMenuItem,
-  predicate: isAdminPredicate
-});
-
-export const adminNewTagGroupMenuItem = MenuRoute({
-  icon: defaultNewIcon,
-  label: "New Tag Group",
-  route: adminTagsMenuItem.route.add("new"),
-  tooltip: () => "Create a new tag group",
-  parent: adminTagGroupsMenuItem,
   predicate: isAdminPredicate
 });
 
@@ -133,5 +69,80 @@ export const adminJobStatusMenuItem = MenuLink({
   tooltip: () => "Job queue status overview",
   uri: () => "/job_queue_status/overview",
   parent: adminDashboardMenuItem,
+  predicate: isAdminPredicate
+});
+
+/*
+  Admin Scripts
+*/
+
+const adminScriptsRoute = adminRoute.add("scripts");
+
+export const adminScriptsMenuItem = MenuRoute({
+  icon: ["fas", "scroll"],
+  label: "Scripts",
+  route: adminScriptsRoute,
+  tooltip: () => "Manage custom scripts",
+  parent: adminDashboardMenuItem,
+  predicate: isAdminPredicate
+});
+
+export const adminScriptsCategory = Category({
+  icon: ["fas", "scroll"],
+  label: "Scripts",
+  route: adminScriptsRoute,
+  parent: adminCategory
+});
+
+export const adminNewScriptsMenuItem = MenuRoute({
+  icon: defaultNewIcon,
+  label: "New Script",
+  route: adminScriptsRoute.add("new"),
+  tooltip: () => "Create a new script",
+  parent: adminScriptsMenuItem,
+  predicate: isAdminPredicate
+});
+
+/**
+ * Admin Tags
+ */
+
+export const adminTagsMenuItem = MenuRoute({
+  icon: ["fas", "tag"],
+  label: "Tags",
+  route: adminRoute.add("tags"),
+  tooltip: () => "Manage tags",
+  parent: adminDashboardMenuItem,
+  predicate: isAdminPredicate
+});
+
+export const adminNewTagMenuItem = MenuRoute({
+  icon: defaultNewIcon,
+  label: "New Tag",
+  route: adminTagsMenuItem.route.add("new"),
+  tooltip: () => "Create a new tag",
+  parent: adminTagsMenuItem,
+  predicate: isAdminPredicate
+});
+
+/**
+ * Admin Tag Groups
+ */
+
+export const adminTagGroupsMenuItem = MenuRoute({
+  icon: ["fas", "tags"],
+  label: "Tag Group",
+  route: adminRoute.add("tags"),
+  tooltip: () => "Manage tags",
+  parent: adminDashboardMenuItem,
+  predicate: isAdminPredicate
+});
+
+export const adminNewTagGroupMenuItem = MenuRoute({
+  icon: defaultNewIcon,
+  label: "New Tag Group",
+  route: adminTagsMenuItem.route.add("new"),
+  tooltip: () => "Create a new tag group",
+  parent: adminTagGroupsMenuItem,
   predicate: isAdminPredicate
 });

--- a/src/app/component/admin/admin.menus.ts
+++ b/src/app/component/admin/admin.menus.ts
@@ -13,18 +13,18 @@ import { sitesCategory } from "../sites/sites.menus";
 
 export const adminRoute = StrongRoute.Base.add("admin");
 
+export const adminCategory = Category({
+  icon: ["fas", "cog"],
+  label: "Admin",
+  route: adminRoute
+});
+
 export const adminDashboardMenuItem = MenuRoute({
   icon: ["fas", "toolbox"],
   label: "Admin Home",
   route: adminRoute,
   tooltip: () => "Administrator dashboard",
   predicate: isAdminPredicate
-});
-
-export const adminCategory = Category({
-  icon: ["fas", "cog"],
-  label: "Admin",
-  route: adminRoute
 });
 
 export const adminUserListMenuItem = MenuRoute({
@@ -78,6 +78,13 @@ export const adminJobStatusMenuItem = MenuLink({
 
 const adminScriptsRoute = adminRoute.add("scripts");
 
+export const adminScriptsCategory = Category({
+  icon: ["fas", "scroll"],
+  label: "Scripts",
+  route: adminScriptsRoute,
+  parent: adminCategory
+});
+
 export const adminScriptsMenuItem = MenuRoute({
   icon: ["fas", "scroll"],
   label: "Scripts",
@@ -85,13 +92,6 @@ export const adminScriptsMenuItem = MenuRoute({
   tooltip: () => "Manage custom scripts",
   parent: adminDashboardMenuItem,
   predicate: isAdminPredicate
-});
-
-export const adminScriptsCategory = Category({
-  icon: ["fas", "scroll"],
-  label: "Scripts",
-  route: adminScriptsRoute,
-  parent: adminCategory
 });
 
 export const adminNewScriptsMenuItem = MenuRoute({

--- a/src/app/component/data-request/data-request.menus.ts
+++ b/src/app/component/data-request/data-request.menus.ts
@@ -1,10 +1,10 @@
-import { Category, MenuRoute } from "src/app/interfaces/menusInterfaces";
+import { MenuRoute } from "src/app/interfaces/menusInterfaces";
 import { StrongRoute } from "src/app/interfaces/strongRoute";
 import { homeCategory } from "../home/home.menus";
 
 export const dataRequestRoute = StrongRoute.Base.add("data_request");
 
-export const dataRequestCategory: Category = homeCategory;
+export const dataRequestCategory = homeCategory;
 
 export const dataRequestMenuItem = MenuRoute({
   icon: ["fas", "table"],

--- a/src/app/component/home/home.menus.ts
+++ b/src/app/component/home/home.menus.ts
@@ -2,11 +2,13 @@ import { Category, MenuRoute } from "src/app/interfaces/menusInterfaces";
 import { StrongRoute } from "src/app/interfaces/strongRoute";
 
 export const homeRoute = StrongRoute.Base.add("");
-export const homeCategory: Category = {
+
+export const homeCategory = Category({
   icon: ["fas", "home"],
   label: "Home",
   route: homeRoute
-};
+});
+
 export const homeMenuItem = MenuRoute({
   icon: ["fas", "home"],
   label: "Home",

--- a/src/app/component/profile/profile.menus.ts
+++ b/src/app/component/profile/profile.menus.ts
@@ -17,15 +17,6 @@ export const myAccountRoute = StrongRoute.Base.add("my_account");
  * My Account Menus
  */
 
-export const myAccountMenuItem = MenuRoute({
-  icon: defaultUserIcon,
-  label: "My Profile",
-  order: 2,
-  predicate: isLoggedInPredicate,
-  route: myAccountRoute,
-  tooltip: () => "View profile"
-});
-
 export const myAccountCategory = Category({
   icon: defaultUserIcon,
   label: "My Profile",
@@ -33,6 +24,15 @@ export const myAccountCategory = Category({
   resolvers: {
     user: "UserShowResolver"
   }
+});
+
+export const myAccountMenuItem = MenuRoute({
+  icon: defaultUserIcon,
+  label: "My Profile",
+  order: 2,
+  predicate: isLoggedInPredicate,
+  route: myAccountRoute,
+  tooltip: () => "View profile"
 });
 
 export const editMyAccountMenuItem = MenuRoute({
@@ -84,15 +84,6 @@ export const theirProfileRoute = StrongRoute.Base.add("user_accounts").add(
   ":accountId"
 );
 
-export const theirProfileMenuItem = MenuRoute({
-  icon: myAccountMenuItem.icon,
-  label: "Their Profile",
-  order: myAccountMenuItem.order,
-  predicate: isLoggedInPredicate,
-  route: theirProfileRoute,
-  tooltip: () => "View their profile"
-});
-
 export const theirProfileCategory = Category({
   icon: myAccountCategory.icon,
   label: "Their Profile",
@@ -100,6 +91,15 @@ export const theirProfileCategory = Category({
   resolvers: {
     account: "AccountShowResolver"
   }
+});
+
+export const theirProfileMenuItem = MenuRoute({
+  icon: myAccountMenuItem.icon,
+  label: "Their Profile",
+  order: myAccountMenuItem.order,
+  predicate: isLoggedInPredicate,
+  route: theirProfileRoute,
+  tooltip: () => "View their profile"
 });
 
 export const theirEditProfileMenuItem = MenuRoute({

--- a/src/app/component/profile/profile.menus.ts
+++ b/src/app/component/profile/profile.menus.ts
@@ -16,14 +16,6 @@ export const myAccountRoute = StrongRoute.Base.add("my_account");
 /**
  * My Account Menus
  */
-export const myAccountCategory: Category = {
-  icon: defaultUserIcon,
-  label: "My Profile",
-  route: myAccountRoute,
-  resolvers: {
-    user: "UserShowResolver"
-  }
-};
 
 export const myAccountMenuItem = MenuRoute({
   icon: defaultUserIcon,
@@ -32,6 +24,15 @@ export const myAccountMenuItem = MenuRoute({
   predicate: isLoggedInPredicate,
   route: myAccountRoute,
   tooltip: () => "View profile"
+});
+
+export const myAccountCategory = Category({
+  icon: defaultUserIcon,
+  label: "My Profile",
+  route: myAccountRoute,
+  resolvers: {
+    user: "UserShowResolver"
+  }
 });
 
 export const editMyAccountMenuItem = MenuRoute({
@@ -83,15 +84,6 @@ export const theirProfileRoute = StrongRoute.Base.add("user_accounts").add(
   ":accountId"
 );
 
-export const theirProfileCategory: Category = {
-  icon: myAccountCategory.icon,
-  label: "Their Profile",
-  route: theirProfileRoute,
-  resolvers: {
-    account: "AccountShowResolver"
-  }
-};
-
 export const theirProfileMenuItem = MenuRoute({
   icon: myAccountMenuItem.icon,
   label: "Their Profile",
@@ -99,6 +91,15 @@ export const theirProfileMenuItem = MenuRoute({
   predicate: isLoggedInPredicate,
   route: theirProfileRoute,
   tooltip: () => "View their profile"
+});
+
+export const theirProfileCategory = Category({
+  icon: myAccountCategory.icon,
+  label: "Their Profile",
+  route: theirProfileRoute,
+  resolvers: {
+    account: "AccountShowResolver"
+  }
 });
 
 export const theirEditProfileMenuItem = MenuRoute({

--- a/src/app/component/projects/projects.menus.ts
+++ b/src/app/component/projects/projects.menus.ts
@@ -16,14 +16,6 @@ import { StrongRoute } from "src/app/interfaces/strongRoute";
 
 export const projectsRoute = StrongRoute.Base.add("projects");
 
-export const projectsMenuItem = MenuRoute({
-  icon: ["fas", "globe-asia"],
-  label: "Projects",
-  order: 4,
-  route: projectsRoute,
-  tooltip: () => "View projects I have access to"
-});
-
 export const projectsCategory = Category({
   label: "Projects",
   icon: ["fas", "globe-asia"],
@@ -31,6 +23,14 @@ export const projectsCategory = Category({
   resolvers: {
     projects: "ProjectListResolver"
   }
+});
+
+export const projectsMenuItem = MenuRoute({
+  icon: ["fas", "globe-asia"],
+  label: "Projects",
+  order: 4,
+  route: projectsRoute,
+  tooltip: () => "View projects I have access to"
 });
 
 export const newProjectMenuItem = MenuRoute({
@@ -57,14 +57,6 @@ export const requestProjectMenuItem = MenuRoute({
 
 const projectRoute = projectsRoute.add(":projectId");
 
-export const projectMenuItem = MenuRoute({
-  icon: ["fas", "folder-open"],
-  label: "Project",
-  parent: projectsMenuItem,
-  route: projectRoute,
-  tooltip: () => "The current project"
-});
-
 export const projectCategory = Category({
   label: "Project",
   icon: projectsCategory.icon,
@@ -74,6 +66,14 @@ export const projectCategory = Category({
     project: "ProjectShowResolver",
     sites: "SiteListResolver"
   }
+});
+
+export const projectMenuItem = MenuRoute({
+  icon: ["fas", "folder-open"],
+  label: "Project",
+  parent: projectsMenuItem,
+  route: projectRoute,
+  tooltip: () => "The current project"
 });
 
 export const editProjectMenuItem = MenuRoute({

--- a/src/app/component/projects/projects.menus.ts
+++ b/src/app/component/projects/projects.menus.ts
@@ -15,14 +15,6 @@ import { StrongRoute } from "src/app/interfaces/strongRoute";
 */
 
 export const projectsRoute = StrongRoute.Base.add("projects");
-export const projectsCategory: Category = {
-  label: "Projects",
-  icon: ["fas", "globe-asia"],
-  route: projectsRoute,
-  resolvers: {
-    projects: "ProjectListResolver"
-  }
-};
 
 export const projectsMenuItem = MenuRoute({
   icon: ["fas", "globe-asia"],
@@ -30,6 +22,15 @@ export const projectsMenuItem = MenuRoute({
   order: 4,
   route: projectsRoute,
   tooltip: () => "View projects I have access to"
+});
+
+export const projectsCategory = Category({
+  label: "Projects",
+  icon: ["fas", "globe-asia"],
+  route: projectsRoute,
+  resolvers: {
+    projects: "ProjectListResolver"
+  }
 });
 
 export const newProjectMenuItem = MenuRoute({
@@ -54,23 +55,25 @@ export const requestProjectMenuItem = MenuRoute({
   Project Category
 */
 
-export const projectCategory: Category = {
-  label: "Project",
-  icon: projectsCategory.icon,
-  route: projectsRoute.add(":projectId"),
-  parent: projectsCategory,
-  resolvers: {
-    project: "ProjectShowResolver",
-    sites: "SiteListResolver"
-  }
-};
+const projectRoute = projectsRoute.add(":projectId");
 
 export const projectMenuItem = MenuRoute({
   icon: ["fas", "folder-open"],
   label: "Project",
   parent: projectsMenuItem,
-  route: projectCategory.route,
+  route: projectRoute,
   tooltip: () => "The current project"
+});
+
+export const projectCategory = Category({
+  label: "Project",
+  icon: projectsCategory.icon,
+  route: projectRoute,
+  parent: projectsCategory,
+  resolvers: {
+    project: "ProjectShowResolver",
+    sites: "SiteListResolver"
+  }
 });
 
 export const editProjectMenuItem = MenuRoute({
@@ -78,7 +81,7 @@ export const editProjectMenuItem = MenuRoute({
   label: "Edit this project",
   parent: projectMenuItem,
   predicate: isOwnerPredicate,
-  route: projectMenuItem.route.add("edit"),
+  route: projectRoute.add("edit"),
   tooltip: () => "Change the details for this project"
 });
 
@@ -87,7 +90,7 @@ export const editProjectPermissionsMenuItem = MenuRoute({
   label: "Edit permissions",
   parent: projectMenuItem,
   predicate: isOwnerPredicate,
-  route: projectMenuItem.route.add("permissions"),
+  route: projectRoute.add("permissions"),
   tooltip: () => "Edit this projects permissions"
 });
 
@@ -96,7 +99,7 @@ export const assignSiteMenuItem = MenuRoute({
   label: "Assign sites",
   parent: projectMenuItem,
   predicate: isAdminPredicate,
-  route: projectMenuItem.route.add("assign"),
+  route: projectRoute.add("assign"),
   tooltip: () => "Change which sites belong to this project"
 });
 
@@ -105,6 +108,6 @@ export const deleteProjectMenuItem = MenuRoute({
   label: "Delete Project",
   parent: projectMenuItem,
   predicate: isOwnerPredicate,
-  route: projectMenuItem.route.add("delete"),
+  route: projectRoute.add("delete"),
   tooltip: () => "Delete this project"
 });

--- a/src/app/component/report-problem/report-problem.menus.ts
+++ b/src/app/component/report-problem/report-problem.menus.ts
@@ -1,10 +1,10 @@
-import { Category, MenuRoute } from "src/app/interfaces/menusInterfaces";
+import { MenuRoute } from "src/app/interfaces/menusInterfaces";
 import { StrongRoute } from "src/app/interfaces/strongRoute";
 import { homeCategory } from "../home/home.menus";
 
 export const reportProblemsRoute = StrongRoute.Base.add("report_problem");
 
-export const reportProblemsCategory: Category = homeCategory;
+export const reportProblemsCategory = homeCategory;
 
 export const reportProblemMenuItem = MenuRoute({
   icon: ["fas", "bug"],

--- a/src/app/component/security/security.menus.ts
+++ b/src/app/component/security/security.menus.ts
@@ -4,11 +4,11 @@ import { StrongRoute } from "src/app/interfaces/strongRoute";
 
 export const securityRoute = StrongRoute.Base.add("security");
 
-export const securityCategory: Category = {
+export const securityCategory = Category({
   icon: defaultUserIcon,
   label: "Accounts",
   route: securityRoute
-};
+});
 
 export const loginMenuItem = MenuRoute({
   icon: ["fas", "sign-in-alt"],

--- a/src/app/component/send-audio/send-audio.menus.ts
+++ b/src/app/component/send-audio/send-audio.menus.ts
@@ -1,9 +1,11 @@
-import { Category, MenuRoute } from "src/app/interfaces/menusInterfaces";
+import { MenuRoute } from "src/app/interfaces/menusInterfaces";
 import { StrongRoute } from "src/app/interfaces/strongRoute";
 import { homeCategory } from "../home/home.menus";
 
 export const sendAudioRoute = StrongRoute.Base.add("send_audio");
-export const sendAudioCategory: Category = homeCategory;
+
+export const sendAudioCategory = homeCategory;
+
 export const sendAudioMenuItem = MenuRoute({
   icon: ["fas", "envelope"],
   label: "Send Audio",

--- a/src/app/component/sites/pages/delete/delete.component.ts
+++ b/src/app/component/sites/pages/delete/delete.component.ts
@@ -19,6 +19,7 @@ import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.servic
 import { ResolvedModel } from "src/app/services/baw-api/resolver-common";
 import { SitesService } from "src/app/services/baw-api/sites.service";
 import { siteMenuItemActions } from "../details/details.component";
+
 @Page({
   category: sitesCategory,
   menus: {

--- a/src/app/component/sites/sites.menus.ts
+++ b/src/app/component/sites/sites.menus.ts
@@ -27,14 +27,6 @@ export const newSiteMenuItem = MenuRoute({
 
 export const siteRoute = sitesRoute.add(":siteId");
 
-export const siteMenuItem = MenuRoute({
-  icon: ["fas", "map-marker-alt"],
-  label: "Site",
-  parent: projectMenuItem,
-  route: siteRoute,
-  tooltip: () => "The current site"
-});
-
 export const sitesCategory = Category({
   icon: ["fas", "map-marker-alt"],
   label: "Sites",
@@ -43,6 +35,14 @@ export const sitesCategory = Category({
   resolvers: {
     site: "SiteShowResolver"
   }
+});
+
+export const siteMenuItem = MenuRoute({
+  icon: ["fas", "map-marker-alt"],
+  label: "Site",
+  parent: projectMenuItem,
+  route: siteRoute,
+  tooltip: () => "The current site"
 });
 
 export const annotationsMenuItem = MenuLink({

--- a/src/app/component/sites/sites.menus.ts
+++ b/src/app/component/sites/sites.menus.ts
@@ -16,16 +16,6 @@ import { projectCategory, projectMenuItem } from "../projects/projects.menus";
 
 export const sitesRoute = projectMenuItem.route.add("sites");
 
-export const sitesCategory: Category = {
-  icon: ["fas", "map-marker-alt"],
-  label: "Sites",
-  route: sitesRoute.add(":siteId"),
-  parent: projectCategory,
-  resolvers: {
-    site: "SiteShowResolver"
-  }
-};
-
 export const newSiteMenuItem = MenuRoute({
   icon: defaultNewIcon,
   label: "New site",
@@ -35,12 +25,24 @@ export const newSiteMenuItem = MenuRoute({
   tooltip: () => "Create a new site"
 });
 
+export const siteRoute = sitesRoute.add(":siteId");
+
 export const siteMenuItem = MenuRoute({
   icon: ["fas", "map-marker-alt"],
   label: "Site",
   parent: projectMenuItem,
-  route: sitesCategory.route,
+  route: siteRoute,
   tooltip: () => "The current site"
+});
+
+export const sitesCategory = Category({
+  icon: ["fas", "map-marker-alt"],
+  label: "Sites",
+  route: siteRoute,
+  parent: projectCategory,
+  resolvers: {
+    site: "SiteShowResolver"
+  }
 });
 
 export const annotationsMenuItem = MenuLink({
@@ -56,7 +58,7 @@ export const editSiteMenuItem = MenuRoute({
   label: "Edit this site",
   parent: siteMenuItem,
   predicate: isOwnerPredicate,
-  route: siteMenuItem.route.add("edit"),
+  route: siteRoute.add("edit"),
   tooltip: () => "Change the details for this site"
 });
 
@@ -65,7 +67,7 @@ export const harvestMenuItem = MenuRoute({
   label: "Harvesting",
   parent: siteMenuItem,
   predicate: isAdminPredicate,
-  route: siteMenuItem.route.add("harvest"),
+  route: siteRoute.add("harvest"),
   tooltip: () => "Upload new audio to this site"
 });
 
@@ -74,6 +76,6 @@ export const deleteSiteMenuItem = MenuRoute({
   label: "Delete Site",
   parent: siteMenuItem,
   predicate: isOwnerPredicate,
-  route: siteMenuItem.route.add("delete"),
+  route: siteRoute.add("delete"),
   tooltip: () => "Delete this site"
 });

--- a/src/app/component/statistics/statistics.menus.ts
+++ b/src/app/component/statistics/statistics.menus.ts
@@ -1,10 +1,10 @@
-import { Category, MenuRoute } from "src/app/interfaces/menusInterfaces";
+import { MenuRoute } from "src/app/interfaces/menusInterfaces";
 import { StrongRoute } from "src/app/interfaces/strongRoute";
 import { homeCategory } from "../home/home.menus";
 
 export const statisticsRoute = StrongRoute.Base.add("website_statistics");
 
-export const statisticsCategory: Category = homeCategory;
+export const statisticsCategory = homeCategory;
 
 export const statisticsMenuItem = MenuRoute({
   icon: ["fas", "chart-line"],

--- a/src/app/helpers/page/pageDecorator.ts
+++ b/src/app/helpers/page/pageDecorator.ts
@@ -24,7 +24,7 @@ export function Page(
   ): DecoratedPageComponent {
     const staticInfo = new PageInfo(componentConstructor, info);
 
-    // Declare this page as the root child of the category
+    // Identify category has root child
     if (staticInfo.category.route === staticInfo.route) {
       staticInfo.category.hasRootChild = true;
     }

--- a/src/app/helpers/page/pageDecorator.ts
+++ b/src/app/helpers/page/pageDecorator.ts
@@ -24,6 +24,11 @@ export function Page(
   ): DecoratedPageComponent {
     const staticInfo = new PageInfo(componentConstructor, info);
 
+    // Declare this page as the root child of the category
+    if (staticInfo.category.route === staticInfo.route) {
+      staticInfo.category.hasRootChild = true;
+    }
+
     // alternate implementation
     // return class extends componentConstructor implements PageComponent
     // {

--- a/src/app/helpers/page/pageRouting.ts
+++ b/src/app/helpers/page/pageRouting.ts
@@ -22,10 +22,16 @@ export function GetRouteConfigForPage(
   }
 
   const resolvers = {};
-  // Assign category resolvers if the page is the top level category page
-  if (page.category.route === page.self.route && page.category.resolvers) {
+
+  // Assign category resolvers
+  if (!page.category.rootChild) {
+    // If this is the root child, append resolvers
+    Object.assign(resolvers, page.category.resolvers);
+  } else if (page.category.rootChild.route === page.route) {
+    // If category has no root child, append resolvers
     Object.assign(resolvers, page.category.resolvers);
   }
+
   // Assign custom page resolvers
   if (page.resolvers) {
     Object.assign(resolvers, page.resolvers);

--- a/src/app/helpers/page/pageRouting.ts
+++ b/src/app/helpers/page/pageRouting.ts
@@ -24,10 +24,10 @@ export function GetRouteConfigForPage(
   const resolvers = {};
 
   // Assign category resolvers
-  if (!page.category.rootChild) {
+  if (!page.category.hasRootChild) {
     // If this is the root child, append resolvers
     Object.assign(resolvers, page.category.resolvers);
-  } else if (page.category.rootChild.route === page.route) {
+  } else if (page.category.route === page.route) {
     // If category has no root child, append resolvers
     Object.assign(resolvers, page.category.resolvers);
   }

--- a/src/app/interfaces/menusInterfaces.ts
+++ b/src/app/interfaces/menusInterfaces.ts
@@ -47,6 +47,7 @@ export interface LabelAndIcon {
  * @extends LabelAndIcon
  */
 export interface Category extends LabelAndIcon {
+  kind: "Category";
   /**
    *  Local route of category Eg. 'security'
    */
@@ -61,10 +62,21 @@ export interface Category extends LabelAndIcon {
    * List of resolvers
    */
   resolvers?: Resolvers;
+
   /**
-   * Root MenuRoute
+   * Does this category have a root MenuRoute using the same StrongRoute.
+   * Used by the page routing to append resolvers. Do not manually assign.
    */
-  rootChild?: MenuRoute;
+  hasRootChild: boolean;
+}
+
+export function Category<T extends Omit<Category, "kind" | "hasRootChild">>(
+  category: T
+): Category {
+  return Object.assign(category, {
+    kind: "Category" as "Category",
+    hasRootChild: false
+  });
 }
 
 /**
@@ -123,7 +135,9 @@ export interface MenuLink extends MenuItem {
   uri: Href;
 }
 
-export function MenuLink<T extends Omit<MenuLink, "kind">>(item: T): MenuLink {
+export function MenuLink<
+  T extends Omit<MenuLink, "kind" | "active" | "indentation">
+>(item: T): MenuLink {
   return Object.assign(item, {
     kind: "MenuLink" as "MenuLink",
     active: false,
@@ -149,7 +163,7 @@ export interface MenuRoute extends MenuItem {
   parent?: MenuRoute;
 }
 
-export function MenuRoute<T extends Omit<MenuRoute, "kind">>(
+export function MenuRoute<T extends Omit<MenuRoute, "kind" | "active">>(
   item: T
 ): MenuRoute {
   return Object.assign(item, {
@@ -170,9 +184,9 @@ export interface MenuAction extends MenuItem {
   action: () => any | void;
 }
 
-export function MenuAction<T extends Omit<MenuAction, "kind">>(
-  item: T
-): MenuAction {
+export function MenuAction<
+  T extends Omit<MenuAction, "kind" | "active" | "indentation">
+>(item: T): MenuAction {
   return Object.assign(item, {
     kind: "MenuAction" as "MenuAction",
     active: false,

--- a/src/app/interfaces/menusInterfaces.ts
+++ b/src/app/interfaces/menusInterfaces.ts
@@ -61,6 +61,10 @@ export interface Category extends LabelAndIcon {
    * List of resolvers
    */
   resolvers?: Resolvers;
+  /**
+   * Root MenuRoute
+   */
+  rootChild?: MenuRoute;
 }
 
 /**

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -1,7 +1,6 @@
 import { Type } from "@angular/core";
 import { Route, Routes } from "@angular/router";
 import { getPageInfo } from "../helpers/page/pageComponent";
-import { Category } from "./menusInterfaces";
 
 export type RouteConfigCallback = (
   component: Type<any> | null,

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -139,14 +139,13 @@ export class StrongRoute {
       callback(current.pageComponent, current.config);
       const thisRoute = current.routeConfig;
       const childRoutes = current.children.map(recursiveAdd);
-      thisRoute.children = [...(thisRoute.children || []), ...childRoutes].sort(
-        sortRoutes
-      );
+      const children = [...(thisRoute.children || []), ...childRoutes];
+      thisRoute.children = children.sort(sortRoutes);
       return thisRoute;
     };
 
     const rootRoute = this.root;
-    return recursiveAdd(rootRoute).children;
+    return rootRoute.children.map(recursiveAdd).sort(sortRoutes);
   }
 
   /**

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -1,5 +1,7 @@
 import { Type } from "@angular/core";
 import { Route, Routes } from "@angular/router";
+import { getPageInfo } from "../helpers/page/pageComponent";
+import { Category } from "./menusInterfaces";
 
 export type RouteConfigCallback = (
   component: Type<any> | null,
@@ -115,8 +117,6 @@ export class StrongRoute {
    * @param callback Callback function (usually: GetRouteConfigForPage)
    */
   compileRoutes(callback: RouteConfigCallback): Routes {
-    const rootRoute = this.root;
-
     const sortRoutes = (a: Route, b: Route): -1 | 0 | 1 => {
       const aParamRoute = a.path.startsWith(":");
       const bParamRoute = b.path.startsWith(":");
@@ -146,9 +146,8 @@ export class StrongRoute {
       return thisRoute;
     };
 
-    const output = rootRoute.children.map(recursiveAdd).sort(sortRoutes);
-
-    return output instanceof Array ? output : [output];
+    const rootRoute = this.root;
+    return recursiveAdd(rootRoute).children;
   }
 
   /**


### PR DESCRIPTION
# Category Resolvers

Bandaide solution to applying resolvers to categories which do not have a root page (page with the same route as the category).

## Changes

- Enabled resolvers for pages where the category has no root page

## Issues

- Resolvers are not attached to the category route, instead they are applied to all category children when no root page is given
  - This means that some unnecessary api requests may occur (currently this only really affects the admin pages)
  - A more optimal solution would be to apply the resolvers to the category route instead
- This appears to be a flaw in the architecture, and may require a significant change to how routes are calculated
