### PR TITLE
Admin tag group pages

### DIFF
--- a/src/app/app.helper.ts
+++ b/src/app/app.helper.ts
@@ -35,6 +35,10 @@ import {
   siteResolvers,
   SitesService
 } from "./services/baw-api/sites.service";
+import {
+  tagGroupResolvers,
+  TagGroupService
+} from "./services/baw-api/tag-group.service";
 import { userResolvers, UserService } from "./services/baw-api/user.service";
 
 /**
@@ -152,11 +156,13 @@ export const providers = [
   SecurityService,
   ShallowSitesService,
   SitesService,
+  TagGroupService,
   UserService,
   ...accountResolvers.providers,
   ...projectResolvers.providers,
   ...scriptResolvers.providers,
   ...siteResolvers.providers,
   ...shallowSiteResolvers.providers,
+  ...tagGroupResolvers.providers,
   ...userResolvers.providers
 ];

--- a/src/app/component/admin/admin.menus.ts
+++ b/src/app/component/admin/admin.menus.ts
@@ -1,5 +1,7 @@
 import {
   defaultAudioIcon,
+  defaultDeleteIcon,
+  defaultEditIcon,
   defaultNewIcon,
   isAdminPredicate
 } from "src/app/app.menus";
@@ -51,8 +53,7 @@ export const adminOrphanSitesMenuItem = MenuRoute({
 export const adminScriptsCategory: Category = {
   icon: ["fas", "scroll"],
   label: "Scripts",
-  route: adminRoute.add("scripts"),
-  parent: adminCategory
+  route: adminRoute.add("scripts")
 };
 
 export const adminScriptsMenuItem = MenuRoute({
@@ -95,11 +96,19 @@ export const adminNewTagMenuItem = MenuRoute({
  * Admin Tag Groups
  */
 
+const adminTagGroupsRoute = adminRoute.add("tag_groups");
+
+export const adminTagGroupsCategory: Category = {
+  icon: ["fas", "tags"],
+  label: "Tag Group",
+  route: adminTagGroupsRoute
+};
+
 export const adminTagGroupsMenuItem = MenuRoute({
   icon: ["fas", "tags"],
   label: "Tag Group",
-  route: adminRoute.add("tags"),
-  tooltip: () => "Manage tags",
+  route: adminTagGroupsRoute,
+  tooltip: () => "Manage tag groups",
   parent: adminDashboardMenuItem,
   predicate: isAdminPredicate
 });
