### PR TITLE
Remove redundant tests

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -17,7 +17,7 @@ import { BehaviorSubject, Subject } from "rxjs";
 import { AppComponent } from "./app.component";
 import { appLibraryImports } from "./app.module";
 import { homeMenuItem } from "./component/home/home.menus";
-import { projectsMenuItem } from "./component/projects/projects.menus";
+import { SharedModule } from "./component/shared/shared.module";
 import { Project } from "./models/Project";
 import { AppConfigService } from "./services/app-config/app-config.service";
 import { ProjectsService } from "./services/baw-api/projects.service";
@@ -36,6 +36,7 @@ describe("AppComponent", () => {
     TestBed.configureTestingModule({
       imports: [
         ...appLibraryImports,
+        SharedModule,
         RouterTestingModule,
         HttpClientTestingModule,
         LoadingBarHttpClientModule

--- a/src/app/component/admin/user-list/user-list.component.spec.ts
+++ b/src/app/component/admin/user-list/user-list.component.spec.ts
@@ -134,12 +134,6 @@ describe("AdminUserListComponent", () => {
       });
       spyOn(api, "filter").and.callFake((filter: Filters) => {
         if (counter === 1) {
-          console.log(
-            "Second Filter: ",
-            filter.paging.page,
-            expectation.paging.page
-          );
-
           expect(filter).toEqual(expectation);
           done();
         } else {

--- a/src/app/component/projects/pages/edit/edit.component.spec.ts
+++ b/src/app/component/projects/pages/edit/edit.component.spec.ts
@@ -1,13 +1,8 @@
-import {
-  ComponentFixture,
-  fakeAsync,
-  flush,
-  TestBed
-} from "@angular/core/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ToastrService } from "ngx-toastr";
-import { BehaviorSubject, Subject } from "rxjs";
+import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { SharedModule } from "src/app/component/shared/shared.module";
 import { Project } from "src/app/models/Project";
@@ -17,12 +12,7 @@ import {
   ProjectsService
 } from "src/app/services/baw-api/projects.service";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
-import {
-  getInputs,
-  inputValue,
-  submitForm,
-  testFormlyField
-} from "src/testHelpers";
+import { assertFormErrorHandling, testFormlyFields } from "src/testHelpers";
 import { fields } from "../../project.json";
 import { EditComponent } from "./edit.component";
 
@@ -34,10 +24,6 @@ describe("ProjectsEditComponent", () => {
   let fixture: ComponentFixture<EditComponent>;
   let notifications: ToastrService;
   let router: Router;
-
-  const nameIndex = 0;
-  const descriptionIndex = 1;
-  const imageIndex = 2;
 
   function configureTestingModule(
     project: Project,
@@ -89,132 +75,65 @@ describe("ProjectsEditComponent", () => {
     };
   });
 
-  it("should create", () => {
-    configureTestingModule(defaultProject, undefined);
-
-    expect(component).toBeTruthy();
-  });
-
-  it("should handle project error", fakeAsync(() => {
-    configureTestingModule(undefined, defaultError);
-
-    const body = fixture.nativeElement;
-    expect(body.childElementCount).toBe(0);
-  }));
+  const formInputs = [
+    {
+      testGroup: "Project Name Input",
+      setup: undefined,
+      field: fields[0],
+      key: "name",
+      htmlType: "input",
+      required: true,
+      label: "Project Name",
+      type: "text",
+      description: undefined
+    },
+    {
+      testGroup: "Project Description Input",
+      setup: undefined,
+      field: fields[1],
+      key: "description",
+      htmlType: "textarea",
+      required: false,
+      label: "Description",
+      type: undefined,
+      description: undefined
+    },
+    {
+      testGroup: "Project Image Input",
+      setup: undefined,
+      field: fields[2],
+      key: "image",
+      htmlType: "image",
+      required: false,
+      label: "Image",
+      type: undefined,
+      description: undefined
+    }
+  ];
 
   describe("form", () => {
-    it("should eventually load form", () => {
-      configureTestingModule(defaultProject, undefined);
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']")
-      ).toBeTruthy();
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']").disabled
-      ).toBeFalsy();
-    });
-
-    it("should contain three inputs", () => {
-      configureTestingModule(defaultProject, undefined);
-      expect(
-        fixture.nativeElement.querySelectorAll("form formly-field").length
-      ).toBe(3);
-    });
-
-    it("should display form with project name in title", fakeAsync(() => {
-      const project = new Project({
-        id: 1,
-        name: "Custom Project"
-      });
-      configureTestingModule(project, undefined);
-
-      const title = fixture.nativeElement.querySelector("h2");
-      expect(title).toBeTruthy();
-      expect(title.innerText).toContain("Custom Project");
-    }));
-
-    /* Project Name Input */
-    testFormlyField(
-      "Project Name Input",
-      () => {
-        configureTestingModule(defaultProject, undefined);
-      },
-      fields[0],
-      "name",
-      "input",
-      true,
-      "Project Name",
-      "text"
-    );
-
-    /* Project Description Input */
-    testFormlyField(
-      "Project Description Input",
-      () => {
-        configureTestingModule(defaultProject, undefined);
-      },
-      fields[1],
-      "description",
-      "textarea",
-      false,
-      "Description"
-    );
-
-    /* Project Image Input */
-    testFormlyField(
-      "Project Image Input",
-      () => {
-        configureTestingModule(defaultProject, undefined);
-      },
-      fields[2],
-      "image",
-      "image",
-      false,
-      "Image"
-    );
-
-    it("should pre-fill project name", () => {
-      const project = new Project({
-        id: 1,
-        name: "Custom Project"
-      });
-      configureTestingModule(project, undefined);
-
-      const inputs = getInputs(fixture);
-      expect(inputs[nameIndex].querySelector("input").value).toBe(
-        "Custom Project"
-      );
-    });
-
-    it("should pre-fill project description", () => {
-      const project = new Project({
-        id: 1,
-        name: "Project",
-        description: "Custom Description"
-      });
-      configureTestingModule(project, undefined);
-
-      const inputs = getInputs(fixture);
-      expect(inputs[descriptionIndex].querySelector("textarea").value).toBe(
-        "Custom Description"
-      );
-    });
+    testFormlyFields(formInputs);
   });
 
-  describe("form error handling", () => {
-    it("should show error message with missing project name", fakeAsync(() => {
+  describe("component", () => {
+    it("should create", () => {
       configureTestingModule(defaultProject, undefined);
+      expect(component).toBeTruthy();
+    });
 
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "");
-      submitForm(fixture);
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
-      );
-    }));
-  });
+    it("should handle project error", () => {
+      configureTestingModule(undefined, defaultError);
+      assertFormErrorHandling(fixture);
+    });
 
-  describe("failed submissions", () => {
-    it("should handle general error", fakeAsync(() => {
+    it("should call api", () => {
+      configureTestingModule(defaultProject, undefined);
+      spyOn(api, "update").and.callThrough();
+      component.submit({});
+      expect(api.update).toHaveBeenCalled();
+    });
+
+    it("should handle general error", () => {
       configureTestingModule(defaultProject, undefined);
       spyOn(api, "update").and.callFake(() => {
         const subject = new Subject<Project>();
@@ -227,16 +146,14 @@ describe("ProjectsEditComponent", () => {
         return subject;
       });
 
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Project");
-      submitForm(fixture);
+      component.submit(defaultProject);
 
       expect(notifications.error).toHaveBeenCalledWith(
         "Sign in to access this feature."
       );
-    }));
+    });
 
-    it("should handle duplicate project name", fakeAsync(() => {
+    it("should handle duplicate project name", () => {
       configureTestingModule(defaultProject, undefined);
       spyOn(api, "update").and.callFake(() => {
         const subject = new Subject<Project>();
@@ -257,164 +174,11 @@ describe("ProjectsEditComponent", () => {
         return subject;
       });
 
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Test Project");
-      submitForm(fixture);
+      component.submit(defaultProject);
 
       expect(notifications.error).toHaveBeenCalledWith(
         "Record could not be saved<br />name has already been taken"
       );
-    }));
-
-    it("should re-enable submit button after failed submission", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined);
-      spyOn(api, "update").and.callFake(() => {
-        const subject = new Subject<Project>();
-
-        subject.error({
-          message: "Sign in to access this feature.",
-          info: 401
-        } as ApiErrorDetails);
-
-        return subject;
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Project");
-      submitForm(fixture);
-
-      flush();
-      fixture.detectChanges();
-
-      const button = fixture.nativeElement.querySelector(
-        "button[type='submit']"
-      );
-      expect(button).toBeTruthy();
-      expect(button.disabled).toBeFalsy("Button should not be disabled");
-    }));
-  });
-
-  describe("successful submissions", () => {
-    it("should call update", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined);
-      spyOn(api, "update");
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Test Project");
-      submitForm(fixture);
-
-      expect(api.update).toHaveBeenCalled();
-    }));
-
-    it("should call update with name", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined);
-      spyOn(api, "update");
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Test Project");
-      submitForm(fixture);
-
-      expect(api.update).toHaveBeenCalledWith(
-        new Project({ id: 1, name: "Test Project" })
-      );
-    }));
-
-    it("should call update with description", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined);
-      spyOn(api, "update");
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Test Project");
-      inputValue(inputs[descriptionIndex], "textarea", "Test Description");
-      submitForm(fixture);
-
-      expect(api.update).toHaveBeenCalledWith(
-        new Project({
-          id: 1,
-          name: "Test Project",
-          description: "Test Description"
-        })
-      );
-    }));
-
-    xit("should call update with image", fakeAsync(() => {}));
-
-    it("should call update on submit", fakeAsync(() => {
-      const project = new Project({
-        id: 1,
-        name: "Custom Project"
-      });
-      configureTestingModule(project, undefined);
-      spyOn(api, "update").and.callFake(() => {
-        return new BehaviorSubject<Project>(
-          new Project({
-            id: 1,
-            name: "Test Project"
-          })
-        );
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Custom Project");
-      submitForm(fixture);
-
-      expect(notifications.success).toHaveBeenCalledWith(
-        "Successfully updated Custom Project"
-      );
-    }));
-
-    it("should navigate user to project on submit", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined);
-      const project = new Project({
-        id: 1,
-        name: "Project"
-      });
-
-      spyOn(api, "update").and.callFake(() => {
-        return new BehaviorSubject<Project>(project);
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Project");
-      submitForm(fixture);
-
-      expect(router.navigateByUrl).toHaveBeenCalledWith(project.redirectPath());
-    }));
-
-    it("should disable submit button during submission", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined);
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Project");
-      submitForm(fixture);
-
-      flush();
-      fixture.detectChanges();
-
-      const button = fixture.nativeElement.querySelector(
-        "button[type='submit']"
-      );
-      expect(button).toBeTruthy();
-      expect(button.disabled).toBeTruthy("Button should be disabled");
-    }));
-
-    it("should reset form on successful submit", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined);
-      spyOn(component, "resetForms");
-      spyOn(api, "update").and.callFake(() => {
-        return new BehaviorSubject<Project>(
-          new Project({
-            id: 1,
-            name: "Project"
-          })
-        );
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Project");
-      submitForm(fixture);
-
-      expect(component.resetForms).toHaveBeenCalled();
-      expect(component.isFormTouched()).toBeFalse();
-    }));
+    });
   });
 });

