### PR TITLE
Admin tag pages

### DIFF
--- a/src/app/app.helper.ts
+++ b/src/app/app.helper.ts
@@ -35,6 +35,7 @@ import {
   siteResolvers,
   SitesService
 } from "./services/baw-api/sites.service";
+import { tagResolvers, TagsService } from "./services/baw-api/tags.service";
 import { userResolvers, UserService } from "./services/baw-api/user.service";
 
 /**
@@ -152,11 +153,13 @@ export const providers = [
   SecurityService,
   ShallowSitesService,
   SitesService,
+  TagsService,
   UserService,
   ...accountResolvers.providers,
   ...projectResolvers.providers,
   ...scriptResolvers.providers,
   ...siteResolvers.providers,
   ...shallowSiteResolvers.providers,
+  ...tagResolvers.providers,
   ...userResolvers.providers
 ];

--- a/src/app/app.helper.ts
+++ b/src/app/app.helper.ts
@@ -3,6 +3,8 @@ import { APP_INITIALIZER } from "@angular/core";
 import { FaIconLibrary } from "@fortawesome/angular-fontawesome";
 import { fas } from "@fortawesome/free-solid-svg-icons";
 import { ConfigOption } from "@ngx-formly/core";
+import { FormlyCheckboxInput } from "./component/shared/formly/checkbox-input.component";
+import { FormlyHorizontalWrapper } from "./component/shared/formly/horizontal-wrapper";
 import { FormlyImageInput } from "./component/shared/formly/image-input.component";
 import { FormlyQuestionAnswerAction } from "./component/shared/formly/question-answer-action.component";
 import { FormlyQuestionAnswer } from "./component/shared/formly/question-answer.component";
@@ -89,6 +91,10 @@ export const toastrRoot = {
 export const formlyRoot = {
   types: [
     {
+      name: "checkbox",
+      component: FormlyCheckboxInput
+    },
+    {
       name: "image",
       component: FormlyImageInput
     },
@@ -104,6 +110,9 @@ export const formlyRoot = {
       name: "question-answer-action",
       component: FormlyQuestionAnswerAction
     }
+  ],
+  wrappers: [
+    { name: "form-field-horizontal", component: FormlyHorizontalWrapper }
   ],
   validationMessages: [
     { name: "required", message: "This field is required" },

--- a/src/app/component/admin/admin.menus.ts
+++ b/src/app/component/admin/admin.menus.ts
@@ -79,16 +79,18 @@ export const adminNewScriptsMenuItem = MenuRoute({
  * Admin Tags
  */
 
