### PR TITLE
Admin modules fix

### DIFF
--- a/src/app/component/admin/admin.menus.ts
+++ b/src/app/component/admin/admin.menus.ts
@@ -92,56 +92,6 @@ export const adminDeleteTagMenuItem = MenuRoute({
   predicate: isAdminPredicate,
 });
 
-/**
- * Admin Tag Groups
- */
-
-const adminTagGroupsRoute = adminRoute.add("tag_groups");
-
-export const adminTagGroupsCategory: Category = {
-  icon: ["fas", "tags"],
-  label: "Tag Group",
-  route: adminTagGroupsRoute,
-};
-
-export const adminTagGroupsMenuItem = MenuRoute({
-  icon: ["fas", "tags"],
-  label: "Tag Group",
-  route: adminTagGroupsRoute,
-  tooltip: () => "Manage tag groups",
-  parent: adminDashboardMenuItem,
-  predicate: isAdminPredicate,
-});
-
-export const adminNewTagGroupMenuItem = MenuRoute({
-  icon: defaultNewIcon,
-  label: "New Tag Group",
-  route: adminTagGroupsRoute.add("new"),
-  tooltip: () => "Create a new tag group",
-  parent: adminTagGroupsMenuItem,
-  predicate: isAdminPredicate,
-});
-
-const adminTagGroupRoute = adminTagGroupsRoute.add(":tagGroupId");
-
-export const adminEditTagGroupMenuItem = MenuRoute({
-  icon: defaultEditIcon,
-  label: "Edit Tag Group",
-  route: adminTagGroupRoute.add("edit"),
-  tooltip: () => "Update an existing tag group",
-  parent: adminTagGroupsMenuItem,
-  predicate: isAdminPredicate,
-});
-
-export const adminDeleteTagGroupMenuItem = MenuRoute({
-  icon: defaultDeleteIcon,
-  label: "Delete Tag Group",
-  route: adminTagGroupRoute.add("delete"),
-  tooltip: () => "Delete an existing tag group",
-  parent: adminTagGroupsMenuItem,
-  predicate: isAdminPredicate,
-});
-
 export const adminAudioRecordingsMenuItem = MenuRoute({
   icon: defaultAudioIcon,
   label: "Audio Recordings",

--- a/src/app/component/admin/admin.menus.ts
+++ b/src/app/component/admin/admin.menus.ts
@@ -42,34 +42,6 @@ export const adminOrphanSitesMenuItem = MenuRoute({
   predicate: isAdminPredicate,
 });
 
-/*
-  Admin Scripts
-*/
-
-export const adminScriptsCategory: Category = {
-  icon: ["fas", "scroll"],
-  label: "Scripts",
-  route: adminRoute.add("scripts"),
-};
-
-export const adminScriptsMenuItem = MenuRoute({
-  icon: ["fas", "scroll"],
-  label: "Scripts",
-  route: adminScriptsCategory.route,
-  tooltip: () => "Manage custom scripts",
-  parent: adminDashboardMenuItem,
-  predicate: isAdminPredicate,
-});
-
-export const adminNewScriptsMenuItem = MenuRoute({
-  icon: defaultNewIcon,
-  label: "New Script",
-  route: adminScriptsMenuItem.route.add("new"),
-  tooltip: () => "Create a new script",
-  parent: adminScriptsMenuItem,
-  predicate: isAdminPredicate,
-});
-
 /**
  * Admin Tags
  */

--- a/src/app/component/admin/admin.menus.ts
+++ b/src/app/component/admin/admin.menus.ts
@@ -1,13 +1,7 @@
 import { sitesCategory } from "@component/sites/sites.menus";
 import { Category, MenuLink, MenuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
-import {
-  defaultAudioIcon,
-  defaultDeleteIcon,
-  defaultEditIcon,
-  defaultNewIcon,
-  isAdminPredicate,
-} from "src/app/app.menus";
+import { defaultAudioIcon, isAdminPredicate } from "src/app/app.menus";
 
 export const adminRoute = StrongRoute.Base.add("admin");
 export const adminCategory: Category = {
@@ -39,56 +33,6 @@ export const adminOrphanSitesMenuItem = MenuRoute({
   route: adminRoute.add("sites"),
   tooltip: () => "Manage orphaned sites",
   parent: adminDashboardMenuItem,
-  predicate: isAdminPredicate,
-});
-
-/**
- * Admin Tags
- */
-
-const adminTagsRoute = adminRoute.add("tags");
-
-export const adminTagsCategory: Category = {
-  icon: ["fas", "tag"],
-  label: "Tags",
-  route: adminTagsRoute,
-};
-
-export const adminTagsMenuItem = MenuRoute({
-  icon: ["fas", "tag"],
-  label: "Tags",
-  route: adminTagsRoute,
-  tooltip: () => "Manage tags",
-  parent: adminDashboardMenuItem,
-  predicate: isAdminPredicate,
-});
-
-export const adminNewTagMenuItem = MenuRoute({
-  icon: defaultNewIcon,
-  label: "New Tag",
-  route: adminTagsRoute.add("new"),
-  tooltip: () => "Create a new tag",
-  parent: adminTagsMenuItem,
-  predicate: isAdminPredicate,
-});
-
-const adminTagRoute = adminTagsRoute.add(":tagId");
-
-export const adminEditTagMenuItem = MenuRoute({
-  icon: defaultEditIcon,
-  label: "Edit Tag",
-  route: adminTagRoute.add("edit"),
-  tooltip: () => "Edit an existing tag",
-  parent: adminTagsMenuItem,
-  predicate: isAdminPredicate,
-});
-
-export const adminDeleteTagMenuItem = MenuRoute({
-  icon: defaultDeleteIcon,
-  label: "Delete Tag",
-  route: adminTagRoute.add("delete"),
-  tooltip: () => "Delete an existing tag",
-  parent: adminTagsMenuItem,
   predicate: isAdminPredicate,
 });
 

--- a/src/app/component/admin/admin.module.ts
+++ b/src/app/component/admin/admin.module.ts
@@ -4,8 +4,6 @@ import { GetRouteConfigForPage } from "@helpers/page/pageRouting";
 import { SharedModule } from "@shared/shared.module";
 import { adminRoute } from "./admin.menus";
 import { AdminDashboardComponent } from "./dashboard/dashboard.component";
-import { AdminScriptsComponent } from "./scripts/list/list.component";
-import { AdminScriptsNewComponent } from "./scripts/new/new.component";
 import { AdminTagGroupsDeleteComponent } from "./tag-group/delete/delete.component";
 import { AdminTagGroupsEditComponent } from "./tag-group/edit/edit.component";
 import { AdminTagGroupsComponent } from "./tag-group/list/list.component";
@@ -15,11 +13,11 @@ import { AdminTagsEditComponent } from "./tags/edit/edit.component";
 import { AdminTagsComponent } from "./tags/list/list.component";
 import { AdminTagsNewComponent } from "./tags/new/new.component";
 import { AdminUserListComponent } from "./users/list/list.component";
+import { ScriptsModule } from "./scripts/scripts.module";
 
+const modules = [ScriptsModule];
 const components = [
   AdminDashboardComponent,
-  AdminScriptsComponent,
-  AdminScriptsNewComponent,
   AdminTagGroupsComponent,
   AdminTagGroupsDeleteComponent,
   AdminTagGroupsEditComponent,
@@ -34,7 +32,7 @@ const routes = adminRoute.compileRoutes(GetRouteConfigForPage);
 
 @NgModule({
   declarations: components,
-  imports: [SharedModule, RouterModule.forChild(routes)],
-  exports: [RouterModule, ...components],
+  imports: [SharedModule, RouterModule.forChild(routes), ...modules],
+  exports: [RouterModule, ...components, ...modules],
 })
 export class AdminModule {}

--- a/src/app/component/admin/admin.module.ts
+++ b/src/app/component/admin/admin.module.ts
@@ -6,21 +6,11 @@ import { adminRoute } from "./admin.menus";
 import { AdminDashboardComponent } from "./dashboard/dashboard.component";
 import { ScriptsModule } from "./scripts/scripts.module";
 import { TagGroupsModule } from "./tag-group/tag-groups.module";
-import { AdminTagsDeleteComponent } from "./tags/delete/delete.component";
-import { AdminTagsEditComponent } from "./tags/edit/edit.component";
-import { AdminTagsComponent } from "./tags/list/list.component";
-import { AdminTagsNewComponent } from "./tags/new/new.component";
+import { TagsModule } from "./tags/tags.module";
 import { AdminUserListComponent } from "./users/list/list.component";
 
-const modules = [ScriptsModule, TagGroupsModule];
-const components = [
-  AdminDashboardComponent,
-  AdminTagsComponent,
-  AdminTagsDeleteComponent,
-  AdminTagsEditComponent,
-  AdminTagsNewComponent,
-  AdminUserListComponent,
-];
+const modules = [ScriptsModule, TagGroupsModule, TagsModule];
+const components = [AdminDashboardComponent, AdminUserListComponent];
 const routes = adminRoute.compileRoutes(GetRouteConfigForPage);
 
 @NgModule({

--- a/src/app/component/admin/admin.module.ts
+++ b/src/app/component/admin/admin.module.ts
@@ -4,24 +4,17 @@ import { GetRouteConfigForPage } from "@helpers/page/pageRouting";
 import { SharedModule } from "@shared/shared.module";
 import { adminRoute } from "./admin.menus";
 import { AdminDashboardComponent } from "./dashboard/dashboard.component";
-import { AdminTagGroupsDeleteComponent } from "./tag-group/delete/delete.component";
-import { AdminTagGroupsEditComponent } from "./tag-group/edit/edit.component";
-import { AdminTagGroupsComponent } from "./tag-group/list/list.component";
-import { AdminTagGroupsNewComponent } from "./tag-group/new/new.component";
+import { ScriptsModule } from "./scripts/scripts.module";
+import { TagGroupsModule } from "./tag-group/tag-groups.module";
 import { AdminTagsDeleteComponent } from "./tags/delete/delete.component";
 import { AdminTagsEditComponent } from "./tags/edit/edit.component";
 import { AdminTagsComponent } from "./tags/list/list.component";
 import { AdminTagsNewComponent } from "./tags/new/new.component";
 import { AdminUserListComponent } from "./users/list/list.component";
-import { ScriptsModule } from "./scripts/scripts.module";
 
-const modules = [ScriptsModule];
+const modules = [ScriptsModule, TagGroupsModule];
 const components = [
   AdminDashboardComponent,
-  AdminTagGroupsComponent,
-  AdminTagGroupsDeleteComponent,
-  AdminTagGroupsEditComponent,
-  AdminTagGroupsNewComponent,
   AdminTagsComponent,
   AdminTagsDeleteComponent,
   AdminTagsEditComponent,

--- a/src/app/component/admin/dashboard/dashboard.component.ts
+++ b/src/app/component/admin/dashboard/dashboard.component.ts
@@ -10,11 +10,11 @@ import {
   adminDashboardMenuItem,
   adminJobStatusMenuItem,
   adminOrphanSitesMenuItem,
-  adminScriptsMenuItem,
   adminTagGroupsMenuItem,
   adminTagsMenuItem,
   adminUserListMenuItem,
 } from "../admin.menus";
+import { adminScriptsMenuItem } from "../scripts/scripts.menus";
 
 export const adminMenuItemActions = [
   adminUserListMenuItem,

--- a/src/app/component/admin/dashboard/dashboard.component.ts
+++ b/src/app/component/admin/dashboard/dashboard.component.ts
@@ -10,11 +10,11 @@ import {
   adminDashboardMenuItem,
   adminJobStatusMenuItem,
   adminOrphanSitesMenuItem,
-  adminTagsMenuItem,
   adminUserListMenuItem,
 } from "../admin.menus";
 import { adminScriptsMenuItem } from "../scripts/scripts.menus";
 import { adminTagGroupsMenuItem } from "../tag-group/tag-group.menus";
+import { adminTagsMenuItem } from "../tags/tags.menus";
 
 export const adminMenuItemActions = [
   adminUserListMenuItem,

--- a/src/app/component/admin/dashboard/dashboard.component.ts
+++ b/src/app/component/admin/dashboard/dashboard.component.ts
@@ -10,11 +10,11 @@ import {
   adminDashboardMenuItem,
   adminJobStatusMenuItem,
   adminOrphanSitesMenuItem,
-  adminTagGroupsMenuItem,
   adminTagsMenuItem,
   adminUserListMenuItem,
 } from "../admin.menus";
 import { adminScriptsMenuItem } from "../scripts/scripts.menus";
+import { adminTagGroupsMenuItem } from "../tag-group/tag-group.menus";
 
 export const adminMenuItemActions = [
   adminUserListMenuItem,

--- a/src/app/component/admin/scripts/list/list.component.ts
+++ b/src/app/component/admin/scripts/list/list.component.ts
@@ -1,17 +1,17 @@
 import { Component, OnInit } from "@angular/core";
 import { ScriptsService } from "@baw-api/scripts.service";
-import {
-  adminDashboardMenuItem,
-  adminNewScriptsMenuItem,
-  adminScriptsCategory,
-  adminScriptsMenuItem,
-} from "@component/admin/admin.menus";
+import { adminDashboardMenuItem } from "@component/admin/admin.menus";
 import { Page } from "@helpers/page/pageDecorator";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
 import { Id } from "@interfaces/apiInterfaces";
 import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { Script } from "@models/Script";
 import { List } from "immutable";
+import {
+  adminNewScriptsMenuItem,
+  adminScriptsCategory,
+  adminScriptsMenuItem,
+} from "../scripts.menus";
 
 export const adminScriptsMenuItemActions = [adminNewScriptsMenuItem];
 

--- a/src/app/component/admin/scripts/new/new.component.ts
+++ b/src/app/component/admin/scripts/new/new.component.ts
@@ -7,9 +7,9 @@ import {
 } from "@helpers/formTemplate/formTemplate";
 import { Page } from "@helpers/page/pageDecorator";
 import { AnyMenuItem } from "@interfaces/menusInterfaces";
+import { Script } from "@models/Script";
 import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
-import { Script } from "src/app/models/Script";
 import { adminScriptsMenuItemActions } from "../list/list.component";
 import { fields } from "../scripts.json";
 import {

--- a/src/app/component/admin/scripts/new/new.component.ts
+++ b/src/app/component/admin/scripts/new/new.component.ts
@@ -2,21 +2,21 @@ import { Component } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { ScriptsService } from "@baw-api/scripts.service";
 import {
-  adminNewScriptsMenuItem,
-  adminScriptsCategory,
-  adminScriptsMenuItem,
-} from "@component/admin/admin.menus";
-import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
 import { Page } from "@helpers/page/pageDecorator";
 import { AnyMenuItem } from "@interfaces/menusInterfaces";
-import { Script } from "@models/Script";
 import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
+import { Script } from "src/app/models/Script";
 import { adminScriptsMenuItemActions } from "../list/list.component";
 import { fields } from "../scripts.json";
+import {
+  adminNewScriptsMenuItem,
+  adminScriptsCategory,
+  adminScriptsMenuItem,
+} from "../scripts.menus";
 
 /**
  * New Scripts Component

--- a/src/app/component/admin/scripts/scripts.menus.ts
+++ b/src/app/component/admin/scripts/scripts.menus.ts
@@ -1,10 +1,8 @@
 import { defaultNewIcon, isAdminPredicate } from "src/app/app.menus";
 import { Category, MenuRoute } from "src/app/interfaces/menusInterfaces";
-import { adminDashboardMenuItem } from "../admin.menus";
+import { adminDashboardMenuItem, adminRoute } from "../admin.menus";
 
-export const adminScriptsRoute = adminDashboardMenuItem.route.addFeatureModule(
-  "scripts"
-);
+export const adminScriptsRoute = adminRoute.addFeatureModule("scripts");
 
 export const adminScriptsCategory: Category = {
   icon: ["fas", "scroll"],

--- a/src/app/component/admin/scripts/scripts.menus.ts
+++ b/src/app/component/admin/scripts/scripts.menus.ts
@@ -1,0 +1,31 @@
+import { defaultNewIcon, isAdminPredicate } from "src/app/app.menus";
+import { Category, MenuRoute } from "src/app/interfaces/menusInterfaces";
+import { adminDashboardMenuItem } from "../admin.menus";
+
+export const adminScriptsRoute = adminDashboardMenuItem.route.addFeatureModule(
+  "scripts"
+);
+
+export const adminScriptsCategory: Category = {
+  icon: ["fas", "scroll"],
+  label: "Scripts",
+  route: adminScriptsRoute,
+};
+
+export const adminScriptsMenuItem = MenuRoute({
+  icon: ["fas", "scroll"],
+  label: "Scripts",
+  route: adminScriptsCategory.route,
+  tooltip: () => "Manage custom scripts",
+  parent: adminDashboardMenuItem,
+  predicate: isAdminPredicate,
+});
+
+export const adminNewScriptsMenuItem = MenuRoute({
+  icon: defaultNewIcon,
+  label: "New Script",
+  route: adminScriptsMenuItem.route.add("new"),
+  tooltip: () => "Create a new script",
+  parent: adminScriptsMenuItem,
+  predicate: isAdminPredicate,
+});

--- a/src/app/component/admin/scripts/scripts.menus.ts
+++ b/src/app/component/admin/scripts/scripts.menus.ts
@@ -1,5 +1,5 @@
+import { Category, MenuRoute } from "@interfaces/menusInterfaces";
 import { defaultNewIcon, isAdminPredicate } from "src/app/app.menus";
-import { Category, MenuRoute } from "src/app/interfaces/menusInterfaces";
 import { adminDashboardMenuItem, adminRoute } from "../admin.menus";
 
 export const adminScriptsRoute = adminRoute.addFeatureModule("scripts");

--- a/src/app/component/admin/scripts/scripts.module.ts
+++ b/src/app/component/admin/scripts/scripts.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from "@angular/core";
 import { RouterModule } from "@angular/router";
-import { GetRouteConfigForPage } from "src/app/helpers/page/pageRouting";
-import { SharedModule } from "../../shared/shared.module";
+import { GetRouteConfigForPage } from "@helpers/page/pageRouting";
+import { SharedModule } from "@shared/shared.module";
 import { AdminScriptsComponent } from "./list/list.component";
 import { AdminScriptsNewComponent } from "./new/new.component";
 import { adminScriptsRoute } from "./scripts.menus";

--- a/src/app/component/admin/scripts/scripts.module.ts
+++ b/src/app/component/admin/scripts/scripts.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from "@angular/core";
+import { RouterModule } from "@angular/router";
+import { GetRouteConfigForPage } from "src/app/helpers/page/pageRouting";
+import { SharedModule } from "../../shared/shared.module";
+import { AdminScriptsComponent } from "./list/list.component";
+import { AdminScriptsNewComponent } from "./new/new.component";
+import { adminScriptsRoute } from "./scripts.menus";
+
+const components = [AdminScriptsComponent, AdminScriptsNewComponent];
+const routes = adminScriptsRoute.compileRoutes(GetRouteConfigForPage);
+
+@NgModule({
+  declarations: components,
+  imports: [SharedModule, RouterModule.forChild(routes)],
+  exports: [RouterModule, ...components],
+})
+export class ScriptsModule {}

--- a/src/app/component/admin/tag-group/delete/delete.component.spec.ts
+++ b/src/app/component/admin/tag-group/delete/delete.component.spec.ts
@@ -3,7 +3,6 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { tagGroupResolvers, TagGroupService } from "@baw-api/tag-group.service";
-import { adminTagGroupsMenuItem } from "@component/admin/admin.menus";
 import { TagGroup } from "@models/TagGroup";
 import { SharedModule } from "@shared/shared.module";
 import { ToastrService } from "ngx-toastr";
@@ -11,6 +10,7 @@ import { BehaviorSubject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
 import { assertFormErrorHandling } from "src/testHelpers";
+import { adminTagGroupsMenuItem } from "../tag-group.menus";
 import { AdminTagGroupsDeleteComponent } from "./delete.component";
 
 describe("AdminTagGroupsDeleteComponent", () => {

--- a/src/app/component/admin/tag-group/delete/delete.component.ts
+++ b/src/app/component/admin/tag-group/delete/delete.component.ts
@@ -2,11 +2,6 @@ import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { tagGroupResolvers, TagGroupService } from "@baw-api/tag-group.service";
 import {
-  adminDeleteTagGroupMenuItem,
-  adminTagGroupsCategory,
-  adminTagGroupsMenuItem,
-} from "@component/admin/admin.menus";
-import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
@@ -15,6 +10,11 @@ import { TagGroup } from "@models/TagGroup";
 import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
 import { adminTagGroupMenuItemActions } from "../list/list.component";
+import {
+  adminDeleteTagGroupMenuItem,
+  adminTagGroupsCategory,
+  adminTagGroupsMenuItem,
+} from "../tag-group.menus";
 
 const tagGroupKey = "tagGroup";
 

--- a/src/app/component/admin/tag-group/edit/edit.component.ts
+++ b/src/app/component/admin/tag-group/edit/edit.component.ts
@@ -2,11 +2,6 @@ import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { tagGroupResolvers, TagGroupService } from "@baw-api/tag-group.service";
 import {
-  adminEditTagGroupMenuItem,
-  adminTagGroupsCategory,
-  adminTagGroupsMenuItem,
-} from "@component/admin/admin.menus";
-import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
@@ -16,6 +11,11 @@ import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
 import { adminTagGroupMenuItemActions } from "../list/list.component";
 import { fields } from "../tag-group.json";
+import {
+  adminEditTagGroupMenuItem,
+  adminTagGroupsCategory,
+  adminTagGroupsMenuItem,
+} from "../tag-group.menus";
 
 const tagGroupKey = "tagGroup";
 

--- a/src/app/component/admin/tag-group/list/list.component.ts
+++ b/src/app/component/admin/tag-group/list/list.component.ts
@@ -1,19 +1,19 @@
 import { Component, OnInit } from "@angular/core";
 import { TagGroupService } from "@baw-api/tag-group.service";
-import {
-  adminDashboardMenuItem,
-  adminDeleteTagGroupMenuItem,
-  adminEditTagGroupMenuItem,
-  adminNewTagGroupMenuItem,
-  adminTagGroupsCategory,
-  adminTagGroupsMenuItem,
-} from "@component/admin/admin.menus";
+import { adminDashboardMenuItem } from "@component/admin/admin.menus";
 import { Page } from "@helpers/page/pageDecorator";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
 import { Id } from "@interfaces/apiInterfaces";
 import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { TagGroup } from "@models/TagGroup";
 import { List } from "immutable";
+import {
+  adminDeleteTagGroupMenuItem,
+  adminEditTagGroupMenuItem,
+  adminNewTagGroupMenuItem,
+  adminTagGroupsCategory,
+  adminTagGroupsMenuItem,
+} from "../tag-group.menus";
 
 export const adminTagGroupsMenuItemActions = [adminNewTagGroupMenuItem];
 export const adminTagGroupMenuItemActions = [

--- a/src/app/component/admin/tag-group/new/new.component.ts
+++ b/src/app/component/admin/tag-group/new/new.component.ts
@@ -2,11 +2,6 @@ import { Component } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { TagGroupService } from "@baw-api/tag-group.service";
 import {
-  adminNewTagGroupMenuItem,
-  adminTagGroupsCategory,
-  adminTagGroupsMenuItem,
-} from "@component/admin/admin.menus";
-import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
@@ -16,6 +11,11 @@ import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
 import { adminTagGroupsMenuItemActions } from "../list/list.component";
 import { fields } from "../tag-group.json";
+import {
+  adminNewTagGroupMenuItem,
+  adminTagGroupsCategory,
+  adminTagGroupsMenuItem,
+} from "../tag-group.menus";
 
 @Page({
   category: adminTagGroupsCategory,

--- a/src/app/component/admin/tag-group/tag-group.menus.ts
+++ b/src/app/component/admin/tag-group/tag-group.menus.ts
@@ -1,0 +1,56 @@
+import { Category, MenuRoute } from "@interfaces/menusInterfaces";
+import {
+  defaultDeleteIcon,
+  defaultEditIcon,
+  defaultNewIcon,
+  isAdminPredicate,
+} from "src/app/app.menus";
+import { adminDashboardMenuItem } from "../admin.menus";
+
+export const adminTagGroupsRoute = adminDashboardMenuItem.route.addFeatureModule(
+  "tag_groups"
+);
+
+export const adminTagGroupsCategory: Category = {
+  icon: ["fas", "tags"],
+  label: "Tag Group",
+  route: adminTagGroupsRoute,
+};
+
+export const adminTagGroupsMenuItem = MenuRoute({
+  icon: ["fas", "tags"],
+  label: "Tag Group",
+  route: adminTagGroupsRoute,
+  tooltip: () => "Manage tag groups",
+  parent: adminDashboardMenuItem,
+  predicate: isAdminPredicate,
+});
+
+export const adminNewTagGroupMenuItem = MenuRoute({
+  icon: defaultNewIcon,
+  label: "New Tag Group",
+  route: adminTagGroupsRoute.add("new"),
+  tooltip: () => "Create a new tag group",
+  parent: adminTagGroupsMenuItem,
+  predicate: isAdminPredicate,
+});
+
+const adminTagGroupRoute = adminTagGroupsRoute.add(":tagGroupId");
+
+export const adminEditTagGroupMenuItem = MenuRoute({
+  icon: defaultEditIcon,
+  label: "Edit Tag Group",
+  route: adminTagGroupRoute.add("edit"),
+  tooltip: () => "Update an existing tag group",
+  parent: adminTagGroupsMenuItem,
+  predicate: isAdminPredicate,
+});
+
+export const adminDeleteTagGroupMenuItem = MenuRoute({
+  icon: defaultDeleteIcon,
+  label: "Delete Tag Group",
+  route: adminTagGroupRoute.add("delete"),
+  tooltip: () => "Delete an existing tag group",
+  parent: adminTagGroupsMenuItem,
+  predicate: isAdminPredicate,
+});

--- a/src/app/component/admin/tag-group/tag-group.menus.ts
+++ b/src/app/component/admin/tag-group/tag-group.menus.ts
@@ -5,11 +5,9 @@ import {
   defaultNewIcon,
   isAdminPredicate,
 } from "src/app/app.menus";
-import { adminDashboardMenuItem } from "../admin.menus";
+import { adminDashboardMenuItem, adminRoute } from "../admin.menus";
 
-export const adminTagGroupsRoute = adminDashboardMenuItem.route.addFeatureModule(
-  "tag_groups"
-);
+export const adminTagGroupsRoute = adminRoute.addFeatureModule("tag_groups");
 
 export const adminTagGroupsCategory: Category = {
   icon: ["fas", "tags"],

--- a/src/app/component/admin/tag-group/tag-groups.module.ts
+++ b/src/app/component/admin/tag-group/tag-groups.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from "@angular/core";
+import { RouterModule } from "@angular/router";
+import { GetRouteConfigForPage } from "@helpers/page/pageRouting";
+import { SharedModule } from "@shared/shared.module";
+import { AdminTagGroupsDeleteComponent } from "./delete/delete.component";
+import { AdminTagGroupsEditComponent } from "./edit/edit.component";
+import { AdminTagGroupsComponent } from "./list/list.component";
+import { AdminTagGroupsNewComponent } from "./new/new.component";
+import { adminTagGroupsRoute } from "./tag-group.menus";
+
+const components = [
+  AdminTagGroupsComponent,
+  AdminTagGroupsDeleteComponent,
+  AdminTagGroupsEditComponent,
+  AdminTagGroupsNewComponent,
+];
+const routes = adminTagGroupsRoute.compileRoutes(GetRouteConfigForPage);
+
+@NgModule({
+  declarations: components,
+  imports: [SharedModule, RouterModule.forChild(routes)],
+  exports: [RouterModule, ...components],
+})
+export class TagGroupsModule {}

--- a/src/app/component/admin/tags/delete/delete.component.spec.ts
+++ b/src/app/component/admin/tags/delete/delete.component.spec.ts
@@ -3,7 +3,6 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { tagResolvers, TagsService } from "@baw-api/tags.service";
-import { adminTagsMenuItem } from "@component/admin/admin.menus";
 import { Tag } from "@models/Tag";
 import { SharedModule } from "@shared/shared.module";
 import { ToastrService } from "ngx-toastr";
@@ -11,6 +10,7 @@ import { BehaviorSubject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
 import { assertFormErrorHandling } from "src/testHelpers";
+import { adminTagsMenuItem } from "../tags.menus";
 import { AdminTagsDeleteComponent } from "./delete.component";
 
 describe("AdminTagsDeleteComponent", () => {

--- a/src/app/component/admin/tags/delete/delete.component.ts
+++ b/src/app/component/admin/tags/delete/delete.component.ts
@@ -2,12 +2,6 @@ import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { tagResolvers, TagsService } from "@baw-api/tags.service";
 import {
-  adminDeleteTagMenuItem,
-  adminEditTagMenuItem,
-  adminTagsCategory,
-  adminTagsMenuItem,
-} from "@component/admin/admin.menus";
-import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
@@ -16,6 +10,12 @@ import { Tag } from "@models/Tag";
 import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
 import { adminTagsMenuItemActions } from "../list/list.component";
+import {
+  adminDeleteTagMenuItem,
+  adminEditTagMenuItem,
+  adminTagsCategory,
+  adminTagsMenuItem,
+} from "../tags.menus";
 
 const tagKey = "tag";
 

--- a/src/app/component/admin/tags/edit/edit.component.ts
+++ b/src/app/component/admin/tags/edit/edit.component.ts
@@ -2,12 +2,6 @@ import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { tagResolvers, TagsService, TagType } from "@baw-api/tags.service";
 import {
-  adminDeleteTagMenuItem,
-  adminEditTagMenuItem,
-  adminTagsCategory,
-  adminTagsMenuItem,
-} from "@component/admin/admin.menus";
-import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
@@ -17,6 +11,12 @@ import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
 import { adminTagsMenuItemActions } from "../list/list.component";
 import { fields } from "../tag.json";
+import {
+  adminDeleteTagMenuItem,
+  adminEditTagMenuItem,
+  adminTagsCategory,
+  adminTagsMenuItem,
+} from "../tags.menus";
 
 const tagKey = "tag";
 const tagTypesKey = "tagTypes";

--- a/src/app/component/admin/tags/list/list.component.ts
+++ b/src/app/component/admin/tags/list/list.component.ts
@@ -1,18 +1,18 @@
 import { Component, OnInit } from "@angular/core";
 import { TagsService } from "@baw-api/tags.service";
-import {
-  adminDashboardMenuItem,
-  adminDeleteTagMenuItem,
-  adminEditTagMenuItem,
-  adminNewTagMenuItem,
-  adminTagsCategory,
-  adminTagsMenuItem,
-} from "@component/admin/admin.menus";
+import { adminDashboardMenuItem } from "@component/admin/admin.menus";
 import { Page } from "@helpers/page/pageDecorator";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
 import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { Tag } from "@models/Tag";
 import { List } from "immutable";
+import {
+  adminDeleteTagMenuItem,
+  adminEditTagMenuItem,
+  adminNewTagMenuItem,
+  adminTagsCategory,
+  adminTagsMenuItem,
+} from "../tags.menus";
 
 export const adminTagsMenuItemActions = [adminNewTagMenuItem];
 

--- a/src/app/component/admin/tags/new/new.component.ts
+++ b/src/app/component/admin/tags/new/new.component.ts
@@ -2,11 +2,6 @@ import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { tagResolvers, TagsService, TagType } from "@baw-api/tags.service";
 import {
-  adminNewTagMenuItem,
-  adminTagsCategory,
-  adminTagsMenuItem,
-} from "@component/admin/admin.menus";
-import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
@@ -16,6 +11,11 @@ import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
 import { adminTagsMenuItemActions } from "../list/list.component";
 import { fields } from "../tag.json";
+import {
+  adminNewTagMenuItem,
+  adminTagsCategory,
+  adminTagsMenuItem,
+} from "../tags.menus";
 
 const typeOfTagsKey = "typeOfTags";
 

--- a/src/app/component/admin/tags/tags.menus.ts
+++ b/src/app/component/admin/tags/tags.menus.ts
@@ -1,0 +1,56 @@
+import { Category, MenuRoute } from "@interfaces/menusInterfaces";
+import {
+  defaultDeleteIcon,
+  defaultEditIcon,
+  defaultNewIcon,
+  isAdminPredicate,
+} from "src/app/app.menus";
+import { adminDashboardMenuItem } from "../admin.menus";
+
+export const adminTagsRoute = adminDashboardMenuItem.route.addFeatureModule(
+  "tags"
+);
+
+export const adminTagsCategory: Category = {
+  icon: ["fas", "tag"],
+  label: "Tags",
+  route: adminTagsRoute,
+};
+
+export const adminTagsMenuItem = MenuRoute({
+  icon: ["fas", "tag"],
+  label: "Tags",
+  route: adminTagsRoute,
+  tooltip: () => "Manage tags",
+  parent: adminDashboardMenuItem,
+  predicate: isAdminPredicate,
+});
+
+export const adminNewTagMenuItem = MenuRoute({
+  icon: defaultNewIcon,
+  label: "New Tag",
+  route: adminTagsRoute.add("new"),
+  tooltip: () => "Create a new tag",
+  parent: adminTagsMenuItem,
+  predicate: isAdminPredicate,
+});
+
+const adminTagRoute = adminTagsRoute.add(":tagId");
+
+export const adminEditTagMenuItem = MenuRoute({
+  icon: defaultEditIcon,
+  label: "Edit Tag",
+  route: adminTagRoute.add("edit"),
+  tooltip: () => "Edit an existing tag",
+  parent: adminTagsMenuItem,
+  predicate: isAdminPredicate,
+});
+
+export const adminDeleteTagMenuItem = MenuRoute({
+  icon: defaultDeleteIcon,
+  label: "Delete Tag",
+  route: adminTagRoute.add("delete"),
+  tooltip: () => "Delete an existing tag",
+  parent: adminTagsMenuItem,
+  predicate: isAdminPredicate,
+});

--- a/src/app/component/admin/tags/tags.menus.ts
+++ b/src/app/component/admin/tags/tags.menus.ts
@@ -5,11 +5,9 @@ import {
   defaultNewIcon,
   isAdminPredicate,
 } from "src/app/app.menus";
-import { adminDashboardMenuItem } from "../admin.menus";
+import { adminDashboardMenuItem, adminRoute } from "../admin.menus";
 
-export const adminTagsRoute = adminDashboardMenuItem.route.addFeatureModule(
-  "tags"
-);
+export const adminTagsRoute = adminRoute.addFeatureModule("tags");
 
 export const adminTagsCategory: Category = {
   icon: ["fas", "tag"],

--- a/src/app/component/admin/tags/tags.module.ts
+++ b/src/app/component/admin/tags/tags.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from "@angular/core";
+import { RouterModule } from "@angular/router";
+import { GetRouteConfigForPage } from "@helpers/page/pageRouting";
+import { SharedModule } from "@shared/shared.module";
+import { AdminTagsDeleteComponent } from "./delete/delete.component";
+import { AdminTagsEditComponent } from "./edit/edit.component";
+import { AdminTagsComponent } from "./list/list.component";
+import { AdminTagsNewComponent } from "./new/new.component";
+import { adminTagsRoute } from "./tags.menus";
+
+const components = [
+  AdminTagsComponent,
+  AdminTagsDeleteComponent,
+  AdminTagsEditComponent,
+  AdminTagsNewComponent,
+];
+const routes = adminTagsRoute.compileRoutes(GetRouteConfigForPage);
+
+@NgModule({
+  declarations: components,
+  imports: [SharedModule, RouterModule.forChild(routes)],
+  exports: [RouterModule, ...components],
+})
+export class TagsModule {}

--- a/src/app/component/sites/sites.menus.ts
+++ b/src/app/component/sites/sites.menus.ts
@@ -4,21 +4,21 @@ import {
   defaultEditIcon,
   defaultNewIcon,
   isLoggedInPredicate,
-  isProjectOwnerPredicate
+  isProjectOwnerPredicate,
 } from "src/app/app.menus";
 import {
   Category,
   MenuLink,
-  MenuRoute
+  MenuRoute,
 } from "src/app/interfaces/menusInterfaces";
-import { projectCategory, projectMenuItem } from "../projects/projects.menus";
+import { projectMenuItem } from "../projects/projects.menus";
 
 export const sitesRoute = projectMenuItem.route.addFeatureModule("sites");
 
 export const sitesCategory: Category = {
   icon: ["fas", "map-marker-alt"],
   label: "Sites",
-  route: sitesRoute.add(":siteId")
+  route: sitesRoute.add(":siteId"),
 };
 
 export const newSiteMenuItem = MenuRoute({
@@ -27,7 +27,7 @@ export const newSiteMenuItem = MenuRoute({
   parent: projectMenuItem,
   predicate: isProjectOwnerPredicate,
   route: sitesRoute.add("new"),
-  tooltip: () => "Create a new site"
+  tooltip: () => "Create a new site",
 });
 
 export const siteMenuItem = MenuRoute({
@@ -35,7 +35,7 @@ export const siteMenuItem = MenuRoute({
   label: "Site",
   parent: projectMenuItem,
   route: sitesCategory.route,
-  tooltip: () => "The current site"
+  tooltip: () => "The current site",
 });
 
 export const annotationsMenuItem = MenuLink({
@@ -43,7 +43,7 @@ export const annotationsMenuItem = MenuLink({
   label: "Download annotations",
   predicate: isLoggedInPredicate,
   tooltip: () => "Download annotations for this site",
-  uri: () => "REPLACE_ME"
+  uri: () => "REPLACE_ME",
 });
 
 export const editSiteMenuItem = MenuRoute({
@@ -52,7 +52,7 @@ export const editSiteMenuItem = MenuRoute({
   parent: siteMenuItem,
   predicate: isProjectOwnerPredicate,
   route: siteMenuItem.route.add("edit"),
-  tooltip: () => "Change the details for this site"
+  tooltip: () => "Change the details for this site",
 });
 
 export const harvestMenuItem = MenuRoute({
@@ -61,7 +61,7 @@ export const harvestMenuItem = MenuRoute({
   parent: siteMenuItem,
   predicate: isProjectOwnerPredicate,
   route: siteMenuItem.route.add("harvest"),
-  tooltip: () => "Upload new audio to this site"
+  tooltip: () => "Upload new audio to this site",
 });
 
 export const deleteSiteMenuItem = MenuRoute({
@@ -70,5 +70,5 @@ export const deleteSiteMenuItem = MenuRoute({
   parent: siteMenuItem,
   predicate: isProjectOwnerPredicate,
   route: siteMenuItem.route.add("delete"),
-  tooltip: () => "Delete this site"
+  tooltip: () => "Delete this site",
 });

--- a/src/app/interfaces/strongRoute.spec.ts
+++ b/src/app/interfaces/strongRoute.spec.ts
@@ -11,19 +11,19 @@ describe("StrongRoute", () => {
     const parents = [
       {
         title: "Base Route",
-        parent: () => StrongRoute.Base
+        parent: () => StrongRoute.Base,
       },
       {
         title: "Child Route",
-        parent: () => StrongRoute.Base.add("parent")
+        parent: () => StrongRoute.Base.add("parent"),
       },
       {
         title: "Feature Module Route",
-        parent: () => StrongRoute.Base.add("test").addFeatureModule("testing")
-      }
+        parent: () => StrongRoute.Base.add("test").addFeatureModule("testing"),
+      },
     ];
 
-    parents.forEach(parent => {
+    parents.forEach((parent) => {
       let parentRoute: StrongRoute;
 
       describe(parent.title, () => {
@@ -83,10 +83,7 @@ describe("StrongRoute", () => {
     });
 
     it("should format mix routes", () => {
-      const paramRoute = strongRoute
-        .add("home")
-        .add(":id")
-        .add("house");
+      const paramRoute = strongRoute.add("home").add(":id").add("house");
       expect(paramRoute.format({ id: 1 })).toBe("/home/1/house");
     });
   });
@@ -96,13 +93,13 @@ describe("StrongRoute", () => {
       {
         title: "Base Route",
         baseRef: "",
-        parent: () => StrongRoute.Base
+        parent: () => StrongRoute.Base,
       },
       {
         title: "Feature Module Route",
         baseRef: "test/testing/",
-        parent: () => StrongRoute.Base.add("test").addFeatureModule("testing")
-      }
+        parent: () => StrongRoute.Base.add("test").addFeatureModule("testing"),
+      },
     ];
 
     class MockComponent {}
@@ -113,39 +110,57 @@ describe("StrongRoute", () => {
         children: [
           {
             path: "",
-            component
-          }
-        ]
+            component,
+          },
+        ],
       } as Route;
     }
 
-    parents.forEach(parent => {
+    parents.forEach((parent) => {
       describe(parent.title, () => {
         let strongRoute: StrongRoute;
+        let rootRoute: Route;
 
         beforeEach(() => {
           strongRoute = parent.parent();
+
+          rootRoute = {
+            path:
+              parent.baseRef.length > 0
+                ? parent.baseRef.substr(0, parent.baseRef.length - 1)
+                : null,
+            pathMatch: "full",
+            children: [
+              {
+                path: "",
+                component: undefined,
+              },
+            ],
+          };
         });
 
         it("should compile base route", () => {
-          const routes: Routes = [];
+          rootRoute.children[0].component = MockComponent;
+          const routes: Routes = [rootRoute];
           strongRoute.pageComponent = MockComponent;
           const compiledRoutes = strongRoute.compileRoutes(callback);
+
           expect(compiledRoutes).toEqual(routes);
         });
 
         it("should compile StrongRoute with route", () => {
           const routes: Routes = [
+            rootRoute,
             {
               path: parent.baseRef + "home",
               pathMatch: "full",
               children: [
                 {
                   path: "",
-                  component: MockComponent
-                }
-              ]
-            }
+                  component: MockComponent,
+                },
+              ],
+            },
           ];
           const homeRoute = strongRoute.add("home");
           homeRoute.pageComponent = MockComponent;
@@ -156,16 +171,17 @@ describe("StrongRoute", () => {
 
         it("should compile StrongRoute with parameter route", () => {
           const routes: Routes = [
+            rootRoute,
             {
               path: parent.baseRef + ":id",
               pathMatch: "full",
               children: [
                 {
                   path: "",
-                  component: MockComponent
-                }
-              ]
-            }
+                  component: MockComponent,
+                },
+              ],
+            },
           ];
           const paramRoute = strongRoute.add(":id");
           paramRoute.pageComponent = MockComponent;
@@ -176,15 +192,16 @@ describe("StrongRoute", () => {
 
         it("should compile StrongRoute with mixed routes", () => {
           const routes: Routes = [
+            rootRoute,
             {
               path: parent.baseRef + "home",
               pathMatch: "full",
               children: [
                 {
                   path: "",
-                  component: undefined
-                }
-              ]
+                  component: undefined,
+                },
+              ],
             },
             {
               path: parent.baseRef + "home/:id",
@@ -192,9 +209,9 @@ describe("StrongRoute", () => {
               children: [
                 {
                   path: "",
-                  component: undefined
-                }
-              ]
+                  component: undefined,
+                },
+              ],
             },
             {
               path: parent.baseRef + "home/:id/house",
@@ -202,15 +219,12 @@ describe("StrongRoute", () => {
               children: [
                 {
                   path: "",
-                  component: MockComponent
-                }
-              ]
-            }
+                  component: MockComponent,
+                },
+              ],
+            },
           ];
-          const paramRoute = strongRoute
-            .add("home")
-            .add(":id")
-            .add("house");
+          const paramRoute = strongRoute.add("home").add(":id").add("house");
           paramRoute.pageComponent = MockComponent;
           const compiledRoutes = paramRoute.compileRoutes(callback);
 
@@ -219,6 +233,7 @@ describe("StrongRoute", () => {
 
         it("should compile StrongRoute with custom config", () => {
           const routes: Routes = [
+            rootRoute,
             {
               path: parent.baseRef + ":id",
               pathMatch: "full",
@@ -226,10 +241,10 @@ describe("StrongRoute", () => {
               children: [
                 {
                   path: "",
-                  component: MockComponent
-                }
-              ]
-            }
+                  component: MockComponent,
+                },
+              ],
+            },
           ];
           const paramRoute = strongRoute.add(":id", { redirectTo: "/test" });
           paramRoute.pageComponent = MockComponent;
@@ -240,15 +255,16 @@ describe("StrongRoute", () => {
 
         it("should order child StrongRoute routes", () => {
           const routes: Routes = [
+            rootRoute,
             {
               path: parent.baseRef + "home",
               pathMatch: "full",
               children: [
                 {
                   path: "",
-                  component: undefined
-                }
-              ]
+                  component: undefined,
+                },
+              ],
             },
             {
               path: parent.baseRef + "home/house",
@@ -256,9 +272,9 @@ describe("StrongRoute", () => {
               children: [
                 {
                   path: "",
-                  component: undefined
-                }
-              ]
+                  component: undefined,
+                },
+              ],
             },
             {
               path: parent.baseRef + "home/:id",
@@ -266,10 +282,10 @@ describe("StrongRoute", () => {
               children: [
                 {
                   path: "",
-                  component: undefined
-                }
-              ]
-            }
+                  component: undefined,
+                },
+              ],
+            },
           ];
           const homeRoute = strongRoute.add("home");
           homeRoute.add(":id");
@@ -281,15 +297,16 @@ describe("StrongRoute", () => {
 
         it("should order base StrongRoute routes", () => {
           const routes: Routes = [
+            rootRoute,
             {
               path: parent.baseRef + "home",
               pathMatch: "full",
               children: [
                 {
                   path: "",
-                  component: undefined
-                }
-              ]
+                  component: undefined,
+                },
+              ],
             },
             {
               path: parent.baseRef + "house",
@@ -297,9 +314,9 @@ describe("StrongRoute", () => {
               children: [
                 {
                   path: "",
-                  component: undefined
-                }
-              ]
+                  component: undefined,
+                },
+              ],
             },
             {
               path: parent.baseRef + ":id",
@@ -307,10 +324,10 @@ describe("StrongRoute", () => {
               children: [
                 {
                   path: "",
-                  component: undefined
-                }
-              ]
-            }
+                  component: undefined,
+                },
+              ],
+            },
           ];
 
           strongRoute.add("home");
@@ -346,10 +363,7 @@ describe("StrongRoute", () => {
     });
 
     it("should handle mixed routes", () => {
-      const grandChildRoute = strongRoute
-        .add("home")
-        .add(":id")
-        .add("house");
+      const grandChildRoute = strongRoute.add("home").add(":id").add("house");
       expect(grandChildRoute.toString()).toBe("/home/:id/house");
     });
 
@@ -377,10 +391,7 @@ describe("StrongRoute", () => {
     });
 
     it("should handle mixed routes", () => {
-      const grandChildRoute = strongRoute
-        .add("home")
-        .add(":id")
-        .add("house");
+      const grandChildRoute = strongRoute.add("home").add(":id").add("house");
       expect(grandChildRoute.toRoute()).toEqual(["home", ":id", "house"]);
     });
 

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -171,7 +171,7 @@ export class StrongRoute {
       }
     };
 
-    rootRoute.children.forEach(recursiveAdd);
+    recursiveAdd(rootRoute);
     return output.sort(sortRoutes);
   }
 
@@ -188,7 +188,7 @@ export class StrongRoute {
    * eg. ["home", "house"]
    */
   toRoute(): string[] {
-    return this.full.slice(1).map(x => x.name);
+    return this.full.slice(1).map((x) => x.name);
   }
 
   /**

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -138,6 +138,12 @@ export class StrongRoute {
     const output: Routes = [];
 
     const sortRoutes = (a: Route, b: Route): -1 | 0 | 1 => {
+      if (a.path === null && b.path === null) {
+        return 0;
+      } else if (a.path === null || b.path === null) {
+        return a.path === null ? -1 : 1;
+      }
+
       const aRoutes = a.path.split("/");
       const bRoutes = b.path.split("/");
       const aParamRoute = aRoutes[aRoutes.length - 1].startsWith(":");

--- a/src/app/models/Script.ts
+++ b/src/app/models/Script.ts
@@ -1,9 +1,9 @@
-import { adminScriptsMenuItem } from "../component/admin/admin.menus";
+import { adminScriptsMenuItem } from "@component/admin/scripts/scripts.menus";
 import {
   DateTimeTimezone,
   dateTimeTimezone,
   Id,
-  Param
+  Param,
 } from "../interfaces/apiInterfaces";
 import { AbstractModel } from "./AbstractModel";
 
@@ -69,7 +69,7 @@ export class Script extends AbstractModel implements ScriptInterface {
       executableSettings: this.executableSettings,
       executableSettingsMediaType: this.executableSettingsMediaType,
       analysisActionParams: this.analysisActionParams,
-      verified: this.verified
+      verified: this.verified,
     };
   }
 

--- a/src/app/models/Tag.ts
+++ b/src/app/models/Tag.ts
@@ -1,8 +1,8 @@
-import { adminTagsMenuItem } from "../component/admin/admin.menus";
+import { adminTagsMenuItem } from "@component/admin/tags/tags.menus";
 import {
   DateTimeTimezone,
   dateTimeTimezone,
-  Id
+  Id,
 } from "../interfaces/apiInterfaces";
 import { AbstractModel } from "./AbstractModel";
 
@@ -67,7 +67,7 @@ export class Tag extends AbstractModel implements TagInterface {
       creatorId: this.creatorId,
       updaterId: this.updaterId,
       createdAt: this.createdAt?.toISO(),
-      updatedAt: this.updatedAt?.toISO()
+      updatedAt: this.updatedAt?.toISO(),
     };
   }
 

--- a/src/app/models/TagGroup.ts
+++ b/src/app/models/TagGroup.ts
@@ -1,8 +1,8 @@
-import { adminTagGroupsMenuItem } from "../component/admin/admin.menus";
+import { adminTagGroupsMenuItem } from "@component/admin/tag-group/tag-group.menus";
 import {
   DateTimeTimezone,
   dateTimeTimezone,
-  Id
+  Id,
 } from "../interfaces/apiInterfaces";
 import { AbstractModel } from "./AbstractModel";
 
@@ -52,7 +52,7 @@ export class TagGroup extends AbstractModel implements TagGroupInterface {
       groupIdentifier: this.groupIdentifier,
       createdAt: this.createdAt?.toISO(),
       creatorId: this.creatorId,
-      tagId: this.tagId
+      tagId: this.tagId,
     };
   }
 }


### PR DESCRIPTION
# Extracted admin modules

Cleaned up admin pages by extracting sub components into their own modules.

## Changes

- Created `ScriptsModule`
- Created `TagGroupsModule`
- Created `TagsModule`
- Fixed StrongRoute bug where `compileRoutes()` was not compiling the root route. This was an issue for modules using `addFeatureModule()`