--- a/src/app/component/projects/pages/new/new.component.spec.ts
+++ b/src/app/component/projects/pages/new/new.component.spec.ts
@@ -1,25 +1,15 @@
-import {
-  ComponentFixture,
-  fakeAsync,
-  flush,
-  TestBed
-} from "@angular/core/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ToastrService } from "ngx-toastr";
-import { BehaviorSubject, Subject } from "rxjs";
+import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { SharedModule } from "src/app/component/shared/shared.module";
 import { Project } from "src/app/models/Project";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
 import { ProjectsService } from "src/app/services/baw-api/projects.service";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
-import {
-  getInputs,
-  inputValue,
-  submitForm,
-  testFormlyField
-} from "src/testHelpers";
+import { testFormlyFields } from "src/testHelpers";
 import { fields } from "../../project.json";
 import { NewComponent } from "./new.component";
 
@@ -30,106 +20,103 @@ describe("ProjectsNewComponent", () => {
   let notifications: ToastrService;
   let router: Router;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
-      declarations: [NewComponent],
-      providers: [
-        ...testBawServices,
-        {
-          provide: ActivatedRoute,
-          useClass: mockActivatedRoute()
-        }
-      ]
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(NewComponent);
-    api = TestBed.inject(ProjectsService);
-    router = TestBed.inject(Router);
-    notifications = TestBed.inject(ToastrService);
-    component = fixture.componentInstance;
-
-    spyOn(notifications, "success").and.stub();
-    spyOn(notifications, "error").and.stub();
-    spyOn(router, "navigateByUrl").and.stub();
-
-    fixture.detectChanges();
-  });
-
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+  const formInputs = [
+    {
+      testGroup: "Project Name Input",
+      setup: undefined,
+      field: fields[0],
+      key: "name",
+      htmlType: "input",
+      required: true,
+      label: "Project Name",
+      type: "text",
+      description: undefined
+    },
+    {
+      testGroup: "Project Description Input",
+      setup: undefined,
+      field: fields[1],
+      key: "description",
+      htmlType: "textarea",
+      required: false,
+      label: "Description",
+      type: undefined,
+      description: undefined
+    },
+    {
+      testGroup: "Project Image Input",
+      setup: undefined,
+      field: fields[2],
+      key: "image",
+      htmlType: "image",
+      required: false,
+      label: "Image",
+      type: undefined,
+      description: undefined
+    }
+  ];
 
   describe("form", () => {
-    it("should eventually load form", () => {
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']")
-      ).toBeTruthy();
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']").disabled
-      ).toBeFalsy();
-    });
-
-    it("should contain three inputs", () => {
-      expect(
-        fixture.nativeElement.querySelectorAll("form formly-field").length
-      ).toBe(3);
-    });
-
-    /* Project Name Input */
-    testFormlyField(
-      "Project Name Input",
-      undefined,
-      fields[0],
-      "name",
-      "input",
-      true,
-      "Project Name",
-      "text"
-    );
-
-    /* Project Description Textarea */
-    testFormlyField(
-      "Project Description Input",
-      undefined,
-      fields[1],
-      "description",
-      "textarea",
-      false,
-      "Description"
-    );
-
-    /* Project Image Input */
-    testFormlyField(
-      "Project Image Input",
-      undefined,
-      fields[2],
-      "image",
-      "image",
-      false,
-      "Image"
-    );
+    testFormlyFields(formInputs);
   });
 
-  describe("form error handling", () => {
-    it("should not call submit function with missing project name", fakeAsync(() => {
-      spyOn(component, "submit");
+  describe("component", () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+        declarations: [NewComponent],
+        providers: [
+          ...testBawServices,
+          {
+            provide: ActivatedRoute,
+            useClass: mockActivatedRoute()
+          }
+        ]
+      }).compileComponents();
 
-      submitForm(fixture);
-      expect(component.submit).not.toHaveBeenCalled();
-    }));
+      fixture = TestBed.createComponent(NewComponent);
+      api = TestBed.inject(ProjectsService);
+      router = TestBed.inject(Router);
+      notifications = TestBed.inject(ToastrService);
+      component = fixture.componentInstance;
 
-    it("should show error message with missing project name", fakeAsync(() => {
-      submitForm(fixture);
+      spyOn(notifications, "success").and.stub();
+      spyOn(notifications, "error").and.stub();
+      spyOn(router, "navigateByUrl").and.stub();
+
+      fixture.detectChanges();
+    });
+
+    it("should create", () => {
+      expect(component).toBeTruthy();
+    });
+
+    it("should call api", () => {
+      spyOn(api, "create").and.callThrough();
+      component.submit({});
+      expect(api.create).toHaveBeenCalled();
+    });
+
+    it("should handle general error", () => {
+      spyOn(api, "create").and.callFake(() => {
+        const subject = new Subject<Project>();
+
+        subject.error({
+          message: "Sign in to access this feature.",
+          info: 401
+        } as ApiErrorDetails);
+
+        return subject;
+      });
+
+      component.submit({});
 
       expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
+        "Sign in to access this feature."
       );
-    }));
-  });
+    });
 
-  describe("failed submissions", () => {
-    it("should handle duplicate project name", fakeAsync(() => {
+    it("should handle duplicate project name", () => {
       spyOn(api, "create").and.callFake(() => {
         const subject = new Subject<Project>();
 
@@ -149,173 +136,11 @@ describe("ProjectsNewComponent", () => {
         return subject;
       });
 
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Test Project");
-      submitForm(fixture);
+      component.submit({});
 
       expect(notifications.error).toHaveBeenCalledWith(
         "Record could not be saved<br />name has already been taken"
       );
-    }));
-
-    it("should handle general error", fakeAsync(() => {
-      spyOn(api, "create").and.callFake(() => {
-        const subject = new Subject<Project>();
-
-        subject.error({
-          message: "Sign in to access this feature.",
-          info: 401
-        } as ApiErrorDetails);
-
-        return subject;
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Test Project");
-      submitForm(fixture);
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Sign in to access this feature."
-      );
-    }));
-
-    it("should re-enable submit button after failed submission", fakeAsync(() => {
-      spyOn(api, "create").and.callFake(() => {
-        const subject = new Subject<Project>();
-
-        subject.error({
-          message: "Sign in to access this feature.",
-          info: 401
-        } as ApiErrorDetails);
-
-        return subject;
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Project");
-      submitForm(fixture);
-
-      flush();
-      fixture.detectChanges();
-
-      const button = fixture.nativeElement.querySelector(
-        "button[type='submit']"
-      );
-      expect(button).toBeTruthy();
-      expect(button.disabled).toBeFalsy("Button should not be disabled");
-    }));
-  });
-
-  describe("successful submissions", () => {
-    it("should call create", fakeAsync(() => {
-      spyOn(api, "create");
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Test Project");
-      submitForm(fixture);
-
-      expect(api.create).toHaveBeenCalled();
-    }));
-
-    it("should call create with name", fakeAsync(() => {
-      spyOn(api, "create");
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Test Project");
-      submitForm(fixture);
-
-      expect(api.create).toHaveBeenCalledWith(
-        new Project({ name: "Test Project" })
-      );
-    }));
-
-    it("should call create with description", fakeAsync(() => {
-      spyOn(api, "create");
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Test Project");
-      inputValue(inputs[1], "textarea", "Test Description");
-      submitForm(fixture);
-
-      expect(api.create).toHaveBeenCalledWith(
-        new Project({
-          name: "Test Project",
-          description: "Test Description"
-        })
-      );
-    }));
-
-    xit("should call create with image", fakeAsync(() => {}));
-    xit("should call create with all inputs", fakeAsync(() => {}));
-
-    it("should create success notification on submit", fakeAsync(() => {
-      spyOn(api, "create").and.callFake(() => {
-        return new BehaviorSubject<Project>(
-          new Project({
-            id: 1,
-            name: "Custom Project"
-          })
-        );
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Custom Project");
-      submitForm(fixture);
-
-      expect(notifications.success).toHaveBeenCalledWith(
-        "Successfully created Custom Project"
-      );
-    }));
-
-    it("should navigate user to project on submit", fakeAsync(() => {
-      const project = new Project({
-        id: 1,
-        name: "Test Project"
-      });
-
-      spyOn(api, "create").and.callFake(() => {
-        return new BehaviorSubject<Project>(project);
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Test Project");
-      submitForm(fixture);
-
-      expect(router.navigateByUrl).toHaveBeenCalledWith(project.redirectPath());
-    }));
-
-    it("should disable submit button during submission", fakeAsync(() => {
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Project");
-      submitForm(fixture);
-
-      flush();
-      fixture.detectChanges();
-
-      const button = fixture.nativeElement.querySelector(
-        "button[type='submit']"
-      );
-      expect(button).toBeTruthy();
-      expect(button.disabled).toBeTruthy("Button should be disabled");
-    }));
-
-    it("should reset form on successful submit", fakeAsync(() => {
-      spyOn(component, "resetForms");
-      spyOn(api, "create").and.callFake(() => {
-        return new BehaviorSubject<Project>(
-          new Project({
-            id: 1,
-            name: "Test Project"
-          })
-        );
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Test Project");
-      submitForm(fixture);
-
-      expect(component.resetForms).toHaveBeenCalled();
-      expect(component.isFormTouched()).toBeFalse();
-    }));
+    });
   });
 });

--- a/src/app/component/security/pages/confirm-account/confirm-account.component.spec.ts
+++ b/src/app/component/security/pages/confirm-account/confirm-account.component.spec.ts
@@ -1,20 +1,10 @@
-import {
-  async,
-  ComponentFixture,
-  fakeAsync,
-  TestBed
-} from "@angular/core/testing";
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { ToastrService } from "ngx-toastr";
 import { appLibraryImports } from "src/app/app.module";
 import { HomeComponent } from "src/app/component/home/home.component";
 import { SharedModule } from "src/app/component/shared/shared.module";
 import { testAppInitializer } from "src/app/test.helper";
-import {
-  getInputs,
-  inputValue,
-  submitForm,
-  testFormlyField
-} from "src/testHelpers";
+import { testFormlyFields } from "src/testHelpers";
 import { ConfirmPasswordComponent } from "./confirm-account.component";
 import { fields } from "./confirm-account.json";
 
@@ -23,75 +13,48 @@ describe("ConfirmPasswordComponent", () => {
   let fixture: ComponentFixture<ConfirmPasswordComponent>;
   let notifications: ToastrService;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule],
-      declarations: [ConfirmPasswordComponent, HomeComponent],
-      providers: [...testAppInitializer]
-    }).compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ConfirmPasswordComponent);
-    component = fixture.componentInstance;
-    notifications = TestBed.inject(ToastrService);
-    fixture.detectChanges();
-
-    spyOn(notifications, "success").and.stub();
-    spyOn(notifications, "error").and.stub();
-  });
-
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+  const formInputs = [
+    {
+      testGroup: "Username/Email Address Input",
+      setup: undefined,
+      field: fields[0],
+      key: "login",
+      htmlType: "input",
+      required: true,
+      label: "Username or Email Address",
+      type: "text",
+      description: undefined
+    }
+  ];
 
   describe("form", () => {
-    it("should load form", () => {
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']")
-      ).toBeTruthy();
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']").disabled
-      ).toBeFalsy();
-    });
-
-    it("should only contain one input", () => {
-      expect(fixture.nativeElement.querySelectorAll("input").length).toBe(1);
-    });
-
-    /* Username/Email Address Input */
-    testFormlyField(
-      "Username/Email Address Input",
-      undefined,
-      fields[0],
-      "login",
-      "input",
-      true,
-      "Username or Email Address",
-      "text"
-    );
+    testFormlyFields(formInputs);
   });
 
-  describe("submit logic", () => {
-    it("should show error message with missing email", fakeAsync(() => {
-      submitForm(fixture);
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
-      );
+  describe("component", () => {
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [...appLibraryImports, SharedModule],
+        declarations: [ConfirmPasswordComponent, HomeComponent],
+        providers: [...testAppInitializer]
+      }).compileComponents();
     }));
 
-    it("should call submit function with username/email", fakeAsync(() => {
-      spyOn(component, "submit");
+    beforeEach(() => {
+      fixture = TestBed.createComponent(ConfirmPasswordComponent);
+      component = fixture.componentInstance;
+      notifications = TestBed.inject(ToastrService);
+      fixture.detectChanges();
 
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "username");
-      submitForm(fixture);
+      spyOn(notifications, "success").and.stub();
+      spyOn(notifications, "error").and.stub();
+    });
 
-      expect(component.submit).toHaveBeenCalledWith({ login: "username" });
-    }));
+    it("should create", () => {
+      expect(component).toBeTruthy();
+    });
+
+    // TODO should call api
+    xit("should call api", () => {});
   });
-
-  // TODO
-  xit("should confirm account on submit", () => {});
 });