@@ -107,8 +116,28 @@ export const adminTagGroupsMenuItem = MenuRoute({
 export const adminNewTagGroupMenuItem = MenuRoute({
   icon: defaultNewIcon,
   label: "New Tag Group",
-  route: adminTagsMenuItem.route.add("new"),
+  route: adminTagGroupsRoute.add("new"),
   tooltip: () => "Create a new tag group",
+  parent: adminTagGroupsMenuItem,
+  predicate: isAdminPredicate
+});
+
+const adminTagGroupRoute = adminTagGroupsRoute.add(":tagGroupId");
+
+export const adminEditTagGroupMenuItem = MenuRoute({
+  icon: defaultEditIcon,
+  label: "Edit Tag Group",
+  route: adminTagGroupRoute.add("edit"),
+  tooltip: () => "Update an existing tag group",
+  parent: adminTagGroupsMenuItem,
+  predicate: isAdminPredicate
+});
+
+export const adminDeleteTagGroupMenuItem = MenuRoute({
+  icon: defaultDeleteIcon,
+  label: "Delete Tag Group",
+  route: adminTagGroupRoute.add("delete"),
+  tooltip: () => "Delete an existing tag group",
   parent: adminTagGroupsMenuItem,
   predicate: isAdminPredicate
 });

--- a/src/app/component/admin/admin.menus.ts
+++ b/src/app/component/admin/admin.menus.ts
@@ -91,6 +91,10 @@ export const adminNewTagMenuItem = MenuRoute({
   predicate: isAdminPredicate
 });
 
+/**
+ * Admin Tag Groups
+ */
+
 export const adminTagGroupsMenuItem = MenuRoute({
   icon: ["fas", "tags"],
   label: "Tag Group",

--- a/src/app/component/admin/admin.module.ts
+++ b/src/app/component/admin/admin.module.ts
@@ -6,13 +6,21 @@ import { adminRoute } from "./admin.menus";
 import { AdminDashboardComponent } from "./dashboard/dashboard.component";
 import { AdminScriptsNewComponent } from "./scripts-new/scripts-new.component";
 import { AdminScriptsComponent } from "./scripts/scripts.component";
+import { AdminTagGroupsDeleteComponent } from "./tag-group/delete/delete.component";
+import { AdminTagGroupsEditComponent } from "./tag-group/edit/edit.component";
+import { AdminTagGroupsComponent } from "./tag-group/list/list.component";
+import { AdminTagGroupsNewComponent } from "./tag-group/new/new.component";
 import { AdminUserListComponent } from "./user-list/user-list.component";
 
 const components = [
   AdminDashboardComponent,
-  AdminUserListComponent,
   AdminScriptsComponent,
-  AdminScriptsNewComponent
+  AdminScriptsNewComponent,
+  AdminTagGroupsComponent,
+  AdminTagGroupsDeleteComponent,
+  AdminTagGroupsEditComponent,
+  AdminTagGroupsNewComponent,
+  AdminUserListComponent
 ];
 const routes = adminRoute.compileRoutes(GetRouteConfigForPage);
 

--- a/src/app/component/admin/tag-group/delete/delete.component.spec.ts
+++ b/src/app/component/admin/tag-group/delete/delete.component.spec.ts
@@ -1,23 +1,111 @@
-import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ActivatedRoute, Router } from "@angular/router";
+import { RouterTestingModule } from "@angular/router/testing";
+import { ToastrService } from "ngx-toastr";
+import { BehaviorSubject } from "rxjs";
+import { appLibraryImports } from "src/app/app.module";
+import { SharedModule } from "src/app/component/shared/shared.module";
+import { TagGroup } from "src/app/models/TagGroup";
+import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
+import {
+  tagGroupResolvers,
+  TagGroupService
+} from "src/app/services/baw-api/tag-group.service";
+import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
+import { assertFormErrorHandling } from "src/testHelpers";
+import { adminTagGroupsMenuItem } from "../../admin.menus";
 import { AdminTagGroupsDeleteComponent } from "./delete.component";
 
-xdescribe("AdminTagGroupsDeleteComponent", () => {
+describe("AdminTagGroupsDeleteComponent", () => {
+  let api: TagGroupService;
   let component: AdminTagGroupsDeleteComponent;
+  let defaultError: ApiErrorDetails;
+  let defaultTagGroup: TagGroup;
   let fixture: ComponentFixture<AdminTagGroupsDeleteComponent>;
+  let notifications: ToastrService;
+  let router: Router;
 
-  beforeEach(async(() => {
+  function configureTestingModule(tagGroup: TagGroup, error: ApiErrorDetails) {
     TestBed.configureTestingModule({
-      declarations: [AdminTagGroupsDeleteComponent]
+      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      declarations: [AdminTagGroupsDeleteComponent],
+      providers: [
+        ...testBawServices,
+        {
+          provide: ActivatedRoute,
+          useClass: mockActivatedRoute(
+            {
+              tagGroup: tagGroupResolvers.show
+            },
+            {
+              tagGroup: {
+                model: tagGroup,
+                error
+              }
+            }
+          )
+        }
+      ]
     }).compileComponents();
-  }));
+
+    fixture = TestBed.createComponent(AdminTagGroupsDeleteComponent);
+    api = TestBed.inject(TagGroupService);
+    router = TestBed.inject(Router);
+    notifications = TestBed.inject(ToastrService);
+    component = fixture.componentInstance;
+
+    spyOn(notifications, "success").and.stub();
+    spyOn(notifications, "error").and.stub();
+    spyOn(router, "navigateByUrl").and.stub();
+
+    fixture.detectChanges();
+  }
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(AdminTagGroupsDeleteComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    defaultTagGroup = new TagGroup({
+      id: 1,
+      groupIdentifier: "Group Identifier",
+      tagId: 1
+    });
+    defaultError = {
+      status: 401,
+      message: "Unauthorized"
+    };
   });
 
-  it("should create", () => {
-    expect(component).toBeTruthy();
+  describe("form", () => {
+    it("should have no fields", () => {
+      configureTestingModule(defaultTagGroup, undefined);
+      expect(component.fields).toEqual([]);
+    });
+  });
+
+  describe("component", () => {
+    it("should create", () => {
+      configureTestingModule(defaultTagGroup, undefined);
+      expect(component).toBeTruthy();
+    });
+
+    it("should handle tag group error", () => {
+      configureTestingModule(undefined, defaultError);
+      assertFormErrorHandling(fixture);
+    });
+
+    it("should call api", () => {
+      configureTestingModule(defaultTagGroup, undefined);
+      spyOn(api, "destroy").and.callThrough();
+      component.submit({});
+      expect(api.destroy).toHaveBeenCalled();
+    });
+
+    it("should redirect to tag group list", () => {
+      configureTestingModule(defaultTagGroup, undefined);
+      spyOn(api, "destroy").and.callFake(() => new BehaviorSubject<void>(null));
+
+      component.submit({});
+      expect(router.navigateByUrl).toHaveBeenCalledWith(
+        adminTagGroupsMenuItem.route.toString()
+      );
+    });
   });
 });

--- a/src/app/component/admin/tag-group/delete/delete.component.spec.ts
+++ b/src/app/component/admin/tag-group/delete/delete.component.spec.ts
@@ -1,0 +1,23 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { AdminTagGroupsDeleteComponent } from "./delete.component";
+
+describe("AdminTagGroupsDeleteComponent", () => {
+  let component: AdminTagGroupsDeleteComponent;
+  let fixture: ComponentFixture<AdminTagGroupsDeleteComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AdminTagGroupsDeleteComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AdminTagGroupsDeleteComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/component/admin/tag-group/delete/delete.component.spec.ts
+++ b/src/app/component/admin/tag-group/delete/delete.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { AdminTagGroupsDeleteComponent } from "./delete.component";
 
-describe("AdminTagGroupsDeleteComponent", () => {
+xdescribe("AdminTagGroupsDeleteComponent", () => {
   let component: AdminTagGroupsDeleteComponent;
   let fixture: ComponentFixture<AdminTagGroupsDeleteComponent>;
 

--- a/src/app/component/admin/tag-group/delete/delete.component.ts
+++ b/src/app/component/admin/tag-group/delete/delete.component.ts
@@ -1,11 +1,79 @@
 import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+import { List } from "immutable";
+import { ToastrService } from "ngx-toastr";
+import {
+  defaultSuccessMsg,
+  FormTemplate
+} from "src/app/helpers/formTemplate/formTemplate";
+import { Page } from "src/app/helpers/page/pageDecorator";
+import { TagGroup } from "src/app/models/TagGroup";
+import {
+  tagGroupResolvers,
+  TagGroupService
+} from "src/app/services/baw-api/tag-group.service";
+import {
+  adminDeleteTagGroupMenuItem,
+  adminTagGroupsCategory,
+  adminTagGroupsMenuItem
+} from "../../admin.menus";
+import { adminTagGroupMenuItemActions } from "../list/list.component";
 
+const tagGroupKey = "tagGroup";
+
+@Page({
+  category: adminTagGroupsCategory,
+  menus: {
+    actions: List([adminTagGroupsMenuItem, ...adminTagGroupMenuItemActions]),
+    links: List()
+  },
+  resolvers: {
+    [tagGroupKey]: tagGroupResolvers.show
+  },
+  self: adminDeleteTagGroupMenuItem
+})
 @Component({
   selector: "app-admin-tag-groups-delete",
-  template: ``
+  template: `
+    <app-form
+      *ngIf="!failure"
+      [title]="title"
+      [model]="model"
+      [fields]="fields"
+      btnColor="btn-danger"
+      submitLabel="Delete"
+      [submitLoading]="loading"
+      (onSubmit)="submit($event)"
+    ></app-form>
+  `
 })
-export class AdminTagGroupsDeleteComponent implements OnInit {
-  constructor() {}
+export class AdminTagGroupsDeleteComponent extends FormTemplate<TagGroup>
+  implements OnInit {
+  public title: string;
 
-  ngOnInit(): void {}
+  constructor(
+    private api: TagGroupService,
+    notifications: ToastrService,
+    route: ActivatedRoute,
+    router: Router
+  ) {
+    super(notifications, route, router, tagGroupKey, model =>
+      defaultSuccessMsg("destroyed", model.groupIdentifier)
+    );
+  }
+
+  ngOnInit() {
+    super.ngOnInit();
+
+    if (!this.failure) {
+      this.title = `Are you certain you wish to delete ${this.model.groupIdentifier}?`;
+    }
+  }
+  protected redirectionPath() {
+    return adminTagGroupsMenuItem.route.toString();
+  }
+
+  protected apiAction(model: Partial<TagGroup>) {
+    return this.api.destroy(new TagGroup(model));
+  }
 }

--- a/src/app/component/admin/tag-group/delete/delete.component.ts
+++ b/src/app/component/admin/tag-group/delete/delete.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from "@angular/core";
+
+@Component({
+  selector: "app-admin-tag-groups-delete",
+  template: ``
+})
+export class AdminTagGroupsDeleteComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/component/admin/tag-group/edit/edit.component.spec.ts
+++ b/src/app/component/admin/tag-group/edit/edit.component.spec.ts
@@ -1,0 +1,23 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { AdminTagGroupsEditComponent } from "./edit.component";
+
+describe("AdminTagGroupsEditComponent", () => {
+  let component: AdminTagGroupsEditComponent;
+  let fixture: ComponentFixture<AdminTagGroupsEditComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AdminTagGroupsEditComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AdminTagGroupsEditComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/component/admin/tag-group/edit/edit.component.spec.ts
+++ b/src/app/component/admin/tag-group/edit/edit.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { AdminTagGroupsEditComponent } from "./edit.component";
 
-describe("AdminTagGroupsEditComponent", () => {
+xdescribe("AdminTagGroupsEditComponent", () => {
   let component: AdminTagGroupsEditComponent;
   let fixture: ComponentFixture<AdminTagGroupsEditComponent>;
 

--- a/src/app/component/admin/tag-group/edit/edit.component.spec.ts
+++ b/src/app/component/admin/tag-group/edit/edit.component.spec.ts
@@ -1,23 +1,94 @@
-import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ActivatedRoute, Router } from "@angular/router";
+import { RouterTestingModule } from "@angular/router/testing";
+import { ToastrService } from "ngx-toastr";
+import { appLibraryImports } from "src/app/app.module";
+import { SharedModule } from "src/app/component/shared/shared.module";
+import { TagGroup } from "src/app/models/TagGroup";
+import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
+import {
+  tagGroupResolvers,
+  TagGroupService
+} from "src/app/services/baw-api/tag-group.service";
+import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
+import { assertFormErrorHandling } from "src/testHelpers";
 import { AdminTagGroupsEditComponent } from "./edit.component";
 
-xdescribe("AdminTagGroupsEditComponent", () => {
+describe("AdminTagGroupsEditComponent", () => {
+  let api: TagGroupService;
   let component: AdminTagGroupsEditComponent;
+  let defaultError: ApiErrorDetails;
+  let defaultTagGroup: TagGroup;
   let fixture: ComponentFixture<AdminTagGroupsEditComponent>;
+  let notifications: ToastrService;
+  let router: Router;
 
-  beforeEach(async(() => {
+  function configureTestingModule(tagGroup: TagGroup, error: ApiErrorDetails) {
     TestBed.configureTestingModule({
-      declarations: [AdminTagGroupsEditComponent]
+      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      declarations: [AdminTagGroupsEditComponent],
+      providers: [
+        ...testBawServices,
+        {
+          provide: ActivatedRoute,
+          useClass: mockActivatedRoute(
+            {
+              tagGroup: tagGroupResolvers.show
+            },
+            {
+              tagGroup: {
+                model: tagGroup,
+                error
+              }
+            }
+          )
+        }
+      ]
     }).compileComponents();
-  }));
+
+    fixture = TestBed.createComponent(AdminTagGroupsEditComponent);
+    api = TestBed.inject(TagGroupService);
+    router = TestBed.inject(Router);
+    notifications = TestBed.inject(ToastrService);
+    component = fixture.componentInstance;
+
+    spyOn(notifications, "success").and.stub();
+    spyOn(notifications, "error").and.stub();
+    spyOn(router, "navigateByUrl").and.stub();
+
+    fixture.detectChanges();
+  }
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(AdminTagGroupsEditComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    defaultTagGroup = new TagGroup({
+      id: 1,
+      groupIdentifier: "Group Identifier",
+      tagId: 1
+    });
+    defaultError = {
+      status: 401,
+      message: "Unauthorized"
+    };
   });
 
-  it("should create", () => {
-    expect(component).toBeTruthy();
+  xdescribe("form", () => {});
+
+  describe("component", () => {
+    it("should create", () => {
+      configureTestingModule(defaultTagGroup, undefined);
+      expect(component).toBeTruthy();
+    });
+
+    it("should handle tag group error", () => {
+      configureTestingModule(undefined, defaultError);
+      assertFormErrorHandling(fixture);
+    });
+
+    it("should call api", () => {
+      configureTestingModule(defaultTagGroup, undefined);
+      spyOn(api, "update").and.callThrough();
+      component.submit({});
+      expect(api.update).toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/component/admin/tag-group/edit/edit.component.ts
+++ b/src/app/component/admin/tag-group/edit/edit.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from "@angular/core";
+
+@Component({
+  selector: "app-admin-tag-groups-edit",
+  template: ``
+})
+export class AdminTagGroupsEditComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/component/admin/tag-group/edit/edit.component.ts
+++ b/src/app/component/admin/tag-group/edit/edit.component.ts
@@ -1,11 +1,77 @@
 import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+import { List } from "immutable";
+import { ToastrService } from "ngx-toastr";
+import {
+  defaultSuccessMsg,
+  FormTemplate
+} from "src/app/helpers/formTemplate/formTemplate";
+import { Page } from "src/app/helpers/page/pageDecorator";
+import { TagGroup } from "src/app/models/TagGroup";
+import {
+  tagGroupResolvers,
+  TagGroupService
+} from "src/app/services/baw-api/tag-group.service";
+import {
+  adminEditTagGroupMenuItem,
+  adminTagGroupsCategory,
+  adminTagGroupsMenuItem
+} from "../../admin.menus";
+import { adminTagGroupMenuItemActions } from "../list/list.component";
+import { fields } from "../tag-group.json";
 
+const tagGroupKey = "tagGroup";
+
+@Page({
+  category: adminTagGroupsCategory,
+  menus: {
+    actions: List([adminTagGroupsMenuItem, ...adminTagGroupMenuItemActions]),
+    links: List()
+  },
+  resolvers: {
+    [tagGroupKey]: tagGroupResolvers.show
+  },
+  self: adminEditTagGroupMenuItem
+})
 @Component({
   selector: "app-admin-tag-groups-edit",
-  template: ``
+  template: `
+    <app-form
+      *ngIf="!failure"
+      [title]="title"
+      [model]="model"
+      [fields]="fields"
+      [submitLoading]="loading"
+      submitLabel="Submit"
+      (onSubmit)="submit($event)"
+    ></app-form>
+  `
 })
-export class AdminTagGroupsEditComponent implements OnInit {
-  constructor() {}
+export class AdminTagGroupsEditComponent extends FormTemplate<TagGroup>
+  implements OnInit {
+  public fields = fields;
+  public title: string;
 
-  ngOnInit(): void {}
+  constructor(
+    private api: TagGroupService,
+    notifications: ToastrService,
+    route: ActivatedRoute,
+    router: Router
+  ) {
+    super(notifications, route, router, tagGroupKey, model =>
+      defaultSuccessMsg("updated", model.groupIdentifier)
+    );
+  }
+
+  ngOnInit() {
+    super.ngOnInit();
+
+    if (!this.failure) {
+      this.title = `Edit ${this.model.groupIdentifier}`;
+    }
+  }
+
+  protected apiAction(model: Partial<TagGroup>) {
+    return this.api.update(new TagGroup(model));
+  }
 }

--- a/src/app/component/admin/tag-group/list/list.component.html
+++ b/src/app/component/admin/tag-group/list/list.component.html
@@ -1,0 +1,1 @@
+<p>list works!</p>

--- a/src/app/component/admin/tag-group/list/list.component.html
+++ b/src/app/component/admin/tag-group/list/list.component.html
@@ -1,1 +1,49 @@
-<p>list works!</p>
+<ng-container *ngIf="rows && !error">
+  <h1>Tag Groups</h1>
+
+  <div class="input-group mb-3">
+    <div class="input-group-prepend">
+      <span class="input-group-text">Filter</span>
+    </div>
+    <input
+      type="text"
+      class="form-control"
+      placeholder="Filter Tag Groups"
+      (keyup)="onFilter($event)"
+    />
+  </div>
+
+  <ngx-datatable
+    #table
+    bawDatatableDefaults
+    [columnMode]="ColumnMode.force"
+    [columns]="columns"
+    [rows]="rows"
+    [count]="totalModels"
+    [offset]="pageNumber"
+    (page)="setPage($event)"
+    (sort)="onSort($event)"
+  >
+    <ngx-datatable-column name="Tag"> </ngx-datatable-column>
+    <ngx-datatable-column name="Group"> </ngx-datatable-column>
+    <ngx-datatable-column
+      name="Model"
+      [width]="130"
+      [maxWidth]="130"
+      [sortable]="false"
+    >
+      <ng-template let-column="column" ngx-datatable-header-template>
+      </ng-template>
+      <ng-template let-value="value" ngx-datatable-cell-template>
+        <a class="btn btn-sm btn-warning mr-1" [routerLink]="[editPath(value)]">
+          Edit
+        </a>
+        <a class="btn btn-sm btn-danger" [routerLink]="[deletePath(value)]">
+          Delete
+        </a>
+      </ng-template>
+    </ngx-datatable-column>
+  </ngx-datatable>
+</ng-container>
+
+<app-error-handler [error]="error"></app-error-handler>

--- a/src/app/component/admin/tag-group/list/list.component.spec.ts
+++ b/src/app/component/admin/tag-group/list/list.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { AdminTagGroupsComponent } from "./list.component";
 
-describe("AdminTagGroupsComponent", () => {
+xdescribe("AdminTagGroupsComponent", () => {
   let component: AdminTagGroupsComponent;
   let fixture: ComponentFixture<AdminTagGroupsComponent>;
 

--- a/src/app/component/admin/tag-group/list/list.component.spec.ts
+++ b/src/app/component/admin/tag-group/list/list.component.spec.ts
@@ -1,0 +1,23 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { AdminTagGroupsComponent } from "./list.component";
+
+describe("AdminTagGroupsComponent", () => {
+  let component: AdminTagGroupsComponent;
+  let fixture: ComponentFixture<AdminTagGroupsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AdminTagGroupsComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AdminTagGroupsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/component/admin/tag-group/list/list.component.ts
+++ b/src/app/component/admin/tag-group/list/list.component.ts
@@ -16,6 +16,11 @@ import {
 } from "../../admin.menus";
 
 export const adminTagGroupsMenuItemActions = [adminNewTagGroupMenuItem];
+export const adminTagGroupMenuItemActions = [
+  adminNewTagGroupMenuItem,
+  adminEditTagGroupMenuItem,
+  adminDeleteTagGroupMenuItem
+];
 
 @Page({
   category: adminTagGroupsCategory,

--- a/src/app/component/admin/tag-group/list/list.component.ts
+++ b/src/app/component/admin/tag-group/list/list.component.ts
@@ -1,12 +1,76 @@
 import { Component, OnInit } from "@angular/core";
+import { List } from "immutable";
+import { Page } from "src/app/helpers/page/pageDecorator";
+import { PagedTableTemplate } from "src/app/helpers/tableTemplate/pagedTableTemplate";
+import { Id } from "src/app/interfaces/apiInterfaces";
+import { AnyMenuItem } from "src/app/interfaces/menusInterfaces";
+import { TagGroup } from "src/app/models/TagGroup";
+import { TagGroupService } from "src/app/services/baw-api/tag-group.service";
+import {
+  adminDashboardMenuItem,
+  adminDeleteTagGroupMenuItem,
+  adminEditTagGroupMenuItem,
+  adminNewTagGroupMenuItem,
+  adminTagGroupsCategory,
+  adminTagGroupsMenuItem
+} from "../../admin.menus";
 
+export const adminTagGroupsMenuItemActions = [adminNewTagGroupMenuItem];
+
+@Page({
+  category: adminTagGroupsCategory,
+  menus: {
+    actions: List<AnyMenuItem>([
+      adminDashboardMenuItem,
+      ...adminTagGroupsMenuItemActions
+    ]),
+    links: List()
+  },
+  self: adminTagGroupsMenuItem
+})
 @Component({
   selector: "app-admin-tag-groups-list",
   templateUrl: "./list.component.html",
   styleUrls: ["./list.component.scss"]
 })
-export class AdminTagGroupsComponent implements OnInit {
-  constructor() {}
+export class AdminTagGroupsComponent
+  extends PagedTableTemplate<TableRow, TagGroup>
+  implements OnInit {
+  constructor(api: TagGroupService) {
+    super(api, tagGroups =>
+      tagGroups.map(tagGroup => ({
+        tag: tagGroup.tagId,
+        group: tagGroup.groupIdentifier,
+        model: tagGroup
+      }))
+    );
+  }
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.columns = [{ name: "Tag" }, { name: "Group" }, { name: "Model" }];
+    this.sortKeys = {
+      tag: "tagId",
+      group: "groupIdentifier"
+    };
+
+    this.getModels();
+  }
+
+  editPath(tagGroup: TagGroup): string {
+    return adminEditTagGroupMenuItem.route
+      .toString()
+      .replace(":tagGroupId", tagGroup.id.toString());
+  }
+
+  deletePath(tag: TagGroup): string {
+    return adminDeleteTagGroupMenuItem.route
+      .toString()
+      .replace(":tagGroupId", tag.id.toString());
+  }
+}
+
+interface TableRow {
+  tag: Id;
+  group: string;
+  model: TagGroup;
 }

--- a/src/app/component/admin/tag-group/list/list.component.ts
+++ b/src/app/component/admin/tag-group/list/list.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from "@angular/core";
+
+@Component({
+  selector: "app-admin-tag-groups-list",
+  templateUrl: "./list.component.html",
+  styleUrls: ["./list.component.scss"]
+})
+export class AdminTagGroupsComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/component/admin/tag-group/new/new.component.spec.ts
+++ b/src/app/component/admin/tag-group/new/new.component.spec.ts
@@ -1,12 +1,12 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { ToastrService } from "ngx-toastr";
 import { appLibraryImports } from "src/app/app.module";
 import { SharedModule } from "src/app/component/shared/shared.module";
+import { TagGroupService } from "src/app/services/baw-api/tag-group.service";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
 import { AdminTagGroupsNewComponent } from "./new.component";
-import { TagGroupService } from "src/app/services/baw-api/tag-group.service";
-import { ToastrService } from "ngx-toastr";
 
 describe("AdminTagGroupsNewComponent", () => {
   let api: TagGroupService;

--- a/src/app/component/admin/tag-group/new/new.component.spec.ts
+++ b/src/app/component/admin/tag-group/new/new.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { AdminTagGroupsNewComponent } from "./new.component";
 
-describe("AdminTagGroupsNewComponent", () => {
+xdescribe("AdminTagGroupsNewComponent", () => {
   let component: AdminTagGroupsNewComponent;
   let fixture: ComponentFixture<AdminTagGroupsNewComponent>;
 

--- a/src/app/component/admin/tag-group/new/new.component.spec.ts
+++ b/src/app/component/admin/tag-group/new/new.component.spec.ts
@@ -1,0 +1,23 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { AdminTagGroupsNewComponent } from "./new.component";
+
+describe("AdminTagGroupsNewComponent", () => {
+  let component: AdminTagGroupsNewComponent;
+  let fixture: ComponentFixture<AdminTagGroupsNewComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AdminTagGroupsNewComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AdminTagGroupsNewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/component/admin/tag-group/new/new.component.spec.ts
+++ b/src/app/component/admin/tag-group/new/new.component.spec.ts
@@ -1,23 +1,59 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { ActivatedRoute, Router } from "@angular/router";
+import { RouterTestingModule } from "@angular/router/testing";
+import { appLibraryImports } from "src/app/app.module";
+import { SharedModule } from "src/app/component/shared/shared.module";
+import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
 import { AdminTagGroupsNewComponent } from "./new.component";
+import { TagGroupService } from "src/app/services/baw-api/tag-group.service";
+import { ToastrService } from "ngx-toastr";
 
-xdescribe("AdminTagGroupsNewComponent", () => {
+describe("AdminTagGroupsNewComponent", () => {
+  let api: TagGroupService;
   let component: AdminTagGroupsNewComponent;
   let fixture: ComponentFixture<AdminTagGroupsNewComponent>;
+  let notifications: ToastrService;
+  let router: Router;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [AdminTagGroupsNewComponent]
-    }).compileComponents();
-  }));
+  xdescribe("form", () => {});
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AdminTagGroupsNewComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+  describe("component", () => {
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+        declarations: [AdminTagGroupsNewComponent],
+        providers: [
+          ...testBawServices,
+          {
+            provide: ActivatedRoute,
+            useClass: mockActivatedRoute()
+          }
+        ]
+      }).compileComponents();
+    }));
 
-  it("should create", () => {
-    expect(component).toBeTruthy();
+    beforeEach(() => {
+      fixture = TestBed.createComponent(AdminTagGroupsNewComponent);
+      api = TestBed.inject(TagGroupService);
+      router = TestBed.inject(Router);
+      notifications = TestBed.inject(ToastrService);
+      component = fixture.componentInstance;
+
+      spyOn(notifications, "success").and.stub();
+      spyOn(notifications, "error").and.stub();
+      spyOn(router, "navigateByUrl").and.stub();
+
+      fixture.detectChanges();
+    });
+
+    it("should create", () => {
+      expect(component).toBeTruthy();
+    });
+
+    it("should call api", () => {
+      spyOn(api, "create").and.callThrough();
+      component.submit({});
+      expect(api.create).toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/component/admin/tag-group/new/new.component.ts
+++ b/src/app/component/admin/tag-group/new/new.component.ts
@@ -1,11 +1,59 @@
-import { Component, OnInit } from "@angular/core";
+import { Component } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+import { List } from "immutable";
+import { ToastrService } from "ngx-toastr";
+import {
+  defaultSuccessMsg,
+  FormTemplate
+} from "src/app/helpers/formTemplate/formTemplate";
+import { Page } from "src/app/helpers/page/pageDecorator";
+import { TagGroup } from "src/app/models/TagGroup";
+import { TagGroupService } from "src/app/services/baw-api/tag-group.service";
+import {
+  adminNewTagGroupMenuItem,
+  adminTagGroupsCategory,
+  adminTagGroupsMenuItem
+} from "../../admin.menus";
+import { adminTagGroupsMenuItemActions } from "../list/list.component";
+import { fields } from "../tag-group.json";
 
+@Page({
+  category: adminTagGroupsCategory,
+  menus: {
+    actions: List([adminTagGroupsMenuItem, ...adminTagGroupsMenuItemActions]),
+    links: List()
+  },
+  self: adminNewTagGroupMenuItem
+})
 @Component({
   selector: "app-admin-tag-groups-new",
-  template: ``
+  template: `
+    <app-form
+      *ngIf="!failure"
+      title="New Tag Group"
+      [model]="model"
+      [fields]="fields"
+      [submitLoading]="loading"
+      submitLabel="Submit"
+      (onSubmit)="submit($event)"
+    ></app-form>
+  `
 })
-export class AdminTagGroupsNewComponent implements OnInit {
-  constructor() {}
+export class AdminTagGroupsNewComponent extends FormTemplate<TagGroup> {
+  public fields = fields;
 
-  ngOnInit(): void {}
+  constructor(
+    private api: TagGroupService,
+    notifications: ToastrService,
+    route: ActivatedRoute,
+    router: Router
+  ) {
+    super(notifications, route, router, undefined, model =>
+      defaultSuccessMsg("created", model.groupIdentifier)
+    );
+  }
+
+  protected apiAction(model: Partial<TagGroup>) {
+    return this.api.create(new TagGroup(model));
+  }
 }

--- a/src/app/component/admin/tag-group/new/new.component.ts
+++ b/src/app/component/admin/tag-group/new/new.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from "@angular/core";
+
+@Component({
+  selector: "app-admin-tag-groups-new",
+  template: ``
+})
+export class AdminTagGroupsNewComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/component/admin/tag-group/tag-group.json
+++ b/src/app/component/admin/tag-group/tag-group.json
@@ -1,0 +1,22 @@
+{
+  "fields": [
+    {
+      "key": "tagId",
+      "type": "input",
+      "templateOptions": {
+        "label": "Tag",
+        "type": "text",
+        "required": true
+      }
+    },
+    {
+      "key": "groupIdentifier",
+      "type": "input",
+      "templateOptions": {
+        "label": "Group Identifier",
+        "type": "text",
+        "required": true
+      }
+    }
+  ]
+}

--- a/src/app/component/admin/user-list/user-list.component.spec.ts
+++ b/src/app/component/admin/user-list/user-list.component.spec.ts
@@ -376,7 +376,7 @@ describe("AdminUserListComponent", () => {
   describe("actions", () => {
     it("should link to user account", () => {
       const user = new User({
-        id: 1,
+        id: 5,
         userName: "username",
         isConfirmed: false
       });
@@ -389,16 +389,16 @@ describe("AdminUserListComponent", () => {
 
       expect(
         userLink.attributes.getNamedItem("ng-reflect-router-link").value
-      ).toBe("/user_accounts/1");
+      ).toBe("/user_accounts/5");
     });
 
     it("should link to edit user account", () => {
       const user = new User({
-        id: 1,
+        id: 5,
         userName: "username",
         isConfirmed: false
       });
-      apiResponse([defaultUser], defaultPaging);
+      apiResponse([user], defaultPaging);
       fixture.detectChanges();
 
       const row = getRows()[0];
@@ -407,7 +407,7 @@ describe("AdminUserListComponent", () => {
 
       expect(
         editLink.attributes.getNamedItem("ng-reflect-router-link").value
-      ).toBe("/user_accounts/1/edit");
+      ).toBe("/user_accounts/5/edit");
     });
   });
 });

--- a/src/app/component/projects/projects.menus.ts
+++ b/src/app/component/projects/projects.menus.ts
@@ -54,8 +54,7 @@ export const requestProjectMenuItem = MenuRoute({
 export const projectCategory: Category = {
   label: "Project",
   icon: projectsCategory.icon,
-  route: projectsRoute.add(":projectId"),
-  parent: projectsCategory
+  route: projectsRoute.add(":projectId")
 };
 
 export const projectMenuItem = MenuRoute({

--- a/src/app/component/sites/sites.menus.ts
+++ b/src/app/component/sites/sites.menus.ts
@@ -18,8 +18,7 @@ export const sitesRoute = projectMenuItem.route.addFeatureModule("sites");
 export const sitesCategory: Category = {
   icon: ["fas", "map-marker-alt"],
   label: "Sites",
-  route: sitesRoute.add(":siteId"),
-  parent: projectCategory
+  route: sitesRoute.add(":siteId")
 };
 
 export const newSiteMenuItem = MenuRoute({

--- a/src/app/interfaces/menusInterfaces.ts
+++ b/src/app/interfaces/menusInterfaces.ts
@@ -51,11 +51,6 @@ export interface Category extends LabelAndIcon {
    *  Local route of category Eg. 'security'
    */
   route: StrongRoute;
-
-  /**
-   * Parent category
-   */
-  parent?: Category;
 }
 
 /**

--- a/src/app/models/TagGroup.ts
+++ b/src/app/models/TagGroup.ts
@@ -1,0 +1,58 @@
+import { adminTagGroupsMenuItem } from "../component/admin/admin.menus";
+import {
+  DateTimeTimezone,
+  dateTimeTimezone,
+  Id
+} from "../interfaces/apiInterfaces";
+import { AbstractModel } from "./AbstractModel";
+
+/**
+ * A tag group model
+ */
+export interface TagGroupInterface {
+  id?: Id;
+  groupIdentifier: string;
+  createdAt: DateTimeTimezone | string;
+  creatorId: Id;
+  tagId: Id;
+}
+
+/**
+ * A tag group model
+ */
+export class TagGroup extends AbstractModel implements TagGroupInterface {
+  public readonly kind: "TagGroup" = "TagGroup";
+  public readonly id?: Id;
+  public readonly groupIdentifier: string;
+  public readonly createdAt: DateTimeTimezone;
+  public readonly creatorId: Id;
+  public readonly tagId: Id;
+
+  constructor(tagGroup: TagGroupInterface) {
+    super(tagGroup);
+
+    this.createdAt = dateTimeTimezone(tagGroup.createdAt as string);
+  }
+
+  static fromJSON = (obj: any) => {
+    if (typeof obj === "string") {
+      obj = JSON.parse(obj);
+    }
+
+    return new TagGroup(obj);
+  };
+
+  public redirectPath(): string {
+    return adminTagGroupsMenuItem.route.toString();
+  }
+
+  public toJSON(): object {
+    return {
+      id: this.id,
+      groupIdentifier: this.groupIdentifier,
+      createdAt: this.createdAt?.toISO(),
+      creatorId: this.creatorId,
+      tagId: this.tagId
+    };
+  }
+}

--- a/src/app/models/TagGroup.ts
+++ b/src/app/models/TagGroup.ts
@@ -11,10 +11,10 @@ import { AbstractModel } from "./AbstractModel";
  */
 export interface TagGroupInterface {
   id?: Id;
-  groupIdentifier: string;
-  createdAt: DateTimeTimezone | string;
-  creatorId: Id;
-  tagId: Id;
+  groupIdentifier?: string;
+  createdAt?: DateTimeTimezone | string;
+  creatorId?: Id;
+  tagId?: Id;
 }
 
 /**
@@ -23,10 +23,10 @@ export interface TagGroupInterface {
 export class TagGroup extends AbstractModel implements TagGroupInterface {
   public readonly kind: "TagGroup" = "TagGroup";
   public readonly id?: Id;
-  public readonly groupIdentifier: string;
-  public readonly createdAt: DateTimeTimezone;
-  public readonly creatorId: Id;
-  public readonly tagId: Id;
+  public readonly groupIdentifier?: string;
+  public readonly createdAt?: DateTimeTimezone;
+  public readonly creatorId?: Id;
+  public readonly tagId?: Id;
 
   constructor(tagGroup: TagGroupInterface) {
     super(tagGroup);

--- a/src/app/services/baw-api/mock/api-commonMock.ts
+++ b/src/app/services/baw-api/mock/api-commonMock.ts
@@ -1,6 +1,7 @@
-import { of } from "rxjs";
+import { Observable, of } from "rxjs";
 import { delay } from "rxjs/operators";
 import { AbstractModel } from "src/app/models/AbstractModel";
+import { id, IdOr } from "../api-common";
 import { Filters, Meta } from "../baw-api.service";
 
 export function listMock<M extends AbstractModel>(
@@ -48,4 +49,11 @@ export function filterMock<M extends AbstractModel>(
   }
 
   return of(models).pipe(delay(1000));
+}
+
+export function showMock<M extends AbstractModel>(
+  model: IdOr<M>,
+  classBuilder: (modelId: number) => M
+): Observable<M> {
+  return of(classBuilder(parseInt(id<M>(model), 10))).pipe(delay(1000));
 }

--- a/src/app/services/baw-api/tag-group.service.spec.ts
+++ b/src/app/services/baw-api/tag-group.service.spec.ts
@@ -1,11 +1,23 @@
+import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+import { testAppInitializer } from "src/app/test.helper";
+import { BawApiService } from "./baw-api.service";
+import { MockBawApiService } from "./mock/baseApiMock.service";
 import { TagGroupService } from "./tag-group.service";
 
 describe("TagGroupService", () => {
   let service: TagGroupService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        ...testAppInitializer,
+        TagGroupService,
+        { provide: BawApiService, useClass: MockBawApiService }
+      ]
+    });
     service = TestBed.inject(TagGroupService);
   });
 

--- a/src/app/services/baw-api/tag-group.service.spec.ts
+++ b/src/app/services/baw-api/tag-group.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed } from "@angular/core/testing";
+import { TagGroupService } from "./tag-group.service";
+
+describe("TagGroupService", () => {
+  let service: TagGroupService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TagGroupService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/baw-api/tag-group.service.ts
+++ b/src/app/services/baw-api/tag-group.service.ts
@@ -7,7 +7,7 @@ import { Id } from "src/app/interfaces/apiInterfaces";
 import { TagGroup } from "src/app/models/TagGroup";
 import { Empty, id, IdOr, IdParamOptional, StandardApi } from "./api-common";
 import { Filters } from "./baw-api.service";
-import { filterMock } from "./mock/api-commonMock";
+import { filterMock, showMock } from "./mock/api-commonMock";
 import { Resolvers } from "./resolver-common";
 
 const tagGroupId: IdParamOptional<TagGroup> = id;
@@ -32,7 +32,7 @@ export class TagGroupService extends StandardApi<TagGroup, []> {
   }
 
   show(model: IdOr<TagGroup>): Observable<TagGroup> {
-    return this.apiShow(endpoint(model));
+    return showMock(model, modelId => createTagGroup(modelId));
   }
   create(model: TagGroup): Observable<TagGroup> {
     return this.apiCreate(endpoint(Empty), model);

--- a/src/app/services/baw-api/tag-group.service.ts
+++ b/src/app/services/baw-api/tag-group.service.ts
@@ -1,0 +1,61 @@
+import { HttpClient } from "@angular/common/http";
+import { Inject, Injectable } from "@angular/core";
+import { Observable } from "rxjs";
+import { API_ROOT } from "src/app/helpers/app-initializer/app-initializer";
+import { stringTemplate } from "src/app/helpers/stringTemplate/stringTemplate";
+import { Id } from "src/app/interfaces/apiInterfaces";
+import { TagGroup } from "src/app/models/TagGroup";
+import { Empty, id, IdOr, IdParamOptional, StandardApi } from "./api-common";
+import { Filters } from "./baw-api.service";
+import { filterMock } from "./mock/api-commonMock";
+import { Resolvers } from "./resolver-common";
+
+const tagGroupId: IdParamOptional<TagGroup> = id;
+const endpoint = stringTemplate`/tag_groups/${tagGroupId}`;
+
+/**
+ * Scripts Service.
+ * Handles API routes pertaining to scripts.
+ */
+@Injectable()
+export class TagGroupService extends StandardApi<TagGroup, []> {
+  constructor(http: HttpClient, @Inject(API_ROOT) apiRoot: string) {
+    super(http, apiRoot, TagGroup);
+  }
+
+  list(): Observable<TagGroup[]> {
+    return this.filter({});
+  }
+
+  filter(filters: Filters): Observable<TagGroup[]> {
+    return filterMock<TagGroup>(filters, modelId => createTagGroup(modelId));
+  }
+
+  show(model: IdOr<TagGroup>): Observable<TagGroup> {
+    return this.apiShow(endpoint(model));
+  }
+  create(model: TagGroup): Observable<TagGroup> {
+    return this.apiCreate(endpoint(Empty), model);
+  }
+  update(model: TagGroup): Observable<TagGroup> {
+    return this.apiUpdate(endpoint(model), model);
+  }
+  destroy(model: IdOr<TagGroup>): Observable<TagGroup | void> {
+    return this.apiDestroy(endpoint(model));
+  }
+}
+
+function createTagGroup(modelId: Id) {
+  return new TagGroup({
+    id: modelId,
+    groupIdentifier: "PLACEHOLDER",
+    createdAt: "2020-03-10T10:51:04.576+10:00",
+    creatorId: 1,
+    tagId: modelId
+  });
+}
+
+export const tagGroupResolvers = new Resolvers<TagGroup, TagGroupService>(
+  [TagGroupService],
+  "tagGroupId"
+).create("TagGroup");

--- a/src/app/services/baw-api/tag-group.service.ts
+++ b/src/app/services/baw-api/tag-group.service.ts
@@ -5,13 +5,20 @@ import { API_ROOT } from "src/app/helpers/app-initializer/app-initializer";
 import { stringTemplate } from "src/app/helpers/stringTemplate/stringTemplate";
 import { Id } from "src/app/interfaces/apiInterfaces";
 import { TagGroup } from "src/app/models/TagGroup";
-import { Empty, id, IdOr, IdParamOptional, StandardApi } from "./api-common";
+import {
+  Empty,
+  id,
+  IdOr,
+  IdParamOptional,
+  option,
+  StandardApi
+} from "./api-common";
 import { Filters } from "./baw-api.service";
 import { filterMock, showMock } from "./mock/api-commonMock";
 import { Resolvers } from "./resolver-common";
 
 const tagGroupId: IdParamOptional<TagGroup> = id;
-const endpoint = stringTemplate`/tag_groups/${tagGroupId}`;
+const endpoint = stringTemplate`/tag_groups/${tagGroupId}${option}`;
 
 /**
  * Scripts Service.
@@ -35,13 +42,13 @@ export class TagGroupService extends StandardApi<TagGroup, []> {
     return showMock(model, modelId => createTagGroup(modelId));
   }
   create(model: TagGroup): Observable<TagGroup> {
-    return this.apiCreate(endpoint(Empty), model);
+    return this.apiCreate(endpoint(Empty, Empty), model);
   }
   update(model: TagGroup): Observable<TagGroup> {
-    return this.apiUpdate(endpoint(model), model);
+    return this.apiUpdate(endpoint(model, Empty), model);
   }
   destroy(model: IdOr<TagGroup>): Observable<TagGroup | void> {
-    return this.apiDestroy(endpoint(model));
+    return this.apiDestroy(endpoint(model, Empty));
   }
 }
 

--- a/src/app/test.helper.ts
+++ b/src/app/test.helper.ts
@@ -32,6 +32,7 @@ import {
   ShallowSitesService,
   SitesService
 } from "./services/baw-api/sites.service";
+import { TagGroupService } from "./services/baw-api/tag-group.service";
 import { UserService } from "./services/baw-api/user.service";
 
 /**
@@ -76,6 +77,7 @@ export const testBawServices = [
   { provide: ScriptsService, useClass: MockStandardApiService },
   { provide: SitesService, useClass: MockStandardApiService },
   { provide: ShallowSitesService, useClass: MockStandardApiService },
+  { provide: TagGroupService, useClass: MockStandardApiService },
   { provide: UserService, useClass: MockShowApiService }
 ];
 


### PR DESCRIPTION
# Admin Tag Group Pages

Created admin tag group pages (list, new, edit, delete)

## Changes

- Created `TagGroupsService`
- Created `TagGroup` model
- Created tag group list/forms

## Issues

- Missing tag group list unit tests (because table values aren't set yet)
- Missing form fields unit tests (because inputs aren't set yet)
- Missing tag group service unit tests (planning to change how they are written once all admin pages are finished)

## Closes

Closes #131 

## Visual Changes

Tag group list page

![image](https://user-images.githubusercontent.com/3955116/77888507-bcc39900-72af-11ea-823a-72e2b1f9a60f.png)

Tag group new page

![image](https://user-images.githubusercontent.com/3955116/77888637-e7aded00-72af-11ea-83a2-2636153d6e6b.png)

Tag group edit page

![image](https://user-images.githubusercontent.com/3955116/77888599-d9f86780-72af-11ea-8936-ffd9bf764b1b.png)

Tag group delete page

![image](https://user-images.githubusercontent.com/3955116/77888615-e086df00-72af-11ea-9bd7-a5bf961fc81e.png)

