### PR TITLE
Admin modules

### DIFF
--- a/src/app/component/admin/admin.menus.ts
+++ b/src/app/component/admin/admin.menus.ts
@@ -3,12 +3,12 @@ import {
   defaultDeleteIcon,
   defaultEditIcon,
   defaultNewIcon,
-  isAdminPredicate
+  isAdminPredicate,
 } from "src/app/app.menus";
 import {
   Category,
   MenuLink,
-  MenuRoute
+  MenuRoute,
 } from "src/app/interfaces/menusInterfaces";
 import { StrongRoute } from "src/app/interfaces/strongRoute";
 import { sitesCategory } from "../sites/sites.menus";
@@ -17,7 +17,7 @@ export const adminRoute = StrongRoute.Base.add("admin");
 export const adminCategory: Category = {
   icon: ["fas", "cog"],
   label: "Admin",
-  route: adminRoute
+  route: adminRoute,
 };
 
 export const adminDashboardMenuItem = MenuRoute({
@@ -25,7 +25,7 @@ export const adminDashboardMenuItem = MenuRoute({
   label: "Admin Home",
   route: adminRoute,
   tooltip: () => "Administrator dashboard",
-  predicate: isAdminPredicate
+  predicate: isAdminPredicate,
 });
 
 export const adminUserListMenuItem = MenuRoute({
@@ -34,7 +34,7 @@ export const adminUserListMenuItem = MenuRoute({
   route: adminRoute.add("user_accounts"),
   tooltip: () => "Manage user accounts",
   parent: adminDashboardMenuItem,
-  predicate: isAdminPredicate
+  predicate: isAdminPredicate,
 });
 
 export const adminOrphanSitesMenuItem = MenuRoute({
@@ -43,35 +43,7 @@ export const adminOrphanSitesMenuItem = MenuRoute({
   route: adminRoute.add("sites"),
   tooltip: () => "Manage orphaned sites",
   parent: adminDashboardMenuItem,
-  predicate: isAdminPredicate
-});
-
-/*
-  Admin Scripts
-*/
-
-export const adminScriptsCategory: Category = {
-  icon: ["fas", "scroll"],
-  label: "Scripts",
-  route: adminRoute.add("scripts")
-};
-
-export const adminScriptsMenuItem = MenuRoute({
-  icon: ["fas", "scroll"],
-  label: "Scripts",
-  route: adminScriptsCategory.route,
-  tooltip: () => "Manage custom scripts",
-  parent: adminDashboardMenuItem,
-  predicate: isAdminPredicate
-});
-
-export const adminNewScriptsMenuItem = MenuRoute({
-  icon: defaultNewIcon,
-  label: "New Script",
-  route: adminScriptsMenuItem.route.add("new"),
-  tooltip: () => "Create a new script",
-  parent: adminScriptsMenuItem,
-  predicate: isAdminPredicate
+  predicate: isAdminPredicate,
 });
 
 /**
@@ -83,7 +55,7 @@ const adminTagsRoute = adminRoute.add("tags");
 export const adminTagsCategory: Category = {
   icon: ["fas", "tag"],
   label: "Tags",
-  route: adminTagsRoute
+  route: adminTagsRoute,
 };
 
 export const adminTagsMenuItem = MenuRoute({
@@ -92,7 +64,7 @@ export const adminTagsMenuItem = MenuRoute({
   route: adminTagsRoute,
   tooltip: () => "Manage tags",
   parent: adminDashboardMenuItem,
-  predicate: isAdminPredicate
+  predicate: isAdminPredicate,
 });
 
 export const adminNewTagMenuItem = MenuRoute({
@@ -101,7 +73,7 @@ export const adminNewTagMenuItem = MenuRoute({
   route: adminTagsRoute.add("new"),
   tooltip: () => "Create a new tag",
   parent: adminTagsMenuItem,
-  predicate: isAdminPredicate
+  predicate: isAdminPredicate,
 });
 
 const adminTagRoute = adminTagsRoute.add(":tagId");
@@ -112,7 +84,7 @@ export const adminEditTagMenuItem = MenuRoute({
   route: adminTagRoute.add("edit"),
   tooltip: () => "Edit an existing tag",
   parent: adminTagsMenuItem,
-  predicate: isAdminPredicate
+  predicate: isAdminPredicate,
 });
 
 export const adminDeleteTagMenuItem = MenuRoute({
@@ -121,7 +93,7 @@ export const adminDeleteTagMenuItem = MenuRoute({
   route: adminTagRoute.add("delete"),
   tooltip: () => "Delete an existing tag",
   parent: adminTagsMenuItem,
-  predicate: isAdminPredicate
+  predicate: isAdminPredicate,
 });
 
 /**
@@ -133,7 +105,7 @@ const adminTagGroupsRoute = adminRoute.add("tag_groups");
 export const adminTagGroupsCategory: Category = {
   icon: ["fas", "tags"],
   label: "Tag Group",
-  route: adminTagGroupsRoute
+  route: adminTagGroupsRoute,
 };
 
 export const adminTagGroupsMenuItem = MenuRoute({
@@ -142,7 +114,7 @@ export const adminTagGroupsMenuItem = MenuRoute({
   route: adminTagGroupsRoute,
   tooltip: () => "Manage tag groups",
   parent: adminDashboardMenuItem,
-  predicate: isAdminPredicate
+  predicate: isAdminPredicate,
 });
 
 export const adminNewTagGroupMenuItem = MenuRoute({
@@ -151,7 +123,7 @@ export const adminNewTagGroupMenuItem = MenuRoute({
   route: adminTagGroupsRoute.add("new"),
   tooltip: () => "Create a new tag group",
   parent: adminTagGroupsMenuItem,
-  predicate: isAdminPredicate
+  predicate: isAdminPredicate,
 });
 
 const adminTagGroupRoute = adminTagGroupsRoute.add(":tagGroupId");
@@ -162,7 +134,7 @@ export const adminEditTagGroupMenuItem = MenuRoute({
   route: adminTagGroupRoute.add("edit"),
   tooltip: () => "Update an existing tag group",
   parent: adminTagGroupsMenuItem,
-  predicate: isAdminPredicate
+  predicate: isAdminPredicate,
 });
 
 export const adminDeleteTagGroupMenuItem = MenuRoute({
@@ -171,7 +143,7 @@ export const adminDeleteTagGroupMenuItem = MenuRoute({
   route: adminTagGroupRoute.add("delete"),
   tooltip: () => "Delete an existing tag group",
   parent: adminTagGroupsMenuItem,
-  predicate: isAdminPredicate
+  predicate: isAdminPredicate,
 });
 
 export const adminAudioRecordingsMenuItem = MenuRoute({
@@ -180,7 +152,7 @@ export const adminAudioRecordingsMenuItem = MenuRoute({
   route: adminRoute.add("audio_recordings"),
   tooltip: () => "Manage audio recordings",
   parent: adminDashboardMenuItem,
-  predicate: isAdminPredicate
+  predicate: isAdminPredicate,
 });
 
 export const adminAnalysisJobsMenuItem = MenuRoute({
@@ -189,7 +161,7 @@ export const adminAnalysisJobsMenuItem = MenuRoute({
   route: adminRoute.add("analysis_jobs"),
   tooltip: () => "Manage analysis jobs",
   parent: adminDashboardMenuItem,
-  predicate: isAdminPredicate
+  predicate: isAdminPredicate,
 });
 
 export const adminJobStatusMenuItem = MenuLink({
@@ -198,5 +170,5 @@ export const adminJobStatusMenuItem = MenuLink({
   tooltip: () => "Job queue status overview",
   uri: () => "/job_queue_status/overview",
   parent: adminDashboardMenuItem,
-  predicate: isAdminPredicate
+  predicate: isAdminPredicate,
 });

--- a/src/app/component/admin/admin.module.ts
+++ b/src/app/component/admin/admin.module.ts
@@ -4,8 +4,6 @@ import { GetRouteConfigForPage } from "src/app/helpers/page/pageRouting";
 import { SharedModule } from "../shared/shared.module";
 import { adminRoute } from "./admin.menus";
 import { AdminDashboardComponent } from "./dashboard/dashboard.component";
-import { AdminScriptsComponent } from "./scripts/list/list.component";
-import { AdminScriptsNewComponent } from "./scripts/new/new.component";
 import { AdminTagGroupsDeleteComponent } from "./tag-group/delete/delete.component";
 import { AdminTagGroupsEditComponent } from "./tag-group/edit/edit.component";
 import { AdminTagGroupsComponent } from "./tag-group/list/list.component";
@@ -15,11 +13,11 @@ import { AdminTagsEditComponent } from "./tags/edit/edit.component";
 import { AdminTagsComponent } from "./tags/list/list.component";
 import { AdminTagsNewComponent } from "./tags/new/new.component";
 import { AdminUserListComponent } from "./users/list/list.component";
+import { ScriptsModule } from "./scripts/scripts.module";
 
+const modules = [ScriptsModule];
 const components = [
   AdminDashboardComponent,
-  AdminScriptsComponent,
-  AdminScriptsNewComponent,
   AdminTagGroupsComponent,
   AdminTagGroupsDeleteComponent,
   AdminTagGroupsEditComponent,
@@ -28,13 +26,13 @@ const components = [
   AdminTagsDeleteComponent,
   AdminTagsEditComponent,
   AdminTagsNewComponent,
-  AdminUserListComponent
+  AdminUserListComponent,
 ];
 const routes = adminRoute.compileRoutes(GetRouteConfigForPage);
 
 @NgModule({
   declarations: components,
-  imports: [SharedModule, RouterModule.forChild(routes)],
-  exports: [RouterModule, ...components]
+  imports: [SharedModule, RouterModule.forChild(routes), ...modules],
+  exports: [RouterModule, ...components, ...modules],
 })
 export class AdminModule {}

--- a/src/app/component/admin/dashboard/dashboard.component.ts
+++ b/src/app/component/admin/dashboard/dashboard.component.ts
@@ -10,11 +10,11 @@ import {
   adminDashboardMenuItem,
   adminJobStatusMenuItem,
   adminOrphanSitesMenuItem,
-  adminScriptsMenuItem,
   adminTagGroupsMenuItem,
   adminTagsMenuItem,
   adminUserListMenuItem
 } from "../admin.menus";
+import { adminScriptsMenuItem } from "../scripts/scripts.menus";
 
 export const adminMenuItemActions = [
   adminUserListMenuItem,

--- a/src/app/component/admin/scripts/list/list.component.ts
+++ b/src/app/component/admin/scripts/list/list.component.ts
@@ -1,17 +1,17 @@
 import { Component, OnInit } from "@angular/core";
+import { ScriptsService } from "@baw-api/scripts.service";
+import { adminDashboardMenuItem } from "@component/admin/admin.menus";
+import { Page } from "@helpers/page/pageDecorator";
+import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
+import { Id } from "@interfaces/apiInterfaces";
+import { AnyMenuItem } from "@interfaces/menusInterfaces";
+import { Script } from "@models/Script";
 import { List } from "immutable";
-import { Page } from "src/app/helpers/page/pageDecorator";
-import { PagedTableTemplate } from "src/app/helpers/tableTemplate/pagedTableTemplate";
-import { Id } from "src/app/interfaces/apiInterfaces";
-import { AnyMenuItem } from "src/app/interfaces/menusInterfaces";
-import { Script } from "src/app/models/Script";
-import { ScriptsService } from "src/app/services/baw-api/scripts.service";
 import {
-  adminDashboardMenuItem,
   adminNewScriptsMenuItem,
   adminScriptsCategory,
-  adminScriptsMenuItem
-} from "../../admin.menus";
+  adminScriptsMenuItem,
+} from "../scripts.menus";
 
 export const adminScriptsMenuItemActions = [adminNewScriptsMenuItem];
 
@@ -20,26 +20,26 @@ export const adminScriptsMenuItemActions = [adminNewScriptsMenuItem];
   menus: {
     actions: List<AnyMenuItem>([
       adminDashboardMenuItem,
-      ...adminScriptsMenuItemActions
+      ...adminScriptsMenuItemActions,
     ]),
-    links: List()
+    links: List(),
   },
-  self: adminScriptsMenuItem
+  self: adminScriptsMenuItem,
 })
 @Component({
   selector: "app-admin-scripts",
   templateUrl: "./list.component.html",
-  styleUrls: ["./list.component.scss"]
+  styleUrls: ["./list.component.scss"],
 })
 export class AdminScriptsComponent extends PagedTableTemplate<TableRow, Script>
   implements OnInit {
   constructor(api: ScriptsService) {
-    super(api, scripts =>
-      scripts.map(script => ({
+    super(api, (scripts) =>
+      scripts.map((script) => ({
         name: script.name,
         version: script.version,
         id: script.id,
-        command: script.executableCommand
+        command: script.executableCommand,
       }))
     );
   }
@@ -49,13 +49,13 @@ export class AdminScriptsComponent extends PagedTableTemplate<TableRow, Script>
       { name: "Name" },
       { name: "Version" },
       { name: "Id" },
-      { name: "Command" }
+      { name: "Command" },
     ];
     this.sortKeys = {
       name: "name",
       version: "version",
       id: "id",
-      command: "executableCommand"
+      command: "executableCommand",
     };
     this.filterKey = "name";
     this.getModels();

--- a/src/app/component/admin/scripts/new/new.component.ts
+++ b/src/app/component/admin/scripts/new/new.component.ts
@@ -1,22 +1,22 @@
 import { Component } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
-import { List } from "immutable";
-import { ToastrService } from "ngx-toastr";
+import { ScriptsService } from "@baw-api/scripts.service";
 import {
   defaultSuccessMsg,
-  FormTemplate
-} from "src/app/helpers/formTemplate/formTemplate";
-import { Page } from "src/app/helpers/page/pageDecorator";
-import { AnyMenuItem } from "src/app/interfaces/menusInterfaces";
-import { Script } from "src/app/models/Script";
-import { ScriptsService } from "src/app/services/baw-api/scripts.service";
+  FormTemplate,
+} from "@helpers/formTemplate/formTemplate";
+import { Page } from "@helpers/page/pageDecorator";
+import { AnyMenuItem } from "@interfaces/menusInterfaces";
+import { Script } from "@models/Script";
+import { List } from "immutable";
+import { ToastrService } from "ngx-toastr";
+import { adminScriptsMenuItemActions } from "../list/list.component";
+import { fields } from "../scripts.json";
 import {
   adminNewScriptsMenuItem,
   adminScriptsCategory,
-  adminScriptsMenuItem
-} from "../../admin.menus";
-import { adminScriptsMenuItemActions } from "../list/list.component";
-import { fields } from "../scripts.json";
+  adminScriptsMenuItem,
+} from "../scripts.menus";
 
 /**
  * New Scripts Component
@@ -26,11 +26,11 @@ import { fields } from "../scripts.json";
   menus: {
     actions: List<AnyMenuItem>([
       adminScriptsMenuItem,
-      ...adminScriptsMenuItemActions
+      ...adminScriptsMenuItemActions,
     ]),
-    links: List()
+    links: List(),
   },
-  self: adminNewScriptsMenuItem
+  self: adminNewScriptsMenuItem,
 })
 @Component({
   selector: "app-admin-scripts-new",
@@ -45,7 +45,7 @@ import { fields } from "../scripts.json";
       (onSubmit)="submit($event)"
     >
     </app-form>
-  `
+  `,
 })
 export class AdminScriptsNewComponent extends FormTemplate<Script> {
   public fields = fields;
@@ -56,7 +56,7 @@ export class AdminScriptsNewComponent extends FormTemplate<Script> {
     route: ActivatedRoute,
     router: Router
   ) {
-    super(notifications, route, router, undefined, model =>
+    super(notifications, route, router, undefined, (model) =>
       defaultSuccessMsg("created", model.name)
     );
   }

--- a/src/app/component/admin/scripts/scripts.menus.ts
+++ b/src/app/component/admin/scripts/scripts.menus.ts
@@ -1,0 +1,31 @@
+import { defaultNewIcon, isAdminPredicate } from "src/app/app.menus";
+import { Category, MenuRoute } from "src/app/interfaces/menusInterfaces";
+import { adminDashboardMenuItem } from "../admin.menus";
+
+export const adminScriptsRoute = adminDashboardMenuItem.route.addFeatureModule(
+  "scripts"
+);
+
+export const adminScriptsCategory: Category = {
+  icon: ["fas", "scroll"],
+  label: "Scripts",
+  route: adminScriptsRoute,
+};
+
+export const adminScriptsMenuItem = MenuRoute({
+  icon: ["fas", "scroll"],
+  label: "Scripts",
+  route: adminScriptsCategory.route,
+  tooltip: () => "Manage custom scripts",
+  parent: adminDashboardMenuItem,
+  predicate: isAdminPredicate,
+});
+
+export const adminNewScriptsMenuItem = MenuRoute({
+  icon: defaultNewIcon,
+  label: "New Script",
+  route: adminScriptsMenuItem.route.add("new"),
+  tooltip: () => "Create a new script",
+  parent: adminScriptsMenuItem,
+  predicate: isAdminPredicate,
+});

--- a/src/app/component/admin/scripts/scripts.module.ts
+++ b/src/app/component/admin/scripts/scripts.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from "@angular/core";
+import { RouterModule } from "@angular/router";
+import { GetRouteConfigForPage } from "src/app/helpers/page/pageRouting";
+import { SharedModule } from "../../shared/shared.module";
+import { AdminScriptsComponent } from "./list/list.component";
+import { AdminScriptsNewComponent } from "./new/new.component";
+import { adminScriptsRoute } from "./scripts.menus";
+
+const components = [AdminScriptsComponent, AdminScriptsNewComponent];
+const routes = adminScriptsRoute.compileRoutes(GetRouteConfigForPage);
+
+@NgModule({
+  declarations: components,
+  imports: [SharedModule, RouterModule.forChild(routes)],
+  exports: [RouterModule, ...components],
+})
+export class ScriptsModule {}

--- a/src/app/models/Script.ts
+++ b/src/app/models/Script.ts
@@ -1,9 +1,9 @@
-import { adminScriptsMenuItem } from "../component/admin/admin.menus";
+import { adminScriptsMenuItem } from "@component/admin/scripts/scripts.menus";
 import {
   DateTimeTimezone,
   dateTimeTimezone,
   Id,
-  Param
+  Param,
 } from "../interfaces/apiInterfaces";
 import { AbstractModel } from "./AbstractModel";
 
@@ -69,7 +69,7 @@ export class Script extends AbstractModel implements ScriptInterface {
       executableSettings: this.executableSettings,
       executableSettingsMediaType: this.executableSettingsMediaType,
       analysisActionParams: this.analysisActionParams,
-      verified: this.verified
+      verified: this.verified,
     };
   }
 


### PR DESCRIPTION
# Extracted admin modules

Cleaned up admin pages by extracting sub components into their own modules.

## Changes

- Created `ScriptsModule`
- Created `TagGroupsModule`
- Created `TagsModule`
- Fixed StrongRoute bug where `compileRoutes()` was not compiling the root route. This was an issue for modules using `addFeatureModule()`