--- a/src/app/component/security/pages/login/login.component.spec.ts
+++ b/src/app/component/security/pages/login/login.component.spec.ts
@@ -1,14 +1,9 @@
 import { Location } from "@angular/common";
-import {
-  ComponentFixture,
-  fakeAsync,
-  TestBed,
-  tick
-} from "@angular/core/testing";
+import { ComponentFixture, fakeAsync, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ToastrService } from "ngx-toastr";
-import { BehaviorSubject, Subject } from "rxjs";
+import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { HomeComponent } from "src/app/component/home/home.component";
 import { SharedModule } from "src/app/component/shared/shared.module";
@@ -19,11 +14,7 @@ import {
   SecurityService
 } from "src/app/services/baw-api/security.service";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
-import {
-  assertValidationMessage,
-  getInputs,
-  testFormlyField
-} from "src/testHelpers";
+import { testFormlyFields } from "src/testHelpers";
 import { LoginComponent } from "./login.component";
 import { fields } from "./login.json";
 
@@ -68,33 +59,8 @@ describe("LoginComponent", () => {
     }));
   }
 
-  function fillUsername(user?: string) {
-    const username = fixture.nativeElement.querySelectorAll("input")[0];
-    username.value = user ? user : "username";
-    username.dispatchEvent(new Event("input"));
-  }
-
-  function fillPassword(pass?: string) {
-    const password = fixture.nativeElement.querySelectorAll("input")[1];
-    password.value = pass ? pass : "password";
-    password.dispatchEvent(new Event("input"));
-  }
-
-  function submit() {
-    const button = fixture.nativeElement.querySelector("button[type='submit']");
-    button.click();
-    fixture.detectChanges();
-
-    tick(100);
-    fixture.detectChanges();
-  }
-
-  function successResponse(signedIn: boolean = true) {
+  function apiResponse() {
     spyOn(api, "signIn").and.callFake(() => {
-      if (signedIn) {
-        return new BehaviorSubject<void>(null);
-      }
-
       const subject = new Subject<void>();
       subject.error({
         status: 401,
@@ -105,201 +71,61 @@ describe("LoginComponent", () => {
     });
   }
 
-  it("should create", () => {
-    configureTestingModule();
-    fixture.detectChanges();
+  const formInputs = [
+    {
+      testGroup: "Username Input",
+      setup: undefined,
+      field: fields[0],
+      key: "login",
+      htmlType: "input",
+      required: true,
+      label: "Username or Email Address",
+      type: "text",
+      description: undefined
+    },
+    {
+      testGroup: "Password Input",
+      setup: undefined,
+      field: fields[1],
+      key: "password",
+      htmlType: "input",
+      required: true,
+      label: "Password",
+      type: "password",
+      description: undefined
+    }
+  ];
 
-    expect(component).toBeTruthy();
+  describe("form", () => {
+    testFormlyFields(formInputs);
   });
 
-  describe("form inputs", () => {
-    it("should eventually load form", () => {
+  describe("component", () => {
+    it("should create", () => {
       configureTestingModule();
       fixture.detectChanges();
-
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']")
-      ).toBeTruthy();
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']").disabled
-      ).toBeFalsy();
+      expect(component).toBeTruthy();
     });
 
-    it("should contain two inputs", () => {
+    it("should call api", () => {
       configureTestingModule();
+      spyOn(api, "signIn").and.callThrough();
       fixture.detectChanges();
 
-      expect(
-        fixture.nativeElement.querySelectorAll("form formly-field").length
-      ).toBe(2);
-    });
-
-    /* Username */
-    testFormlyField(
-      "Username Input",
-      () => {
-        configureTestingModule();
-      },
-      fields[0],
-      "login",
-      "input",
-      true,
-      "Username or Email Address",
-      "text"
-    );
-
-    /* Project Description Textarea */
-    testFormlyField(
-      "Password Input",
-      () => {
-        configureTestingModule();
-      },
-      fields[1],
-      "password",
-      "input",
-      true,
-      "Password",
-      "password"
-    );
-  });
-
-  describe("submit logic", () => {
-    it("should show error message with missing username", fakeAsync(() => {
-      configureTestingModule();
-      successResponse();
-      spyOn(component, "submit");
-      fixture.detectChanges();
-
-      fillPassword();
-      submit();
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
-      );
-    }));
-
-    it("should show error message with missing password", fakeAsync(() => {
-      configureTestingModule();
-      successResponse();
-      spyOn(component, "submit");
-      fixture.detectChanges();
-
-      fillUsername();
-      submit();
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
-      );
-    }));
-
-    it("should show error message with missing fields", fakeAsync(() => {
-      configureTestingModule();
-      successResponse();
-      spyOn(component, "submit");
-      fixture.detectChanges();
-
-      submit();
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
-      );
-    }));
-
-    it("should show error message with password less than 6 characters long", fakeAsync(() => {
-      configureTestingModule();
-      successResponse();
-      spyOn(component, "submit");
-      fixture.detectChanges();
-
-      fillUsername();
-      fillPassword("12345");
-      submit();
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
-      );
-      assertValidationMessage(
-        getInputs(fixture)[1],
-        "Input should have at least 6 characters"
-      );
-    }));
-
-    it("should login account on submit", fakeAsync(() => {
-      configureTestingModule();
-      successResponse();
-      spyOn(component, "submit").and.callThrough();
-      fixture.detectChanges();
-
-      fillUsername();
-      fillPassword();
-      submit();
-
-      expect(component.submit).toHaveBeenCalled();
-      expect(api.signIn).toHaveBeenCalled();
+      component.submit({ login: "username", password: "password" });
       expect(api.signIn).toHaveBeenCalledWith(
-        new LoginDetails({
-          login: "username",
-          password: "password"
-        })
+        new LoginDetails({ login: "username", password: "password" })
       );
-    }));
-
-    it("should show error on bad credentials", fakeAsync(() => {
-      configureTestingModule();
-      successResponse(false);
-      spyOn(component, "submit").and.callThrough();
-      fixture.detectChanges();
-
-      fillUsername();
-      fillPassword();
-      submit();
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Incorrect user name, email, or password. Alternatively, you may need to confirm your account or it may be locked."
-      );
-    }));
-
-    it("should disable submit button during submission", fakeAsync(() => {
-      configureTestingModule();
-      spyOn(component, "submit").and.callThrough();
-      fixture.detectChanges();
-
-      const button = fixture.nativeElement.querySelector(
-        "button[type='submit']"
-      );
-
-      fillUsername();
-      fillPassword();
-      submit();
-
-      expect(button).toBeTruthy();
-      expect(button.disabled).toBeTruthy();
-    }));
-
-    it("should display success on successful submit", fakeAsync(() => {
-      configureTestingModule();
-      successResponse();
-      fixture.detectChanges();
-
-      fillUsername();
-      fillPassword();
-      submit();
-
-      expect(notifications.success).toHaveBeenCalledWith(
-        "Successfully signed in"
-      );
-    }));
+    });
   });
 
   describe("redirection", () => {
     it("should redirect user to previous page on login", fakeAsync(() => {
       configureTestingModule(undefined, 2);
-      successResponse();
+      apiResponse();
       fixture.detectChanges();
 
-      fillUsername();
-      fillPassword();
-      submit();
+      component["redirectUser"]();
 
       expect(router.navigateByUrl).not.toHaveBeenCalled();
       expect(location.back).toHaveBeenCalled();
@@ -307,12 +133,10 @@ describe("LoginComponent", () => {
 
     it("should redirect user to home page on redirect=false", fakeAsync(() => {
       configureTestingModule(false);
-      successResponse();
+      apiResponse();
       fixture.detectChanges();
 
-      fillUsername();
-      fillPassword();
-      submit();
+      component["redirectUser"]();
 
       expect(router.navigateByUrl).toHaveBeenCalled();
       expect(router.navigateByUrl).toHaveBeenCalledWith("/");
@@ -321,12 +145,10 @@ describe("LoginComponent", () => {
 
     it("should redirect user to home page when no previous location remembered", fakeAsync(() => {
       configureTestingModule();
-      successResponse();
+      apiResponse();
       fixture.detectChanges();
 
-      fillUsername();
-      fillPassword();
-      submit();
+      component["redirectUser"]();
 
       expect(router.navigateByUrl).toHaveBeenCalled();
       expect(router.navigateByUrl).toHaveBeenCalledWith("/");
@@ -335,12 +157,10 @@ describe("LoginComponent", () => {
 
     it("should handle redirect url", fakeAsync(() => {
       configureTestingModule("/broken_link");
-      successResponse();
+      apiResponse();
       fixture.detectChanges();
 
-      fillUsername();
-      fillPassword();
-      submit();
+      component["redirectUser"]();
 
       expect(router.navigateByUrl).toHaveBeenCalled();
       expect(router.navigateByUrl).toHaveBeenCalledWith("/broken_link");
@@ -350,12 +170,10 @@ describe("LoginComponent", () => {
       configureTestingModule(
         testApiConfig.environment.apiRoot + "/broken_link"
       );
-      successResponse();
+      apiResponse();
       fixture.detectChanges();
 
-      fillUsername();
-      fillPassword();
-      submit();
+      component["redirectUser"]();
 
       expect(router.navigateByUrl).not.toHaveBeenCalled();
       expect(component.externalRedirect).toHaveBeenCalled();
@@ -366,12 +184,10 @@ describe("LoginComponent", () => {
 
     it("should ignore non-ecosounds redirect url", fakeAsync(() => {
       configureTestingModule("http://broken_link");
-      successResponse();
+      apiResponse();
       fixture.detectChanges();
 
-      fillUsername();
-      fillPassword();
-      submit();
+      component["redirectUser"]();
 
       expect(router.navigateByUrl).toHaveBeenCalled();
       expect(router.navigateByUrl).toHaveBeenCalledWith("/");

--- a/src/app/component/security/pages/register/register.component.spec.ts
+++ b/src/app/component/security/pages/register/register.component.spec.ts
@@ -15,7 +15,7 @@ import {
   getInputs,
   inputValue,
   submitForm,
-  testFormlyField
+  testFormlyFields
 } from "src/testHelpers";
 import { RegisterComponent } from "./register.component";
 import { fields } from "./register.json";
@@ -35,164 +35,84 @@ describe("RegisterComponent", () => {
     spyOn(api, "isLoggedIn").and.callFake(() => signedIn);
   }
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [...appLibraryImports, RouterTestingModule, SharedModule],
-      declarations: [RegisterComponent],
-      providers: [...testBawServices]
-    }).compileComponents();
-  }));
+  const formInputs = [
+    {
+      testGroup: "Username Input",
+      setup: undefined,
+      field: fields[0].fieldGroup[0],
+      key: "username",
+      htmlType: "input",
+      required: true,
+      label: "Username",
+      type: "text",
+      description: undefined
+    },
+    {
+      testGroup: "Email Input",
+      setup: undefined,
+      field: fields[0].fieldGroup[1],
+      key: "email",
+      htmlType: "input",
+      required: true,
+      label: "Email Address",
+      type: "email",
+      description: undefined
+    },
+    {
+      testGroup: "Password Input",
+      setup: undefined,
+      field: fields[0].fieldGroup[2],
+      key: "password",
+      htmlType: "input",
+      required: true,
+      label: "Password",
+      type: "password",
+      description: undefined
+    },
+    {
+      testGroup: "Password Confirmation Input",
+      setup: undefined,
+      field: fields[0].fieldGroup[3],
+      key: "passwordConfirm",
+      htmlType: "input",
+      required: true,
+      label: "Password Confirmation",
+      type: "password",
+      description: undefined
+    }
+  ];
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(RegisterComponent);
-    component = fixture.componentInstance;
-    api = TestBed.inject(SecurityService);
-    notifications = TestBed.inject(ToastrService);
-
-    spyOn(notifications, "success").and.stub();
-    spyOn(notifications, "error").and.stub();
+  describe("form", () => {
+    testFormlyFields(formInputs);
   });
 
-  it("should create", () => {
-    isSignedIn(false);
-    fixture.detectChanges();
+  describe("component", () => {
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [...appLibraryImports, RouterTestingModule, SharedModule],
+        declarations: [RegisterComponent],
+        providers: [...testBawServices]
+      }).compileComponents();
+    }));
 
-    expect(component).toBeTruthy();
-  });
+    beforeEach(() => {
+      fixture = TestBed.createComponent(RegisterComponent);
+      component = fixture.componentInstance;
+      api = TestBed.inject(SecurityService);
+      notifications = TestBed.inject(ToastrService);
 
-  describe("form inputs", () => {
-    it("should eventually load form", () => {
-      isSignedIn(false);
-      fixture.detectChanges();
-
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']")
-      ).toBeTruthy();
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']").disabled
-      ).toBeFalsy();
+      spyOn(notifications, "success").and.stub();
+      spyOn(notifications, "error").and.stub();
     });
 
-    it("should contain four inputs", () => {
+    it("should create", () => {
       isSignedIn(false);
       fixture.detectChanges();
-
-      expect(fixture.nativeElement.querySelectorAll("input").length).toBe(4);
+      expect(component).toBeTruthy();
     });
 
-    /* Username */
-    testFormlyField(
-      "Username Input",
-      undefined,
-      fields[0].fieldGroup[0],
-      "username",
-      "input",
-      true,
-      "Username",
-      "text"
-    );
-
-    /* Email */
-    testFormlyField(
-      "Email Input",
-      undefined,
-      fields[0].fieldGroup[1],
-      "email",
-      "input",
-      true,
-      "Email Address",
-      "email"
-    );
-
-    /* Password */
-    testFormlyField(
-      "Password Input",
-      undefined,
-      fields[0].fieldGroup[2],
-      "password",
-      "input",
-      true,
-      "Password",
-      "password"
-    );
-
-    /* Password Confirmation */
-    testFormlyField(
-      "Password Confirmation Input",
-      undefined,
-      fields[0].fieldGroup[3],
-      "passwordConfirm",
-      "input",
-      true,
-      "Password Confirmation",
-      "password"
-    );
-  });
-
-  describe("submit logic", () => {
-    it("should display error with missing username", fakeAsync(() => {
-      isSignedIn(false);
-      spyOn(component, "submit");
-      fixture.detectChanges();
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[emailIndex], "input", "a@b.com.au");
-      inputValue(inputs[passwordIndex], "input", "password");
-      inputValue(inputs[passwordConfIndex], "input", "password");
-      submitForm(fixture);
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
-      );
-    }));
-
-    it("should display error with missing email", fakeAsync(() => {
-      isSignedIn(false);
-      spyOn(component, "submit");
-      fixture.detectChanges();
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[usernameIndex], "input", "username");
-      inputValue(inputs[passwordIndex], "input", "password");
-      inputValue(inputs[passwordConfIndex], "input", "password");
-      submitForm(fixture);
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
-      );
-    }));
-
-    it("should display error with missing password", fakeAsync(() => {
-      isSignedIn(false);
-      spyOn(component, "submit");
-      fixture.detectChanges();
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[usernameIndex], "input", "username");
-      inputValue(inputs[emailIndex], "input", "a@b.com.au");
-      inputValue(inputs[passwordConfIndex], "input", "password");
-      submitForm(fixture);
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
-      );
-    }));
-
-    it("should display error with missing password confirmation", fakeAsync(() => {
-      isSignedIn(false);
-      spyOn(component, "submit");
-      fixture.detectChanges();
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[usernameIndex], "input", "username");
-      inputValue(inputs[emailIndex], "input", "a@b.com.au");
-      inputValue(inputs[passwordIndex], "input", "password");
-      submitForm(fixture);
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
-      );
-    }));
+    // TODO
+    xit("should call api", () => {});
 
     it("should display error if password and password confirmation do not match", fakeAsync(() => {
       isSignedIn(false);
@@ -235,30 +155,27 @@ describe("RegisterComponent", () => {
         "Input should have at least 6 characters"
       );
     }));
-  });
 
-  describe("authenticated user", () => {
-    it("should show error for authenticated user", () => {
-      isSignedIn(true);
-      fixture.detectChanges();
+    describe("authenticated user", () => {
+      it("should show error for authenticated user", () => {
+        isSignedIn(true);
+        fixture.detectChanges();
 
-      expect(notifications.error).toHaveBeenCalledWith(
-        "You are already logged in."
-      );
+        expect(notifications.error).toHaveBeenCalledWith(
+          "You are already logged in."
+        );
+      });
+
+      it("should disable submit button for authenticated user", () => {
+        isSignedIn(true);
+        fixture.detectChanges();
+
+        const button = fixture.nativeElement.querySelector(
+          "button[type='submit']"
+        );
+        expect(button).toBeTruthy();
+        expect(button.disabled).toBeTruthy();
+      });
     });
-
-    it("should disable submit button for authenticated user", () => {
-      isSignedIn(true);
-      fixture.detectChanges();
-
-      const button = fixture.nativeElement.querySelector(
-        "button[type='submit']"
-      );
-      expect(button).toBeTruthy();
-      expect(button.disabled).toBeTruthy();
-    });
   });
-
-  // TODO Write this test
-  xit("should register account on submit", () => {});
 });

--- a/src/app/component/security/pages/reset-password/reset-password.component.spec.ts
+++ b/src/app/component/security/pages/reset-password/reset-password.component.spec.ts
@@ -1,20 +1,10 @@
-import {
-  async,
-  ComponentFixture,
-  fakeAsync,
-  TestBed
-} from "@angular/core/testing";
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { ToastrService } from "ngx-toastr";
 import { appLibraryImports } from "src/app/app.module";
 import { HomeComponent } from "src/app/component/home/home.component";
 import { SharedModule } from "src/app/component/shared/shared.module";
 import { testAppInitializer } from "src/app/test.helper";
-import {
-  getInputs,
-  inputValue,
-  submitForm,
-  testFormlyField
-} from "src/testHelpers";
+import { testFormlyFields } from "src/testHelpers";
 import { ResetPasswordComponent } from "./reset-password.component";
 import { fields } from "./reset-password.json";
 
@@ -23,75 +13,48 @@ describe("ResetPasswordComponent", () => {
   let fixture: ComponentFixture<ResetPasswordComponent>;
   let notifications: ToastrService;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule],
-      declarations: [ResetPasswordComponent, HomeComponent],
-      providers: [...testAppInitializer]
-    }).compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ResetPasswordComponent);
-    component = fixture.componentInstance;
-    notifications = TestBed.inject(ToastrService);
-    fixture.detectChanges();
-
-    spyOn(notifications, "success").and.stub();
-    spyOn(notifications, "error").and.stub();
-  });
-
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+  const formInputs = [
+    {
+      testGroup: "Username/Email Address Input",
+      setup: undefined,
+      field: fields[0],
+      key: "login",
+      htmlType: "input",
+      required: true,
+      label: "Username or Email Address",
+      type: "text",
+      description: undefined
+    }
+  ];
 
   describe("form", () => {
-    it("should load form", () => {
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']")
-      ).toBeTruthy();
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']").disabled
-      ).toBeFalsy();
-    });
-
-    it("should only contain one input", () => {
-      expect(fixture.nativeElement.querySelectorAll("input").length).toBe(1);
-    });
-
-    /* Username/Email Address Input */
-    testFormlyField(
-      "Username/Email Address Input",
-      undefined,
-      fields[0],
-      "login",
-      "input",
-      true,
-      "Username or Email Address",
-      "text"
-    );
+    testFormlyFields(formInputs);
   });
 
-  describe("submit logic", () => {
-    it("should show error message with missing email", fakeAsync(() => {
-      submitForm(fixture);
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
-      );
+  describe("component", () => {
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [...appLibraryImports, SharedModule],
+        declarations: [ResetPasswordComponent, HomeComponent],
+        providers: [...testAppInitializer]
+      }).compileComponents();
     }));
 
-    it("should call submit function with username/email", fakeAsync(() => {
-      spyOn(component, "submit");
+    beforeEach(() => {
+      fixture = TestBed.createComponent(ResetPasswordComponent);
+      component = fixture.componentInstance;
+      notifications = TestBed.inject(ToastrService);
+      fixture.detectChanges();
 
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "username");
-      submitForm(fixture);
+      spyOn(notifications, "success").and.stub();
+      spyOn(notifications, "error").and.stub();
+    });
 
-      expect(component.submit).toHaveBeenCalledWith({ login: "username" });
-    }));
+    it("should create", () => {
+      expect(component).toBeTruthy();
+    });
+
+    // TODO should call api
+    xit("should call api", () => {});
   });
-
-  // TODO
-  xit("should reset password on submit", () => {});
 });

--- a/src/app/component/security/pages/unlock-account/unlock-account.component.spec.ts
+++ b/src/app/component/security/pages/unlock-account/unlock-account.component.spec.ts
@@ -1,20 +1,10 @@
-import {
-  async,
-  ComponentFixture,
-  fakeAsync,
-  TestBed
-} from "@angular/core/testing";
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { ToastrService } from "ngx-toastr";
 import { appLibraryImports } from "src/app/app.module";
 import { HomeComponent } from "src/app/component/home/home.component";
 import { SharedModule } from "src/app/component/shared/shared.module";
 import { testAppInitializer } from "src/app/test.helper";
-import {
-  getInputs,
-  inputValue,
-  submitForm,
-  testFormlyField
-} from "src/testHelpers";
+import { testFormlyFields } from "src/testHelpers";
 import { UnlockAccountComponent } from "./unlock-account.component";
 import { fields } from "./unlock-account.json";
 
@@ -23,75 +13,48 @@ describe("UnlockAccountComponent", () => {
   let fixture: ComponentFixture<UnlockAccountComponent>;
   let notifications: ToastrService;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule],
-      declarations: [UnlockAccountComponent, HomeComponent],
-      providers: [...testAppInitializer]
-    }).compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(UnlockAccountComponent);
-    component = fixture.componentInstance;
-    notifications = TestBed.inject(ToastrService);
-    fixture.detectChanges();
-
-    spyOn(notifications, "success").and.stub();
-    spyOn(notifications, "error").and.stub();
-  });
-
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+  const formInputs = [
+    {
+      testGroup: "Username/Email Address Input",
+      setup: undefined,
+      field: fields[0],
+      key: "login",
+      htmlType: "input",
+      required: true,
+      label: "Username or Email Address",
+      type: "text",
+      description: undefined
+    }
+  ];
 
   describe("form", () => {
-    it("should load form", () => {
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']")
-      ).toBeTruthy();
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']").disabled
-      ).toBeFalsy();
-    });
-
-    it("should only contain one input", () => {
-      expect(fixture.nativeElement.querySelectorAll("input").length).toBe(1);
-    });
-
-    /* Username/Email Address Input */
-    testFormlyField(
-      "Username/Email Address Input",
-      undefined,
-      fields[0],
-      "login",
-      "input",
-      true,
-      "Username or Email Address",
-      "text"
-    );
+    testFormlyFields(formInputs);
   });
 
-  describe("submit logic", () => {
-    it("should show error message with missing email", fakeAsync(() => {
-      submitForm(fixture);
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
-      );
+  describe("component", () => {
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [...appLibraryImports, SharedModule],
+        declarations: [UnlockAccountComponent, HomeComponent],
+        providers: [...testAppInitializer]
+      }).compileComponents();
     }));
 
-    it("should call submit function with username/email", fakeAsync(() => {
-      spyOn(component, "submit");
+    beforeEach(() => {
+      fixture = TestBed.createComponent(UnlockAccountComponent);
+      component = fixture.componentInstance;
+      notifications = TestBed.inject(ToastrService);
+      fixture.detectChanges();
 
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "username");
-      submitForm(fixture);
+      spyOn(notifications, "success").and.stub();
+      spyOn(notifications, "error").and.stub();
+    });
 
-      expect(component.submit).toHaveBeenCalledWith({ login: "username" });
-    }));
+    it("should create", () => {
+      expect(component).toBeTruthy();
+    });
+
+    // TODO should call api
+    xit("should call api", () => {});
   });
-
-  // TODO
-  xit("should unlock account on submit", () => {});
 });