+const adminTagsRoute = adminRoute.add("tags");
+
 export const adminTagsCategory: Category = {
   icon: ["fas", "tag"],
   label: "Tags",
-  route: adminRoute.add("tags")
+  route: adminTagsRoute
 };
 
 export const adminTagsMenuItem = MenuRoute({
   icon: ["fas", "tag"],
   label: "Tags",
-  route: adminTagsCategory.route,
+  route: adminTagsRoute,
   tooltip: () => "Manage tags",
   parent: adminDashboardMenuItem,
   predicate: isAdminPredicate
@@ -97,16 +99,18 @@ export const adminTagsMenuItem = MenuRoute({
 export const adminNewTagMenuItem = MenuRoute({
   icon: defaultNewIcon,
   label: "New Tag",
-  route: adminTagsCategory.route.add("new"),
+  route: adminTagsRoute.add("new"),
   tooltip: () => "Create a new tag",
   parent: adminTagsMenuItem,
   predicate: isAdminPredicate
 });
 
+const adminTagRoute = adminTagsRoute.add(":tagId");
+
 export const adminEditTagMenuItem = MenuRoute({
   icon: defaultEditIcon,
   label: "Edit Tag",
-  route: adminTagsCategory.route.add("edit"),
+  route: adminTagRoute.add("edit"),
   tooltip: () => "Edit an existing tag",
   parent: adminTagsMenuItem,
   predicate: isAdminPredicate
@@ -115,7 +119,7 @@ export const adminEditTagMenuItem = MenuRoute({
 export const adminDeleteTagMenuItem = MenuRoute({
   icon: defaultDeleteIcon,
   label: "Delete Tag",
-  route: adminTagsCategory.route.add("delete"),
+  route: adminTagRoute.add("delete"),
   tooltip: () => "Delete an existing tag",
   parent: adminTagsMenuItem,
   predicate: isAdminPredicate

--- a/src/app/component/admin/admin.menus.ts
+++ b/src/app/component/admin/admin.menus.ts
@@ -1,5 +1,7 @@
 import {
   defaultAudioIcon,
+  defaultDeleteIcon,
+  defaultEditIcon,
   defaultNewIcon,
   isAdminPredicate
 } from "src/app/app.menus";
@@ -73,10 +75,20 @@ export const adminNewScriptsMenuItem = MenuRoute({
   predicate: isAdminPredicate
 });
 
+/**
+ * Admin Tags
+ */
+
+export const adminTagsCategory: Category = {
+  icon: ["fas", "tag"],
+  label: "Tags",
+  route: adminRoute.add("tags")
+};
+
 export const adminTagsMenuItem = MenuRoute({
   icon: ["fas", "tag"],
   label: "Tags",
-  route: adminRoute.add("tags"),
+  route: adminTagsCategory.route,
   tooltip: () => "Manage tags",
   parent: adminDashboardMenuItem,
   predicate: isAdminPredicate
@@ -85,8 +97,26 @@ export const adminTagsMenuItem = MenuRoute({
 export const adminNewTagMenuItem = MenuRoute({
   icon: defaultNewIcon,
   label: "New Tag",
-  route: adminTagsMenuItem.route.add("new"),
+  route: adminTagsCategory.route.add("new"),
   tooltip: () => "Create a new tag",
+  parent: adminTagsMenuItem,
+  predicate: isAdminPredicate
+});
+
+export const adminEditTagMenuItem = MenuRoute({
+  icon: defaultEditIcon,
+  label: "Edit Tag",
+  route: adminTagsCategory.route.add("edit"),
+  tooltip: () => "Edit an existing tag",
+  parent: adminTagsMenuItem,
+  predicate: isAdminPredicate
+});
+
+export const adminDeleteTagMenuItem = MenuRoute({
+  icon: defaultDeleteIcon,
+  label: "Destroy Tag",
+  route: adminTagsCategory.route.add("destroy"),
+  tooltip: () => "Destroy an existing tag",
   parent: adminTagsMenuItem,
   predicate: isAdminPredicate
 });
@@ -94,7 +124,7 @@ export const adminNewTagMenuItem = MenuRoute({
 export const adminTagGroupsMenuItem = MenuRoute({
   icon: ["fas", "tags"],
   label: "Tag Group",
-  route: adminRoute.add("tags"),
+  route: adminRoute.add("tag_groups"),
   tooltip: () => "Manage tags",
   parent: adminDashboardMenuItem,
   predicate: isAdminPredicate

--- a/src/app/component/admin/admin.menus.ts
+++ b/src/app/component/admin/admin.menus.ts
@@ -114,9 +114,9 @@ export const adminEditTagMenuItem = MenuRoute({
 
 export const adminDeleteTagMenuItem = MenuRoute({
   icon: defaultDeleteIcon,
-  label: "Destroy Tag",
-  route: adminTagsCategory.route.add("destroy"),
-  tooltip: () => "Destroy an existing tag",
+  label: "Delete Tag",
+  route: adminTagsCategory.route.add("delete"),
+  tooltip: () => "Delete an existing tag",
   parent: adminTagsMenuItem,
   predicate: isAdminPredicate
 });

--- a/src/app/component/admin/admin.module.ts
+++ b/src/app/component/admin/admin.module.ts
@@ -6,13 +6,21 @@ import { adminRoute } from "./admin.menus";
 import { AdminDashboardComponent } from "./dashboard/dashboard.component";
 import { AdminScriptsNewComponent } from "./scripts-new/scripts-new.component";
 import { AdminScriptsComponent } from "./scripts/scripts.component";
+import { AdminTagsDeleteComponent } from "./tags/delete/delete.component";
+import { AdminTagsEditComponent } from "./tags/edit/edit.component";
+import { AdminTagsComponent } from "./tags/list/list.component";
+import { AdminTagsNewComponent } from "./tags/new/new.component";
 import { AdminUserListComponent } from "./user-list/user-list.component";
 
 const components = [
   AdminDashboardComponent,
   AdminUserListComponent,
   AdminScriptsComponent,
-  AdminScriptsNewComponent
+  AdminScriptsNewComponent,
+  AdminTagsComponent,
+  AdminTagsNewComponent,
+  AdminTagsEditComponent,
+  AdminTagsDeleteComponent
 ];
 const routes = adminRoute.compileRoutes(GetRouteConfigForPage);
 

--- a/src/app/component/admin/tags/delete/delete.component.spec.ts
+++ b/src/app/component/admin/tags/delete/delete.component.spec.ts
@@ -1,0 +1,23 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { AdminTagsDeleteComponent } from "./delete.component";
+
+describe("AdminTagsDeleteComponent", () => {
+  let component: AdminTagsDeleteComponent;
+  let fixture: ComponentFixture<AdminTagsDeleteComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AdminTagsDeleteComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AdminTagsDeleteComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/component/admin/tags/delete/delete.component.spec.ts
+++ b/src/app/component/admin/tags/delete/delete.component.spec.ts
@@ -1,27 +1,111 @@
-import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { ToastrService } from "ngx-toastr";
+import { BehaviorSubject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { SharedModule } from "src/app/component/shared/shared.module";
-import { testBawServices } from "src/app/test.helper";
+import { Tag } from "src/app/models/Tag";
+import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
+import {
+  tagResolvers,
+  TagsService,
+  TagType
+} from "src/app/services/baw-api/tags.service";
+import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
+import { assertFormErrorHandling } from "src/testHelpers";
+import { adminTagsMenuItem } from "../../admin.menus";
 import { AdminTagsDeleteComponent } from "./delete.component";
 
 describe("AdminTagsDeleteComponent", () => {
+  let api: TagsService;
   let component: AdminTagsDeleteComponent;
+  let defaultError: ApiErrorDetails;
+  let defaultTag: Tag;
   let fixture: ComponentFixture<AdminTagsDeleteComponent>;
+  let notifications: ToastrService;
+  let router: Router;
 
-  beforeEach(async(() => {
+  function configureTestingModule(tag: Tag, tagError: ApiErrorDetails) {
     TestBed.configureTestingModule({
       imports: [...appLibraryImports, SharedModule, RouterTestingModule],
       declarations: [AdminTagsDeleteComponent],
-      providers: [...testBawServices]
+      providers: [
+        ...testBawServices,
+        {
+          provide: ActivatedRoute,
+          useClass: mockActivatedRoute(
+            {
+              tag: tagResolvers.show
+            },
+            {
+              tag: {
+                model: tag,
+                error: tagError
+              }
+            }
+          )
+        }
+      ]
     }).compileComponents();
-  }));
+
+    fixture = TestBed.createComponent(AdminTagsDeleteComponent);
+    api = TestBed.inject(TagsService);
+    router = TestBed.inject(Router);
+    notifications = TestBed.inject(ToastrService);
+    component = fixture.componentInstance;
+
+    spyOn(notifications, "success").and.stub();
+    spyOn(notifications, "error").and.stub();
+    spyOn(router, "navigateByUrl").and.stub();
+
+    fixture.detectChanges();
+  }
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(AdminTagsDeleteComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    defaultTag = new Tag({
+      id: 1,
+      text: "Tag"
+    });
+    defaultError = {
+      status: 401,
+      message: "Unauthorized"
+    };
   });
 
-  // TODO Write Tests
+  describe("form", () => {
+    it("should have no fields", () => {
+      configureTestingModule(defaultTag, undefined);
+      expect(component.fields).toEqual([]);
+    });
+  });
+
+  describe("component", () => {
+    it("should create", () => {
+      configureTestingModule(defaultTag, undefined);
+      expect(component).toBeTruthy();
+    });
+
+    it("should handle tag error", () => {
+      configureTestingModule(undefined, defaultError);
+      assertFormErrorHandling(fixture);
+    });
+
+    it("should call api", () => {
+      configureTestingModule(defaultTag, undefined);
+      spyOn(api, "destroy").and.callThrough();
+      component.submit({});
+      expect(api.destroy).toHaveBeenCalled();
+    });
+
+    it("should redirect to tag list", () => {
+      configureTestingModule(defaultTag, undefined);
+      spyOn(api, "destroy").and.callFake(() => new BehaviorSubject<void>(null));
+
+      component.submit({});
+      expect(router.navigateByUrl).toHaveBeenCalledWith(
+        adminTagsMenuItem.route.toString()
+      );
+    });
+  });
 });

--- a/src/app/component/admin/tags/delete/delete.component.spec.ts
+++ b/src/app/component/admin/tags/delete/delete.component.spec.ts
@@ -1,4 +1,8 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+import { appLibraryImports } from "src/app/app.module";
+import { SharedModule } from "src/app/component/shared/shared.module";
+import { testBawServices } from "src/app/test.helper";
 import { AdminTagsDeleteComponent } from "./delete.component";
 
 describe("AdminTagsDeleteComponent", () => {
@@ -7,7 +11,9 @@ describe("AdminTagsDeleteComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [AdminTagsDeleteComponent]
+      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      declarations: [AdminTagsDeleteComponent],
+      providers: [...testBawServices]
     }).compileComponents();
   }));
 
@@ -17,7 +23,5 @@ describe("AdminTagsDeleteComponent", () => {
     fixture.detectChanges();
   });
 
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+  // TODO Write Tests
 });

--- a/src/app/component/admin/tags/delete/delete.component.ts
+++ b/src/app/component/admin/tags/delete/delete.component.ts
@@ -14,6 +14,7 @@ import {
 } from "src/app/services/baw-api/tags.service";
 import {
   adminDeleteTagMenuItem,
+  adminEditTagMenuItem,
   adminTagsCategory,
   adminTagsMenuItem
 } from "../../admin.menus";
@@ -24,7 +25,12 @@ const tagKey = "tag";
 @Page({
   category: adminTagsCategory,
   menus: {
-    actions: List([adminTagsMenuItem, ...adminTagsMenuItemActions]),
+    actions: List([
+      adminTagsMenuItem,
+      ...adminTagsMenuItemActions,
+      adminEditTagMenuItem,
+      adminDeleteTagMenuItem
+    ]),
     links: List()
   },
   resolvers: {
@@ -57,7 +63,7 @@ export class AdminTagsDeleteComponent extends FormTemplate<Tag>
     route: ActivatedRoute,
     router: Router
   ) {
-    super(notifications, route, router, undefined, model =>
+    super(notifications, route, router, tagKey, model =>
       defaultSuccessMsg("destroyed", model.text)
     );
   }

--- a/src/app/component/admin/tags/delete/delete.component.ts
+++ b/src/app/component/admin/tags/delete/delete.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from "@angular/core";
+
+@Component({
+  selector: "app-delete",
+  template: ``
+})
+export class AdminTagsDeleteComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/component/admin/tags/delete/delete.component.ts
+++ b/src/app/component/admin/tags/delete/delete.component.ts
@@ -73,7 +73,6 @@ export class AdminTagsDeleteComponent extends FormTemplate<Tag>
 
     if (!this.failure) {
       this.title = `Are you certain you wish to delete ${this.model.text}?`;
-      // TODO Update typeOfTag with options
     }
   }
 

--- a/src/app/component/admin/tags/delete/delete.component.ts
+++ b/src/app/component/admin/tags/delete/delete.component.ts
@@ -1,11 +1,81 @@
 import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+import { List } from "immutable";
+import { ToastrService } from "ngx-toastr";
+import {
+  defaultSuccessMsg,
+  FormTemplate
+} from "src/app/helpers/formTemplate/formTemplate";
+import { Page } from "src/app/helpers/page/pageDecorator";
+import { Tag } from "src/app/models/Tag";
+import {
+  tagResolvers,
+  TagsService
+} from "src/app/services/baw-api/tags.service";
+import {
+  adminDeleteTagMenuItem,
+  adminTagsCategory,
+  adminTagsMenuItem
+} from "../../admin.menus";
+import { adminTagsMenuItemActions } from "../list/list.component";
 
+const tagKey = "tag";
+
+@Page({
+  category: adminTagsCategory,
+  menus: {
+    actions: List([adminTagsMenuItem, ...adminTagsMenuItemActions]),
+    links: List()
+  },
+  resolvers: {
+    [tagKey]: tagResolvers.show
+  },
+  self: adminDeleteTagMenuItem
+})
 @Component({
   selector: "app-delete",
-  template: ``
+  template: `
+    <app-form
+      *ngIf="!failure"
+      [title]="title"
+      [model]="model"
+      [fields]="fields"
+      btnColor="btn-danger"
+      submitLabel="Delete"
+      [submitLoading]="loading"
+      (onSubmit)="submit($event)"
+    ></app-form>
+  `
 })
-export class AdminTagsDeleteComponent implements OnInit {
-  constructor() {}
+export class AdminTagsDeleteComponent extends FormTemplate<Tag>
+  implements OnInit {
+  public title: string;
 
-  ngOnInit(): void {}
+  constructor(
+    private api: TagsService,
+    notifications: ToastrService,
+    route: ActivatedRoute,
+    router: Router
+  ) {
+    super(notifications, route, router, undefined, model =>
+      defaultSuccessMsg("destroyed", model.text)
+    );
+  }
+
+  ngOnInit(): void {
+    super.ngOnInit();
+
+    if (!this.failure) {
+      this.title = `Are you certain you wish to delete ${this.model.text}?`;
+      // TODO Update typeOfTag with options
+    }
+  }
+
+  protected redirectionPath() {
+    return adminTagsMenuItem.route.toString();
+  }
+
+  protected apiAction(model: Partial<Tag>) {
+    return this.api.destroy(new Tag(model));
+  }
 }

--- a/src/app/component/admin/tags/edit/edit.component.spec.ts
+++ b/src/app/component/admin/tags/edit/edit.component.spec.ts
@@ -1,0 +1,23 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { AdminTagsEditComponent } from "./edit.component";
+
+describe("AdminTagsEditComponent", () => {
+  let component: AdminTagsEditComponent;
+  let fixture: ComponentFixture<AdminTagsEditComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AdminTagsEditComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AdminTagsEditComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/component/admin/tags/edit/edit.component.spec.ts
+++ b/src/app/component/admin/tags/edit/edit.component.spec.ts
@@ -1,27 +1,120 @@
-import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { ToastrService } from "ngx-toastr";
 import { appLibraryImports } from "src/app/app.module";
 import { SharedModule } from "src/app/component/shared/shared.module";
-import { testBawServices } from "src/app/test.helper";
+import { Tag } from "src/app/models/Tag";
+import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
+import {
+  tagResolvers,
+  TagsService,
+  TagType
+} from "src/app/services/baw-api/tags.service";
+import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
+import { assertFormErrorHandling } from "src/testHelpers";
 import { AdminTagsEditComponent } from "./edit.component";
 
 describe("AdminTagsEditComponent", () => {
+  let api: TagsService;
   let component: AdminTagsEditComponent;
+  let defaultError: ApiErrorDetails;
+  let defaultTag: Tag;
+  let defaultTagTypes: TagType[];
   let fixture: ComponentFixture<AdminTagsEditComponent>;
+  let notifications: ToastrService;
+  let router: Router;
 
-  beforeEach(async(() => {
+  function configureTestingModule(
+    tag: Tag,
+    tagError: ApiErrorDetails,
+    tagTypes: TagType[],
+    tagTypesError: ApiErrorDetails
+  ) {
     TestBed.configureTestingModule({
       imports: [...appLibraryImports, SharedModule, RouterTestingModule],
       declarations: [AdminTagsEditComponent],
-      providers: [...testBawServices]
+      providers: [
+        ...testBawServices,
+        {
+          provide: ActivatedRoute,
+          useClass: mockActivatedRoute(
+            {
+              tag: tagResolvers.show,
+              typeOfTags: tagResolvers.typeOfTags
+            },
+            {
+              tag: {
+                model: tag,
+                error: tagError
+              },
+              tagTypes: {
+                model: tagTypes,
+                error: tagTypesError
+              }
+            }
+          )
+        }
+      ]
     }).compileComponents();
-  }));
+
+    fixture = TestBed.createComponent(AdminTagsEditComponent);
+    api = TestBed.inject(TagsService);
+    router = TestBed.inject(Router);
+    notifications = TestBed.inject(ToastrService);
+    component = fixture.componentInstance;
+
+    spyOn(notifications, "success").and.stub();
+    spyOn(notifications, "error").and.stub();
+    spyOn(router, "navigateByUrl").and.stub();
+
+    fixture.detectChanges();
+  }
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(AdminTagsEditComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    defaultTag = new Tag({
+      id: 1,
+      text: "Tag"
+    });
+    defaultTagTypes = [
+      new TagType({
+        name: "common_name"
+      })
+    ];
+    defaultError = {
+      status: 401,
+      message: "Unauthorized"
+    };
   });
 
-  // TODO Write Tests
+  xdescribe("form", () => {});
+
+  describe("component", () => {
+    it("should create", () => {
+      configureTestingModule(defaultTag, undefined, defaultTagTypes, undefined);
+      expect(component).toBeTruthy();
+    });
+
+    it("should handle tag error", () => {
+      configureTestingModule(
+        undefined,
+        defaultError,
+        defaultTagTypes,
+        undefined
+      );
+      assertFormErrorHandling(fixture);
+    });
+
+    it("should handle tag types error", () => {
+      configureTestingModule(defaultTag, undefined, undefined, defaultError);
+      assertFormErrorHandling(fixture);
+    });
+
+    it("should call api", () => {
+      configureTestingModule(defaultTag, undefined, defaultTagTypes, undefined);
+      spyOn(api, "update").and.callThrough();
+      component.submit({});
+      expect(api.update).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/component/admin/tags/edit/edit.component.spec.ts
+++ b/src/app/component/admin/tags/edit/edit.component.spec.ts
@@ -1,4 +1,8 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+import { appLibraryImports } from "src/app/app.module";
+import { SharedModule } from "src/app/component/shared/shared.module";
+import { testBawServices } from "src/app/test.helper";
 import { AdminTagsEditComponent } from "./edit.component";
 
 describe("AdminTagsEditComponent", () => {
@@ -7,7 +11,9 @@ describe("AdminTagsEditComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [AdminTagsEditComponent]
+      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      declarations: [AdminTagsEditComponent],
+      providers: [...testBawServices]
     }).compileComponents();
   }));
 
@@ -17,7 +23,5 @@ describe("AdminTagsEditComponent", () => {
     fixture.detectChanges();
   });
 
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+  // TODO Write Tests
 });

--- a/src/app/component/admin/tags/edit/edit.component.ts
+++ b/src/app/component/admin/tags/edit/edit.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from "@angular/core";
+
+@Component({
+  selector: "app-edit",
+  template: ``
+})
+export class AdminTagsEditComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/component/admin/tags/edit/edit.component.ts
+++ b/src/app/component/admin/tags/edit/edit.component.ts
@@ -10,7 +10,8 @@ import { Page } from "src/app/helpers/page/pageDecorator";
 import { Tag } from "src/app/models/Tag";
 import {
   tagResolvers,
-  TagsService
+  TagsService,
+  TagType
 } from "src/app/services/baw-api/tags.service";
 import {
   adminDeleteTagMenuItem,
@@ -22,6 +23,7 @@ import { adminTagsMenuItemActions } from "../list/list.component";
 import { fields } from "../tag.json";
 
 const tagKey = "tag";
+const typeOfTagsKey = "typeOfTags";
 
 @Page({
   category: adminTagsCategory,
@@ -35,7 +37,8 @@ const tagKey = "tag";
     links: List()
   },
   resolvers: {
-    [tagKey]: tagResolvers.show
+    [tagKey]: tagResolvers.show,
+    [typeOfTagsKey]: tagResolvers.typeOfTags
   },
   self: adminEditTagMenuItem
 })
@@ -71,11 +74,21 @@ export class AdminTagsEditComponent extends FormTemplate<Tag>
 
   ngOnInit() {
     super.ngOnInit();
+    const typeOfTagIndex = 1;
 
     if (!this.failure) {
       this.title = `Edit ${this.model.text}`;
-      // TODO Update typeOfTag with options
+      this.fields[typeOfTagIndex].templateOptions.options = this.typeOfTags.map(
+        tagType => ({
+          label: tagType.toString(),
+          value: tagType.name
+        })
+      );
     }
+  }
+
+  public get typeOfTags(): TagType[] {
+    return (this.models[typeOfTagsKey] as unknown) as TagType[];
   }
 
   protected apiAction(model: Partial<Tag>) {

--- a/src/app/component/admin/tags/edit/edit.component.ts
+++ b/src/app/component/admin/tags/edit/edit.component.ts
@@ -13,6 +13,7 @@ import {
   TagsService
 } from "src/app/services/baw-api/tags.service";
 import {
+  adminDeleteTagMenuItem,
   adminEditTagMenuItem,
   adminTagsCategory,
   adminTagsMenuItem
@@ -25,7 +26,12 @@ const tagKey = "tag";
 @Page({
   category: adminTagsCategory,
   menus: {
-    actions: List([adminTagsMenuItem, ...adminTagsMenuItemActions]),
+    actions: List([
+      adminTagsMenuItem,
+      ...adminTagsMenuItemActions,
+      adminEditTagMenuItem,
+      adminDeleteTagMenuItem
+    ]),
     links: List()
   },
   resolvers: {
@@ -58,7 +64,7 @@ export class AdminTagsEditComponent extends FormTemplate<Tag>
     route: ActivatedRoute,
     router: Router
   ) {
-    super(notifications, route, router, undefined, model =>
+    super(notifications, route, router, tagKey, model =>
       defaultSuccessMsg("updated", model.text)
     );
   }

--- a/src/app/component/admin/tags/edit/edit.component.ts
+++ b/src/app/component/admin/tags/edit/edit.component.ts
@@ -23,7 +23,7 @@ import { adminTagsMenuItemActions } from "../list/list.component";
 import { fields } from "../tag.json";
 
 const tagKey = "tag";
-const typeOfTagsKey = "typeOfTags";
+const tagTypesKey = "tagTypes";
 
 @Page({
   category: adminTagsCategory,
@@ -38,7 +38,7 @@ const typeOfTagsKey = "typeOfTags";
   },
   resolvers: {
     [tagKey]: tagResolvers.show,
-    [typeOfTagsKey]: tagResolvers.typeOfTags
+    [tagTypesKey]: tagResolvers.typeOfTags
   },
   self: adminEditTagMenuItem
 })
@@ -88,7 +88,7 @@ export class AdminTagsEditComponent extends FormTemplate<Tag>
   }
 
   public get typeOfTags(): TagType[] {
-    return (this.models[typeOfTagsKey] as unknown) as TagType[];
+    return (this.models[tagTypesKey] as unknown) as TagType[];
   }
 
   protected apiAction(model: Partial<Tag>) {

--- a/src/app/component/admin/tags/edit/edit.component.ts
+++ b/src/app/component/admin/tags/edit/edit.component.ts
@@ -1,11 +1,78 @@
 import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+import { List } from "immutable";
+import { ToastrService } from "ngx-toastr";
+import {
+  defaultSuccessMsg,
+  FormTemplate
+} from "src/app/helpers/formTemplate/formTemplate";
+import { Page } from "src/app/helpers/page/pageDecorator";
+import { Tag } from "src/app/models/Tag";
+import {
+  tagResolvers,
+  TagsService
+} from "src/app/services/baw-api/tags.service";
+import {
+  adminEditTagMenuItem,
+  adminTagsCategory,
+  adminTagsMenuItem
+} from "../../admin.menus";
+import { adminTagsMenuItemActions } from "../list/list.component";
+import { fields } from "../tag.json";
 
-@Component({
-  selector: "app-edit",
-  template: ``
+const tagKey = "tag";
+
+@Page({
+  category: adminTagsCategory,
+  menus: {
+    actions: List([adminTagsMenuItem, ...adminTagsMenuItemActions]),
+    links: List()
+  },
+  resolvers: {
+    [tagKey]: tagResolvers.show
+  },
+  self: adminEditTagMenuItem
 })
-export class AdminTagsEditComponent implements OnInit {
-  constructor() {}
+@Component({
+  selector: "app-admin-tags-edit",
+  template: `
+    <app-form
+      *ngIf="!failure"
+      [title]="title"
+      [model]="model"
+      [fields]="fields"
+      [submitLoading]="loading"
+      submitLabel="Submit"
+      (onSubmit)="submit($event)"
+    ></app-form>
+  `
+})
+export class AdminTagsEditComponent extends FormTemplate<Tag>
+  implements OnInit {
+  public fields = fields;
+  public title: string;
 
-  ngOnInit(): void {}
+  constructor(
+    private api: TagsService,
+    notifications: ToastrService,
+    route: ActivatedRoute,
+    router: Router
+  ) {
+    super(notifications, route, router, undefined, model =>
+      defaultSuccessMsg("updated", model.text)
+    );
+  }
+
+  ngOnInit() {
+    super.ngOnInit();
+
+    if (!this.failure) {
+      this.title = `Edit ${this.model.text}`;
+      // TODO Update typeOfTag with options
+    }
+  }
+
+  protected apiAction(model: Partial<Tag>) {
+    return this.api.update(new Tag(model));
+  }
 }

--- a/src/app/component/admin/tags/list/list.component.html
+++ b/src/app/component/admin/tags/list/list.component.html
@@ -1,0 +1,66 @@
+<ng-container *ngIf="rows && !error">
+  <h1>Tag List</h1>
+
+  <ngx-datatable
+    #table
+    bawDatatableDefaults
+    [columnMode]="ColumnMode.force"
+    [columns]="columns"
+    [rows]="rows"
+    [externalPaging]="true"
+    [count]="totalModels"
+    [offset]="pageNumber"
+    (page)="setPage($event)"
+  >
+    <ngx-datatable-column name="Text" [sortable]="false">
+      <ng-template let-column="column" ngx-datatable-header-template>
+        <fa-icon [icon]="['fas', 'book']"></fa-icon>
+        Text
+      </ng-template>
+    </ngx-datatable-column>
+    <ngx-datatable-column name="Taxanomic" [sortable]="false">
+    </ngx-datatable-column>
+    <ngx-datatable-column
+      name="Retired"
+      [width]="90"
+      [maxWidth]="90"
+      [sortable]="false"
+    >
+      <ng-template let-row="row" let-value="value" ngx-datatable-cell-template>
+        <div class="mx-auto" style="width: 24px;">
+          <div class="custom-control custom-checkbox">
+            <input
+              type="checkbox"
+              class="custom-control-input"
+              disabled
+              [id]="row.text + '-checkbox'"
+              [checked]="value"
+            />
+            <label class="custom-control-label" for="checkbox"></label>
+          </div>
+        </div>
+      </ng-template>
+    </ngx-datatable-column>
+    <ngx-datatable-column name="Type" [sortable]="false">
+    </ngx-datatable-column>
+    <ngx-datatable-column
+      name="Tag"
+      [width]="130"
+      [maxWidth]="130"
+      [sortable]="false"
+    >
+      <ng-template let-column="column" ngx-datatable-header-template>
+      </ng-template>
+      <ng-template let-value="value" ngx-datatable-cell-template>
+        <a class="btn btn-sm btn-warning mr-1" [routerLink]="[editPath(value)]">
+          Edit
+        </a>
+        <a class="btn btn-sm btn-danger" [routerLink]="[deletePath(value)]">
+          Delete
+        </a>
+      </ng-template>
+    </ngx-datatable-column>
+  </ngx-datatable>
+</ng-container>
+
+<app-error-handler [error]="error"></app-error-handler>

--- a/src/app/component/admin/tags/list/list.component.html
+++ b/src/app/component/admin/tags/list/list.component.html
@@ -1,31 +1,40 @@
 <ng-container *ngIf="rows && !error">
   <h1>Tag List</h1>
 
+  <div class="input-group mb-3">
+    <div class="input-group-prepend">
+      <span class="input-group-text">Filter</span>
+    </div>
+    <input
+      type="text"
+      class="form-control"
+      placeholder="Filter Tags"
+      (keyup)="onFilter($event)"
+    />
+  </div>
+
   <ngx-datatable
     #table
     bawDatatableDefaults
     [columnMode]="ColumnMode.force"
     [columns]="columns"
     [rows]="rows"
-    [externalPaging]="true"
     [count]="totalModels"
     [offset]="pageNumber"
     (page)="setPage($event)"
+    (sort)="onSort($event)"
   >
-    <ngx-datatable-column name="Text" [sortable]="false">
-      <ng-template let-column="column" ngx-datatable-header-template>
-        <fa-icon [icon]="['fas', 'book']"></fa-icon>
-        Text
-      </ng-template>
-    </ngx-datatable-column>
-    <ngx-datatable-column name="Taxanomic" [sortable]="false">
-    </ngx-datatable-column>
+    <ngx-datatable-column name="Text"> </ngx-datatable-column>
     <ngx-datatable-column
-      name="Retired"
-      [width]="90"
-      [maxWidth]="90"
+      name="Count"
+      width="80"
+      maxWidth="80"
       [sortable]="false"
     >
+    </ngx-datatable-column>
+    <ngx-datatable-column name="Taxanomic" width="100" maxWidth="100">
+    </ngx-datatable-column>
+    <ngx-datatable-column name="Retired" width="90" maxWidth="90">
       <ng-template let-row="row" let-value="value" ngx-datatable-cell-template>
         <div class="mx-auto" style="width: 24px;">
           <div class="custom-control custom-checkbox">
@@ -41,8 +50,7 @@
         </div>
       </ng-template>
     </ngx-datatable-column>
-    <ngx-datatable-column name="Type" [sortable]="false">
-    </ngx-datatable-column>
+    <ngx-datatable-column name="Type"> </ngx-datatable-column>
     <ngx-datatable-column
       name="Tag"
       [width]="130"

--- a/src/app/component/admin/tags/list/list.component.html
+++ b/src/app/component/admin/tags/list/list.component.html
@@ -36,18 +36,11 @@
     </ngx-datatable-column>
     <ngx-datatable-column name="Retired" width="90" maxWidth="90">
       <ng-template let-row="row" let-value="value" ngx-datatable-cell-template>
-        <div class="mx-auto" style="width: 24px;">
-          <div class="custom-control custom-checkbox">
-            <input
-              type="checkbox"
-              class="custom-control-input"
-              disabled
-              [id]="row.text + '-checkbox'"
-              [checked]="value"
-            />
-            <label class="custom-control-label" for="checkbox"></label>
-          </div>
-        </div>
+        <app-checkbox
+          [id]="row.text"
+          [checked]="value"
+          [disabled]="true"
+        ></app-checkbox>
       </ng-template>
     </ngx-datatable-column>
     <ngx-datatable-column name="Type"> </ngx-datatable-column>

--- a/src/app/component/admin/tags/list/list.component.spec.ts
+++ b/src/app/component/admin/tags/list/list.component.spec.ts
@@ -1,0 +1,23 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { AdminTagsComponent } from "./list.component";
+
+describe("AdminTagsComponent", () => {
+  let component: AdminTagsComponent;
+  let fixture: ComponentFixture<AdminTagsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AdminTagsComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AdminTagsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/component/admin/tags/list/list.component.spec.ts
+++ b/src/app/component/admin/tags/list/list.component.spec.ts
@@ -1,4 +1,8 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+import { appLibraryImports } from "src/app/app.module";
+import { SharedModule } from "src/app/component/shared/shared.module";
+import { testBawServices } from "src/app/test.helper";
 import { AdminTagsComponent } from "./list.component";
 
 describe("AdminTagsComponent", () => {
@@ -7,7 +11,9 @@ describe("AdminTagsComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [AdminTagsComponent]
+      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      declarations: [AdminTagsComponent],
+      providers: [...testBawServices]
     }).compileComponents();
   }));
 
@@ -20,4 +26,5 @@ describe("AdminTagsComponent", () => {
   it("should create", () => {
     expect(component).toBeTruthy();
   });
+  // TODO Write Tests
 });

--- a/src/app/component/admin/tags/list/list.component.ts
+++ b/src/app/component/admin/tags/list/list.component.ts
@@ -1,0 +1,88 @@
+import { Component, OnInit } from "@angular/core";
+import { List } from "immutable";
+import { Page } from "src/app/helpers/page/pageDecorator";
+import { PagedTableTemplate } from "src/app/helpers/tableTemplate/pagedTableTemplate";
+import { AnyMenuItem } from "src/app/interfaces/menusInterfaces";
+import { Tag } from "src/app/models/Tag";
+import { TagsService } from "src/app/services/baw-api/tags.service";
+import {
+  adminDashboardMenuItem,
+  adminDeleteTagMenuItem,
+  adminEditTagMenuItem,
+  adminNewTagMenuItem,
+  adminTagsCategory,
+  adminTagsMenuItem
+} from "../../admin.menus";
+
+export const adminTagsMenuItemActions = [
+  adminNewTagMenuItem,
+  adminEditTagMenuItem,
+  adminDeleteTagMenuItem
+];
+
+@Page({
+  category: adminTagsCategory,
+  menus: {
+    actions: List<AnyMenuItem>([
+      adminDashboardMenuItem,
+      ...adminTagsMenuItemActions
+    ]),
+    links: List()
+  },
+  self: adminTagsMenuItem
+})
+@Component({
+  selector: "app-admin-tags",
+  templateUrl: "./list.component.html",
+  styleUrls: ["./list.component.scss"]
+})
+export class AdminTagsComponent extends PagedTableTemplate<TableRow, Tag>
+  implements OnInit {
+  constructor(api: TagsService) {
+    super(api, tags =>
+      tags.map(tag => ({
+        text: tag.text,
+        count: tag.count,
+        taxanomic: tag.isTaxanomic ? "Taxanomic" : "Folksonomic",
+        retired: tag.retired,
+        type: tag.typeOfTag,
+        tag
+      }))
+    );
+  }
+
+  ngOnInit(): void {
+    this.columns = [
+      { name: "Text" },
+      { name: "Count" },
+      { name: "Taxanomic" },
+      { name: "Retired" },
+      { name: "type" },
+      { name: "Actions" },
+      { name: "Tag" }
+    ];
+
+    this.getModels();
+  }
+
+  editPath(tag: Tag): string {
+    return adminEditTagMenuItem.route
+      .toString()
+      .replace(":tagId", tag.id.toString());
+  }
+
+  deletePath(tag: Tag): string {
+    return adminDeleteTagMenuItem.route
+      .toString()
+      .replace(":tagId", tag.id.toString());
+  }
+}
+
+interface TableRow {
+  text: string;
+  count: number;
+  taxanomic: "Taxanomic" | "Folksonomic";
+  retired: boolean;
+  type: string;
+  tag: Tag;
+}

--- a/src/app/component/admin/tags/list/list.component.ts
+++ b/src/app/component/admin/tags/list/list.component.ts
@@ -58,9 +58,14 @@ export class AdminTagsComponent extends PagedTableTemplate<TableRow, Tag>
       { name: "Taxanomic" },
       { name: "Retired" },
       { name: "type" },
-      { name: "Actions" },
       { name: "Tag" }
     ];
+    this.sortKeys = {
+      text: "text",
+      taxanomic: "isTaxanomic",
+      retired: "retired",
+      type: "typeOfTag"
+    };
 
     this.getModels();
   }

--- a/src/app/component/admin/tags/list/list.component.ts
+++ b/src/app/component/admin/tags/list/list.component.ts
@@ -14,11 +14,7 @@ import {
   adminTagsMenuItem
 } from "../../admin.menus";
 
-export const adminTagsMenuItemActions = [
-  adminNewTagMenuItem,
-  adminEditTagMenuItem,
-  adminDeleteTagMenuItem
-];
+export const adminTagsMenuItemActions = [adminNewTagMenuItem];
 
 @Page({
   category: adminTagsCategory,

--- a/src/app/component/admin/tags/new/new.component.spec.ts
+++ b/src/app/component/admin/tags/new/new.component.spec.ts
@@ -1,27 +1,96 @@
-import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { ToastrService } from "ngx-toastr";
 import { appLibraryImports } from "src/app/app.module";
 import { SharedModule } from "src/app/component/shared/shared.module";
-import { testBawServices } from "src/app/test.helper";
+import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
+import {
+  tagResolvers,
+  TagsService,
+  TagType
+} from "src/app/services/baw-api/tags.service";
+import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
+import { assertFormErrorHandling } from "src/testHelpers";
 import { AdminTagsNewComponent } from "./new.component";
 
 describe("AdminTagsNewComponent", () => {
+  let api: TagsService;
   let component: AdminTagsNewComponent;
+  let defaultError: ApiErrorDetails;
+  let defaultTagTypes: TagType[];
   let fixture: ComponentFixture<AdminTagsNewComponent>;
+  let notifications: ToastrService;
+  let router: Router;
 
-  beforeEach(async(() => {
+  function configureTestingModule(
+    tagTypes: TagType[],
+    tagTypesError: ApiErrorDetails
+  ) {
     TestBed.configureTestingModule({
       imports: [...appLibraryImports, SharedModule, RouterTestingModule],
       declarations: [AdminTagsNewComponent],
-      providers: [...testBawServices]
+      providers: [
+        ...testBawServices,
+        {
+          provide: ActivatedRoute,
+          useClass: mockActivatedRoute(
+            {
+              typeOfTags: tagResolvers.typeOfTags
+            },
+            {
+              tagTypes: {
+                model: tagTypes,
+                error: tagTypesError
+              }
+            }
+          )
+        }
+      ]
     }).compileComponents();
-  }));
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(AdminTagsNewComponent);
+    api = TestBed.inject(TagsService);
+    router = TestBed.inject(Router);
+    notifications = TestBed.inject(ToastrService);
     component = fixture.componentInstance;
+
+    spyOn(notifications, "success").and.stub();
+    spyOn(notifications, "error").and.stub();
+    spyOn(router, "navigateByUrl").and.stub();
+
     fixture.detectChanges();
+  }
+  beforeEach(() => {
+    defaultTagTypes = [
+      new TagType({
+        name: "common_name"
+      })
+    ];
+    defaultError = {
+      status: 401,
+      message: "Unauthorized"
+    };
   });
 
-  // TODO Write Tests
+  xdescribe("form", () => {});
+
+  describe("component", () => {
+    it("should create", () => {
+      configureTestingModule(defaultTagTypes, undefined);
+      expect(component).toBeTruthy();
+    });
+
+    it("should handle tag types error", () => {
+      configureTestingModule(undefined, defaultError);
+      assertFormErrorHandling(fixture);
+    });
+
+    it("should call api", () => {
+      configureTestingModule(defaultTagTypes, undefined);
+      spyOn(api, "create").and.callThrough();
+      component.submit({});
+      expect(api.create).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/component/admin/tags/new/new.component.spec.ts
+++ b/src/app/component/admin/tags/new/new.component.spec.ts
@@ -1,4 +1,8 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+import { appLibraryImports } from "src/app/app.module";
+import { SharedModule } from "src/app/component/shared/shared.module";
+import { testBawServices } from "src/app/test.helper";
 import { AdminTagsNewComponent } from "./new.component";
 
 describe("AdminTagsNewComponent", () => {
@@ -7,7 +11,9 @@ describe("AdminTagsNewComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [AdminTagsNewComponent]
+      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      declarations: [AdminTagsNewComponent],
+      providers: [...testBawServices]
     }).compileComponents();
   }));
 
@@ -17,7 +23,5 @@ describe("AdminTagsNewComponent", () => {
     fixture.detectChanges();
   });
 
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+  // TODO Write Tests
 });

--- a/src/app/component/admin/tags/new/new.component.spec.ts
+++ b/src/app/component/admin/tags/new/new.component.spec.ts
@@ -1,0 +1,23 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { AdminTagsNewComponent } from "./new.component";
+
+describe("AdminTagsNewComponent", () => {
+  let component: AdminTagsNewComponent;
+  let fixture: ComponentFixture<AdminTagsNewComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AdminTagsNewComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AdminTagsNewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/component/admin/tags/new/new.component.ts
+++ b/src/app/component/admin/tags/new/new.component.ts
@@ -1,11 +1,67 @@
 import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+import { List } from "immutable";
+import { ToastrService } from "ngx-toastr";
+import {
+  defaultSuccessMsg,
+  FormTemplate
+} from "src/app/helpers/formTemplate/formTemplate";
+import { Page } from "src/app/helpers/page/pageDecorator";
+import { Tag } from "src/app/models/Tag";
+import { TagsService } from "src/app/services/baw-api/tags.service";
+import {
+  adminNewTagMenuItem,
+  adminTagsCategory,
+  adminTagsMenuItem
+} from "../../admin.menus";
+import { adminTagsMenuItemActions } from "../list/list.component";
+import { fields } from "../tag.json";
 
-@Component({
-  selector: "app-new",
-  template: ``
+@Page({
+  category: adminTagsCategory,
+  menus: {
+    actions: List([adminTagsMenuItem, ...adminTagsMenuItemActions]),
+    links: List()
+  },
+  self: adminNewTagMenuItem
 })
-export class AdminTagsNewComponent implements OnInit {
-  constructor() {}
+@Component({
+  selector: "app-admin-tags-new",
+  template: `
+    <app-form
+      *ngIf="!failure"
+      title="New Site"
+      [model]="model"
+      [fields]="fields"
+      [submitLoading]="loading"
+      submitLabel="Submit"
+      (onSubmit)="submit($event)"
+    ></app-form>
+  `
+})
+export class AdminTagsNewComponent extends FormTemplate<Tag> implements OnInit {
+  public fields = fields;
 
-  ngOnInit(): void {}
+  constructor(
+    private api: TagsService,
+    notifications: ToastrService,
+    route: ActivatedRoute,
+    router: Router
+  ) {
+    super(notifications, route, router, undefined, model =>
+      defaultSuccessMsg("created", model.text)
+    );
+  }
+
+  ngOnInit() {
+    super.ngOnInit();
+
+    if (!this.failure) {
+      // TODO Update typeOfTag with options
+    }
+  }
+
+  protected apiAction(model: Partial<Tag>) {
+    return this.api.create(new Tag(model));
+  }
 }

--- a/src/app/component/admin/tags/new/new.component.ts
+++ b/src/app/component/admin/tags/new/new.component.ts
@@ -30,7 +30,7 @@ import { fields } from "../tag.json";
   template: `
     <app-form
       *ngIf="!failure"
-      title="New Site"
+      title="New Tag"
       [model]="model"
       [fields]="fields"
       [submitLoading]="loading"

--- a/src/app/component/admin/tags/new/new.component.ts
+++ b/src/app/component/admin/tags/new/new.component.ts
@@ -8,7 +8,11 @@ import {
 } from "src/app/helpers/formTemplate/formTemplate";
 import { Page } from "src/app/helpers/page/pageDecorator";
 import { Tag } from "src/app/models/Tag";
-import { TagsService } from "src/app/services/baw-api/tags.service";
+import {
+  tagResolvers,
+  TagsService,
+  TagType
+} from "src/app/services/baw-api/tags.service";
 import {
   adminNewTagMenuItem,
   adminTagsCategory,
@@ -17,11 +21,16 @@ import {
 import { adminTagsMenuItemActions } from "../list/list.component";
 import { fields } from "../tag.json";
 
+const typeOfTagsKey = "typeOfTags";
+
 @Page({
   category: adminTagsCategory,
   menus: {
     actions: List([adminTagsMenuItem, ...adminTagsMenuItemActions]),
     links: List()
+  },
+  resolvers: {
+    [typeOfTagsKey]: tagResolvers.typeOfTags
   },
   self: adminNewTagMenuItem
 })
@@ -55,10 +64,20 @@ export class AdminTagsNewComponent extends FormTemplate<Tag> implements OnInit {
 
   ngOnInit() {
     super.ngOnInit();
+    const typeOfTagIndex = 1;
 
     if (!this.failure) {
-      // TODO Update typeOfTag with options
+      this.fields[typeOfTagIndex].templateOptions.options = this.typeOfTags.map(
+        tagType => ({
+          label: tagType.toString(),
+          value: tagType.name
+        })
+      );
     }
+  }
+
+  public get typeOfTags(): TagType[] {
+    return (this.models[typeOfTagsKey] as unknown) as TagType[];
   }
 
   protected apiAction(model: Partial<Tag>) {

--- a/src/app/component/admin/tags/new/new.component.ts
+++ b/src/app/component/admin/tags/new/new.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from "@angular/core";
+
+@Component({
+  selector: "app-new",
+  template: ``
+})
+export class AdminTagsNewComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/component/admin/tags/tag.json
+++ b/src/app/component/admin/tags/tag.json
@@ -29,19 +29,19 @@
     },
     {
       "key": "retired",
-      "type": "input",
+      "type": "checkbox",
+      "wrappers": ["form-field-horizontal"],
       "templateOptions": {
         "label": "Retired",
-        "type": "checkbox",
         "required": false
       }
     },
     {
       "key": "isTaxanomic",
-      "type": "input",
+      "type": "checkbox",
+      "wrappers": ["form-field-horizontal"],
       "templateOptions": {
         "label": "Is Taxanomic",
-        "type": "checkbox",
         "required": false
       }
     }

--- a/src/app/component/admin/tags/tag.json
+++ b/src/app/component/admin/tags/tag.json
@@ -1,0 +1,49 @@
+{
+  "fields": [
+    {
+      "key": "text",
+      "type": "input",
+      "templateOptions": {
+        "label": "Text",
+        "type": "text",
+        "required": true
+      }
+    },
+    {
+      "key": "typeOfTag",
+      "type": "select",
+      "templateOptions": {
+        "label": "Type of Tag",
+        "required": true,
+        "options": []
+      }
+    },
+    {
+      "key": "notes",
+      "type": "textarea",
+      "templateOptions": {
+        "label": "Notes",
+        "required": false,
+        "rows": 8
+      }
+    },
+    {
+      "key": "retired",
+      "type": "input",
+      "templateOptions": {
+        "label": "Retired",
+        "type": "checkbox",
+        "required": false
+      }
+    },
+    {
+      "key": "isTaxanomic",
+      "type": "input",
+      "templateOptions": {
+        "label": "Is Taxanomic",
+        "type": "checkbox",
+        "required": false
+      }
+    }
+  ]
+}

--- a/src/app/component/shared/checkbox/checkbox.component.spec.ts
+++ b/src/app/component/shared/checkbox/checkbox.component.spec.ts
@@ -1,0 +1,59 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { CheckboxComponent } from "./checkbox.component";
+
+describe("CheckboxComponent", () => {
+  let component: CheckboxComponent;
+  let fixture: ComponentFixture<CheckboxComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [CheckboxComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CheckboxComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("should create", () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it("should be checked", () => {
+    component.checked = true;
+    fixture.detectChanges();
+    const checkbox: HTMLInputElement = fixture.nativeElement.querySelector(
+      "input"
+    );
+    expect(checkbox.checked).toBeTruthy();
+  });
+
+  it("should not be checked", () => {
+    component.checked = false;
+    fixture.detectChanges();
+    const checkbox: HTMLInputElement = fixture.nativeElement.querySelector(
+      "input"
+    );
+    expect(checkbox.checked).toBeFalsy();
+  });
+
+  it("should be disabled", () => {
+    component.disabled = true;
+    fixture.detectChanges();
+    const checkbox: HTMLInputElement = fixture.nativeElement.querySelector(
+      "input"
+    );
+    expect(checkbox.disabled).toBeTruthy();
+  });
+
+  it("should not be disabled", () => {
+    component.disabled = false;
+    fixture.detectChanges();
+    const checkbox: HTMLInputElement = fixture.nativeElement.querySelector(
+      "input"
+    );
+    expect(checkbox.disabled).toBeFalsy();
+  });
+});

--- a/src/app/component/shared/checkbox/checkbox.component.ts
+++ b/src/app/component/shared/checkbox/checkbox.component.ts
@@ -1,0 +1,34 @@
+import {
+  Component,
+  OnInit,
+  ChangeDetectionStrategy,
+  Input
+} from "@angular/core";
+
+@Component({
+  selector: "app-checkbox",
+  template: `
+    <div class="mx-auto" style="width: 24px;">
+      <div class="custom-control custom-checkbox">
+        <input
+          type="checkbox"
+          class="custom-control-input"
+          [id]="id + '-checkbox'"
+          [checked]="checked"
+          [disabled]="disabled"
+        />
+        <label class="custom-control-label" for="checkbox"></label>
+      </div>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class CheckboxComponent implements OnInit {
+  @Input() id: string;
+  @Input() checked: boolean;
+  @Input() disabled: boolean;
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/component/shared/checkbox/checkbox.component.ts
+++ b/src/app/component/shared/checkbox/checkbox.component.ts
@@ -1,8 +1,8 @@
 import {
-  Component,
-  OnInit,
   ChangeDetectionStrategy,
-  Input
+  Component,
+  Input,
+  OnInit
 } from "@angular/core";
 
 @Component({

--- a/src/app/component/shared/formly/checkbox-input.component.ts
+++ b/src/app/component/shared/formly/checkbox-input.component.ts
@@ -1,0 +1,27 @@
+import { Component } from "@angular/core";
+import { FormControl } from "@angular/forms";
+import { FieldType } from "@ngx-formly/core";
+
+@Component({
+  // tslint:disable-next-line: component-selector
+  selector: "formly-checkbox-input",
+  template: `
+    <div
+      style="width: 24px;"
+      class="custom-control custom-checkbox col-form-label"
+    >
+      <input
+        type="checkbox"
+        class="custom-control-input"
+        [id]="id + '-checkbox'"
+        [formControl]="formControl"
+        [formlyAttributes]="field"
+      />
+      <label class="custom-control-label" [for]="id + '-checkbox'"></label>
+    </div>
+  `
+})
+// tslint:disable-next-line: component-class-suffix
+export class FormlyCheckboxInput extends FieldType {
+  formControl: FormControl;
+}

--- a/src/app/component/shared/formly/horizontal-wrapper.ts
+++ b/src/app/component/shared/formly/horizontal-wrapper.ts
@@ -1,0 +1,26 @@
+import { Component } from "@angular/core";
+import { FieldWrapper } from "@ngx-formly/core";
+
+@Component({
+  // tslint:disable-next-line: component-selector
+  selector: "formly-horizontal-wrapper",
+  template: `
+    <div class="form-group row">
+      <label [attr.for]="id" class="col-sm-2 col-form-label" *ngIf="to.label">
+        {{ to.label }}
+        <ng-container *ngIf="to.required && to.hideRequiredMarker !== true"
+          >*</ng-container
+        >
+      </label>
+      <div class="col-sm-7">
+        <ng-template #fieldComponent></ng-template>
+      </div>
+
+      <div *ngIf="showError" class="col-sm-3 invalid-feedback d-block">
+        <formly-validation-message [field]="field"></formly-validation-message>
+      </div>
+    </div>
+  `
+})
+// tslint:disable-next-line: component-class-suffix
+export class FormlyHorizontalWrapper extends FieldWrapper {}

--- a/src/app/component/shared/shared.components.ts
+++ b/src/app/component/shared/shared.components.ts
@@ -17,7 +17,9 @@ import { CmsComponent } from "./cms/cms.component";
 import { ErrorHandlerComponent } from "./error-handler/error-handler.component";
 import { FooterComponent } from "./footer/footer.component";
 import { FormComponent } from "./form/form.component";
+import { FormlyCheckboxInput } from "./formly/checkbox-input.component";
 import { FileValueAccessor } from "./formly/file-input.directive";
+import { FormlyHorizontalWrapper } from "./formly/horizontal-wrapper";
 import { FormlyImageInput } from "./formly/image-input.component";
 import { FormlyQuestionAnswerAction } from "./formly/question-answer-action.component";
 import { FormlyQuestionAnswer } from "./formly/question-answer.component";
@@ -37,6 +39,8 @@ export const sharedComponents = [
   ErrorHandlerComponent,
   FooterComponent,
   FormComponent,
+  FormlyCheckboxInput,
+  FormlyHorizontalWrapper,
   FormlyImageInput,
   FormlyQuestionAnswer,
   FormlyQuestionAnswerAction,

--- a/src/app/component/shared/shared.components.ts
+++ b/src/app/component/shared/shared.components.ts
@@ -12,6 +12,7 @@ import { ToastrModule } from "ngx-toastr";
 import { DirectivesModule } from "src/app/directives/directives.module";
 import { ActionMenuComponent } from "./action-menu/action-menu.component";
 import { CardsModule } from "./cards/cards.module";
+import { CheckboxComponent } from "./checkbox/checkbox.component";
 import { CmsComponent } from "./cms/cms.component";
 import { ErrorHandlerComponent } from "./error-handler/error-handler.component";
 import { FooterComponent } from "./footer/footer.component";
@@ -30,19 +31,20 @@ import { TimezoneFormPipe } from "./timezone/timezone.pipe";
 import { WIPComponent } from "./wip/wip.component";
 
 export const sharedComponents = [
-  FooterComponent,
   ActionMenuComponent,
-  SecondaryMenuComponent,
-  FormComponent,
-  ErrorHandlerComponent,
-  WIPComponent,
+  CheckboxComponent,
   CmsComponent,
+  ErrorHandlerComponent,
+  FooterComponent,
+  FormComponent,
   FormlyImageInput,
-  FormlyTimezoneInput,
   FormlyQuestionAnswer,
   FormlyQuestionAnswerAction,
+  FormlyTimezoneInput,
+  LoadingComponent,
+  SecondaryMenuComponent,
   TimezoneFormPipe,
-  LoadingComponent
+  WIPComponent
 ];
 
 export const sharedModules = [

--- a/src/app/helpers/formTemplate/formTemplate.spec.ts
+++ b/src/app/helpers/formTemplate/formTemplate.spec.ts
@@ -63,7 +63,7 @@ describe("formTemplate", () => {
   let errorResponse: (model: Partial<MockModel>) => Observable<MockModel>;
 
   function configureTestingModule(
-    resolvers: MockResolvers = {},
+    resolvers?: MockResolvers,
     data: MockData = {}
   ) {
     TestBed.configureTestingModule({
@@ -110,6 +110,13 @@ describe("formTemplate", () => {
   describe("resolvers", () => {
     it("should handle no resolvers", () => {
       configureTestingModule();
+      fixture.detectChanges();
+
+      expect(component.failure).toBeFalsy();
+    });
+
+    it("should handle empty resolvers", () => {
+      configureTestingModule({});
       fixture.detectChanges();
 
       expect(component.failure).toBeFalsy();

--- a/src/app/helpers/formTemplate/formTemplate.ts
+++ b/src/app/helpers/formTemplate/formTemplate.ts
@@ -5,6 +5,7 @@ import { ToastrService } from "ngx-toastr";
 import { Observable } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { WithFormCheck } from "src/app/guards/form/form.guard";
+import { AbstractData } from "src/app/models/AbstractData";
 import { AbstractModel } from "src/app/models/AbstractModel";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
 import { ResolvedModel } from "src/app/services/baw-api/resolver-common";
@@ -29,7 +30,13 @@ export abstract class FormTemplate<M extends AbstractModel>
   /**
    * Extra models stored in data
    */
-  public models: { [key: string]: AbstractModel | AbstractModel[] } = {};
+  public models: {
+    [key: string]:
+      | AbstractModel
+      | AbstractModel[]
+      | AbstractData
+      | AbstractData[];
+  } = {};
   /**
    * Formly fields
    */

--- a/src/app/helpers/formTemplate/formTemplate.ts
+++ b/src/app/helpers/formTemplate/formTemplate.ts
@@ -62,8 +62,22 @@ export abstract class FormTemplate<M extends AbstractModel>
   }
 
   ngOnInit() {
+    // Override form checking
+    if (!this.hasFormCheck) {
+      this.isFormTouched = () => {
+        return false;
+      };
+
+      this.resetForms = () => {};
+    }
+
     // Retrieve models from router
     const data = this.route.snapshot.data as PageInfo;
+
+    // If no resolvers, return early
+    if (!data.resolvers) {
+      return;
+    }
 
     // Grab all models
     for (const key of Object.keys(data.resolvers)) {
@@ -96,15 +110,6 @@ export abstract class FormTemplate<M extends AbstractModel>
     */
     if (this.model.kind) {
       this.successMessage = this.successMsg(this.model);
-    }
-
-    // Override form checking
-    if (!this.hasFormCheck) {
-      this.isFormTouched = () => {
-        return false;
-      };
-
-      this.resetForms = () => {};
     }
   }
 

--- a/src/app/models/AbstractData.ts
+++ b/src/app/models/AbstractData.ts
@@ -1,0 +1,7 @@
+export abstract class AbstractData {
+  constructor(raw: object) {
+    return Object.assign(this, raw);
+  }
+
+  public readonly kind: string;
+}

--- a/src/app/models/Site.ts
+++ b/src/app/models/Site.ts
@@ -84,12 +84,3 @@ export class Site extends AbstractModel implements SiteInterface {
     });
   }
 }
-
-export const mockSite = new Site({
-  id: 1,
-  name: "name",
-  description: "description",
-  creatorId: 1,
-  projectIds: new Set([0]),
-  imageUrl: "/assets/images/site/site_span4.png"
-});

--- a/src/app/models/Tag.ts
+++ b/src/app/models/Tag.ts
@@ -1,0 +1,77 @@
+import { adminTagsMenuItem } from "../component/admin/admin.menus";
+import {
+  DateTimeTimezone,
+  dateTimeTimezone,
+  Id
+} from "../interfaces/apiInterfaces";
+import { AbstractModel } from "./AbstractModel";
+
+/**
+ * Tag model interface
+ */
+export interface TagInterface {
+  id?: Id;
+  text?: string;
+  count?: number;
+  isTaxanomic?: boolean;
+  typeOfTag?: string;
+  retired?: boolean;
+  notes?: string;
+  creatorId?: Id;
+  updaterId?: Id;
+  createdAt?: DateTimeTimezone | string;
+  updatedAt?: DateTimeTimezone | string;
+}
+
+/**
+ * Tag model
+ */
+export class Tag extends AbstractModel implements TagInterface {
+  public readonly kind: "AbstractModel" = "AbstractModel";
+  public readonly id?: Id;
+  public readonly text?: string;
+  public readonly count?: number;
+  public readonly isTaxanomic?: boolean;
+  public readonly typeOfTag?: string;
+  public readonly retired?: boolean;
+  public readonly notes?: string;
+  public readonly creatorId?: Id;
+  public readonly updaterId?: Id;
+  public readonly createdAt?: DateTimeTimezone;
+  public readonly updatedAt?: DateTimeTimezone;
+
+  constructor(tag: TagInterface) {
+    super(tag);
+
+    this.createdAt = dateTimeTimezone(tag.createdAt as string);
+    this.updatedAt = dateTimeTimezone(tag.updatedAt as string);
+  }
+
+  static fromJSON = (obj: any) => {
+    if (typeof obj === "string") {
+      obj = JSON.parse(obj);
+    }
+
+    return new Tag(obj);
+  };
+
+  toJSON() {
+    return {
+      id: this.id,
+      text: this.text,
+      count: this.count,
+      isTaxanomic: this.isTaxanomic,
+      typeOfTag: this.typeOfTag,
+      retired: this.retired,
+      notes: this.notes,
+      creatorId: this.creatorId,
+      updaterId: this.updaterId,
+      createdAt: this.createdAt?.toISO(),
+      updatedAt: this.updatedAt?.toISO()
+    };
+  }
+
+  redirectPath(): string {
+    return adminTagsMenuItem.route.toString();
+  }
+}

--- a/src/app/services/baw-api/mock/api-commonMock.ts
+++ b/src/app/services/baw-api/mock/api-commonMock.ts
@@ -1,11 +1,12 @@
-import { of } from "rxjs";
+import { Observable, of } from "rxjs";
 import { delay } from "rxjs/operators";
 import { AbstractModel } from "src/app/models/AbstractModel";
+import { id, IdOr } from "../api-common";
 import { Filters, Meta } from "../baw-api.service";
 
 export function listMock<M extends AbstractModel>(
   classBuilder: (index: number) => M
-) {
+): Observable<M[]> {
   const models: M[] = [];
 
   for (let i = 0; i < 25; i++) {
@@ -18,7 +19,7 @@ export function listMock<M extends AbstractModel>(
 export function filterMock<M extends AbstractModel>(
   filters: Filters,
   classBuilder: (index: number) => M
-) {
+): Observable<M[]> {
   const models: M[] = [];
   const meta: Meta = {
     status: 200,
@@ -48,4 +49,11 @@ export function filterMock<M extends AbstractModel>(
   }
 
   return of(models).pipe(delay(1000));
+}
+
+export function showMock<M extends AbstractModel>(
+  model: IdOr<M>,
+  classBuilder: (modelId: number) => M
+): Observable<M> {
+  return of(classBuilder(parseInt(id<M>(model), 10))).pipe(delay(1000));
 }

--- a/src/app/services/baw-api/mock/api-commonMock.ts
+++ b/src/app/services/baw-api/mock/api-commonMock.ts
@@ -59,10 +59,3 @@ export function showMock<M extends AbstractModel>(
 ): Observable<M> {
   return of(classBuilder(parseInt(id<M>(model), 10))).pipe(delay(delayPeriod));
 }
-
-export function showMock<M extends AbstractModel>(
-  model: IdOr<M>,
-  classBuilder: (modelId: number) => M
-): Observable<M> {
-  return of(classBuilder(parseInt(id<M>(model), 10))).pipe(delay(1000));
-}

--- a/src/app/services/baw-api/mock/api-commonMock.ts
+++ b/src/app/services/baw-api/mock/api-commonMock.ts
@@ -4,6 +4,8 @@ import { AbstractModel } from "src/app/models/AbstractModel";
 import { id, IdOr } from "../api-common";
 import { Filters, Meta } from "../baw-api.service";
 
+const delayPeriod = 1000;
+
 export function listMock<M extends AbstractModel>(
   classBuilder: (index: number) => M
 ): Observable<M[]> {
@@ -13,7 +15,7 @@ export function listMock<M extends AbstractModel>(
     models.push(classBuilder(i));
   }
 
-  return of(models).pipe(delay(1000));
+  return of(models).pipe(delay(delayPeriod));
 }
 
 export function filterMock<M extends AbstractModel>(
@@ -48,12 +50,12 @@ export function filterMock<M extends AbstractModel>(
     models.push(model);
   }
 
-  return of(models).pipe(delay(1000));
+  return of(models).pipe(delay(delayPeriod));
 }
 
 export function showMock<M extends AbstractModel>(
   model: IdOr<M>,
   classBuilder: (modelId: number) => M
 ): Observable<M> {
-  return of(classBuilder(parseInt(id<M>(model), 10))).pipe(delay(1000));
+  return of(classBuilder(parseInt(id<M>(model), 10))).pipe(delay(delayPeriod));
 }

--- a/src/app/services/baw-api/resolver-common.ts
+++ b/src/app/services/baw-api/resolver-common.ts
@@ -3,6 +3,7 @@ import { ActivatedRouteSnapshot, Resolve } from "@angular/router";
 import { Observable, of } from "rxjs";
 import { catchError, map, take } from "rxjs/operators";
 import { Id } from "src/app/interfaces/apiInterfaces";
+import { AbstractData } from "src/app/models/AbstractData";
 import { AbstractModel } from "src/app/models/AbstractModel";
 import {
   ApiCreate,
@@ -21,7 +22,7 @@ import { BawApiService } from "./baw-api.service";
  */
 export abstract class BawResolver<
   // Output Model
-  O extends any,
+  O extends AbstractData | AbstractData[] | AbstractModel | AbstractModel[],
   // API Service Model
   M extends AbstractModel,
   // API Service
@@ -218,7 +219,9 @@ export interface BawProvider {
 /**
  * Resolver model output
  */
-export interface ResolvedModel<T = AbstractModel | AbstractModel[]> {
+export interface ResolvedModel<
+  T = AbstractModel | AbstractModel[] | AbstractData | AbstractData[]
+> {
   model?: T;
   error?: ApiErrorDetails;
 }

--- a/src/app/services/baw-api/resolver-common.ts
+++ b/src/app/services/baw-api/resolver-common.ts
@@ -4,8 +4,105 @@ import { Observable, of } from "rxjs";
 import { catchError, map, take } from "rxjs/operators";
 import { Id } from "src/app/interfaces/apiInterfaces";
 import { AbstractModel } from "src/app/models/AbstractModel";
-import { ApiList, ApiShow, IdOr } from "./api-common";
+import {
+  ApiCreate,
+  ApiDestroy,
+  ApiFilter,
+  ApiList,
+  ApiShow,
+  ApiUpdate,
+  IdOr
+} from "./api-common";
 import { ApiErrorDetails } from "./api.interceptor.service";
+import { BawApiService } from "./baw-api.service";
+
+/**
+ * Baw Resolver Wrapper Class
+ */
+export abstract class BawResolver<
+  // Output Model
+  O extends any,
+  // API Service Model
+  M extends AbstractModel,
+  // API Service
+  A extends
+    | BawApiService<M>
+    | ApiList<M, any[]>
+    | ApiFilter<M, any[]>
+    | ApiShow<M, any[], IdOr<M>>
+    | ApiCreate<M, any[]>
+    | ApiUpdate<M, any[]>
+    | ApiDestroy<M, any[], IdOr<M>>,
+  // Resolver output model name
+  T = { customResolver: string }
+> {
+  constructor(
+    protected deps: Type<A>[],
+    protected id?: string,
+    protected ids?: string[]
+  ) {}
+
+  public create(name: string): T & { providers: BawProvider[] } {
+    const id = this.id;
+    const ids = this.ids;
+    const resolverFn = this.resolverFn;
+
+    class Resolver implements Resolve<ResolvedModel<O>> {
+      constructor(private api: A) {}
+
+      /**
+       * Resolve the model
+       * @param route Route Snapshot
+       */
+      public resolve(
+        route: ActivatedRouteSnapshot
+      ): Observable<ResolvedModel<O>> {
+        // Grab Model ID from URL
+        const modelId = id ? convertToId(route.paramMap.get(id)) : undefined;
+        // Grab additional ID's from URL
+        const args = ids
+          ? ids.map(urlId => convertToId(route.paramMap.get(urlId)))
+          : [];
+
+        return resolverFn(route, this.api, modelId, args).pipe(
+          map(model => ({ model })), // Modify output to match ResolvedModel interface
+          take(1), // Only take first response
+          catchError((error: ApiErrorDetails) => {
+            return of({ error }); // Modify output to match ResolvedModel interface
+          })
+        );
+      }
+    }
+
+    return this.createProviders(name, Resolver, this.deps);
+  }
+
+  /**
+   * Create providers required for app modules
+   * @param name Resolver name
+   * @param resolver Resolver class
+   * @param deps Resolver dependencies
+   */
+  public abstract createProviders(
+    name: string,
+    resolver: Type<Resolve<ResolvedModel<O>>>,
+    deps: Type<A>[]
+  ): T & { providers: BawProvider[] };
+
+  /**
+   * Create resolver api request
+   * @param route Activated Route Snapshot
+   * @param api Baw api service
+   * @param id Model id
+   * @param ids Additional id arguments
+   */
+  public abstract resolverFn(
+    route: ActivatedRouteSnapshot,
+    api: A,
+    id: Id,
+    ids: Id[]
+  ): Observable<O>;
+}
 
 /**
  * Resolvers Class.
@@ -13,8 +110,8 @@ import { ApiErrorDetails } from "./api.interceptor.service";
  * Id's for the models are retrieved from the URL.
  */
 export class Resolvers<
-  T extends AbstractModel,
-  A extends ApiList<T, any[]> & ApiShow<T, any[], IdOr<T>>
+  M extends AbstractModel,
+  A extends ApiList<M, any[]> & ApiShow<M, any[], IdOr<M>>
 > {
   constructor(
     private deps: Type<A>[],
@@ -31,8 +128,8 @@ export class Resolvers<
     const id = this.id;
     const ids = this.ids;
 
-    const listProvider = new ListResolver<T, A>(deps, ids).create(name);
-    const showProvider = new ShowResolver<T, A>(deps, id, ids).create(name);
+    const listProvider = new ListResolver<M, A>(deps, ids).create(name);
+    const showProvider = new ShowResolver<M, A>(deps, id, ids).create(name);
     const providers = [...listProvider.providers, ...showProvider.providers];
 
     return { ...listProvider, ...showProvider, providers };
@@ -45,55 +142,32 @@ export class Resolvers<
  * the id's stored in the URL.
  */
 export class ListResolver<
-  T extends AbstractModel,
-  L extends ApiList<T, any[]>
-> {
-  constructor(private deps: Type<L>[], private ids?: string[]) {}
+  M extends AbstractModel,
+  A extends ApiList<M, any[]>
+> extends BawResolver<M[], M, A, { list: string }> {
+  constructor(deps: Type<A>[], ids?: string[]) {
+    super(deps, undefined, ids);
+  }
 
-  /**
-   * Create provider
-   * @param name Name of provider
-   */
-  public create(name: string) {
-    const deps = this.deps;
-    const ids = this.ids;
-
-    class Resolver implements Resolve<ResolvedModel<T[]>> {
-      constructor(private api: L) {}
-
-      /**
-       * Resolve the model
-       * @param route Route Snapshot
-       */
-      public resolve(
-        route: ActivatedRouteSnapshot
-      ): Observable<ResolvedModel<T[]>> {
-        // Grab ID's from URL
-        const args: Id[] = ids
-          ? ids.map(id => convertToId(route.paramMap.get(id)))
-          : [];
-
-        // Return models
-        return this.api.list(...args).pipe(
-          map(model => ({ model })), // Modify output to match ResolvedModel interface
-          take(1), // Only take first response
-          catchError((error: ApiErrorDetails) => {
-            return of({ error }); // Modify output to match ResolvedModel interface
-          })
-        );
-      }
-    }
-
+  public createProviders(
+    name: string,
+    resolver: Type<Resolve<ResolvedModel<M[]>>>,
+    deps: Type<A>[]
+  ) {
     return {
       list: name + "ListResolver",
       providers: [
         {
           provide: name + "ListResolver",
-          useClass: Resolver,
+          useClass: resolver,
           deps
         }
       ]
     };
+  }
+
+  public resolverFn(_: ActivatedRouteSnapshot, api: A, __: Id, ids: Id[]) {
+    return api.list(...ids);
   }
 }
 
@@ -103,67 +177,47 @@ export class ListResolver<
  * the id's stored in the URL.
  */
 export class ShowResolver<
-  T extends AbstractModel,
-  S extends ApiShow<T, any[], IdOr<T>>
-> {
-  constructor(
-    private deps: Type<S>[],
-    private id?: string,
-    private ids?: string[]
-  ) {}
+  M extends AbstractModel,
+  A extends ApiShow<M, any[], IdOr<M>>
+> extends BawResolver<M, M, A, { show: string }> {
+  constructor(deps: Type<A>[], id?: string, ids?: string[]) {
+    super(deps, id, ids);
+  }
 
-  /**
-   * Create provider
-   * @param name Name of provider
-   */
-  public create(name: string) {
-    const deps = this.deps;
-    const id = this.id;
-    const ids = this.ids;
-
-    class Resolver implements Resolve<ResolvedModel<T>> {
-      constructor(private api: S) {}
-
-      /**
-       * Resolve the model
-       * @param route Route Snapshot
-       */
-      public resolve(
-        route: ActivatedRouteSnapshot
-      ): Observable<ResolvedModel<T>> {
-        // Grab Show ID from URL
-        const showId = id ? convertToId(route.paramMap.get(id)) : undefined;
-        // Grab additional ID's from URL
-        const args =
-          id && ids
-            ? ids.map(urlId => convertToId(route.paramMap.get(urlId)))
-            : [];
-
-        // Return model
-        return this.api.show(showId, ...args).pipe(
-          map(model => ({ model })), // Modify output to match ResolvedModel interface
-          take(1), // Only take first response
-          catchError((error: ApiErrorDetails) => {
-            return of({ error }); // Modify output to match ResolvedModel interface
-          })
-        );
-      }
-    }
-
+  public createProviders(
+    name: string,
+    resolver: Type<Resolve<ResolvedModel<M>>>,
+    deps: Type<A>[]
+  ) {
     return {
       show: name + "ShowResolver",
       providers: [
         {
           provide: name + "ShowResolver",
-          useClass: Resolver,
+          useClass: resolver,
           deps
         }
       ]
     };
   }
+
+  public resolverFn(_: ActivatedRouteSnapshot, api: A, id: Id, ids: Id[]) {
+    return api.show(id, ...ids);
+  }
 }
 
-// Resolver model output
+/**
+ * App provider details
+ */
+export interface BawProvider {
+  provide: string;
+  useClass: Type<Resolve<any>>;
+  deps: Type<any>[];
+}
+
+/**
+ * Resolver model output
+ */
 export interface ResolvedModel<T = AbstractModel | AbstractModel[]> {
   model?: T;
   error?: ApiErrorDetails;

--- a/src/app/services/baw-api/sites.service.ts
+++ b/src/app/services/baw-api/sites.service.ts
@@ -65,15 +65,7 @@ export class ShallowSitesService extends StandardApi<Site, []> {
   }
 
   list(): Observable<Site[]> {
-    return listMock<Site>(
-      index =>
-        new Site({
-          id: index,
-          name: "PLACEHOLDER SITE",
-          description: "PLACEHOLDER DESCRIPTION",
-          creatorId: 1
-        })
-    );
+    return this.filter({});
     // return this.apiList(endpointShallow(Empty, Empty));
   }
   filter(filters: Filters): Observable<Site[]> {

--- a/src/app/services/baw-api/tags.service.spec.ts
+++ b/src/app/services/baw-api/tags.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed } from "@angular/core/testing";
+import { TagsService } from "./tags.service";
+
+describe("TagsService", () => {
+  let service: TagsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TagsService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/baw-api/tags.service.spec.ts
+++ b/src/app/services/baw-api/tags.service.spec.ts
@@ -1,11 +1,23 @@
+import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+import { testAppInitializer } from "src/app/test.helper";
+import { BawApiService } from "./baw-api.service";
+import { MockBawApiService } from "./mock/baseApiMock.service";
 import { TagsService } from "./tags.service";
 
 describe("TagsService", () => {
   let service: TagsService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        ...testAppInitializer,
+        TagsService,
+        { provide: BawApiService, useClass: MockBawApiService }
+      ]
+    });
     service = TestBed.inject(TagsService);
   });
 

--- a/src/app/services/baw-api/tags.service.ts
+++ b/src/app/services/baw-api/tags.service.ts
@@ -3,10 +3,11 @@ import { Inject, Injectable } from "@angular/core";
 import { Observable } from "rxjs";
 import { API_ROOT } from "src/app/helpers/app-initializer/app-initializer";
 import { stringTemplate } from "src/app/helpers/stringTemplate/stringTemplate";
+import { Id } from "src/app/interfaces/apiInterfaces";
 import { Tag } from "src/app/models/Tag";
 import { Empty, id, IdOr, IdParamOptional, StandardApi } from "./api-common";
 import { Filters } from "./baw-api.service";
-import { filterMock } from "./mock/api-commonMock";
+import { filterMock, showMock } from "./mock/api-commonMock";
 import { Resolvers } from "./resolver-common";
 
 const tagId: IdParamOptional<Tag> = id;
@@ -23,27 +24,12 @@ export class TagsService extends StandardApi<Tag, []> {
   }
 
   filter(filters: Filters): Observable<Tag[]> {
-    return filterMock<Tag>(
-      filters,
-      index =>
-        new Tag({
-          id: index,
-          text: "PLACEHOLDER TAG",
-          count: Math.floor(Math.random() * 10000),
-          isTaxanomic: index % 5 === 0,
-          typeOfTag: "general",
-          retired: index % 5 === 0,
-          notes: "PLACEHOLDER NOTES",
-          creatorId: 1,
-          updaterId: 1,
-          createdAt: "2020-03-10T10:51:04.576+10:00",
-          updatedAt: "2020-03-10T10:51:04.576+10:00"
-        })
-    );
+    return filterMock<Tag>(filters, index => createTag(index));
   }
 
   show(model: IdOr<Tag>): Observable<Tag> {
-    return this.apiShow(endpoint(model));
+    return showMock(model, modelId => createTag(modelId));
+    // return this.apiShow(endpoint(model));
   }
   create(model: Tag): Observable<Tag> {
     return this.apiCreate(endpoint(Empty), model);
@@ -60,3 +46,19 @@ export const tagResolvers = new Resolvers<Tag, TagsService>(
   [TagsService],
   "tagId"
 ).create("Tag");
+
+function createTag(modelId: Id) {
+  return new Tag({
+    id: modelId,
+    text: "PLACEHOLDER TAG",
+    count: Math.floor(Math.random() * 10000),
+    isTaxanomic: modelId % 5 === 0,
+    typeOfTag: "general",
+    retired: modelId % 5 === 0,
+    notes: "PLACEHOLDER NOTES",
+    creatorId: 1,
+    updaterId: 1,
+    createdAt: "2020-03-10T10:51:04.576+10:00",
+    updatedAt: "2020-03-10T10:51:04.576+10:00"
+  });
+}

--- a/src/app/services/baw-api/tags.service.ts
+++ b/src/app/services/baw-api/tags.service.ts
@@ -1,17 +1,40 @@
 import { HttpClient } from "@angular/common/http";
-import { Inject, Injectable } from "@angular/core";
-import { Observable } from "rxjs";
+import { Inject, Injectable, Type } from "@angular/core";
+import { ActivatedRouteSnapshot, Resolve } from "@angular/router";
+import _ from "lodash";
+import { Observable, of } from "rxjs";
+import { map } from "rxjs/operators";
 import { API_ROOT } from "src/app/helpers/app-initializer/app-initializer";
 import { stringTemplate } from "src/app/helpers/stringTemplate/stringTemplate";
 import { Id } from "src/app/interfaces/apiInterfaces";
 import { Tag } from "src/app/models/Tag";
-import { Empty, id, IdOr, IdParamOptional, StandardApi } from "./api-common";
+import {
+  Empty,
+  id,
+  IdOr,
+  IdParamOptional,
+  option,
+  StandardApi
+} from "./api-common";
 import { Filters } from "./baw-api.service";
 import { filterMock, showMock } from "./mock/api-commonMock";
-import { Resolvers } from "./resolver-common";
+import {
+  BawProvider,
+  BawResolver,
+  ResolvedModel,
+  Resolvers
+} from "./resolver-common";
 
 const tagId: IdParamOptional<Tag> = id;
-const endpoint = stringTemplate`/tags/${tagId}`;
+const endpoint = stringTemplate`/tags/${tagId}${option}`;
+
+export class TagType {
+  constructor(public name: string) {}
+
+  toString() {
+    return _.startCase(this.name);
+  }
+}
 
 @Injectable()
 export class TagsService extends StandardApi<Tag, []> {
@@ -22,30 +45,35 @@ export class TagsService extends StandardApi<Tag, []> {
   list(): Observable<Tag[]> {
     return this.filter({});
   }
-
   filter(filters: Filters): Observable<Tag[]> {
     return filterMock<Tag>(filters, index => createTag(index));
   }
-
   show(model: IdOr<Tag>): Observable<Tag> {
     return showMock(model, modelId => createTag(modelId));
-    // return this.apiShow(endpoint(model));
   }
   create(model: Tag): Observable<Tag> {
-    return this.apiCreate(endpoint(Empty), model);
+    return this.apiCreate(endpoint(Empty, Empty), model);
   }
   update(model: Tag): Observable<Tag> {
-    return this.apiUpdate(endpoint(model), model);
+    return this.apiUpdate(endpoint(model, Empty), model);
   }
   destroy(model: IdOr<Tag>): Observable<Tag | void> {
-    return this.apiDestroy(endpoint(model));
+    return this.apiDestroy(endpoint(model, Empty));
+  }
+  /**
+   * List type of tags
+   * TODO Replace with reference to baw server
+   */
+  typeOfTags(): Observable<TagType[]> {
+    return of([
+      "general",
+      "common_name",
+      "species_name",
+      "looks_like",
+      "sounds_like"
+    ]).pipe(map(types => types.map(type => new TagType(type))));
   }
 }
-
-export const tagResolvers = new Resolvers<Tag, TagsService>(
-  [TagsService],
-  "tagId"
-).create("Tag");
 
 function createTag(modelId: Id) {
   return new Tag({
@@ -62,3 +90,62 @@ function createTag(modelId: Id) {
     updatedAt: "2020-03-10T10:51:04.576+10:00"
   });
 }
+
+class TagResolvers {
+  public create(name: string) {
+    const additionalProvider = new Resolvers<Tag, TagsService>(
+      [TagsService],
+      "tagId"
+    ).create(name);
+    const typeOfTagsProvider = new TypeOfTagsResolver().create(name);
+    const providers = [
+      ...additionalProvider.providers,
+      ...typeOfTagsProvider.providers
+    ];
+
+    return {
+      ...additionalProvider,
+      ...typeOfTagsProvider,
+      providers
+    };
+  }
+}
+
+class TypeOfTagsResolver extends BawResolver<
+  TagType[],
+  Tag,
+  TagsService,
+  { typeOfTags: string }
+> {
+  constructor() {
+    super([TagsService], undefined, undefined);
+  }
+
+  public createProviders(
+    name: string,
+    resolver: Type<Resolve<ResolvedModel<TagType[]>>>,
+    deps: Type<TagsService>[]
+  ): { typeOfTags: string } & {
+    providers: BawProvider[];
+  } {
+    return {
+      typeOfTags: name + "TypeOfTagsResolver",
+      providers: [
+        {
+          provide: name + "TypeOfTagsResolver",
+          useClass: resolver,
+          deps
+        }
+      ]
+    };
+  }
+
+  public resolverFn(
+    __: ActivatedRouteSnapshot,
+    api: TagsService
+  ): Observable<TagType[]> {
+    return api.typeOfTags();
+  }
+}
+
+export const tagResolvers = new TagResolvers().create("Tag");

--- a/src/app/services/baw-api/tags.service.ts
+++ b/src/app/services/baw-api/tags.service.ts
@@ -29,6 +29,7 @@ export class TagsService extends StandardApi<Tag, []> {
         new Tag({
           id: index,
           text: "PLACEHOLDER TAG",
+          count: Math.floor(Math.random() * 10000),
           isTaxanomic: index % 5 === 0,
           typeOfTag: "general",
           retired: index % 5 === 0,

--- a/src/app/services/baw-api/tags.service.ts
+++ b/src/app/services/baw-api/tags.service.ts
@@ -1,0 +1,61 @@
+import { HttpClient } from "@angular/common/http";
+import { Inject, Injectable } from "@angular/core";
+import { Observable } from "rxjs";
+import { API_ROOT } from "src/app/helpers/app-initializer/app-initializer";
+import { stringTemplate } from "src/app/helpers/stringTemplate/stringTemplate";
+import { Tag } from "src/app/models/Tag";
+import { Empty, id, IdOr, IdParamOptional, StandardApi } from "./api-common";
+import { Filters } from "./baw-api.service";
+import { filterMock } from "./mock/api-commonMock";
+import { Resolvers } from "./resolver-common";
+
+const tagId: IdParamOptional<Tag> = id;
+const endpoint = stringTemplate`/tags/${tagId}`;
+
+@Injectable()
+export class TagsService extends StandardApi<Tag, []> {
+  constructor(http: HttpClient, @Inject(API_ROOT) apiRoot: string) {
+    super(http, apiRoot, Tag);
+  }
+
+  list(): Observable<Tag[]> {
+    return this.filter({});
+  }
+
+  filter(filters: Filters): Observable<Tag[]> {
+    return filterMock<Tag>(
+      filters,
+      index =>
+        new Tag({
+          id: index,
+          text: "PLACEHOLDER TAG",
+          isTaxanomic: index % 5 === 0,
+          typeOfTag: "general",
+          retired: index % 5 === 0,
+          notes: "PLACEHOLDER NOTES",
+          creatorId: 1,
+          updaterId: 1,
+          createdAt: "2020-03-10T10:51:04.576+10:00",
+          updatedAt: "2020-03-10T10:51:04.576+10:00"
+        })
+    );
+  }
+
+  show(model: IdOr<Tag>): Observable<Tag> {
+    return this.apiShow(endpoint(model));
+  }
+  create(model: Tag): Observable<Tag> {
+    return this.apiCreate(endpoint(Empty), model);
+  }
+  update(model: Tag): Observable<Tag> {
+    return this.apiUpdate(endpoint(model), model);
+  }
+  destroy(model: IdOr<Tag>): Observable<Tag | void> {
+    return this.apiDestroy(endpoint(model));
+  }
+}
+
+export const tagResolvers = new Resolvers<Tag, TagsService>(
+  [TagsService],
+  "tagId"
+).create("Tag");

--- a/src/app/services/baw-api/tags.service.ts
+++ b/src/app/services/baw-api/tags.service.ts
@@ -7,6 +7,7 @@ import { map } from "rxjs/operators";
 import { API_ROOT } from "src/app/helpers/app-initializer/app-initializer";
 import { stringTemplate } from "src/app/helpers/stringTemplate/stringTemplate";
 import { Id } from "src/app/interfaces/apiInterfaces";
+import { AbstractData } from "src/app/models/AbstractData";
 import { Tag } from "src/app/models/Tag";
 import {
   Empty,
@@ -28,8 +29,13 @@ import {
 const tagId: IdParamOptional<Tag> = id;
 const endpoint = stringTemplate`/tags/${tagId}${option}`;
 
-export class TagType {
-  constructor(public name: string) {}
+export class TagType extends AbstractData {
+  public readonly kind: "TagType" = "TagType";
+  public readonly name: string;
+
+  constructor(data: { name: string }) {
+    super(data);
+  }
 
   toString() {
     return _.startCase(this.name);
@@ -71,7 +77,7 @@ export class TagsService extends StandardApi<Tag, []> {
       "species_name",
       "looks_like",
       "sounds_like"
-    ]).pipe(map(types => types.map(type => new TagType(type))));
+    ]).pipe(map(types => types.map(type => new TagType({ name: type }))));
   }
 }
 

--- a/src/app/test.helper.ts
+++ b/src/app/test.helper.ts
@@ -32,6 +32,7 @@ import {
   ShallowSitesService,
   SitesService
 } from "./services/baw-api/sites.service";
+import { TagsService } from "./services/baw-api/tags.service";
 import { UserService } from "./services/baw-api/user.service";
 
 /**
@@ -76,6 +77,7 @@ export const testBawServices = [
   { provide: ScriptsService, useClass: MockStandardApiService },
   { provide: SitesService, useClass: MockStandardApiService },
   { provide: ShallowSitesService, useClass: MockStandardApiService },
+  { provide: TagsService, useClass: MockStandardApiService },
   { provide: UserService, useClass: MockShowApiService }
 ];
 


### PR DESCRIPTION
# Admin Tag Pages

Created admin tag pages (list, new, edit, delete).

## Changes

- Created `TagsService`
- Created `Tag` model
- Created `FormlyCheckboxInput`
- Created `FormlyHorizontalWrapper`
- Created tag list/forms

## Issues

- Update forms to provide `typeOfTags` dropdown
  - Create custom resolver and service function
- Missing unit tests

## Visual Changes

Tag list page
![image](https://user-images.githubusercontent.com/3955116/77750249-2e60d480-706f-11ea-82a4-8fd622464a81.png)

New Tag Form
![image](https://user-images.githubusercontent.com/3955116/77812311-36ab2500-70ec-11ea-9670-94c95250b12b.png)


Edit Tag Form
![image](https://user-images.githubusercontent.com/3955116/77812347-62c6a600-70ec-11ea-9571-1039df60d706.png)

Delete Tag Form
![image](https://user-images.githubusercontent.com/3955116/77812351-69551d80-70ec-11ea-87a3-c4ea08ca67a0.png)
