### PR TITLE
Implement user projects

### DIFF
--- a/src/app/component/admin/tag-group/delete/delete.component.spec.ts
+++ b/src/app/component/admin/tag-group/delete/delete.component.spec.ts
@@ -10,7 +10,7 @@ import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
-import { assertFormErrorHandling } from "src/testHelpers";
+import { assertResolverErrorHandling } from "src/testHelpers";
 import { AdminTagGroupsDeleteComponent } from "./delete.component";
 
 describe("AdminTagGroupsDeleteComponent", () => {
@@ -85,7 +85,7 @@ describe("AdminTagGroupsDeleteComponent", () => {
 
     it("should handle tag group error", () => {
       configureTestingModule(undefined, defaultError);
-      assertFormErrorHandling(fixture);
+      assertResolverErrorHandling(fixture);
     });
 
     it("should call api", () => {

--- a/src/app/component/admin/tag-group/edit/edit.component.spec.ts
+++ b/src/app/component/admin/tag-group/edit/edit.component.spec.ts
@@ -8,7 +8,7 @@ import { SharedModule } from "@shared/shared.module";
 import { ToastrService } from "ngx-toastr";
 import { appLibraryImports } from "src/app/app.module";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
-import { assertFormErrorHandling } from "src/testHelpers";
+import { assertResolverErrorHandling } from "src/testHelpers";
 import { AdminTagGroupsEditComponent } from "./edit.component";
 
 describe("AdminTagGroupsEditComponent", () => {
@@ -78,7 +78,7 @@ describe("AdminTagGroupsEditComponent", () => {
 
     it("should handle tag group error", () => {
       configureTestingModule(undefined, defaultError);
-      assertFormErrorHandling(fixture);
+      assertResolverErrorHandling(fixture);
     });
 
     it("should call api", () => {

--- a/src/app/component/admin/tags/delete/delete.component.spec.ts
+++ b/src/app/component/admin/tags/delete/delete.component.spec.ts
@@ -10,7 +10,7 @@ import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
-import { assertFormErrorHandling } from "src/testHelpers";
+import { assertResolverErrorHandling } from "src/testHelpers";
 import { AdminTagsDeleteComponent } from "./delete.component";
 
 describe("AdminTagsDeleteComponent", () => {
@@ -84,7 +84,7 @@ describe("AdminTagsDeleteComponent", () => {
 
     it("should handle tag error", () => {
       configureTestingModule(undefined, defaultError);
-      assertFormErrorHandling(fixture);
+      assertResolverErrorHandling(fixture);
     });
 
     it("should call api", () => {

--- a/src/app/component/admin/tags/edit/edit.component.spec.ts
+++ b/src/app/component/admin/tags/edit/edit.component.spec.ts
@@ -8,7 +8,7 @@ import { SharedModule } from "@shared/shared.module";
 import { ToastrService } from "ngx-toastr";
 import { appLibraryImports } from "src/app/app.module";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
-import { assertFormErrorHandling } from "src/testHelpers";
+import { assertResolverErrorHandling } from "src/testHelpers";
 import { AdminTagsEditComponent } from "./edit.component";
 
 describe("AdminTagsEditComponent", () => {
@@ -98,12 +98,12 @@ describe("AdminTagsEditComponent", () => {
         defaultTagTypes,
         undefined
       );
-      assertFormErrorHandling(fixture);
+      assertResolverErrorHandling(fixture);
     });
 
     it("should handle tag types error", () => {
       configureTestingModule(defaultTag, undefined, undefined, defaultError);
-      assertFormErrorHandling(fixture);
+      assertResolverErrorHandling(fixture);
     });
 
     it("should call api", () => {

--- a/src/app/component/admin/tags/new/new.component.spec.ts
+++ b/src/app/component/admin/tags/new/new.component.spec.ts
@@ -7,7 +7,7 @@ import { SharedModule } from "@shared/shared.module";
 import { ToastrService } from "ngx-toastr";
 import { appLibraryImports } from "src/app/app.module";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
-import { assertFormErrorHandling } from "src/testHelpers";
+import { assertResolverErrorHandling } from "src/testHelpers";
 import { AdminTagsNewComponent } from "./new.component";
 
 describe("AdminTagsNewComponent", () => {
@@ -79,7 +79,7 @@ describe("AdminTagsNewComponent", () => {
 
     it("should handle tag types error", () => {
       configureTestingModule(undefined, defaultError);
-      assertFormErrorHandling(fixture);
+      assertResolverErrorHandling(fixture);
     });
 
     it("should call api", () => {

--- a/src/app/component/profile/pages/projects/my-projects.component.spec.ts
+++ b/src/app/component/profile/pages/projects/my-projects.component.spec.ts
@@ -1,23 +1,62 @@
-import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ActivatedRoute } from "@angular/router";
+import { RouterTestingModule } from "@angular/router/testing";
+import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { userResolvers } from "@baw-api/user.service";
+import { User } from "@models/User";
+import { SharedModule } from "@shared/shared.module";
+import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
 import { MyProjectsComponent } from "./my-projects.component";
 
-xdescribe("MyProjectsComponent", () => {
+describe("MyProjectsComponent", () => {
   let component: MyProjectsComponent;
+  let defaultUser: User;
+  let defaultError: ApiErrorDetails;
   let fixture: ComponentFixture<MyProjectsComponent>;
 
-  beforeEach(async(() => {
+  function configureTestingModule(model?: User, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       declarations: [MyProjectsComponent],
+      imports: [SharedModule, RouterTestingModule],
+      providers: [
+        ...testBawServices,
+        {
+          provide: ActivatedRoute,
+          useClass: mockActivatedRoute(
+            { account: userResolvers.show },
+            { account: { model, error } }
+          ),
+        },
+      ],
     }).compileComponents();
-  }));
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(MyProjectsComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    defaultUser = new User({ id: 1, userName: "username" });
+    defaultError = { status: 401, message: "Unauthorized" };
   });
 
   it("should create", () => {
+    configureTestingModule(defaultUser);
+    fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  xit("should display username in title", () => {});
+  xit("should handle user", () => {});
+  xit("should handle user error", () => {});
+  xit("should use projects api", () => {});
+
+  xdescribe("table", () => {
+    it("should display project name", () => {});
+    it("should display project name link", () => {});
+    it("should display number of sites", () => {});
+    it("should display reader permissions", () => {});
+    it("should display writer permissions", () => {});
+    it("should display owner permissions", () => {});
+    it("should display owner permissions link", () => {});
   });
 });

--- a/src/app/component/profile/pages/projects/my-projects.component.spec.ts
+++ b/src/app/component/profile/pages/projects/my-projects.component.spec.ts
@@ -2,13 +2,18 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { ProjectsService } from "@baw-api/projects.service";
 import { userResolvers } from "@baw-api/user.service";
+import { Project, ProjectInterface } from "@models/Project";
 import { User } from "@models/User";
 import { SharedModule } from "@shared/shared.module";
+import { BehaviorSubject } from "rxjs";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
+import { assertResolverErrorHandling, assertRoute } from "src/testHelpers";
 import { MyProjectsComponent } from "./my-projects.component";
 
 describe("MyProjectsComponent", () => {
+  let api: ProjectsService;
   let component: MyProjectsComponent;
   let defaultUser: User;
   let defaultError: ApiErrorDetails;
@@ -31,6 +36,7 @@ describe("MyProjectsComponent", () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(MyProjectsComponent);
+    api = TestBed.inject(ProjectsService);
     component = fixture.componentInstance;
   }
 
@@ -45,18 +51,78 @@ describe("MyProjectsComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  xit("should display username in title", () => {});
-  xit("should handle user", () => {});
-  xit("should handle user error", () => {});
-  xit("should use projects api", () => {});
+  it("should display username in title", () => {
+    configureTestingModule(
+      new User({ ...defaultUser, userName: "custom username" })
+    );
+    fixture.detectChanges();
 
-  xdescribe("table", () => {
-    it("should display project name", () => {});
-    it("should display project name link", () => {});
-    it("should display number of sites", () => {});
-    it("should display reader permissions", () => {});
-    it("should display writer permissions", () => {});
-    it("should display owner permissions", () => {});
-    it("should display owner permissions link", () => {});
+    const title = fixture.nativeElement.querySelector("small");
+    expect(title.innerText.trim()).toContain("custom username");
+  });
+
+  it("should handle user error", () => {
+    configureTestingModule(undefined, defaultError);
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+
+    assertResolverErrorHandling(fixture);
+  });
+
+  describe("table", () => {
+    function setProject(data: ProjectInterface) {
+      const project = new Project({ id: 1, name: "project", ...data });
+      project.addMetadata({
+        status: 200,
+        message: "OK",
+        paging: {
+          page: 1,
+          items: 25,
+          total: 1,
+          maxPage: 1,
+        },
+      });
+
+      spyOn(api, "filter").and.callFake(() => {
+        return new BehaviorSubject<Project[]>([project]);
+      });
+
+      return project;
+    }
+
+    function getCells(): NodeListOf<HTMLDivElement> {
+      return fixture.nativeElement.querySelectorAll("datatable-body-cell");
+    }
+
+    it("should display project name", () => {
+      configureTestingModule(defaultUser);
+      setProject({ name: "custom project" });
+      fixture.detectChanges();
+
+      expect(getCells()[0].innerText.trim()).toBe("custom project");
+    });
+
+    it("should display project name link", () => {
+      configureTestingModule(defaultUser);
+      const project = setProject({ name: "custom project" });
+      fixture.detectChanges();
+
+      const link = getCells()[0].querySelector("a");
+      assertRoute(link, project.redirectPath());
+    });
+
+    it("should display number of sites", () => {
+      configureTestingModule(defaultUser);
+      setProject({ siteIds: new Set([1, 2, 3, 4, 5]) });
+      fixture.detectChanges();
+
+      expect(getCells()[1].innerText).toBe("5");
+    });
+
+    // TODO Implement
+    xit("should display reader permissions", () => {});
+    xit("should display writer permissions", () => {});
+    xit("should display owner permissions", () => {});
+    xit("should display owner permissions link", () => {});
   });
 });

--- a/src/app/component/profile/pages/projects/my-projects.component.ts
+++ b/src/app/component/profile/pages/projects/my-projects.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from "@angular/core";
+import { Component } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { ProjectsService } from "@baw-api/projects.service";
 import { userResolvers } from "@baw-api/user.service";
@@ -48,7 +48,10 @@ export class MyProjectsComponent extends PagedTableTemplate<TableRow, Project> {
       api,
       (projects) =>
         projects.map((project) => ({
-          name: project.name,
+          name: {
+            label: project.name,
+            route: project.redirectPath(),
+          },
           sites: project.siteIds.size,
           permission: "UNKNOWN",
         })),
@@ -62,7 +65,10 @@ export class MyProjectsComponent extends PagedTableTemplate<TableRow, Project> {
 }
 
 interface TableRow {
-  name: string;
+  name: {
+    label: string;
+    route: string;
+  };
   sites: number;
   permission: string;
 }

--- a/src/app/component/profile/pages/projects/my-projects.component.ts
+++ b/src/app/component/profile/pages/projects/my-projects.component.ts
@@ -38,7 +38,7 @@ const accountKey = "account";
 })
 export class MyProjectsComponent extends PagedTableTemplate<TableRow, Project> {
   public columns = [
-    { name: "Name" },
+    { name: "Project" },
     { name: "Sites" },
     { name: "Permission" },
   ];
@@ -48,7 +48,7 @@ export class MyProjectsComponent extends PagedTableTemplate<TableRow, Project> {
       api,
       (projects) =>
         projects.map((project) => ({
-          name: {
+          project: {
             label: project.name,
             route: project.redirectPath(),
           },
@@ -65,7 +65,7 @@ export class MyProjectsComponent extends PagedTableTemplate<TableRow, Project> {
 }
 
 interface TableRow {
-  name: {
+  project: {
     label: string;
     route: string;
   };

--- a/src/app/component/profile/pages/projects/my-projects.component.ts
+++ b/src/app/component/profile/pages/projects/my-projects.component.ts
@@ -53,7 +53,7 @@ export class MyProjectsComponent extends PagedTableTemplate<TableRow, Project> {
             route: project.redirectPath(),
           },
           sites: project.siteIds.size,
-          permission: "UNKNOWN",
+          permission: "UNKNOWN", // TODO After https://github.com/QutEcoacoustics/baw-server/issues/425
         })),
       route
     );

--- a/src/app/component/profile/pages/projects/projects.component.html
+++ b/src/app/component/profile/pages/projects/projects.component.html
@@ -22,7 +22,7 @@
     (page)="setPage($event)"
     (sort)="onSort($event)"
   >
-    <ngx-datatable-column name="Name">
+    <ngx-datatable-column name="Project">
       <ng-template let-value="value" ngx-datatable-cell-template>
         <a [routerLink]="[value.route]">{{ value.label }}</a>
       </ng-template>

--- a/src/app/component/profile/pages/projects/projects.component.html
+++ b/src/app/component/profile/pages/projects/projects.component.html
@@ -22,7 +22,11 @@
     (page)="setPage($event)"
     (sort)="onSort($event)"
   >
-    <ngx-datatable-column name="Name"> </ngx-datatable-column>
+    <ngx-datatable-column name="Name">
+      <ng-template let-value="value" ngx-datatable-cell-template>
+        <a [routerLink]="[value.route]">{{ value.label }}</a>
+      </ng-template>
+    </ngx-datatable-column>
     <ngx-datatable-column name="Sites"> </ngx-datatable-column>
     <ngx-datatable-column name="Permission"> </ngx-datatable-column>
   </ngx-datatable>

--- a/src/app/component/profile/pages/projects/their-projects.component.spec.ts
+++ b/src/app/component/profile/pages/projects/their-projects.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { TheirProjectsComponent } from "./their-projects.component";
 
+// TODO Implement
 xdescribe("TheirProjectsComponent", () => {
   let component: TheirProjectsComponent;
   let fixture: ComponentFixture<TheirProjectsComponent>;

--- a/src/app/component/profile/pages/projects/their-projects.component.ts
+++ b/src/app/component/profile/pages/projects/their-projects.component.ts
@@ -41,7 +41,7 @@ export class TheirProjectsComponent extends PagedTableTemplate<
   Project
 > {
   public columns = [
-    { name: "Name" },
+    { name: "Project" },
     { name: "Sites" },
     { name: "Permission" },
   ];
@@ -52,7 +52,7 @@ export class TheirProjectsComponent extends PagedTableTemplate<
       api,
       (projects) =>
         projects.map((project) => ({
-          name: {
+          project: {
             label: project.name,
             route: project.redirectPath(),
           },
@@ -69,7 +69,7 @@ export class TheirProjectsComponent extends PagedTableTemplate<
 }
 
 interface TableRow {
-  name: {
+  project: {
     label: string;
     route: string;
   };

--- a/src/app/component/profile/pages/projects/their-projects.component.ts
+++ b/src/app/component/profile/pages/projects/their-projects.component.ts
@@ -57,7 +57,7 @@ export class TheirProjectsComponent extends PagedTableTemplate<
             route: project.redirectPath(),
           },
           sites: project.siteIds.size,
-          permission: "UNKNOWN",
+          permission: "FIX ME",
         })),
       route
     );

--- a/src/app/component/profile/pages/projects/their-projects.component.ts
+++ b/src/app/component/profile/pages/projects/their-projects.component.ts
@@ -52,7 +52,10 @@ export class TheirProjectsComponent extends PagedTableTemplate<
       api,
       (projects) =>
         projects.map((project) => ({
-          name: project.name,
+          name: {
+            label: project.name,
+            route: project.redirectPath(),
+          },
           sites: project.siteIds.size,
           permission: "UNKNOWN",
         })),
@@ -66,7 +69,10 @@ export class TheirProjectsComponent extends PagedTableTemplate<
 }
 
 interface TableRow {
-  name: string;
+  name: {
+    label: string;
+    route: string;
+  };
   sites: number;
   permission: string;
 }

--- a/src/app/component/profile/pages/sites/my-sites.component.spec.ts
+++ b/src/app/component/profile/pages/sites/my-sites.component.spec.ts
@@ -1,0 +1,123 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ActivatedRoute } from "@angular/router";
+import { RouterTestingModule } from "@angular/router/testing";
+import { accountResolvers } from "@baw-api/account.service";
+import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { ShallowSitesService } from "@baw-api/sites.service";
+import { Site, SiteInterface } from "@models/Site";
+import { User } from "@models/User";
+import { SharedModule } from "@shared/shared.module";
+import { BehaviorSubject } from "rxjs";
+import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
+import { assertResolverErrorHandling, assertRoute } from "src/testHelpers";
+import { MySitesComponent } from "./my-sites.component";
+
+describe("MySitesComponent", () => {
+  let api: ShallowSitesService;
+  let component: MySitesComponent;
+  let defaultUser: User;
+  let defaultError: ApiErrorDetails;
+  let fixture: ComponentFixture<MySitesComponent>;
+
+  function configureTestingModule(model?: User, error?: ApiErrorDetails) {
+    TestBed.configureTestingModule({
+      declarations: [MySitesComponent],
+      imports: [SharedModule, RouterTestingModule],
+      providers: [
+        ...testBawServices,
+        {
+          provide: ActivatedRoute,
+          useClass: mockActivatedRoute(
+            { account: accountResolvers.show },
+            { account: { model, error } }
+          ),
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MySitesComponent);
+    api = TestBed.inject(ShallowSitesService);
+    component = fixture.componentInstance;
+  }
+
+  beforeEach(() => {
+    defaultUser = new User({ id: 1, userName: "username" });
+    defaultError = { status: 401, message: "Unauthorized" };
+  });
+
+  it("should create", () => {
+    configureTestingModule(defaultUser);
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it("should display username in title", () => {
+    configureTestingModule(
+      new User({ ...defaultUser, userName: "custom username" })
+    );
+    fixture.detectChanges();
+
+    const title = fixture.nativeElement.querySelector("small");
+    expect(title.innerText.trim()).toContain("custom username");
+  });
+
+  it("should handle user error", () => {
+    configureTestingModule(undefined, defaultError);
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+
+    assertResolverErrorHandling(fixture);
+  });
+
+  describe("table", () => {
+    function setSite(data: SiteInterface) {
+      const site = new Site({ id: 1, name: "site", ...data });
+      site.addMetadata({
+        status: 200,
+        message: "OK",
+        paging: {
+          page: 1,
+          items: 25,
+          total: 1,
+          maxPage: 1,
+        },
+      });
+
+      spyOn(api, "filter").and.callFake(() => {
+        return new BehaviorSubject<Site[]>([site]);
+      });
+
+      return site;
+    }
+
+    function getCells(): NodeListOf<HTMLDivElement> {
+      return fixture.nativeElement.querySelectorAll("datatable-body-cell");
+    }
+
+    it("should display site name", () => {
+      configureTestingModule(defaultUser);
+      setSite({ name: "custom site" });
+      fixture.detectChanges();
+
+      expect(getCells()[0].innerText.trim()).toBe("custom site");
+    });
+
+    it("should display site name link", () => {
+      configureTestingModule(defaultUser);
+      const site = setSite({ projectIds: new Set([1]) });
+      fixture.detectChanges();
+
+      const link = getCells()[0].querySelector("a");
+      assertRoute(link, site.redirectPath());
+    });
+
+    // TODO Implement
+    xit("should display no recent audio upload", () => {});
+    xit("should display recent audio upload", () => {});
+    xit("should display reader permissions", () => {});
+    xit("should display writer permissions", () => {});
+    xit("should display owner permissions", () => {});
+    xit("should display owner permissions link", () => {});
+    xit("should display annotation link", () => {});
+  });
+});

--- a/src/app/component/profile/pages/sites/my-sites.component.ts
+++ b/src/app/component/profile/pages/sites/my-sites.component.ts
@@ -1,16 +1,17 @@
 import { Component } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
-import { ProjectsService } from "@baw-api/projects.service";
+import { ShallowSitesService } from "@baw-api/sites.service";
 import { userResolvers } from "@baw-api/user.service";
 import {
   myAccountCategory,
   myAccountMenuItem,
-  myProjectsMenuItem,
+  mySitesMenuItem,
 } from "@component/profile/profile.menus";
+import { annotationsMenuItem } from "@component/sites/sites.menus";
 import { Page } from "@helpers/page/pageDecorator";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
 import { AnyMenuItem } from "@interfaces/menusInterfaces";
-import { Project } from "@models/Project";
+import { Site } from "@models/Site";
 import { User } from "@models/User";
 import { List } from "immutable";
 import { myAccountMenuItemActions } from "../profile/my-profile.component";
@@ -29,31 +30,29 @@ const accountKey = "account";
   resolvers: {
     [accountKey]: userResolvers.show,
   },
-  self: myProjectsMenuItem,
+  self: mySitesMenuItem,
 })
 @Component({
-  selector: "app-my-account-projects",
-  templateUrl: "./projects.component.html",
-  styleUrls: ["./projects.component.scss"],
+  selector: "app-my-account-sites",
+  templateUrl: "./sites.component.html",
+  styleUrls: ["./sites.component.scss"],
 })
-export class MyProjectsComponent extends PagedTableTemplate<TableRow, Project> {
-  public columns = [
-    { name: "Project" },
-    { name: "Sites" },
-    { name: "Permission" },
-  ];
-
-  constructor(api: ProjectsService, route: ActivatedRoute) {
+export class MySitesComponent extends PagedTableTemplate<TableRow, Site> {
+  constructor(api: ShallowSitesService, route: ActivatedRoute) {
+    // TODO Add missing details
+    // https://github.com/QutEcoacoustics/baw-server/issues/438
+    // https://github.com/QutEcoacoustics/baw-server/issues/406
     super(
       api,
-      (projects) =>
-        projects.map((project) => ({
-          project: {
-            label: project.name,
-            route: project.redirectPath(),
+      (sites) =>
+        sites.map((site) => ({
+          site: {
+            label: site.name,
+            route: site.redirectPath(),
           },
-          sites: project.siteIds.size,
-          permission: "UNKNOWN", // TODO After https://github.com/QutEcoacoustics/baw-server/issues/425
+          recentAudioUpload: "(none)",
+          permission: "UNKNOWN",
+          annotation: annotationsMenuItem.uri(undefined),
         })),
       route
     );
@@ -65,11 +64,12 @@ export class MyProjectsComponent extends PagedTableTemplate<TableRow, Project> {
 }
 
 interface TableRow {
-  // name: Project
-  project: {
+  // name: Site
+  site: {
     label: string;
     route: string;
   };
-  sites: number;
+  recentAudioUpload: string;
   permission: string;
+  annotation: string;
 }

--- a/src/app/component/profile/pages/sites/sites.component.html
+++ b/src/app/component/profile/pages/sites/sites.component.html
@@ -1,0 +1,39 @@
+<div *ngIf="rows && !error && !failure">
+  <h1>
+    Sites
+    <small class="text-muted">accessible by {{ account.userName }}</small>
+  </h1>
+
+  <p>
+    Displaying <strong>all {{ totalModels }}</strong> sites.
+  </p>
+
+  <ngx-datatable
+    #table
+    bawDatatableDefaults
+    [columnMode]="ColumnMode.force"
+    [columns]="columns"
+    [rows]="rows"
+    [count]="totalModels"
+    [offset]="pageNumber"
+    (page)="setPage($event)"
+    (sort)="onSort($event)"
+  >
+    <ngx-datatable-column name="Site">
+      <ng-template let-value="value" ngx-datatable-cell-template>
+        <a [routerLink]="[value.route]">{{ value.label }}</a>
+      </ng-template>
+    </ngx-datatable-column>
+    <ngx-datatable-column name="Recent Audio Upload"> </ngx-datatable-column>
+    <ngx-datatable-column name="Permission"> </ngx-datatable-column>
+    <ngx-datatable-column name="Annotation" width="115" maxWidth="115">
+      <ng-template let-value="value" ngx-datatable-cell-template>
+        <a class="btn btn-sm btn-default" [routerLink]="[value]">
+          Annotation
+        </a>
+      </ng-template>
+    </ngx-datatable-column>
+  </ngx-datatable>
+</div>
+
+<app-error-handler *ngIf="!failure" [error]="error"></app-error-handler>

--- a/src/app/component/profile/pages/sites/their-sites.component.spec.ts
+++ b/src/app/component/profile/pages/sites/their-sites.component.spec.ts
@@ -1,0 +1,23 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { TheirSitesComponent } from "./their-sites.component";
+
+xdescribe("TheirSitesComponent", () => {
+  let component: TheirSitesComponent;
+  let fixture: ComponentFixture<TheirSitesComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [TheirSitesComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TheirSitesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/component/profile/pages/sites/their-sites.component.ts
+++ b/src/app/component/profile/pages/sites/their-sites.component.ts
@@ -1,16 +1,17 @@
 import { Component } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { accountResolvers } from "@baw-api/account.service";
-import { ProjectsService } from "@baw-api/projects.service";
+import { ShallowSitesService } from "@baw-api/sites.service";
 import {
   theirProfileCategory,
   theirProfileMenuItem,
-  theirProjectsMenuItem,
+  theirSitesMenuItem,
 } from "@component/profile/profile.menus";
+import { annotationsMenuItem } from "@component/sites/sites.menus";
 import { Page } from "@helpers/page/pageDecorator";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
 import { AnyMenuItem } from "@interfaces/menusInterfaces";
-import { Project } from "@models/Project";
+import { Site } from "@models/Site";
 import { User } from "@models/User";
 import { List } from "immutable";
 import { theirProfileMenuItemActions } from "../profile/their-profile.component";
@@ -29,35 +30,27 @@ const accountKey = "account";
   resolvers: {
     [accountKey]: accountResolvers.show,
   },
-  self: theirProjectsMenuItem,
+  self: theirSitesMenuItem,
 })
 @Component({
-  selector: "app-their-account-projects",
-  templateUrl: "./projects.component.html",
-  styleUrls: ["./projects.component.scss"],
+  selector: "app-their-account-sites",
+  templateUrl: "./sites.component.html",
+  styleUrls: ["./sites.component.scss"],
 })
-export class TheirProjectsComponent extends PagedTableTemplate<
-  TableRow,
-  Project
-> {
-  public columns = [
-    { name: "Project" },
-    { name: "Sites" },
-    { name: "Permission" },
-  ];
-
-  // TODO Utilize https://github.com/QutEcoacoustics/baw-server/issues/438 service
-  constructor(api: ProjectsService, route: ActivatedRoute) {
+export class TheirSitesComponent extends PagedTableTemplate<TableRow, Site> {
+  constructor(api: ShallowSitesService, route: ActivatedRoute) {
+    // TODO Add missing details https://github.com/QutEcoacoustics/baw-server/issues/406
     super(
       api,
-      (projects) =>
-        projects.map((project) => ({
-          project: {
-            label: project.name,
-            route: project.redirectPath(),
+      (sites) =>
+        sites.map((site) => ({
+          site: {
+            label: site.name,
+            route: site.redirectPath(),
           },
-          sites: project.siteIds.size,
+          recentAudioUpload: "(none)",
           permission: "FIX ME",
+          annotation: annotationsMenuItem.uri(undefined),
         })),
       route
     );
@@ -69,11 +62,12 @@ export class TheirProjectsComponent extends PagedTableTemplate<
 }
 
 interface TableRow {
-  // name: Project
-  project: {
+  // name: Site
+  site: {
     label: string;
     route: string;
   };
-  sites: number;
+  recentAudioUpload: string;
   permission: string;
+  annotation: string;
 }

--- a/src/app/component/profile/profile.menus.ts
+++ b/src/app/component/profile/profile.menus.ts
@@ -45,12 +45,13 @@ export const myProjectsMenuItem = MenuRoute({
   tooltip: (user) => `Projects ${user.userName} can access`,
 });
 
-export const mySitesMenuItem = MenuLink({
+export const mySitesMenuItem = MenuRoute({
   icon: ["fas", "map-marker-alt"],
   label: "My Sites",
-  predicate: (user) => !!user,
+  parent: myAccountMenuItem,
+  predicate: isLoggedInPredicate,
+  route: myAccountMenuItem.route.add("sites"),
   tooltip: (user) => `Sites ${user.userName} can access`,
-  uri: () => "BROKEN LINK",
 });
 
 export const myBookmarksMenuItem = MenuLink({
@@ -110,12 +111,13 @@ export const theirProjectsMenuItem = MenuRoute({
   tooltip: () => "Projects they can access",
 });
 
-export const theirSitesMenuItem = MenuLink({
+export const theirSitesMenuItem = MenuRoute({
   icon: ["fas", "map-marker-alt"],
   label: "Their Sites",
-  predicate: (user) => !!user,
+  parent: theirProfileMenuItem,
+  predicate: isAdminPredicate,
+  route: theirProfileMenuItem.route.add("sites"),
   tooltip: () => "Sites they can access",
-  uri: () => "BROKEN LINK",
 });
 
 export const theirBookmarksMenuItem = MenuLink({

--- a/src/app/component/profile/profile.menus.ts
+++ b/src/app/component/profile/profile.menus.ts
@@ -106,7 +106,7 @@ export const theirProjectsMenuItem = MenuRoute({
   label: "Their Projects",
   parent: theirProfileMenuItem,
   predicate: isAdminPredicate,
-  route: myAccountMenuItem.route.add("projects"),
+  route: theirProfileMenuItem.route.add("projects"),
   tooltip: () => "Projects they can access",
 });
 

--- a/src/app/component/profile/profile.module.ts
+++ b/src/app/component/profile/profile.module.ts
@@ -7,6 +7,8 @@ import { MyProfileComponent } from "./pages/profile/my-profile.component";
 import { TheirProfileComponent } from "./pages/profile/their-profile.component";
 import { MyProjectsComponent } from "./pages/projects/my-projects.component";
 import { TheirProjectsComponent } from "./pages/projects/their-projects.component";
+import { MySitesComponent } from "./pages/sites/my-sites.component";
+import { TheirSitesComponent } from "./pages/sites/their-sites.component";
 import { TheirEditComponent } from "./pages/their-edit/their-edit.component";
 import { myAccountRoute, theirProfileRoute } from "./profile.menus";
 
@@ -14,11 +16,13 @@ const MyAccountComponents = [
   MyProfileComponent,
   MyEditComponent,
   MyProjectsComponent,
+  MySitesComponent,
 ];
 const TheirProfileComponents = [
   TheirProfileComponent,
   TheirEditComponent,
   TheirProjectsComponent,
+  TheirSitesComponent,
 ];
 
 const myAccountRoutes = myAccountRoute.compileRoutes(GetRouteConfigForPage);

--- a/src/app/component/projects/pages/delete/delete.component.spec.ts
+++ b/src/app/component/projects/pages/delete/delete.component.spec.ts
@@ -10,7 +10,7 @@ import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
-import { assertFormErrorHandling } from "src/testHelpers";
+import { assertResolverErrorHandling } from "src/testHelpers";
 import { DeleteComponent } from "./delete.component";
 
 describe("ProjectsDeleteComponent", () => {
@@ -87,7 +87,7 @@ describe("ProjectsDeleteComponent", () => {
 
     it("should handle project error", () => {
       configureTestingModule(undefined, defaultError);
-      assertFormErrorHandling(fixture);
+      assertResolverErrorHandling(fixture);
     });
 
     it("should call api", () => {

--- a/src/app/component/projects/pages/edit/edit.component.spec.ts
+++ b/src/app/component/projects/pages/edit/edit.component.spec.ts
@@ -9,7 +9,7 @@ import { ToastrService } from "ngx-toastr";
 import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
-import { assertFormErrorHandling, testFormlyFields } from "src/testHelpers";
+import { assertResolverErrorHandling, testFormlyFields } from "src/testHelpers";
 import { fields } from "../../project.json";
 import { EditComponent } from "./edit.component";
 
@@ -120,7 +120,7 @@ describe("ProjectsEditComponent", () => {
 
     it("should handle project error", () => {
       configureTestingModule(undefined, defaultError);
-      assertFormErrorHandling(fixture);
+      assertResolverErrorHandling(fixture);
     });
 
     it("should call api", () => {

--- a/src/app/component/sites/pages/delete/delete.component.spec.ts
+++ b/src/app/component/sites/pages/delete/delete.component.spec.ts
@@ -11,10 +11,10 @@ import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.servic
 import { projectResolvers } from "src/app/services/baw-api/projects.service";
 import {
   siteResolvers,
-  SitesService
+  SitesService,
 } from "src/app/services/baw-api/sites.service";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
-import { assertFormErrorHandling } from "src/testHelpers";
+import { assertResolverErrorHandling } from "src/testHelpers";
 import { DeleteComponent } from "./delete.component";
 
 describe("SitesDeleteComponent", () => {
@@ -43,21 +43,21 @@ describe("SitesDeleteComponent", () => {
           useClass: mockActivatedRoute(
             {
               project: projectResolvers.show,
-              site: siteResolvers.show
+              site: siteResolvers.show,
             },
             {
               project: {
                 model: project,
-                error: projectError
+                error: projectError,
               },
               site: {
                 model: site,
-                error: siteError
-              }
+                error: siteError,
+              },
             }
-          )
-        }
-      ]
+          ),
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DeleteComponent);
@@ -76,15 +76,15 @@ describe("SitesDeleteComponent", () => {
   beforeEach(() => {
     defaultProject = new Project({
       id: 1,
-      name: "Project"
+      name: "Project",
     });
     defaultSite = new Site({
       id: 1,
-      name: "Site"
+      name: "Site",
     });
     defaultError = {
       status: 401,
-      message: "Unauthorized"
+      message: "Unauthorized",
     };
   });
 
@@ -103,7 +103,7 @@ describe("SitesDeleteComponent", () => {
 
     it("should handle project error", () => {
       configureTestingModule(undefined, defaultError, defaultSite, undefined);
-      assertFormErrorHandling(fixture);
+      assertResolverErrorHandling(fixture);
     });
 
     it("should handle site error", () => {
@@ -113,7 +113,7 @@ describe("SitesDeleteComponent", () => {
         undefined,
         defaultError
       );
-      assertFormErrorHandling(fixture);
+      assertResolverErrorHandling(fixture);
     });
 
     it("should call api", () => {

--- a/src/app/component/sites/pages/edit/edit.component.spec.ts
+++ b/src/app/component/sites/pages/edit/edit.component.spec.ts
@@ -11,10 +11,10 @@ import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.servic
 import { projectResolvers } from "src/app/services/baw-api/projects.service";
 import {
   siteResolvers,
-  SitesService
+  SitesService,
 } from "src/app/services/baw-api/sites.service";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
-import { assertFormErrorHandling, testFormlyFields } from "src/testHelpers";
+import { assertResolverErrorHandling, testFormlyFields } from "src/testHelpers";
 import { fields } from "../../site.json";
 import { EditComponent } from "./edit.component";
 
@@ -44,21 +44,21 @@ describe("SitesEditComponent", () => {
           useClass: mockActivatedRoute(
             {
               project: projectResolvers.show,
-              site: siteResolvers.show
+              site: siteResolvers.show,
             },
             {
               project: {
                 model: project,
-                error: projectError
+                error: projectError,
               },
               site: {
                 model: site,
-                error: siteError
-              }
+                error: siteError,
+              },
             }
-          )
-        }
-      ]
+          ),
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(EditComponent);
@@ -77,15 +77,15 @@ describe("SitesEditComponent", () => {
   beforeEach(() => {
     defaultProject = new Project({
       id: 1,
-      name: "Project"
+      name: "Project",
     });
     defaultSite = new Site({
       id: 1,
-      name: "Site"
+      name: "Site",
     });
     defaultError = {
       status: 401,
-      message: "Unauthorized"
+      message: "Unauthorized",
     };
   });
 
@@ -99,7 +99,7 @@ describe("SitesEditComponent", () => {
       required: true,
       label: "Site Name",
       type: "text",
-      description: undefined
+      description: undefined,
     },
     {
       testGroup: "Site Description Input",
@@ -110,7 +110,7 @@ describe("SitesEditComponent", () => {
       required: false,
       label: "Description",
       type: undefined,
-      description: undefined
+      description: undefined,
     },
     {
       testGroup: "Site Latitude Input",
@@ -121,7 +121,7 @@ describe("SitesEditComponent", () => {
       required: false,
       label: "Latitude",
       type: "number",
-      description: undefined
+      description: undefined,
     },
     {
       testGroup: "Site Longitude Input",
@@ -132,7 +132,7 @@ describe("SitesEditComponent", () => {
       required: false,
       label: "Longitude",
       type: "number",
-      description: undefined
+      description: undefined,
     },
     {
       testGroup: "Site Image Input",
@@ -143,8 +143,8 @@ describe("SitesEditComponent", () => {
       required: false,
       label: "Image",
       type: undefined,
-      description: undefined
-    }
+      description: undefined,
+    },
   ];
 
   describe("form", () => {
@@ -162,7 +162,7 @@ describe("SitesEditComponent", () => {
 
     it("should handle project error", () => {
       configureTestingModule(undefined, defaultError, defaultSite, undefined);
-      assertFormErrorHandling(fixture);
+      assertResolverErrorHandling(fixture);
     });
 
     it("should handle site error", () => {
@@ -172,7 +172,7 @@ describe("SitesEditComponent", () => {
         undefined,
         defaultError
       );
-      assertFormErrorHandling(fixture);
+      assertResolverErrorHandling(fixture);
     });
 
     it("should call api", () => {

--- a/src/app/component/sites/pages/new/new.component.spec.ts
+++ b/src/app/component/sites/pages/new/new.component.spec.ts
@@ -11,7 +11,7 @@ import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.servic
 import { projectResolvers } from "src/app/services/baw-api/projects.service";
 import { SitesService } from "src/app/services/baw-api/sites.service";
 import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
-import { assertFormErrorHandling, testFormlyFields } from "src/testHelpers";
+import { assertResolverErrorHandling, testFormlyFields } from "src/testHelpers";
 import { fields } from "../../site.json";
 import { NewComponent } from "./new.component";
 
@@ -37,18 +37,18 @@ describe("SitesNewComponent", () => {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
             {
-              project: projectResolvers.show
+              project: projectResolvers.show,
             },
             {
               project: {
                 model: project,
-                error: projectError
-              }
+                error: projectError,
+              },
             },
             { projectId: project?.id }
-          )
-        }
-      ]
+          ),
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(NewComponent);
@@ -67,11 +67,11 @@ describe("SitesNewComponent", () => {
   beforeEach(() => {
     defaultProject = new Project({
       id: 1,
-      name: "Project"
+      name: "Project",
     });
     defaultError = {
       status: 401,
-      message: "Unauthorized"
+      message: "Unauthorized",
     };
   });
 
@@ -86,7 +86,7 @@ describe("SitesNewComponent", () => {
       required: true,
       label: "Site Name",
       type: "text",
-      description: undefined
+      description: undefined,
     },
     {
       testGroup: "Site Description Input",
@@ -97,7 +97,7 @@ describe("SitesNewComponent", () => {
       required: false,
       label: "Description",
       type: undefined,
-      description: undefined
+      description: undefined,
     },
     {
       testGroup: "Site Latitude Input",
@@ -108,7 +108,7 @@ describe("SitesNewComponent", () => {
       required: false,
       label: "Latitude",
       type: "number",
-      description: undefined
+      description: undefined,
     },
     {
       testGroup: "Site Longitude Input",
@@ -119,7 +119,7 @@ describe("SitesNewComponent", () => {
       required: false,
       label: "Longitude",
       type: "number",
-      description: undefined
+      description: undefined,
     },
     {
       testGroup: "Site Image Input",
@@ -130,8 +130,8 @@ describe("SitesNewComponent", () => {
       required: false,
       label: "Image",
       type: undefined,
-      description: undefined
-    }
+      description: undefined,
+    },
   ];
 
   describe("form", () => {
@@ -149,7 +149,7 @@ describe("SitesNewComponent", () => {
 
     it("should handle project error", fakeAsync(() => {
       configureTestingModule(undefined, defaultError);
-      assertFormErrorHandling(fixture);
+      assertResolverErrorHandling(fixture);
     }));
 
     it("should call api", () => {

--- a/src/app/component/sites/sites.menus.ts
+++ b/src/app/component/sites/sites.menus.ts
@@ -4,21 +4,21 @@ import {
   defaultEditIcon,
   defaultNewIcon,
   isLoggedInPredicate,
-  isProjectOwnerPredicate
+  isProjectOwnerPredicate,
 } from "src/app/app.menus";
 import {
   Category,
   MenuLink,
-  MenuRoute
+  MenuRoute,
 } from "src/app/interfaces/menusInterfaces";
-import { projectCategory, projectMenuItem } from "../projects/projects.menus";
+import { projectMenuItem } from "../projects/projects.menus";
 
 export const sitesRoute = projectMenuItem.route.addFeatureModule("sites");
 
 export const sitesCategory: Category = {
   icon: ["fas", "map-marker-alt"],
   label: "Sites",
-  route: sitesRoute.add(":siteId")
+  route: sitesRoute.add(":siteId"),
 };
 
 export const newSiteMenuItem = MenuRoute({
@@ -27,7 +27,7 @@ export const newSiteMenuItem = MenuRoute({
   parent: projectMenuItem,
   predicate: isProjectOwnerPredicate,
   route: sitesRoute.add("new"),
-  tooltip: () => "Create a new site"
+  tooltip: () => "Create a new site",
 });
 
 export const siteMenuItem = MenuRoute({
@@ -35,7 +35,7 @@ export const siteMenuItem = MenuRoute({
   label: "Site",
   parent: projectMenuItem,
   route: sitesCategory.route,
-  tooltip: () => "The current site"
+  tooltip: () => "The current site",
 });
 
 export const annotationsMenuItem = MenuLink({
@@ -43,7 +43,7 @@ export const annotationsMenuItem = MenuLink({
   label: "Download annotations",
   predicate: isLoggedInPredicate,
   tooltip: () => "Download annotations for this site",
-  uri: () => "REPLACE_ME"
+  uri: () => "REPLACE_ME",
 });
 
 export const editSiteMenuItem = MenuRoute({
@@ -52,7 +52,7 @@ export const editSiteMenuItem = MenuRoute({
   parent: siteMenuItem,
   predicate: isProjectOwnerPredicate,
   route: siteMenuItem.route.add("edit"),
-  tooltip: () => "Change the details for this site"
+  tooltip: () => "Change the details for this site",
 });
 
 export const harvestMenuItem = MenuRoute({
@@ -61,7 +61,7 @@ export const harvestMenuItem = MenuRoute({
   parent: siteMenuItem,
   predicate: isProjectOwnerPredicate,
   route: siteMenuItem.route.add("harvest"),
-  tooltip: () => "Upload new audio to this site"
+  tooltip: () => "Upload new audio to this site",
 });
 
 export const deleteSiteMenuItem = MenuRoute({
@@ -70,5 +70,5 @@ export const deleteSiteMenuItem = MenuRoute({
   parent: siteMenuItem,
   predicate: isProjectOwnerPredicate,
   route: siteMenuItem.route.add("delete"),
-  tooltip: () => "Delete this site"
+  tooltip: () => "Delete this site",
 });

--- a/src/app/models/Site.ts
+++ b/src/app/models/Site.ts
@@ -6,7 +6,7 @@ import {
   Id,
   Ids,
   Param,
-  TimezoneInformation
+  TimezoneInformation,
 } from "../interfaces/apiInterfaces";
 import { AbstractModel } from "./AbstractModel";
 import { Project } from "./Project";
@@ -69,18 +69,22 @@ export class Site extends AbstractModel implements SiteInterface {
 
   toJSON() {
     // TODO Add image, latitude, longitude, timezone
-
     return {
       id: this.id,
       name: this.name,
-      description: this.description
+      description: this.description,
     };
   }
 
-  redirectPath(project: Project): string {
+  redirectPath(project?: Project): string {
+    if (!project?.id && this.projectIds.size === 0) {
+      console.error("Site model has no project id, cannot find url.");
+      return "";
+    }
+
     return siteMenuItem.route.format({
-      projectId: project.id,
-      siteId: this.id
+      projectId: project?.id || this.projectIds[0],
+      siteId: this.id,
     });
   }
 }

--- a/src/testHelpers.ts
+++ b/src/testHelpers.ts
@@ -57,7 +57,7 @@ export function assertRoute(target: HTMLElement, route: string) {
 export function getText(target: DebugElement, selector: string) {
   return target
     .queryAll(By.css(selector))
-    .map(x => x.nativeElement.textContent.trim());
+    .map((x) => x.nativeElement.textContent.trim());
 }
 
 /**
@@ -108,7 +108,7 @@ export function assertValidationMessage(wrapper: any, message: string) {
  * Assert form component handles pre-loading model failure
  * @param fixture Component fixture
  */
-export function assertFormErrorHandling(fixture: ComponentFixture<any>) {
+export function assertResolverErrorHandling(fixture: ComponentFixture<any>) {
   const body = fixture.nativeElement;
   expect(body.childElementCount).toBe(0);
 }
@@ -198,7 +198,7 @@ export function testFormlyFields(
       required,
       label,
       type,
-      description
+      description,
     }) => {
       testFormlyField(
         testGroup,


### PR DESCRIPTION
# Implement User Projects Pages

Implemented the user projects pages. (`their-projects.component.ts` non-functional).

## Issues

Unable to fully implement because of the following issues:

- No route for accessing a users projects
- Project output does not contain permissions data

## Closes

Addresses https://github.com/QutEcoacoustics/workbench-client/issues/135

## Visual Changes

My Projects Page
![image](https://user-images.githubusercontent.com/3955116/79213633-dc041e00-7e8c-11ea-8346-9e27160f159f.png)

Their Projects Page
![image](https://user-images.githubusercontent.com/3955116/79213603-d27ab600-7e8c-11ea-92b7-6457ec7acfb5.png)