--- a/src/app/component/shared/form/form.component.html
+++ b/src/app/component/shared/form/form.component.html
@@ -1,7 +1,11 @@
-<div class="login-form pl-2 pr-2 pb-3" [ngClass]="{ small: size === 'small' }">
-  <h2 class="text-center" *ngIf="title" [innerHTML]="title"></h2>
-  <small class="text-muted">
-    <h6 *ngIf="subTitle" [innerHTML]="subTitle"></h6>
+<div
+  *ngIf="fields"
+  class="login-form pl-2 pr-2 pb-3"
+  [ngClass]="{ small: size === 'small' }"
+>
+  <h2 *ngIf="title" class="text-center" [innerHTML]="title"></h2>
+  <small *ngIf="subTitle" class="text-muted">
+    <h6 [innerHTML]="subTitle"></h6>
   </small>
 
   <div class="clearfix">

--- a/src/app/component/shared/form/form.component.ts
+++ b/src/app/component/shared/form/form.component.ts
@@ -28,7 +28,7 @@ export class FormComponent extends WithUnsubscribe() implements OnInit {
   @Input() fieldsUrl: string;
   @Input() model: AbstractModel;
   @Input() size: "small" | "default" = "default";
-  @Input() submitLabel: string;
+  @Input() submitLabel = "Submit";
   @Input() submitLoading: boolean;
   @Input() subTitle?: string;
   @Input() title?: string;
@@ -50,7 +50,7 @@ export class FormComponent extends WithUnsubscribe() implements OnInit {
       // TODO Retrieve Schema from url
       // this.convertFunctions(this.fields);
     } else {
-      this.convertFunctions(this.fields);
+      this.fields = this.convertFunctions(this.fields);
     }
   }
 
