### PR TITLE
Case Converter Adjustments

### DIFF
--- a/src/app/helpers/case-converter/case-converter.spec.ts
+++ b/src/app/helpers/case-converter/case-converter.spec.ts
@@ -20,10 +20,10 @@ const conversionCallbacks = [
 ];
 
 conversionCallbacks.forEach((test) => {
-  let fieldOne = test.fieldOne;
-  let fieldTwo = test.fieldTwo;
-  let whitelistKey = test.whitelistKey;
-  let whitelistValue = test.whitelistValue;
+  const fieldOne = test.fieldOne;
+  const fieldTwo = test.fieldTwo;
+  const whitelistKey = test.whitelistKey;
+  const whitelistValue = test.whitelistValue;
 
   describe(test.name, () => {
     it("simple objects", () => {

--- a/src/app/helpers/case-converter/case-converter.spec.ts
+++ b/src/app/helpers/case-converter/case-converter.spec.ts
@@ -1,211 +1,170 @@
 import { toCamelCase, toSnakeCase } from "./case-converter";
 
-/**
- * Tests are developed here: https://github.com/travelperk/case-converter
- * @copyright MIT
- */
+const conversionCallbacks = [
+  {
+    name: "to camelCase",
+    callback: toCamelCase,
+    fieldOne: "fieldOne",
+    fieldTwo: "fieldTwo",
+    whitelistKey: "whitelistKey",
+    whitelistValue: "contentOne",
+  },
+  {
+    name: "to snake_case",
+    callback: toSnakeCase,
+    fieldOne: "field_one",
+    fieldTwo: "field_two",
+    whitelistKey: "whitelist_key",
+    whitelistValue: "content_one",
+  },
+];
 
-describe("to camelCase", () => {
-  it("simple objects", () => {
-    const before = { field_one: "content one", "field-two": "content two" };
-    const expected = { fieldOne: "content one", fieldTwo: "content two" };
-    const result = toCamelCase(before);
-    expect(expected).toEqual(result);
-  });
+conversionCallbacks.forEach((test) => {
+  let fieldOne = test.fieldOne;
+  let fieldTwo = test.fieldTwo;
+  let whitelistKey = test.whitelistKey;
+  let whitelistValue = test.whitelistValue;
 
-  it("nested objects", () => {
-    const before = {
-      field_one: {
-        nested_field_one: "content one",
-        nested_field_two: "content two"
-      },
-      field_two: {
-        "nested-field-one": "content one",
-        "nested-field-two": "content two"
-      }
-    };
-    const expected = {
-      fieldOne: {
-        nestedFieldOne: "content one",
-        nestedFieldTwo: "content two"
-      },
-      fieldTwo: { nestedFieldOne: "content one", nestedFieldTwo: "content two" }
-    };
-    const result = toCamelCase(before);
-    expect(expected).toEqual(result);
-  });
+  describe(test.name, () => {
+    it("simple objects", () => {
+      const before = { field_one: "content one", "field-two": "content two" };
+      const expected = { [fieldOne]: "content one", [fieldTwo]: "content two" };
+      const result = test.callback(before);
+      expect(expected).toEqual(result);
+    });
 
-  it("objects in arrays", () => {
-    const before = [
-      { field_one_one: "content one one", field_one_two: "content two two" },
-      { "field-two-one": "content two one", "field-two-two": "content two two" }
-    ];
-    const expected = [
-      { fieldOneOne: "content one one", fieldOneTwo: "content two two" },
-      { fieldTwoOne: "content two one", fieldTwoTwo: "content two two" }
-    ];
-    const result = toCamelCase(before);
-    expect(expected).toEqual(result);
-  });
+    it("nested objects", () => {
+      const before = {
+        field_one: {
+          field_one: "content one",
+          field_two: "content two",
+        },
+        field_two: {
+          "field-one": "content one",
+          "field-two": "content two",
+        },
+      };
+      const expected = {
+        [fieldOne]: {
+          [fieldOne]: "content one",
+          [fieldTwo]: "content two",
+        },
+        [fieldTwo]: {
+          [fieldOne]: "content one",
+          [fieldTwo]: "content two",
+        },
+      };
+      const result = test.callback(before);
+      expect(expected).toEqual(result);
+    });
 
-  it("objects in arrays in arrays", () => {
-    const before = [
-      [{ field_one_one: "content one one", field_one_two: "content two two" }],
-      [
+    it("objects in arrays", () => {
+      const before = [
         {
-          "field-two-one": "content two one",
-          "field-two-two": "content two two"
-        }
-      ]
-    ];
-    const expected = [
-      [{ fieldOneOne: "content one one", fieldOneTwo: "content two two" }],
-      [{ fieldTwoOne: "content two one", fieldTwoTwo: "content two two" }]
-    ];
-    const result = toCamelCase(before);
-    expect(expected).toEqual(result);
-  });
-
-  it("objects in arrays in objects", () => {
-    const before = {
-      an_array: [
-        { field_one_one: "content one one", field_one_two: "content two two" },
+          field_one: "content one one",
+          field_two: "content two two",
+        },
         {
-          "field-two-one": "content two one",
-          "field-two-two": "content two two"
-        }
-      ]
-    };
-    const expected = {
-      anArray: [
-        { fieldOneOne: "content one one", fieldOneTwo: "content two two" },
-        { fieldTwoOne: "content two one", fieldTwoTwo: "content two two" }
-      ]
-    };
-    const result = toCamelCase(before);
-    expect(expected).toEqual(result);
-  });
+          "field-one": "content two one",
+          "field-two": "content two two",
+        },
+      ];
+      const expected = [
+        { [fieldOne]: "content one one", [fieldTwo]: "content two two" },
+        { [fieldOne]: "content two one", [fieldTwo]: "content two two" },
+      ];
+      const result = test.callback(before);
+      expect(expected).toEqual(result);
+    });
 
-  it("undefined and null object", () => {
-    const before = {
-      an_array: [
-        { field_one_one: "content one one", field_one_two: "content two two" },
-        {
-          "field-two-one": "content two one",
-          "field-two-two": "content two two"
-        }
-      ]
-    };
-    const expected = {
-      anArray: [
-        { fieldOneOne: "content one one", fieldOneTwo: "content two two" },
-        { fieldTwoOne: "content two one", fieldTwoTwo: "content two two" }
-      ]
-    };
-    const result = toCamelCase(before);
-    expect(expected).toEqual(result);
-  });
+    it("objects in arrays in arrays", () => {
+      const before = [
+        [
+          {
+            field_one: "content one one",
+            field_two: "content two two",
+          },
+        ],
+        [
+          {
+            "field-one": "content two one",
+            "field-two": "content two two",
+          },
+        ],
+      ];
+      const expected = [
+        [{ [fieldOne]: "content one one", [fieldTwo]: "content two two" }],
+        [{ [fieldOne]: "content two one", [fieldTwo]: "content two two" }],
+      ];
+      const result = test.callback(before);
+      expect(expected).toEqual(result);
+    });
 
-  it("objects containing dates", () => {
-    const date = new Date();
-    const before = { a_date: date };
-    const expected = { aDate: date };
-    const result = toCamelCase(before);
-    expect(result.aDate instanceof Date).toBe(true);
-    expect(expected).toEqual(result);
-  });
-});
+    it("objects in arrays in objects", () => {
+      const before = {
+        field_one: [
+          {
+            field_one: "content one one",
+            field_two: "content two two",
+          },
+          {
+            "field-one": "content two one",
+            "field-two": "content two two",
+          },
+        ],
+      };
+      const expected = {
+        [fieldOne]: [
+          { [fieldOne]: "content one one", [fieldTwo]: "content two two" },
+          { [fieldOne]: "content two one", [fieldTwo]: "content two two" },
+        ],
+      };
+      const result = test.callback(before);
+      expect(expected).toEqual(result);
+    });
 
-describe("to snake_case", () => {
-  it("simple objects", () => {
-    const before = { fieldOne: "content one", "field-two": "content two" };
-    const expected = { field_one: "content one", field_two: "content two" };
-    const result = toSnakeCase(before);
-    expect(expected).toEqual(result);
-  });
+    it("undefined and null object", () => {
+      const before = { field_one: undefined, field_two: null };
+      const expected = { [fieldOne]: undefined, [fieldTwo]: null };
+      const result = test.callback(before);
+      expect(expected).toEqual(result);
+    });
 
-  it("nested objects", () => {
-    const before = {
-      fieldOne: {
-        nestedFieldOne: "content one",
-        nestedFieldTwo: "content two"
-      },
-      fieldTwo: {
-        "nested-field-one": "content one",
-        "nested-field-two": "content two"
-      }
-    };
-    const expected = {
-      field_one: {
-        nested_field_one: "content one",
-        nested_field_two: "content two"
-      },
-      field_two: {
-        nested_field_one: "content one",
-        nested_field_two: "content two"
-      }
-    };
-    const result = toSnakeCase(before);
-    expect(expected).toEqual(result);
-  });
+    it("should not convert .'s", () => {
+      const before = {
+        ["field_one.field_two"]: "content one",
+        ["field-two.field-one"]: "content two",
+      };
+      const expected = {
+        [`${fieldOne}.${fieldTwo}`]: "content one",
+        [`${fieldTwo}.${fieldOne}`]: "content two",
+      };
+      const result = test.callback(before);
+      expect(expected).toEqual(result);
+    });
 
-  it("objects in arrays", () => {
-    const before = [
-      { fieldOneOne: "content one one", fieldOneTwo: "content two two" },
-      { "field-two-one": "content two one", "field-two-two": "content two two" }
-    ];
-    const expected = [
-      { field_one_one: "content one one", field_one_two: "content two two" },
-      { field_two_one: "content two one", field_two_two: "content two two" }
-    ];
-    const result = toSnakeCase(before);
-    expect(expected).toEqual(result);
-  });
+    // TODO Add checking for whitelisted key after conversion
+    describe("whitelist", () => {
+      it("should convert whitelisted value", () => {
+        const before = { ["whitelist-key"]: "content one" };
+        const expected = { [whitelistKey]: whitelistValue };
+        const result = test.callback(before);
+        expect(expected).toEqual(result);
+      });
 
-  it("objects in arrays in arrays", () => {
-    const before = [
-      [{ fieldOneOne: "content one one", fieldOneTwo: "content two two" }],
-      [
-        {
-          "field-two-one": "content two one",
-          "field-two-two": "content two two"
-        }
-      ]
-    ];
-    const expected = [
-      [{ field_one_one: "content one one", field_one_two: "content two two" }],
-      [{ field_two_one: "content two one", field_two_two: "content two two" }]
-    ];
-    const result = toSnakeCase(before);
-    expect(expected).toEqual(result);
-  });
+      it("should convert whitelisted value object", () => {
+        const before = { ["whitelist-key"]: { field_one: "content one" } };
+        const expected = { [whitelistKey]: { [fieldOne]: whitelistValue } };
+        const result = test.callback(before);
+        expect(expected).toEqual(result);
+      });
 
-  it("objects in arrays in objects", () => {
-    const before = {
-      anArray: [
-        { fieldOneOne: "content one one", fieldOneTwo: "content two two" },
-        {
-          "field-two-one": "content two one",
-          "field-two-two": "content two two"
-        }
-      ]
-    };
-    const expected = {
-      an_array: [
-        { field_one_one: "content one one", field_one_two: "content two two" },
-        { field_two_one: "content two one", field_two_two: "content two two" }
-      ]
-    };
-    const result = toSnakeCase(before);
-    expect(expected).toEqual(result);
-  });
-
-  it("objects containing dates", () => {
-    const date = new Date();
-    const before = { aDate: date };
-    const expected = { a_date: date };
-    const result = toSnakeCase(before);
-    expect(result.a_date instanceof Date).toBe(true);
-    expect(expected).toEqual(result);
+      it("should convert whitelisted value array", () => {
+        const before = { ["whitelist-key"]: ["content one"] };
+        const expected = { [whitelistKey]: [whitelistValue] };
+        const result = test.callback(before);
+        expect(expected).toEqual(result);
+      });
+    });
   });
 });

--- a/src/app/helpers/case-converter/case-converter.ts
+++ b/src/app/helpers/case-converter/case-converter.ts
@@ -1,21 +1,32 @@
 import camelCase from "lodash.camelcase";
 import snakeCase from "lodash.snakecase";
+
+// List of whitelist keys which should have their values converted
 import * as whitelist from "./whitelist.json";
 
 /**
  * Deeply converts keys of an object from one case to another.
- * Function was created here: https://github.com/travelperk/case-converter
+ * Function was created here: https://github.com/travelperk/case-converter (repo no longer exists)
  * @copyright MIT
+ * @author travelperk
  * @param oldObject to convert
- * @param converterFunction to convert key.
+ * @param callback to convert key.
  * @return converted object
  */
 const convertCase = (
   oldObject: any,
-  converterFunction: (string?: string) => string,
+  callback: (string?: string) => string,
   convertValue?: boolean
 ): any => {
   let newObject: any;
+
+  // Prevent conversion of periods (.)
+  function converterFn(string?: string): string {
+    return string
+      .split(".")
+      .map((split) => callback(split))
+      .join(".");
+  }
 
   if (
     !oldObject ||
@@ -23,32 +34,24 @@ const convertCase = (
     !Object.keys(oldObject).length
   ) {
     // Change object value
-    return convertValue ? converterFunction(oldObject) : oldObject;
+    return convertValue ? converterFn(oldObject) : oldObject;
   }
 
   if (Array.isArray(oldObject)) {
-    newObject = oldObject.map(element =>
-      convertCase(element, converterFunction)
+    newObject = oldObject.map((element) =>
+      convertCase(element, callback, convertValue)
     );
   } else {
     newObject = {};
 
     // Change object keys
-    Object.keys(oldObject).forEach(oldKey => {
-      const newKey = converterFunction(oldKey);
-      let whitelisted = false;
+    Object.keys(oldObject).forEach((oldKey) => {
+      const newKey = converterFn(oldKey);
+      const whitelisted =
+        convertValue ||
+        whitelist.keys.some((key) => key === newKey || key === oldKey);
 
-      whitelist.keys.map(key => {
-        if (newKey === key || oldKey === key) {
-          whitelisted = true;
-        }
-      });
-
-      newObject[newKey] = convertCase(
-        oldObject[oldKey],
-        converterFunction,
-        whitelisted
-      );
+      newObject[newKey] = convertCase(oldObject[oldKey], callback, whitelisted);
     });
   }
 

--- a/src/app/helpers/case-converter/whitelist.json
+++ b/src/app/helpers/case-converter/whitelist.json
@@ -1,3 +1,3 @@
 {
-  "keys": ["order_by", "tag_of_type"]
+  "keys": ["whitelist-key", "order_by", "tag_of_type"]
 }


### PR DESCRIPTION
# Case Converter Adjustments

Making some adjustments to the case converter file and its classes.

## Changes

- Prevented `convertCase` function from removing '.' from keys
- Updated test suite to 100% coverage
- Fixed whitelisted value conversions (was previously not working for arrays and objects)
