### PR TITLE
Owner Predicate

### DIFF
--- a/src/app/app.menus.spec.ts
+++ b/src/app/app.menus.spec.ts
@@ -1,0 +1,121 @@
+import {
+  isAdminPredicate,
+  isGuestPredicate,
+  isLoggedInPredicate,
+  isProjectOwnerPredicate
+} from "./app.menus";
+import { Project } from "./models/Project";
+import { SessionUser } from "./models/User";
+import { ApiErrorDetails } from "./services/baw-api/api.interceptor.service";
+import { ResolvedModel } from "./services/baw-api/resolver-common";
+
+describe("Predicates", () => {
+  let defaultUser: SessionUser;
+  let adminUser: SessionUser;
+  let guestUser: SessionUser;
+
+  beforeEach(() => {
+    defaultUser = new SessionUser({
+      id: 1,
+      userName: "username",
+      authToken: "xxxxxxxxxxxxxxx",
+      rolesMask: 2,
+      rolesMaskNames: ["user"]
+    });
+    adminUser = new SessionUser({
+      id: 1,
+      userName: "username",
+      authToken: "xxxxxxxxxxxxxxx",
+      rolesMask: 3,
+      rolesMaskNames: ["admin"]
+    });
+    guestUser = undefined;
+  });
+
+  describe("isGuestPredicate", () => {
+    it("should be true when logged out", () => {
+      expect(isGuestPredicate(guestUser)).toBeTrue();
+    });
+    it("should be false when logged in", () => {
+      expect(isGuestPredicate(defaultUser)).toBeFalse();
+    });
+  });
+
+  describe("isLoggedInPredicate", () => {
+    it("should be true when logged in", () => {
+      expect(isLoggedInPredicate(defaultUser)).toBeTrue();
+    });
+    it("should be false when logged out", () => {
+      expect(isLoggedInPredicate(guestUser)).toBeFalse();
+    });
+  });
+
+  describe("isProjectOwnerPredicate", () => {
+    let data: {
+      project: ResolvedModel<Project>;
+    };
+
+    beforeEach(() => {
+      data = {
+        project: {
+          model: new Project({
+            id: 1,
+            name: "Project",
+            ownerId: 5
+          })
+        }
+      };
+    });
+
+    it("should be true when logged in as admin", () => {
+      expect(isProjectOwnerPredicate(adminUser, data)).toBeTrue();
+    });
+
+    it("should be true when logged in as owner", () => {
+      const user = new SessionUser({
+        ...defaultUser,
+        id: 5
+      });
+
+      expect(isProjectOwnerPredicate(user, data)).toBeTrue();
+    });
+
+    it("should be false when logged in as regular user", () => {
+      expect(isProjectOwnerPredicate(defaultUser, data)).toBeFalse();
+    });
+
+    it("should be false when logged out", () => {
+      expect(isProjectOwnerPredicate(guestUser, data)).toBeFalse();
+    });
+
+    it("should handle missing data", () => {
+      expect(isProjectOwnerPredicate(defaultUser, undefined)).toBeFalse();
+    });
+
+    it("should handle missing project", () => {
+      expect(isProjectOwnerPredicate(defaultUser, {})).toBeFalse();
+    });
+
+    it("should handle error project", () => {
+      expect(
+        isProjectOwnerPredicate(defaultUser, {
+          project: { status: 401, message: "Unauthorized" } as ApiErrorDetails
+        })
+      ).toBeFalse();
+    });
+  });
+
+  describe("isAdminPredicate", () => {
+    it("should be true when logged in as admin", () => {
+      expect(isAdminPredicate(adminUser)).toBeTrue();
+    });
+
+    it("should be false when logged in as regular user", () => {
+      expect(isAdminPredicate(defaultUser)).toBeFalse();
+    });
+
+    it("should be false when logged out", () => {
+      expect(isAdminPredicate(guestUser)).toBeFalse();
+    });
+  });
+});

--- a/src/app/app.menus.ts
+++ b/src/app/app.menus.ts
@@ -1,5 +1,7 @@
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
+import { Project } from "./models/Project";
 import { SessionUser } from "./models/User";
+import { ResolvedModel } from "./services/baw-api/resolver-common";
 
 export const defaultAudioIcon: IconProp = ["fas", "file-audio"];
 export const defaultDeleteIcon: IconProp = ["fas", "trash"];
@@ -8,7 +10,32 @@ export const defaultNewIcon: IconProp = ["fas", "plus"];
 export const defaultPermissionsIcon: IconProp = ["fas", "key"];
 export const defaultUserIcon: IconProp = ["fas", "user"];
 
+/**
+ * Returns true only if user is a guest
+ * @param user Session User Data
+ */
 export const isGuestPredicate = (user: SessionUser) => !user;
+
+/**
+ * Returns true only if user is logged in
+ * @param user Session User Data
+ */
 export const isLoggedInPredicate = (user: SessionUser) => !!user;