@@ -61,6 +61,10 @@ export class FormComponent extends WithUnsubscribe() implements OnInit {
    * @param fields Form fields
    */
   convertFunctions(fields: any) {
+    if (!fields) {
+      return [];
+    }
+
     fields.forEach((field: any) => {
       const validator = field.validators;
 
@@ -71,6 +75,8 @@ export class FormComponent extends WithUnsubscribe() implements OnInit {
         );
       }
     });
+
+    return fields;
   }
 
   /**

--- a/src/app/component/sites/pages/delete/delete.component.spec.ts
+++ b/src/app/component/sites/pages/delete/delete.component.spec.ts
@@ -1,13 +1,8 @@
-import {
-  ComponentFixture,
-  fakeAsync,
-  flush,
-  TestBed
-} from "@angular/core/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ToastrService } from "ngx-toastr";
-import { BehaviorSubject, Subject } from "rxjs";
+import { BehaviorSubject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { SharedModule } from "src/app/component/shared/shared.module";
 import { Project } from "src/app/models/Project";
@@ -19,7 +14,7 @@ import {
   SitesService
 } from "src/app/services/baw-api/sites.service";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
-import { submitForm } from "src/testHelpers";
+import { assertFormErrorHandling } from "src/testHelpers";
 import { DeleteComponent } from "./delete.component";
 
 describe("SitesDeleteComponent", () => {
@@ -93,189 +88,48 @@ describe("SitesDeleteComponent", () => {
     };
   });
 
-  it("should create", () => {
-    configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-    expect(component).toBeTruthy();
+  describe("form", () => {
+    it("should have no fields", () => {
+      configureTestingModule(defaultProject, undefined, defaultSite, undefined);
+      expect(component.fields).toEqual([]);
+    });
   });
 
-  it("should handle project error", fakeAsync(() => {
-    configureTestingModule(undefined, defaultError, defaultSite, undefined);
-
-    const body = fixture.nativeElement;
-    expect(body.childElementCount).toBe(0);
-  }));
-
-  it("should handle site error", fakeAsync(() => {
-    configureTestingModule(defaultProject, undefined, undefined, defaultError);
-
-    const body = fixture.nativeElement;
-    expect(body.childElementCount).toBe(0);
-  }));
-
-  describe("form", () => {
-    it("should eventually load form", () => {
+  describe("component", () => {
+    it("should create", () => {
       configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']")
-      ).toBeTruthy();
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']").disabled
-      ).toBeFalsy();
+      expect(component).toBeTruthy();
     });
 
-    it("should display form with site name in title", fakeAsync(() => {
-      const site = new Site({
-        id: 1,
-        name: "Custom Site"
-      });
-      configureTestingModule(defaultProject, undefined, site, undefined);
+    it("should handle project error", () => {
+      configureTestingModule(undefined, defaultError, defaultSite, undefined);
+      assertFormErrorHandling(fixture);
+    });
 
-      const title = fixture.nativeElement.querySelector("h2");
-      expect(title).toBeTruthy();
-      expect(title.innerText).toContain("Custom Site");
-    }));
+    it("should handle site error", () => {
+      configureTestingModule(
+        defaultProject,
+        undefined,
+        undefined,
+        defaultError
+      );
+      assertFormErrorHandling(fixture);
+    });
 
-    it("should display form with red delete button", fakeAsync(() => {
+    it("should call api", () => {
       configureTestingModule(defaultProject, undefined, defaultSite, undefined);
+      spyOn(api, "destroy").and.callThrough();
+      component.submit({});
+      expect(api.destroy).toHaveBeenCalled();
+    });
 
-      const button = fixture.nativeElement.querySelector("button.btn-danger");
-      expect(button).toBeTruthy();
-      expect(button.innerText).toContain("Delete");
-    }));
-  });
-
-  describe("failed submissions", () => {
-    it("should display form error on failure to submit", fakeAsync(() => {
-      const site = new Site({
-        id: 1,
-        name: "Custom Site"
-      });
-      configureTestingModule(defaultProject, undefined, site, undefined);
-      spyOn(api, "destroy").and.callFake(() => {
-        const subject = new Subject<void>();
-
-        subject.error({
-          status: 401,
-          message: "You need to log in or register before continuing."
-        } as ApiErrorDetails);
-
-        return subject;
-      });
-
-      submitForm(fixture);
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "You need to log in or register before continuing."
-      );
-    }));
-
-    it("should re-enable submit button after failed submission", fakeAsync(() => {
+    it("should redirect to projects", () => {
+      spyOn(defaultProject, "redirectPath");
       configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-      spyOn(api, "destroy").and.callFake(() => {
-        const subject = new Subject<Site>();
+      spyOn(api, "destroy").and.callFake(() => new BehaviorSubject<void>(null));
 
-        subject.error({
-          message: "Sign in to access this feature.",
-          info: 401
-        } as ApiErrorDetails);
-
-        return subject;
-      });
-
-      submitForm(fixture);
-
-      flush();
-      fixture.detectChanges();
-
-      const button = fixture.nativeElement.querySelector(
-        "button[type='submit']"
-      );
-      expect(button).toBeTruthy();
-      expect(button.disabled).toBeFalsy("Button should not be disabled");
-    }));
-  });
-
-  describe("successful submissions", () => {
-    it("should delete site on submit", fakeAsync(() => {
-      const site = new Site({
-        id: 1,
-        name: "Custom Site"
-      });
-      configureTestingModule(defaultProject, undefined, site, undefined);
-      const deleteSpy = spyOn(api, "destroy").and.callFake(() => {
-        return new BehaviorSubject<null>(null);
-      });
-
-      submitForm(fixture);
-      expect(deleteSpy).toHaveBeenCalledWith(site, defaultProject);
-    }));
-
-    it("should delete site on submit with random ids", fakeAsync(() => {
-      const project = new Project({
-        id: 5,
-        name: "Custom Project"
-      });
-      const site = new Site({
-        id: 10,
-        name: "Custom Site"
-      });
-      configureTestingModule(project, undefined, site, undefined);
-      const deleteSpy = spyOn(api, "destroy").and.callFake(() => {
-        return new BehaviorSubject<null>(null);
-      });
-
-      submitForm(fixture);
-      expect(deleteSpy).toHaveBeenCalledWith(site, project);
-    }));
-
-    it("should navigate on successful submit", fakeAsync(() => {
-      const site = new Site({
-        id: 1,
-        name: "Custom Site"
-      });
-      configureTestingModule(defaultProject, undefined, site, undefined);
-      spyOn(api, "destroy").and.callFake(() => {
-        return new BehaviorSubject<null>(null);
-      });
-
-      submitForm(fixture);
-
-      expect(router.navigateByUrl).toHaveBeenCalled();
-      expect(router.navigateByUrl).toHaveBeenCalledWith(
-        defaultProject.redirectPath()
-      );
-    }));
-
-    it("should navigate on successful submit with random ids", fakeAsync(() => {
-      const project = new Project({
-        id: 5,
-        name: "Custom Project"
-      });
-      const site = new Site({
-        id: 10,
-        name: "Custom Site"
-      });
-      configureTestingModule(project, undefined, site, undefined);
-      spyOn(api, "destroy").and.callFake(() => {
-        return new BehaviorSubject<null>(null);
-      });
-
-      submitForm(fixture);
-
-      expect(router.navigateByUrl).toHaveBeenCalled();
-      expect(router.navigateByUrl).toHaveBeenCalledWith(project.redirectPath());
-    }));
-
-    it("should disable submit button while submitting", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-      spyOn(api, "destroy").and.stub();
-
-      submitForm(fixture);
-
-      const button = fixture.nativeElement.querySelector(
-        "button[type='submit']"
-      );
-      expect(button.disabled).toBeTruthy();
-    }));
+      component.submit({});
+      expect(defaultProject.redirectPath).toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/component/sites/pages/edit/edit.component.spec.ts
+++ b/src/app/component/sites/pages/edit/edit.component.spec.ts
@@ -1,13 +1,8 @@
-import {
-  ComponentFixture,
-  fakeAsync,
-  flush,
-  TestBed
-} from "@angular/core/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ToastrService } from "ngx-toastr";
-import { BehaviorSubject, Subject } from "rxjs";
+import { BehaviorSubject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { SharedModule } from "src/app/component/shared/shared.module";
 import { Project } from "src/app/models/Project";
@@ -19,12 +14,7 @@ import {
   SitesService
 } from "src/app/services/baw-api/sites.service";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
-import {
-  getInputs,
-  inputValue,
-  submitForm,
-  testFormlyField
-} from "src/testHelpers";
+import { assertFormErrorHandling, testFormlyFields } from "src/testHelpers";
 import { fields } from "../../site.json";
 import { EditComponent } from "./edit.component";
 
@@ -37,13 +27,6 @@ describe("SitesEditComponent", () => {
   let fixture: ComponentFixture<EditComponent>;
   let notifications: ToastrService;
   let router: Router;
-
-  const nameIndex = 0;
-  const descriptionIndex = 1;
-  const latitudeIndex = 3;
-  const longitudeIndex = 4;
-  const imageIndex = 5;
-  const timezoneIndex = 6;
 
   function configureTestingModule(
     project: Project,
@@ -106,405 +89,118 @@ describe("SitesEditComponent", () => {
     };
   });
 
-  it("should create", () => {
-    configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-
-    expect(component).toBeTruthy();
-  });
-
-  it("should handle project error", fakeAsync(() => {
-    configureTestingModule(undefined, defaultError, defaultSite, undefined);
-
-    const body = fixture.nativeElement;
-    expect(body.childElementCount).toBe(0);
-  }));
-
-  it("should handle site error", fakeAsync(() => {
-    configureTestingModule(defaultProject, undefined, undefined, defaultError);
-
-    const body = fixture.nativeElement;
-    expect(body.childElementCount).toBe(0);
-  }));
+  const formInputs = [
+    {
+      testGroup: "Site Name Input",
+      setup: undefined,
+      field: fields[0],
+      key: "name",
+      htmlType: "input",
+      required: true,
+      label: "Site Name",
+      type: "text",
+      description: undefined
+    },
+    {
+      testGroup: "Site Description Input",
+      setup: undefined,
+      field: fields[1],
+      key: "description",
+      htmlType: "textarea",
+      required: false,
+      label: "Description",
+      type: undefined,
+      description: undefined
+    },
+    {
+      testGroup: "Site Latitude Input",
+      setup: undefined,
+      field: fields[2].fieldGroup[0],
+      key: "customLatitude",
+      htmlType: "input",
+      required: false,
+      label: "Latitude",
+      type: "number",
+      description: undefined
+    },
+    {
+      testGroup: "Site Longitude Input",
+      setup: undefined,
+      field: fields[2].fieldGroup[1],
+      key: "customLongitude",
+      htmlType: "input",
+      required: false,
+      label: "Longitude",
+      type: "number",
+      description: undefined
+    },
+    {
+      testGroup: "Site Image Input",
+      setup: undefined,
+      field: fields[3],
+      key: "image",
+      htmlType: "image",
+      required: false,
+      label: "Image",
+      type: undefined,
+      description: undefined
+    }
+  ];
 
   describe("form", () => {
-    it("should eventually load form", () => {
-      configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']")
-      ).toBeTruthy();
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']").disabled
-      ).toBeFalsy();
-    });
-
-    it("should contain six inputs", () => {
-      configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-      expect(
-        fixture.nativeElement.querySelectorAll("form formly-field").length
-      ).toBe(7); // FieldGroup adds a formly-field
-    });
-
-    it("should display form with site name in title", fakeAsync(() => {
-      const site = new Site({
-        id: 1,
-        name: "Custom Site"
-      });
-      configureTestingModule(defaultProject, undefined, site, undefined);
-
-      const title = fixture.nativeElement.querySelector("h2");
-      expect(title).toBeTruthy();
-      expect(title.innerText).toContain("Custom Site");
-    }));
-
-    /* Site Name Input */
-    testFormlyField(
-      "Site Name Input",
-      () => {
-        configureTestingModule(
-          defaultProject,
-          undefined,
-          defaultSite,
-          undefined
-        );
-      },
-      fields[0],
-      "name",
-      "input",
-      true,
-      "Site Name",
-      "text"
-    );
-
-    /* Site Description Textarea */
-    testFormlyField(
-      "Site Description Input",
-      () => {
-        configureTestingModule(
-          defaultProject,
-          undefined,
-          defaultSite,
-          undefined
-        );
-      },
-      fields[1],
-      "description",
-      "textarea",
-      false,
-      "Description"
-    );
-
-    /* Site Latitude Input */
-    testFormlyField(
-      "Site Latitude Input",
-      () => {
-        configureTestingModule(
-          defaultProject,
-          undefined,
-          defaultSite,
-          undefined
-        );
-      },
-      fields[2].fieldGroup[0],
-      "customLatitude",
-      "input",
-      false,
-      "Latitude",
-      "number"
-    );
-
-    /* Site Longitude Input */
-    testFormlyField(
-      "Site Longitude Input",
-      () => {
-        configureTestingModule(
-          defaultProject,
-          undefined,
-          defaultSite,
-          undefined
-        );
-      },
-      fields[2].fieldGroup[1],
-      "customLongitude",
-      "input",
-      false,
-      "Longitude",
-      "number"
-    );
-
-    /* Site Image Input */
-    testFormlyField(
-      "Site Image Input",
-      () => {
-        configureTestingModule(
-          defaultProject,
-          undefined,
-          defaultSite,
-          undefined
-        );
-      },
-      fields[3],
-      "image",
-      "image",
-      false,
-      "Image"
-    );
-
-    /* Site Timezone Input */
-    /* testFormlyField(
-      "Site Timezone Input",
-      () => {
-        configureTestingModule(
-          defaultProject,
-          undefined,
-          defaultSite,
-          undefined
-        );
-      },
-      fields[4],
-      "timezoneInformation",
-      "timezone",
-      false,
-      "Time Zone"
-    ); */
+    testFormlyFields(formInputs);
 
     // TODO Add input validation for custom location logic
+  });
 
-    it("should pre-fill project name", () => {
-      const site = new Site({
-        id: 1,
-        name: "Custom Site"
-      });
-      configureTestingModule(defaultProject, undefined, site, undefined);
+  describe("component", () => {
+    it("should create", () => {
+      configureTestingModule(defaultProject, undefined, defaultSite, undefined);
 
-      const inputs = getInputs(fixture);
-      expect(inputs[nameIndex].querySelector("input").value).toBe(
-        "Custom Site"
-      );
+      expect(component).toBeTruthy();
     });
 
-    it("should pre-fill project description", () => {
-      const site = new Site({
-        id: 1,
-        name: "Site",
-        description: "Custom Description"
-      });
-      configureTestingModule(defaultProject, undefined, site, undefined);
-
-      const inputs = getInputs(fixture);
-      expect(inputs[descriptionIndex].querySelector("textarea").value).toBe(
-        "Custom Description"
-      );
+    it("should handle project error", () => {
+      configureTestingModule(undefined, defaultError, defaultSite, undefined);
+      assertFormErrorHandling(fixture);
     });
-  });
 
-  describe("form error handling", () => {
-    it("should show error message with missing project name", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "");
-      submitForm(fixture);
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
+    it("should handle site error", () => {
+      configureTestingModule(
+        defaultProject,
+        undefined,
+        undefined,
+        defaultError
       );
-    }));
-  });
+      assertFormErrorHandling(fixture);
+    });
 
-  describe("failed submissions", () => {
-    it("should handle general error", fakeAsync(() => {
+    it("should call api", () => {
       configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-      spyOn(api, "update").and.callFake(() => {
-        const subject = new Subject<Site>();
+      spyOn(api, "update").and.callThrough();
 
-        subject.error({
-          message: "Sign in to access this feature.",
-          info: 401
-        } as ApiErrorDetails);
-
-        return subject;
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Site");
-      submitForm(fixture);
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Sign in to access this feature."
-      );
-    }));
-
-    it("should re-enable submit button after failed submission", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-      spyOn(api, "update").and.callFake(() => {
-        const subject = new Subject<Site>();
-
-        subject.error({
-          message: "Sign in to access this feature.",
-          info: 401
-        } as ApiErrorDetails);
-
-        return subject;
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Project");
-      submitForm(fixture);
-
-      flush();
-      fixture.detectChanges();
-
-      const button = fixture.nativeElement.querySelector(
-        "button[type='submit']"
-      );
-      expect(button).toBeTruthy();
-      expect(button.disabled).toBeFalsy("Button should not be disabled");
-    }));
-  });
-
-  describe("successful submissions", () => {
-    it("should call update", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-      spyOn(api, "update");
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Test Site");
-      submitForm(fixture);
-
+      component.submit({});
       expect(api.update).toHaveBeenCalled();
-    }));
+    });
 
-    it("should call update with random id", fakeAsync(() => {
-      const site = new Site({
-        id: 5,
-        name: "Site"
-      });
-      configureTestingModule(defaultProject, undefined, site, undefined);
-      spyOn(api, "update");
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Test Site");
-      submitForm(fixture);
-
-      expect(api.update).toHaveBeenCalledWith(
-        new Site({ id: 5, name: "Test Site" }),
-        defaultProject
-      );
-    }));
-
-    it("should call update with name", fakeAsync(() => {
+    it("should redirect to site", () => {
       configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-      spyOn(api, "update");
+      const site = new Site({ id: 1, name: "Site" });
+      spyOn(site, "redirectPath").and.stub();
+      spyOn(api, "update").and.callFake(() => new BehaviorSubject<Site>(site));
 
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Test Site");
-      submitForm(fixture);
+      component.submit({});
+      expect(site.redirectPath).toHaveBeenCalled();
+    });
 
-      expect(api.update).toHaveBeenCalledWith(
-        new Site({ id: 1, name: "Test Site" }),
-        defaultProject
-      );
-    }));
-
-    it("should call update with description", fakeAsync(() => {
+    it("should redirect to site with project", () => {
       configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-      spyOn(api, "update");
+      const site = new Site({ id: 1, name: "Site" });
+      spyOn(site, "redirectPath").and.stub();
+      spyOn(api, "update").and.callFake(() => new BehaviorSubject<Site>(site));
 
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Test Project");
-      inputValue(inputs[1], "textarea", "Test Description");
-      submitForm(fixture);
-
-      expect(api.update).toHaveBeenCalledWith(
-        new Site({
-          id: 1,
-          name: "Test Project",
-          description: "Test Description"
-        }),
-        defaultProject
-      );
-    }));
-
-    xit("should call update with image", fakeAsync(() => {}));
-    xit("should call update with all inputs", fakeAsync(() => {}));
-
-    it("should create success notification on submit", fakeAsync(() => {
-      const site = new Site({
-        id: 1,
-        name: "Custom Site"
-      });
-      configureTestingModule(defaultProject, undefined, site, undefined);
-      spyOn(api, "update").and.callFake(() => {
-        return new BehaviorSubject<Site>(
-          new Site({
-            id: 1,
-            name: "Test Site"
-          })
-        );
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Test Site");
-      submitForm(fixture);
-
-      expect(notifications.success).toHaveBeenCalledWith(
-        "Successfully updated Custom Site"
-      );
-    }));
-
-    it("should navigate user to site on submit", fakeAsync(() => {
-      const site = new Site({
-        id: 5,
-        name: "Test Site"
-      });
-      configureTestingModule(defaultProject, undefined, site, undefined);
-
-      spyOn(api, "update").and.callFake(() => {
-        return new BehaviorSubject<Site>(site);
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Test Project");
-      submitForm(fixture);
-
-      expect(router.navigateByUrl).toHaveBeenCalledWith(
-        site.redirectPath(defaultProject)
-      );
-    }));
-
-    it("should disable submit button during submission", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Site");
-      submitForm(fixture);
-
-      flush();
-      fixture.detectChanges();
-
-      const button = fixture.nativeElement.querySelector(
-        "button[type='submit']"
-      );
-      expect(button).toBeTruthy();
-      expect(button.disabled).toBeTruthy("Button should be disabled");
-    }));
-
-    it("should reset form on successful submit", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-      spyOn(component, "resetForms");
-      spyOn(api, "update").and.callFake(() => {
-        return new BehaviorSubject<Site>(
-          new Site({
-            id: 1,
-            name: "Test Project"
-          })
-        );
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Test Site");
-      submitForm(fixture);
-
-      expect(component.resetForms).toHaveBeenCalled();
-      expect(component.isFormTouched()).toBeFalse();
-    }));
+      component.submit({});
+      expect(site.redirectPath).toHaveBeenCalledWith(defaultProject);
+    });
   });
 });