-export const isOwnerPredicate = (user: SessionUser) => !!user;
+
+/**
+ * Returns true only if user is an admin or user id matches project owner id
+ * @param user Session User Data
+ * @param data Page Data
+ */
+export const isProjectOwnerPredicate = (user: SessionUser, data: any) => {
+  const project: ResolvedModel<Project> = data?.project;
+  return (
+    isAdminPredicate(user) || (!!user && user.id === project?.model?.ownerId)
+  );
+};
+
+/**
+ * Returns true only if user is an admin
+ * @param user Session User Data
+ */
 export const isAdminPredicate = (user: SessionUser) => !!user && user.isAdmin;

--- a/src/app/component/projects/projects.menus.ts
+++ b/src/app/component/projects/projects.menus.ts
@@ -5,7 +5,7 @@ import {
   defaultPermissionsIcon,
   isAdminPredicate,
   isLoggedInPredicate,
-  isOwnerPredicate
+  isProjectOwnerPredicate
 } from "src/app/app.menus";
 import { Category, MenuRoute } from "src/app/interfaces/menusInterfaces";
 import { StrongRoute } from "src/app/interfaces/strongRoute";
@@ -77,7 +77,7 @@ export const editProjectMenuItem = MenuRoute({
   icon: defaultEditIcon,
   label: "Edit this project",
   parent: projectMenuItem,
-  predicate: isOwnerPredicate,
+  predicate: isProjectOwnerPredicate,
   route: projectMenuItem.route.add("edit"),
   tooltip: () => "Change the details for this project"
 });
@@ -86,7 +86,7 @@ export const editProjectPermissionsMenuItem = MenuRoute({
   icon: defaultPermissionsIcon,
   label: "Edit permissions",
   parent: projectMenuItem,
-  predicate: isOwnerPredicate,
+  predicate: isProjectOwnerPredicate,
   route: projectMenuItem.route.add("permissions"),
   tooltip: () => "Edit this projects permissions"
 });
@@ -104,7 +104,7 @@ export const deleteProjectMenuItem = MenuRoute({
   icon: defaultDeleteIcon,
   label: "Delete Project",
   parent: projectMenuItem,
-  predicate: isOwnerPredicate,
+  predicate: isProjectOwnerPredicate,
   route: projectMenuItem.route.add("delete"),
   tooltip: () => "Delete this project"
 });