--- a/src/app/component/sites/pages/new/new.component.spec.ts
+++ b/src/app/component/sites/pages/new/new.component.spec.ts
@@ -1,13 +1,8 @@
-import {
-  ComponentFixture,
-  fakeAsync,
-  flush,
-  TestBed
-} from "@angular/core/testing";
+import { ComponentFixture, fakeAsync, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ToastrService } from "ngx-toastr";
-import { BehaviorSubject, Subject } from "rxjs";
+import { BehaviorSubject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { SharedModule } from "src/app/component/shared/shared.module";
 import { Project } from "src/app/models/Project";
@@ -16,13 +11,7 @@ import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.servic
 import { projectResolvers } from "src/app/services/baw-api/projects.service";
 import { SitesService } from "src/app/services/baw-api/sites.service";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
-import {
-  assertValidationMessage,
-  getInputs,
-  inputValue,
-  submitForm,
-  testFormlyField
-} from "src/testHelpers";
+import { assertFormErrorHandling, testFormlyFields } from "src/testHelpers";
 import { fields } from "../../site.json";
 import { NewComponent } from "./new.component";
 
@@ -34,13 +23,6 @@ describe("SitesNewComponent", () => {
   let fixture: ComponentFixture<NewComponent>;
   let notifications: ToastrService;
   let router: Router;
-
-  const nameIndex = 0;
-  const descriptionIndex = 1;
-  const latitudeIndex = 3;
-  const longitudeIndex = 4;
-  const imageIndex = 5;
-  const timezoneIndex = 6;
 
   function configureTestingModule(
     project: Project,
@@ -93,360 +75,109 @@ describe("SitesNewComponent", () => {
     };
   });
 
-  it("should create", () => {
-    configureTestingModule(defaultProject, undefined);
-
-    expect(component).toBeTruthy();
-  });
-
-  it("should handle project error", fakeAsync(() => {
-    configureTestingModule(undefined, defaultError);
-
-    const body = fixture.nativeElement;
-    expect(body.childElementCount).toBe(0);
-  }));
+  // TODO Add timezone checks
+  const formInputs = [
+    {
+      testGroup: "Site Name Input",
+      setup: undefined,
+      field: fields[0],
+      key: "name",
+      htmlType: "input",
+      required: true,
+      label: "Site Name",
+      type: "text",
+      description: undefined
+    },
+    {
+      testGroup: "Site Description Input",
+      setup: undefined,
+      field: fields[1],
+      key: "description",
+      htmlType: "textarea",
+      required: false,
+      label: "Description",
+      type: undefined,
+      description: undefined
+    },
+    {
+      testGroup: "Site Latitude Input",
+      setup: undefined,
+      field: fields[2].fieldGroup[0],
+      key: "customLatitude",
+      htmlType: "input",
+      required: false,
+      label: "Latitude",
+      type: "number",
+      description: undefined
+    },
+    {
+      testGroup: "Site Longitude Input",
+      setup: undefined,
+      field: fields[2].fieldGroup[1],
+      key: "customLongitude",
+      htmlType: "input",
+      required: false,
+      label: "Longitude",
+      type: "number",
+      description: undefined
+    },
+    {
+      testGroup: "Site Image Input",
+      setup: undefined,
+      field: fields[3],
+      key: "image",
+      htmlType: "image",
+      required: false,
+      label: "Image",
+      type: undefined,
+      description: undefined
+    }
+  ];
 
   describe("form", () => {
-    it("should eventually load form", () => {
-      configureTestingModule(defaultProject, undefined);
-
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']")
-      ).toBeTruthy();
-      expect(
-        fixture.nativeElement.querySelector("button[type='submit']").disabled
-      ).toBeFalsy();
-    });
-
-    it("should contain six inputs", () => {
-      configureTestingModule(defaultProject, undefined);
-
-      expect(
-        fixture.nativeElement.querySelectorAll("form formly-field").length
-      ).toBe(7); // FieldGroup adds a formly-field
-    });
-
-    /* Site Name Input */
-    testFormlyField(
-      "Site Name Input",
-      () => {
-        configureTestingModule(defaultProject, undefined);
-      },
-      fields[0],
-      "name",
-      "input",
-      true,
-      "Site Name",
-      "text"
-    );
-
-    /* Site Description Textarea */
-    testFormlyField(
-      "Site Description Input",
-      () => {
-        configureTestingModule(defaultProject, undefined);
-      },
-      fields[1],
-      "description",
-      "textarea",
-      false,
-      "Description"
-    );
-
-    /* Site Latitude Input */
-    testFormlyField(
-      "Site Latitude Input",
-      () => {
-        configureTestingModule(defaultProject, undefined);
-      },
-      fields[2].fieldGroup[0],
-      "customLatitude",
-      "input",
-      false,
-      "Latitude",
-      "number"
-    );
-
-    /* Site Longitude Input */
-    testFormlyField(
-      "Site Longitude Input",
-      () => {
-        configureTestingModule(defaultProject, undefined);
-      },
-      fields[2].fieldGroup[1],
-      "customLongitude",
-      "input",
-      false,
-      "Longitude",
-      "number"
-    );
-
-    /* Site Image Input */
-    testFormlyField(
-      "Site Image Input",
-      () => {
-        configureTestingModule(defaultProject, undefined);
-      },
-      fields[3],
-      "image",
-      "image",
-      false,
-      "Image"
-    );
-
-    /* Site Timezone Input */
-    /* testFormlyField(
-      "Site Timezone Input",
-      () => {
-        configureTestingModule(defaultProject, undefined);
-      },
-      fields[4],
-      "timezoneInformation",
-      "timezone",
-      false,
-      "Time Zone"
-    ); */
+    testFormlyFields(formInputs);
 
     // TODO Add input validation for custom location logic
   });
 
-  describe("form error handling", () => {
-    it("should show error message with missing site name", fakeAsync(() => {
+  describe("component", () => {
+    it("should create", () => {
       configureTestingModule(defaultProject, undefined);
 
-      submitForm(fixture);
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
-      );
+      expect(component).toBeTruthy();
+    });
+
+    it("should handle project error", fakeAsync(() => {
+      configureTestingModule(undefined, defaultError);
+      assertFormErrorHandling(fixture);
     }));
 
-    it("should show error message when only latitude is given", fakeAsync(() => {
+    it("should call api", () => {
       configureTestingModule(defaultProject, undefined);
+      spyOn(api, "create").and.callThrough();
 
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Test Site");
-      inputValue(inputs[latitudeIndex], "input", "5");
-      submitForm(fixture);
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
-      );
-      assertValidationMessage(
-        inputs[longitudeIndex],
-        "Both latitude and longitude must be set or left empty."
-      );
-    }));
-
-    it("should show error message when only longitude is given", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined);
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Test Site");
-      inputValue(inputs[longitudeIndex], "input", "5");
-      submitForm(fixture);
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Please fill all required fields."
-      );
-      assertValidationMessage(
-        inputs[longitudeIndex],
-        "Both latitude and longitude must be set or left empty."
-      );
-    }));
-  });
-
-  describe("failed submissions", () => {
-    it("should handle general error", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined);
-      spyOn(api, "create").and.callFake(() => {
-        const subject = new Subject<Site>();
-
-        subject.error({
-          message: "Sign in to access this feature.",
-          info: 401
-        } as ApiErrorDetails);
-
-        return subject;
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Site");
-      submitForm(fixture);
-
-      expect(notifications.error).toHaveBeenCalledWith(
-        "Sign in to access this feature."
-      );
-    }));
-
-    it("should re-enable submit button after failed submission", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined);
-      spyOn(api, "create").and.callFake(() => {
-        const subject = new Subject<Site>();
-
-        subject.error({
-          message: "Sign in to access this feature.",
-          info: 401
-        } as ApiErrorDetails);
-
-        return subject;
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Site");
-      submitForm(fixture);
-
-      flush();
-      fixture.detectChanges();
-
-      const button = fixture.nativeElement.querySelector(
-        "button[type='submit']"
-      );
-      expect(button).toBeTruthy();
-      expect(button.disabled).toBeFalsy("Button should not be disabled");
-    }));
-  });
-
-  describe("successful submissions", () => {
-    it("should call create", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined);
-      spyOn(api, "create");
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Test Site");
-      submitForm(fixture);
-
+      component.submit({});
       expect(api.create).toHaveBeenCalled();
-    }));
+    });
 
-    it("should call create with name", fakeAsync(() => {
+    it("should redirect to site", () => {
       configureTestingModule(defaultProject, undefined);
-      spyOn(api, "create");
+      const site = new Site({ id: 1, name: "Site" });
+      spyOn(site, "redirectPath").and.stub();
+      spyOn(api, "create").and.callFake(() => new BehaviorSubject<Site>(site));
 
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Test Site");
-      submitForm(fixture);
+      component.submit({});
+      expect(site.redirectPath).toHaveBeenCalled();
+    });
 
-      expect(api.create).toHaveBeenCalledWith(
-        new Site({ name: "Test Site" }),
-        defaultProject
-      );
-    }));
-
-    it("should call create with description", fakeAsync(() => {
+    it("should redirect to site with project", () => {
       configureTestingModule(defaultProject, undefined);
-      spyOn(api, "create");
+      const site = new Site({ id: 1, name: "Site" });
+      spyOn(site, "redirectPath").and.stub();
+      spyOn(api, "create").and.callFake(() => new BehaviorSubject<Site>(site));
 
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Test Site");
-      inputValue(inputs[descriptionIndex], "textarea", "Test Description");
-      submitForm(fixture);
-
-      expect(api.create).toHaveBeenCalledWith(
-        new Site({
-          name: "Test Site",
-          description: "Test Description"
-        }),
-        defaultProject
-      );
-    }));
-
-    it("should call create with location", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined);
-      spyOn(api, "create");
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Test Site");
-      inputValue(inputs[latitudeIndex], "input", "5");
-      inputValue(inputs[longitudeIndex], "input", "10");
-      submitForm(fixture);
-
-      expect(api.create).toHaveBeenCalledWith(
-        new Site({
-          name: "Test Site",
-          customLatitude: 5,
-          customLongitude: 10
-        }),
-        defaultProject
-      );
-    }));
-
-    xit("should call create with image", fakeAsync(() => {}));
-    xit("should call create with timezone", fakeAsync(() => {}));
-
-    it("should create notification on submission", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined);
-      spyOn(api, "create").and.callFake(() => {
-        return new BehaviorSubject<Site>(
-          new Site({
-            id: 1,
-            name: "Custom Site"
-          })
-        );
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[nameIndex], "input", "Custom Site");
-      submitForm(fixture);
-
-      expect(notifications.success).toHaveBeenCalledWith(
-        "Successfully created Custom Site"
-      );
-    }));
-
-    it("should navigate user to project on submit", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined);
-      const site = new Site({
-        id: 1,
-        name: "Site"
-      });
-
-      spyOn(api, "create").and.callFake(() => {
-        return new BehaviorSubject<Site>(site);
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Site");
-      submitForm(fixture);
-
-      expect(router.navigateByUrl).toHaveBeenCalledWith(
-        site.redirectPath(defaultProject)
-      );
-    }));
-
-    it("should disable submit button during submission", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined);
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Site");
-      submitForm(fixture);
-
-      flush();
-      fixture.detectChanges();
-
-      const button = fixture.nativeElement.querySelector(
-        "button[type='submit']"
-      );
-      expect(button).toBeTruthy();
-      expect(button.disabled).toBeTruthy("Button should be disabled");
-    }));
-
-    it("should reset form on successful submit", fakeAsync(() => {
-      configureTestingModule(defaultProject, undefined);
-      spyOn(component, "resetForms");
-      spyOn(api, "create").and.callFake(() => {
-        return new BehaviorSubject<Site>(
-          new Site({
-            id: 1,
-            name: "Site"
-          })
-        );
-      });
-
-      const inputs = getInputs(fixture);
-      inputValue(inputs[0], "input", "Site");
-      submitForm(fixture);
-
-      expect(component.resetForms).toHaveBeenCalled();
-      expect(component.isFormTouched()).toBeFalse();
-    }));
+      component.submit({});
+      expect(site.redirectPath).toHaveBeenCalledWith(defaultProject);
+    });
   });
 });

--- a/src/testHelpers.ts
+++ b/src/testHelpers.ts
@@ -105,6 +105,15 @@ export function assertValidationMessage(wrapper: any, message: string) {
 }
 
 /**
+ * Assert form component handles pre-loading model failure
+ * @param fixture Component fixture
+ */
+export function assertFormErrorHandling(fixture: ComponentFixture<any>) {
+  const body = fixture.nativeElement;
+  expect(body.childElementCount).toBe(0);
+}
+
+/**
  * Test a formly field
  * @param field Input to test
  * @param key Input ID/Key
@@ -164,4 +173,44 @@ export function testFormlyField(
       });
     }
   });
+}
+
+export function testFormlyFields(
+  formInputs: {
+    testGroup: string;
+    setup: () => void;
+    field: any;
+    key: string;
+    htmlType: string;
+    required: boolean;
+    label?: string;
+    type?: string;
+    description?: string;
+  }[]
+) {
+  formInputs.forEach(
+    ({
+      testGroup,
+      setup,
+      field,
+      key,
+      htmlType,
+      required,
+      label,
+      type,
+      description
+    }) => {
+      testFormlyField(
+        testGroup,
+        setup,
+        field,
+        key,
+        htmlType,
+        required,
+        label,
+        type,
+        description
+      );
+    }
+  );
 }


### PR DESCRIPTION
# Remove Redundant Unit Tests

New `FormTemplate` class extracts a lot of common code out of the form dependent components. This is now safe to remove to speedup tests.

## Stats

CI time spent running unit tests:

Linux: 4.5 minutes -> 3 minutes
Mac: 5 minutes -> 3 minutes
Windows: 5 minutes -> 3 minutes

## Closes

Closes #146 