--- a/src/app/component/shared/menu/menu.component.spec.ts
+++ b/src/app/component/shared/menu/menu.component.spec.ts
@@ -4,7 +4,6 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { List } from "immutable";
-import { isGuestPredicate, isLoggedInPredicate } from "src/app/app.menus";
 import { assertIcon, assertTooltip } from "src/app/helpers/tests/helpers";
 import {
   AnyMenuItem,
@@ -15,7 +14,7 @@ import {
 import { StrongRoute } from "src/app/interfaces/strongRoute";
 import { SessionUser } from "src/app/models/User";
 import { SecurityService } from "src/app/services/baw-api/security.service";
-import { testBawServices } from "src/app/test.helper";
+import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
 import { getText } from "src/testHelpers";
 import { SharedModule } from "../shared.module";
 import { MenuButtonComponent } from "./button/button.component";
@@ -33,12 +32,6 @@ describe("MenuComponent", () => {
     userName: "username",
     authToken: "xxxxxxxxxxxxxxx"
   });
-
-  class MockActivatedRoute {
-    public snapshot = {
-      params: { attribute: 10 }
-    };
-  }
 
   function assertTitle(target: HTMLElement, header: string) {
     expect(target).toBeTruthy();
@@ -61,7 +54,7 @@ describe("MenuComponent", () => {
     spyOn(api, "getLocalUser").and.callFake(() => sessionUser);
   }
 
-  beforeEach(() => {
+  function configureTestingModule(data?: any) {
     TestBed.configureTestingModule({
       imports: [
         SharedModule,
@@ -76,7 +69,10 @@ describe("MenuComponent", () => {
       ],
       providers: [
         ...testBawServices,
-        { provide: ActivatedRoute, useClass: MockActivatedRoute }
+        {
+          provide: ActivatedRoute,
+          useClass: mockActivatedRoute(data, { attribute: 10 })
+        }
       ]
     }).compileComponents();
 
@@ -85,135 +81,137 @@ describe("MenuComponent", () => {
     fixture = TestBed.createComponent(MenuComponent);
     component = fixture.componentInstance;
     componentElement = fixture.debugElement;
-  });
+  }
 
   afterEach(() => {
     localStorage.clear();
   });
 
-  it("should create", () => {
-    fixture.detectChanges();
-    expect(component).toBeTruthy();
+  describe("menu", () => {
+    beforeEach(() => {
+      configureTestingModule();
+    });
+
+    it("should create default title when none provided", () => {
+      component.links = List<AnyMenuItem>([]);
+      fixture.detectChanges();
+
+      const title = fixture.nativeElement.querySelector("h6");
+      assertTitle(title, "MENU");
+    });
+
+    it("should create title when provided", () => {
+      component.title = { label: "SECONDARY", icon: ["fas", "home"] };
+      component.links = List<AnyMenuItem>([]);
+      fixture.detectChanges();
+
+      const title = fixture.nativeElement.querySelector("h6");
+      assertTitle(title, "SECONDARY");
+    });
+
+    it("should create title icon when provided", () => {
+      component.title = { label: "SECONDARY", icon: ["fas", "home"] };
+      component.links = List<AnyMenuItem>([]);
+      fixture.detectChanges();
+
+      const title = fixture.nativeElement.querySelector("h6");
+      assertIcon(title, "fas,home");
+    });
+
+    it("should create capitalized title", () => {
+      component.title = { label: "secondary", icon: ["fas", "home"] };
+      component.links = List<AnyMenuItem>([]);
+      fixture.detectChanges();
+
+      const title = fixture.nativeElement.querySelector("h6");
+      assertTitle(title, "SECONDARY");
+    });
+
+    it("should create no links on action menu", () => {
+      component.menuType = "action";
+      component.links = List<AnyMenuItem>([]);
+      fixture.detectChanges();
+
+      expect(findLinks("internal-link").length).toBe(0);
+      expect(findLinks("external-link").length).toBe(0);
+      expect(findLinks("button").length).toBe(0);
+    });
+
+    it("should create no links on secondary menu", () => {
+      component.menuType = "secondary";
+      component.links = List<AnyMenuItem>([]);
+      fixture.detectChanges();
+
+      expect(findLinks("internal-link").length).toBe(0);
+      expect(findLinks("external-link").length).toBe(0);
+      expect(findLinks("button").length).toBe(0);
+    });
+
+    it("should create mixed links on action menu", () => {
+      component.menuType = "action";
+      component.links = List<AnyMenuItem>([
+        MenuRoute({
+          label: "label",
+          icon: ["fas", "home"],
+          tooltip: () => "tooltip",
+          route: StrongRoute.Base.add("home")
+        }),
+        MenuLink({
+          label: "label",
+          icon: ["fas", "home"],
+          tooltip: () => "tooltip",
+          uri: () => "http://brokenlink/"
+        }),
+        MenuAction({
+          label: "label",
+          icon: ["fas", "home"],
+          tooltip: () => "tooltip",
+          action: () => {}
+        })
+      ]);
+      fixture.detectChanges();
+
+      expect(findLinks("internal-link").length).toBe(1);
+      expect(findLinks("external-link").length).toBe(1);
+      expect(findLinks("button").length).toBe(1);
+    });
+
+    it("should create mixed links on secondary menu", () => {
+      component.menuType = "secondary";
+      component.links = List<AnyMenuItem>([
+        MenuRoute({
+          label: "label",
+          icon: ["fas", "home"],
+          tooltip: () => "tooltip",
+          route: StrongRoute.Base.add("home")
+        }),
+        MenuLink({
+          label: "label",
+          icon: ["fas", "home"],
+          tooltip: () => "tooltip",
+          uri: () => "http://brokenlink/"
+        }),
+        MenuAction({
+          label: "label",
+          icon: ["fas", "home"],
+          tooltip: () => "tooltip",
+          action: () => {}
+        })
+      ]);
+      fixture.detectChanges();
+
+      expect(findLinks("internal-link").length).toBe(1);
+      expect(findLinks("external-link").length).toBe(1);
+      expect(findLinks("button").length).toBe(1);
+    });
+
+    xit("should not create widget when none provided", () => {});
+    xit("should create widget when provided", () => {});
   });
-
-  it("should create default title when none provided", () => {
-    component.links = List<AnyMenuItem>([]);
-    fixture.detectChanges();
-
-    const title = fixture.nativeElement.querySelector("h6");
-    assertTitle(title, "MENU");
-  });
-
-  it("should create title when provided", () => {
-    component.title = { label: "SECONDARY", icon: ["fas", "home"] };
-    component.links = List<AnyMenuItem>([]);
-    fixture.detectChanges();
-
-    const title = fixture.nativeElement.querySelector("h6");
-    assertTitle(title, "SECONDARY");
-  });
-
-  it("should create title icon when provided", () => {
-    component.title = { label: "SECONDARY", icon: ["fas", "home"] };
-    component.links = List<AnyMenuItem>([]);
-    fixture.detectChanges();
-
-    const title = fixture.nativeElement.querySelector("h6");
-    assertIcon(title, "fas,home");
-  });
-
-  it("should create capitalized title", () => {
-    component.title = { label: "secondary", icon: ["fas", "home"] };
-    component.links = List<AnyMenuItem>([]);
-    fixture.detectChanges();
-
-    const title = fixture.nativeElement.querySelector("h6");
-    assertTitle(title, "SECONDARY");
-  });
-
-  it("should create no links on action menu", () => {
-    component.menuType = "action";
-    component.links = List<AnyMenuItem>([]);
-    fixture.detectChanges();
-
-    expect(findLinks("internal-link").length).toBe(0);
-    expect(findLinks("external-link").length).toBe(0);
-    expect(findLinks("button").length).toBe(0);
-  });
-
-  it("should create no links on secondary menu", () => {
-    component.menuType = "secondary";
-    component.links = List<AnyMenuItem>([]);
-    fixture.detectChanges();
-
-    expect(findLinks("internal-link").length).toBe(0);
-    expect(findLinks("external-link").length).toBe(0);
-    expect(findLinks("button").length).toBe(0);
-  });
-
-  it("should create mixed links on action menu", () => {
-    component.menuType = "action";
-    component.links = List<AnyMenuItem>([
-      MenuRoute({
-        label: "label",
-        icon: ["fas", "home"],
-        tooltip: () => "tooltip",
-        route: StrongRoute.Base.add("home")
-      }),
-      MenuLink({
-        label: "label",
-        icon: ["fas", "home"],
-        tooltip: () => "tooltip",
-        uri: () => "http://brokenlink/"
-      }),
-      MenuAction({
-        label: "label",
-        icon: ["fas", "home"],
-        tooltip: () => "tooltip",
-        action: () => {}
-      })
-    ]);
-    fixture.detectChanges();
-
-    expect(findLinks("internal-link").length).toBe(1);
-    expect(findLinks("external-link").length).toBe(1);
-    expect(findLinks("button").length).toBe(1);
-  });
-
-  it("should create mixed links on secondary menu", () => {
-    component.menuType = "secondary";
-    component.links = List<AnyMenuItem>([
-      MenuRoute({
-        label: "label",
-        icon: ["fas", "home"],
-        tooltip: () => "tooltip",
-        route: StrongRoute.Base.add("home")
-      }),
-      MenuLink({
-        label: "label",
-        icon: ["fas", "home"],
-        tooltip: () => "tooltip",
-        uri: () => "http://brokenlink/"
-      }),
-      MenuAction({
-        label: "label",
-        icon: ["fas", "home"],
-        tooltip: () => "tooltip",
-        action: () => {}
-      })
-    ]);
-    fixture.detectChanges();
-
-    expect(findLinks("internal-link").length).toBe(1);
-    expect(findLinks("external-link").length).toBe(1);
-    expect(findLinks("button").length).toBe(1);
-  });
-
-  xit("should not create widget when none provided", () => {});
-  xit("should create widget when provided", () => {});
 
   describe("internal links", () => {
     const linkSelector = "internal-link";
+    let defaultLink: MenuRoute;
 
     function assertRoute(target: HTMLElement, route: string) {
       const anchor: HTMLElement = target.querySelector("a");
@@ -226,16 +224,20 @@ describe("MenuComponent", () => {
       ).toBe(route);
     }
 
+    beforeEach(() => {
+      configureTestingModule();
+
+      defaultLink = MenuRoute({
+        label: "label",
+        icon: ["fas", "home"],
+        tooltip: () => "tooltip",
+        route: StrongRoute.Base.add("home")
+      });
+    });
+
     it("should create single link in action menu", () => {
       component.menuType = "action";
-      component.links = List<AnyMenuItem>([
-        MenuRoute({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          route: StrongRoute.Base.add("home")
-        })
-      ]);
+      component.links = List<AnyMenuItem>([defaultLink]);
       fixture.detectChanges();
 
       expect(findLinks("internal-link").length).toBe(1);
@@ -245,14 +247,7 @@ describe("MenuComponent", () => {
 
     it("should create single link in secondary menu", () => {
       component.menuType = "secondary";
-      component.links = List<AnyMenuItem>([
-        MenuRoute({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          route: StrongRoute.Base.add("home")
-        })
-      ]);
+      component.links = List<AnyMenuItem>([defaultLink]);
       fixture.detectChanges();
 
       expect(findLinks("internal-link").length).toBe(1);
@@ -264,16 +259,12 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuRoute({
-          label: "label 1",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          route: StrongRoute.Base.add("home")
+          ...defaultLink,
+          label: "label 1"
         }),
         MenuRoute({
-          label: "label 2",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          route: StrongRoute.Base.add("home")
+          ...defaultLink,
+          label: "label 2"
         })
       ]);
       fixture.detectChanges();
@@ -287,10 +278,8 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuRoute({
-          label: "Custom Label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          route: StrongRoute.Base.add("home")
+          ...defaultLink,
+          label: "Custom Label"
         })
       ]);
       fixture.detectChanges();
@@ -303,10 +292,8 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuRoute({
-          label: "label",
-          icon: ["fas", "exclamation-triangle"],
-          tooltip: () => "tooltip",
-          route: StrongRoute.Base.add("home")
+          ...defaultLink,
+          icon: ["fas", "exclamation-triangle"]
         })
       ]);
       fixture.detectChanges();
@@ -319,10 +306,8 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuRoute({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "Custom Tooltip",
-          route: StrongRoute.Base.add("home")
+          ...defaultLink,
+          tooltip: () => "Custom Tooltip"
         })
       ]);
       fixture.detectChanges();
@@ -336,10 +321,8 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuRoute({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: user => `${user.userName} tooltip`,
-          route: StrongRoute.Base.add("home")
+          ...defaultLink,
+          tooltip: user => `${user.userName} tooltip`
         })
       ]);
       fixture.detectChanges();
@@ -352,9 +335,7 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuRoute({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
+          ...defaultLink,
           route: StrongRoute.Base.add("custom_route")
         })
       ]);
@@ -368,9 +349,7 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuRoute({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
+          ...defaultLink,
           route: StrongRoute.Base.add("home").add(":attribute")
         })
       ]);
@@ -385,9 +364,7 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuRoute({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
+          ...defaultLink,
           route: StrongRoute.Base.add("home")
         })
       ]);
@@ -397,22 +374,18 @@ describe("MenuComponent", () => {
       expect(links.length).toBe(1);
     });
 
-    it("should filter authenticated only links", () => {
+    it("should filter links without passing predicates", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuRoute({
+          ...defaultLink,
           label: "label 1",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          route: StrongRoute.Base.add("home"),
-          predicate: isGuestPredicate
+          predicate: () => true
         }),
         MenuRoute({
+          ...defaultLink,
           label: "label 2",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          route: StrongRoute.Base.add("home"),
-          predicate: isLoggedInPredicate
+          predicate: () => false
         })
       ]);
       fixture.detectChanges();
@@ -422,41 +395,9 @@ describe("MenuComponent", () => {
       assertLabel(links[0], "label 1");
     });
 
-    it("should filter guest only links", () => {
-      setLoggedInState();
-      component.menuType = "action";
-      component.links = List<AnyMenuItem>([
-        MenuRoute({
-          label: "label 1",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          route: StrongRoute.Base.add("home"),
-          predicate: isGuestPredicate
-        }),
-        MenuRoute({
-          label: "label 2",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          route: StrongRoute.Base.add("home"),
-          predicate: isLoggedInPredicate
-        })
-      ]);
-      fixture.detectChanges();
-
-      const links = findLinks(linkSelector);
-      expect(links.length).toBe(1);
-      assertLabel(links[0], "label 2");
-    });
-
     it("should filter duplicate links (by object identity)", () => {
-      const menuRoute = MenuRoute({
-        label: "label",
-        icon: ["fas", "home"],
-        tooltip: () => "tooltip",
-        route: StrongRoute.Base.add("home")
-      });
       component.menuType = "action";
-      component.links = List<AnyMenuItem>([menuRoute, menuRoute]);
+      component.links = List<AnyMenuItem>([defaultLink, defaultLink]);
       fixture.detectChanges();
 
       const links = findLinks(linkSelector);
@@ -466,6 +407,7 @@ describe("MenuComponent", () => {
 
   describe("external links", () => {
     const linkSelector = "external-link";
+    let defaultLink: MenuLink;
 
     function assertHref(target: HTMLElement, href: string) {
       const anchor: HTMLAnchorElement = target.querySelector("a");
@@ -473,16 +415,19 @@ describe("MenuComponent", () => {
       expect(anchor.href).toBe(href);
     }
 
+    beforeEach(() => {
+      configureTestingModule();
+      defaultLink = MenuLink({
+        label: "label",
+        icon: ["fas", "home"],
+        tooltip: () => "tooltip",
+        uri: () => "http://brokenlink/"
+      });
+    });
+
     it("should create single link in action menu", () => {
       component.menuType = "action";
-      component.links = List<AnyMenuItem>([
-        MenuLink({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          uri: () => "http://brokenlink/"
-        })
-      ]);
+      component.links = List<AnyMenuItem>([defaultLink]);
       fixture.detectChanges();
 
       expect(findLinks("internal-link").length).toBe(0);
@@ -492,14 +437,7 @@ describe("MenuComponent", () => {
 
     it("should create single link in secondary menu", () => {
       component.menuType = "secondary";
-      component.links = List<AnyMenuItem>([
-        MenuLink({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          uri: () => "http://brokenlink/"
-        })
-      ]);
+      component.links = List<AnyMenuItem>([defaultLink]);
       fixture.detectChanges();
 
       expect(findLinks("internal-link").length).toBe(0);
@@ -511,16 +449,12 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuLink({
-          label: "label 1",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          uri: () => "http://brokenlink/"
+          ...defaultLink,
+          label: "label 1"
         }),
         MenuLink({
-          label: "label 2",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          uri: () => "http://brokenlink/"
+          ...defaultLink,
+          label: "label 2"
         })
       ]);
       fixture.detectChanges();
@@ -534,10 +468,8 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuLink({
-          label: "Custom Label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          uri: () => "http://brokenlink/"
+          ...defaultLink,
+          label: "Custom Label"
         })
       ]);
       fixture.detectChanges();
@@ -550,10 +482,8 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuLink({
-          label: "label",
-          icon: ["fas", "exclamation-triangle"],
-          tooltip: () => "tooltip",
-          uri: () => "http://brokenlink/"
+          ...defaultLink,
+          icon: ["fas", "exclamation-triangle"]
         })
       ]);
       fixture.detectChanges();
@@ -566,10 +496,8 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuLink({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "Custom Tooltip",
-          uri: () => "http://brokenlink/"
+          ...defaultLink,
+          tooltip: () => "Custom Tooltip"
         })
       ]);
       fixture.detectChanges();
@@ -583,10 +511,8 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuLink({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: user => `${user.userName} tooltip`,
-          uri: () => "http://brokenlink/"
+          ...defaultLink,
+          tooltip: user => `${user.userName} tooltip`
         })
       ]);
       fixture.detectChanges();
@@ -599,9 +525,7 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuLink({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
+          ...defaultLink,
           uri: () => "http://brokenlink/"
         })
       ]);
@@ -615,9 +539,7 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuLink({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
+          ...defaultLink,
           uri: params => "http://brokenlink/" + params.attribute
         })
       ]);
@@ -630,36 +552,25 @@ describe("MenuComponent", () => {
     it("should not filter links without predicate", () => {
       setLoggedInState();
       component.menuType = "action";
-      component.links = List<AnyMenuItem>([
-        MenuLink({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          uri: () => "http://brokenlink/"
-        })
-      ]);
+      component.links = List<AnyMenuItem>([defaultLink]);
       fixture.detectChanges();
 
       const links = findLinks(linkSelector);
       expect(links.length).toBe(1);
     });
 
-    it("should filter authenticated only links", () => {
+    it("should filter links without passing predicates", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuLink({
+          ...defaultLink,
           label: "label 1",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          uri: () => "http://brokenlink/",
-          predicate: isGuestPredicate
+          predicate: () => true
         }),
         MenuLink({
+          ...defaultLink,
           label: "label 2",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          uri: () => "http://brokenlink/",
-          predicate: isLoggedInPredicate
+          predicate: () => false
         })
       ]);
       fixture.detectChanges();
@@ -669,41 +580,9 @@ describe("MenuComponent", () => {
       assertLabel(links[0], "label 1");
     });
 
-    it("should filter guest only links", () => {
-      setLoggedInState();
-      component.menuType = "action";
-      component.links = List<AnyMenuItem>([
-        MenuLink({
-          label: "label 1",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          uri: () => "http://brokenlink/",
-          predicate: isGuestPredicate
-        }),
-        MenuLink({
-          label: "label 2",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          uri: () => "http://brokenlink/",
-          predicate: isLoggedInPredicate
-        })
-      ]);
-      fixture.detectChanges();
-
-      const links = findLinks(linkSelector);
-      expect(links.length).toBe(1);
-      assertLabel(links[0], "label 2");
-    });
-
     it("should filter duplicate links (by object identity)", () => {
-      const menuLink = MenuLink({
-        label: "label",
-        icon: ["fas", "home"],
-        tooltip: () => "tooltip",
-        uri: () => "http://brokenlink/"
-      });
       component.menuType = "action";
-      component.links = List<AnyMenuItem>([menuLink, menuLink]);
+      component.links = List<AnyMenuItem>([defaultLink, defaultLink]);
       fixture.detectChanges();
 
       const links = findLinks(linkSelector);
@@ -713,6 +592,7 @@ describe("MenuComponent", () => {
 
   describe("action buttons", () => {
     const linkSelector = "button";
+    let defaultLink: MenuAction;
 
     function assertFunction(target: HTMLElement, spy: jasmine.Spy) {
       const button: HTMLButtonElement = target.querySelector("button");
@@ -722,16 +602,19 @@ describe("MenuComponent", () => {
       expect(spy).toHaveBeenCalled();
     }
 
+    beforeEach(() => {
+      configureTestingModule();
+      defaultLink = MenuAction({
+        label: "label",
+        icon: ["fas", "home"],
+        tooltip: () => "tooltip",
+        action: () => {}
+      });
+    });
+
     it("should create single link in action menu", () => {
       component.menuType = "action";
-      component.links = List<AnyMenuItem>([
-        MenuAction({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          action: () => {}
-        })
-      ]);
+      component.links = List<AnyMenuItem>([defaultLink]);
       fixture.detectChanges();
 
       expect(findLinks("internal-link").length).toBe(0);
@@ -741,14 +624,7 @@ describe("MenuComponent", () => {
 
     it("should create single link in secondary menu", () => {
       component.menuType = "secondary";
-      component.links = List<AnyMenuItem>([
-        MenuAction({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          action: () => {}
-        })
-      ]);
+      component.links = List<AnyMenuItem>([defaultLink]);
       fixture.detectChanges();
 
       expect(findLinks("internal-link").length).toBe(0);
@@ -760,16 +636,12 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuAction({
-          label: "label 1",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          action: () => {}
+          ...defaultLink,
+          label: "label 1"
         }),
         MenuAction({
-          label: "label 2",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          action: () => {}
+          ...defaultLink,
+          label: "label 2"
         })
       ]);
       fixture.detectChanges();
@@ -783,10 +655,8 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuAction({
-          label: "Custom Label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          action: () => {}
+          ...defaultLink,
+          label: "Custom Label"
         })
       ]);
       fixture.detectChanges();
@@ -799,10 +669,8 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuAction({
-          label: "label",
-          icon: ["fas", "exclamation-triangle"],
-          tooltip: () => "tooltip",
-          action: () => {}
+          ...defaultLink,
+          icon: ["fas", "exclamation-triangle"]
         })
       ]);
       fixture.detectChanges();
@@ -815,10 +683,8 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuAction({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "Custom Tooltip",
-          action: () => {}
+          ...defaultLink,
+          tooltip: () => "Custom Tooltip"
         })
       ]);
       fixture.detectChanges();
@@ -832,10 +698,8 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuAction({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: user => `${user.userName} tooltip`,
-          action: () => {}
+          ...defaultLink,
+          tooltip: user => `${user.userName} tooltip`
         })
       ]);
       fixture.detectChanges();
@@ -849,10 +713,7 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuAction({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          action: () => {}
+          ...defaultLink
         })
       ]);
       fixture.detectChanges();
@@ -861,22 +722,18 @@ describe("MenuComponent", () => {
       expect(links.length).toBe(1);
     });
 
-    it("should filter authenticated only links", () => {
+    it("should filter links without passing predicates", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuAction({
+          ...defaultLink,
           label: "label 1",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          action: () => {},
-          predicate: isGuestPredicate
+          predicate: () => true
         }),
         MenuAction({
+          ...defaultLink,
           label: "label 2",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          action: () => {},
-          predicate: isLoggedInPredicate
+          predicate: () => false
         })
       ]);
       fixture.detectChanges();
@@ -886,41 +743,9 @@ describe("MenuComponent", () => {
       assertLabel(links[0], "label 1");
     });
 
-    it("should filter guest only links", () => {
-      setLoggedInState();
-      component.menuType = "action";
-      component.links = List<AnyMenuItem>([
-        MenuAction({
-          label: "label 1",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          action: () => {},
-          predicate: isGuestPredicate
-        }),
-        MenuAction({
-          label: "label 2",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
-          action: () => {},
-          predicate: isLoggedInPredicate
-        })
-      ]);
-      fixture.detectChanges();
-
-      const links = findLinks(linkSelector);
-      expect(links.length).toBe(1);
-      assertLabel(links[0], "label 2");
-    });
-
     it("should filter duplicate links (by object identity)", () => {
-      const menuLink = MenuAction({
-        label: "label",
-        icon: ["fas", "home"],
-        tooltip: () => "tooltip",
-        action: () => {}
-      });
       component.menuType = "action";
-      component.links = List<AnyMenuItem>([menuLink, menuLink]);
+      component.links = List<AnyMenuItem>([defaultLink, defaultLink]);
       fixture.detectChanges();
 
       const links = findLinks(linkSelector);
@@ -932,9 +757,7 @@ describe("MenuComponent", () => {
       component.menuType = "action";
       component.links = List<AnyMenuItem>([
         MenuAction({
-          label: "label",
-          icon: ["fas", "home"],
-          tooltip: () => "tooltip",
+          ...defaultLink,
           action: spy
         })
       ]);
@@ -973,6 +796,10 @@ describe("MenuComponent", () => {
       component.menuType = menuType;
       fixture.detectChanges();
     }
+
+    beforeEach(() => {
+      configureTestingModule();
+    });
 
     it("should order links on secondary menu", () => {
       arrange(3, 2, 1, "secondary");
@@ -1187,6 +1014,96 @@ describe("MenuComponent", () => {
         "label b",
         "tooltip"
       ]);
+    });
+  });
+
+  describe("predicate", () => {
+    it("should not call predicate with user when unauthenticated", () => {
+      configureTestingModule();
+      const link = MenuRoute({
+        label: "label",
+        icon: ["fas", "home"],
+        tooltip: () => "tooltip",
+        route: StrongRoute.Base.add("home"),
+        predicate: (user, data) => true
+      });
+
+      spyOn(link, "predicate").and.callThrough();
+
+      component.menuType = "action";
+      component.links = List<AnyMenuItem>([link]);
+      fixture.detectChanges();
+
+      expect(link.predicate).toHaveBeenCalledWith(null, {});
+    });
+
+    it("should call predicate with user with authenticated", () => {
+      configureTestingModule();
+      setLoggedInState();
+      const link = MenuRoute({
+        label: "label",
+        icon: ["fas", "home"],
+        tooltip: () => "tooltip",
+        route: StrongRoute.Base.add("home"),
+        predicate: (user, data) => true
+      });
+
+      spyOn(link, "predicate").and.callThrough();
+
+      component.menuType = "action";
+      component.links = List<AnyMenuItem>([link]);
+      fixture.detectChanges();
+
+      expect(link.predicate).toHaveBeenCalledWith(sessionUser, {});
+    });
+
+    it("should call predicate with page data when unauthenticated", () => {
+      const pageData = {
+        value1: 1,
+        value2: 2
+      };
+
+      configureTestingModule(pageData);
+      const link = MenuRoute({
+        label: "label",
+        icon: ["fas", "home"],
+        tooltip: () => "tooltip",
+        route: StrongRoute.Base.add("home"),
+        predicate: (user, data) => true
+      });
+
+      spyOn(link, "predicate").and.callThrough();
+
+      component.menuType = "action";
+      component.links = List<AnyMenuItem>([link]);
+      fixture.detectChanges();
+
+      expect(link.predicate).toHaveBeenCalledWith(null, pageData);
+    });
+
+    it("should call predicate with page data when authenticated", () => {
+      const pageData = {
+        value1: 1,
+        value2: 2
+      };
+
+      configureTestingModule(pageData);
+      setLoggedInState();
+      const link = MenuRoute({
+        label: "label",
+        icon: ["fas", "home"],
+        tooltip: () => "tooltip",
+        route: StrongRoute.Base.add("home"),
+        predicate: (user, data) => true
+      });
+
+      spyOn(link, "predicate").and.callThrough();
+
+      component.menuType = "action";
+      component.links = List<AnyMenuItem>([link]);
+      fixture.detectChanges();
+
+      expect(link.predicate).toHaveBeenCalledWith(sessionUser, pageData);
     });
   });
 });

--- a/src/app/component/shared/menu/menu.component.ts
+++ b/src/app/component/shared/menu/menu.component.ts
@@ -58,6 +58,7 @@ export class MenuComponent extends WithUnsubscribe() implements OnInit {
     // Get user details
     this.user = this.api.getLocalUser();
     this.placement = this.menuType === "action" ? "left" : "right";
+    const pageData = this.route.snapshot.data;
 
     // Filter links
     this.filteredLinks = new Set(
@@ -70,7 +71,7 @@ export class MenuComponent extends WithUnsubscribe() implements OnInit {
           }
 
           // If link has predicate function, test if returns true
-          return link.predicate(this?.user);
+          return link.predicate(this?.user, pageData);
         })
         ?.sort(this.compare)
     );

--- a/src/app/component/sites/sites.menus.ts
+++ b/src/app/component/sites/sites.menus.ts
@@ -5,7 +5,7 @@ import {
   defaultNewIcon,
   isAdminPredicate,
   isLoggedInPredicate,
-  isOwnerPredicate
+  isProjectOwnerPredicate
 } from "src/app/app.menus";
 import {
   Category,
@@ -30,7 +30,7 @@ export const newSiteMenuItem = MenuRoute({
   icon: defaultNewIcon,
   label: "New site",
   parent: projectMenuItem,
-  predicate: isLoggedInPredicate,
+  predicate: isProjectOwnerPredicate,
   route: sitesRoute.add("new"),
   tooltip: () => "Create a new site"
 });
@@ -55,7 +55,7 @@ export const editSiteMenuItem = MenuRoute({
   icon: defaultEditIcon,
   label: "Edit this site",
   parent: siteMenuItem,
-  predicate: isOwnerPredicate,
+  predicate: isProjectOwnerPredicate,
   route: siteMenuItem.route.add("edit"),
   tooltip: () => "Change the details for this site"
 });
@@ -64,7 +64,7 @@ export const harvestMenuItem = MenuRoute({
   icon: defaultAudioIcon,
   label: "Harvesting",
   parent: siteMenuItem,
-  predicate: isAdminPredicate,
+  predicate: isProjectOwnerPredicate,
   route: siteMenuItem.route.add("harvest"),
   tooltip: () => "Upload new audio to this site"
 });
@@ -73,7 +73,7 @@ export const deleteSiteMenuItem = MenuRoute({
   icon: defaultDeleteIcon,
   label: "Delete Site",
   parent: siteMenuItem,
-  predicate: isOwnerPredicate,
+  predicate: isProjectOwnerPredicate,
   route: siteMenuItem.route.add("delete"),
   tooltip: () => "Delete this site"
 });

--- a/src/app/interfaces/menusInterfaces.ts
+++ b/src/app/interfaces/menusInterfaces.ts
@@ -72,7 +72,7 @@ export type MenuItemKinds = "MenuAction" | "MenuLink" | "MenuRoute";
 /**
  * User callback function
  */
-export type UserCallback<T> = null | ((user?: SessionUser) => T);
+export type UserCallback<T> = null | ((user?: SessionUser, data?: any) => T);
 
 /**
  * An item designed to be in a menu.

--- a/src/app/test.helper.ts
+++ b/src/app/test.helper.ts
@@ -82,7 +82,7 @@ export function mockActivatedRoute(
   queryParams: Params = {}
 ) {
   return class MockActivatedRoute {
-    public snapshot = { data, queryParams };
+    public snapshot = { data, params, queryParams };
     public data = new BehaviorSubject<any>(data);
     public params = new BehaviorSubject<any>(params);
     public queryParams = new BehaviorSubject<Params>(queryParams);


### PR DESCRIPTION
# Link Project Owner Predicate

Updated link predicate for detecting project owners so that it now checks the `user.id` against the `project.ownerId`.

## Issues

- Currently the BAW Server does not provide the ownerId in its output for a project so this predicate only functions for the admin user group
- Unit tests failing on edge browser (will fix in separate PR)
  - AdminUserListComponent > api > should request final page from api
  - AdminUserListComponent > api > should request the second page from api
  - AdminUserListComponent > api > should request next page from api

## Closes

Closes #144 