### PR TITLE
User sites pages

### DIFF
--- a/src/app/component/profile/pages/projects/my-projects.component.ts
+++ b/src/app/component/profile/pages/projects/my-projects.component.ts
@@ -65,6 +65,7 @@ export class MyProjectsComponent extends PagedTableTemplate<TableRow, Project> {
 }
 
 interface TableRow {
+  // name: Project
   name: {
     label: string;
     route: string;

--- a/src/app/component/profile/pages/projects/their-projects.component.ts
+++ b/src/app/component/profile/pages/projects/their-projects.component.ts
@@ -69,6 +69,7 @@ export class TheirProjectsComponent extends PagedTableTemplate<
 }
 
 interface TableRow {
+  // name: Project
   name: {
     label: string;
     route: string;

--- a/src/app/component/profile/pages/projects/their-projects.component.ts
+++ b/src/app/component/profile/pages/projects/their-projects.component.ts
@@ -32,7 +32,7 @@ const accountKey = "account";
   self: theirProjectsMenuItem,
 })
 @Component({
-  selector: "app-projects",
+  selector: "app-their-account-projects",
   templateUrl: "./projects.component.html",
   styleUrls: ["./projects.component.scss"],
 })

--- a/src/app/component/profile/pages/sites/my-sites.component.spec.ts
+++ b/src/app/component/profile/pages/sites/my-sites.component.spec.ts
@@ -1,23 +1,123 @@
-import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ActivatedRoute } from "@angular/router";
+import { RouterTestingModule } from "@angular/router/testing";
+import { accountResolvers } from "@baw-api/account.service";
+import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { ShallowSitesService } from "@baw-api/sites.service";
+import { Site, SiteInterface } from "@models/Site";
+import { User } from "@models/User";
+import { SharedModule } from "@shared/shared.module";
+import { BehaviorSubject } from "rxjs";
+import { mockActivatedRoute, testBawServices } from "src/app/test.helper";
+import { assertResolverErrorHandling, assertRoute } from "src/testHelpers";
 import { MySitesComponent } from "./my-sites.component";
 
 describe("MySitesComponent", () => {
+  let api: ShallowSitesService;
   let component: MySitesComponent;
+  let defaultUser: User;
+  let defaultError: ApiErrorDetails;
   let fixture: ComponentFixture<MySitesComponent>;
 
-  beforeEach(async(() => {
+  function configureTestingModule(model?: User, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       declarations: [MySitesComponent],
+      imports: [SharedModule, RouterTestingModule],
+      providers: [
+        ...testBawServices,
+        {
+          provide: ActivatedRoute,
+          useClass: mockActivatedRoute(
+            { account: accountResolvers.show },
+            { account: { model, error } }
+          ),
+        },
+      ],
     }).compileComponents();
-  }));
+
+    fixture = TestBed.createComponent(MySitesComponent);
+    api = TestBed.inject(ShallowSitesService);
+    component = fixture.componentInstance;
+  }
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(MySitesComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    defaultUser = new User({ id: 1, userName: "username" });
+    defaultError = { status: 401, message: "Unauthorized" };
   });
 
   it("should create", () => {
+    configureTestingModule(defaultUser);
+    fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  it("should display username in title", () => {
+    configureTestingModule(
+      new User({ ...defaultUser, userName: "custom username" })
+    );
+    fixture.detectChanges();
+
+    const title = fixture.nativeElement.querySelector("small");
+    expect(title.innerText.trim()).toContain("custom username");
+  });
+
+  it("should handle user error", () => {
+    configureTestingModule(undefined, defaultError);
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+
+    assertResolverErrorHandling(fixture);
+  });
+
+  describe("table", () => {
+    function setSite(data: SiteInterface) {
+      const site = new Site({ id: 1, name: "site", ...data });
+      site.addMetadata({
+        status: 200,
+        message: "OK",
+        paging: {
+          page: 1,
+          items: 25,
+          total: 1,
+          maxPage: 1,
+        },
+      });
+
+      spyOn(api, "filter").and.callFake(() => {
+        return new BehaviorSubject<Site[]>([site]);
+      });
+
+      return site;
+    }
+
+    function getCells(): NodeListOf<HTMLDivElement> {
+      return fixture.nativeElement.querySelectorAll("datatable-body-cell");
+    }
+
+    it("should display site name", () => {
+      configureTestingModule(defaultUser);
+      setSite({ name: "custom site" });
+      fixture.detectChanges();
+
+      expect(getCells()[0].innerText.trim()).toBe("custom site");
+    });
+
+    it("should display site name link", () => {
+      configureTestingModule(defaultUser);
+      const site = setSite({ projectIds: new Set([1]) });
+      fixture.detectChanges();
+
+      const link = getCells()[0].querySelector("a");
+      assertRoute(link, site.redirectPath());
+    });
+
+    // TODO Implement
+    xit("should display no recent audio upload", () => {});
+    xit("should display recent audio upload", () => {});
+    xit("should display reader permissions", () => {});
+    xit("should display writer permissions", () => {});
+    xit("should display owner permissions", () => {});
+    xit("should display owner permissions link", () => {});
+    xit("should display annotation link", () => {});
   });
 });

--- a/src/app/component/profile/pages/sites/my-sites.component.spec.ts
+++ b/src/app/component/profile/pages/sites/my-sites.component.spec.ts
@@ -1,0 +1,23 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { MySitesComponent } from "./my-sites.component";
+
+describe("MySitesComponent", () => {
+  let component: MySitesComponent;
+  let fixture: ComponentFixture<MySitesComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [MySitesComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MySitesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/component/profile/pages/sites/my-sites.component.ts
+++ b/src/app/component/profile/pages/sites/my-sites.component.ts
@@ -1,0 +1,71 @@
+import { Component } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
+import { ShallowSitesService } from "@baw-api/sites.service";
+import { userResolvers } from "@baw-api/user.service";
+import {
+  myAccountCategory,
+  myAccountMenuItem,
+  mySitesMenuItem,
+} from "@component/profile/profile.menus";
+import { annotationsMenuItem } from "@component/sites/sites.menus";
+import { Page } from "@helpers/page/pageDecorator";
+import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
+import { AnyMenuItem } from "@interfaces/menusInterfaces";
+import { Site } from "@models/Site";
+import { User } from "@models/User";
+import { List } from "immutable";
+import { myAccountMenuItemActions } from "../profile/my-profile.component";
+
+const accountKey = "account";
+
+@Page({
+  category: myAccountCategory,
+  menus: {
+    actions: List<AnyMenuItem>([
+      myAccountMenuItem,
+      ...myAccountMenuItemActions,
+    ]),
+    links: List(),
+  },
+  resolvers: {
+    [accountKey]: userResolvers.show,
+  },
+  self: mySitesMenuItem,
+})
+@Component({
+  selector: "app-my-account-sites",
+  templateUrl: "./sites.component.html",
+  styleUrls: ["./sites.component.scss"],
+})
+export class MySitesComponent extends PagedTableTemplate<TableRow, Site> {
+  constructor(api: ShallowSitesService, route: ActivatedRoute) {
+    super(
+      api,
+      (sites) =>
+        sites.map((site) => ({
+          site: {
+            label: site.name,
+            route: site.redirectPath(site.projectIds[0] || 0),
+          },
+          recentAudioUpload: "(none)",
+          permission: "UNKNOWN",
+          annotation: annotationsMenuItem.uri(undefined),
+        })),
+      route
+    );
+  }
+
+  public get account(): User {
+    return this.models[accountKey] as User;
+  }
+}
+
+interface TableRow {
+  site: {
+    label: string;
+    route: string;
+  };
+  recentAudioUpload: string;
+  permission: string;
+  annotation: string;
+}

--- a/src/app/component/profile/pages/sites/my-sites.component.ts
+++ b/src/app/component/profile/pages/sites/my-sites.component.ts
@@ -40,6 +40,8 @@ const accountKey = "account";
 export class MySitesComponent extends PagedTableTemplate<TableRow, Site> {
   constructor(api: ShallowSitesService, route: ActivatedRoute) {
     // TODO Add missing details
+    // https://github.com/QutEcoacoustics/baw-server/issues/438
+    // https://github.com/QutEcoacoustics/baw-server/issues/406
     super(
       api,
       (sites) =>

--- a/src/app/component/profile/pages/sites/my-sites.component.ts
+++ b/src/app/component/profile/pages/sites/my-sites.component.ts
@@ -62,6 +62,7 @@ export class MySitesComponent extends PagedTableTemplate<TableRow, Site> {
 }
 
 interface TableRow {
+  // name: Site
   site: {
     label: string;
     route: string;

--- a/src/app/component/profile/pages/sites/sites.component.html
+++ b/src/app/component/profile/pages/sites/sites.component.html
@@ -26,7 +26,13 @@
     </ngx-datatable-column>
     <ngx-datatable-column name="Recent Audio Upload"> </ngx-datatable-column>
     <ngx-datatable-column name="Permission"> </ngx-datatable-column>
-    <ngx-datatable-column name="Annotation"> </ngx-datatable-column>
+    <ngx-datatable-column name="Annotation" width="115" maxWidth="115">
+      <ng-template let-value="value" ngx-datatable-cell-template>
+        <a class="btn btn-sm btn-default" [routerLink]="[value]">
+          Annotation
+        </a>
+      </ng-template>
+    </ngx-datatable-column>
   </ngx-datatable>
 </div>
 

--- a/src/app/component/profile/pages/sites/sites.component.html
+++ b/src/app/component/profile/pages/sites/sites.component.html
@@ -1,0 +1,33 @@
+<div *ngIf="rows && !error && !failure">
+  <h1>
+    Sites
+    <small class="text-muted">accessible by {{ account.userName }}</small>
+  </h1>
+
+  <p>
+    Displaying <strong>all {{ totalModels }}</strong> sites.
+  </p>
+
+  <ngx-datatable
+    #table
+    bawDatatableDefaults
+    [columnMode]="ColumnMode.force"
+    [columns]="columns"
+    [rows]="rows"
+    [count]="totalModels"
+    [offset]="pageNumber"
+    (page)="setPage($event)"
+    (sort)="onSort($event)"
+  >
+    <ngx-datatable-column name="Site">
+      <ng-template let-value="value" ngx-datatable-cell-template>
+        <a [routerLink]="[value.route]">{{ value.label }}</a>
+      </ng-template>
+    </ngx-datatable-column>
+    <ngx-datatable-column name="Recent Audio Upload"> </ngx-datatable-column>
+    <ngx-datatable-column name="Permission"> </ngx-datatable-column>
+    <ngx-datatable-column name="Annotation"> </ngx-datatable-column>
+  </ngx-datatable>
+</div>
+
+<app-error-handler *ngIf="!failure" [error]="error"></app-error-handler>

--- a/src/app/component/profile/pages/sites/their-sites.component.spec.ts
+++ b/src/app/component/profile/pages/sites/their-sites.component.spec.ts
@@ -1,0 +1,23 @@
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { TheirSitesComponent } from "./their-sites.component";
+
+xdescribe("TheirSitesComponent", () => {
+  let component: TheirSitesComponent;
+  let fixture: ComponentFixture<TheirSitesComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [TheirSitesComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TheirSitesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/component/profile/pages/sites/their-sites.component.ts
+++ b/src/app/component/profile/pages/sites/their-sites.component.ts
@@ -1,11 +1,11 @@
 import { Component } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
+import { accountResolvers } from "@baw-api/account.service";
 import { ShallowSitesService } from "@baw-api/sites.service";
-import { userResolvers } from "@baw-api/user.service";
 import {
-  myAccountCategory,
-  myAccountMenuItem,
-  mySitesMenuItem,
+  theirProfileCategory,
+  theirProfileMenuItem,
+  theirSitesMenuItem,
 } from "@component/profile/profile.menus";
 import { annotationsMenuItem } from "@component/sites/sites.menus";
 import { Page } from "@helpers/page/pageDecorator";
@@ -14,30 +14,30 @@ import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { Site } from "@models/Site";
 import { User } from "@models/User";
 import { List } from "immutable";
-import { myAccountMenuItemActions } from "../profile/my-profile.component";
+import { theirProfileMenuItemActions } from "../profile/their-profile.component";
 
 const accountKey = "account";
 
 @Page({
-  category: myAccountCategory,
+  category: theirProfileCategory,
   menus: {
     actions: List<AnyMenuItem>([
-      myAccountMenuItem,
-      ...myAccountMenuItemActions,
+      theirProfileMenuItem,
+      ...theirProfileMenuItemActions,
     ]),
     links: List(),
   },
   resolvers: {
-    [accountKey]: userResolvers.show,
+    [accountKey]: accountResolvers.show,
   },
-  self: mySitesMenuItem,
+  self: theirSitesMenuItem,
 })
 @Component({
-  selector: "app-my-account-sites",
+  selector: "app-their-account-sites",
   templateUrl: "./sites.component.html",
   styleUrls: ["./sites.component.scss"],
 })
-export class MySitesComponent extends PagedTableTemplate<TableRow, Site> {
+export class TheirSitesComponent extends PagedTableTemplate<TableRow, Site> {
   constructor(api: ShallowSitesService, route: ActivatedRoute) {
     // TODO Add missing details
     super(
@@ -49,7 +49,7 @@ export class MySitesComponent extends PagedTableTemplate<TableRow, Site> {
             route: site.redirectPath(),
           },
           recentAudioUpload: "(none)",
-          permission: "UNKNOWN",
+          permission: "FIX ME",
           annotation: annotationsMenuItem.uri(undefined),
         })),
       route

--- a/src/app/component/profile/pages/sites/their-sites.component.ts
+++ b/src/app/component/profile/pages/sites/their-sites.component.ts
@@ -62,6 +62,7 @@ export class TheirSitesComponent extends PagedTableTemplate<TableRow, Site> {
 }
 
 interface TableRow {
+  // name: Site
   site: {
     label: string;
     route: string;

--- a/src/app/component/profile/pages/sites/their-sites.component.ts
+++ b/src/app/component/profile/pages/sites/their-sites.component.ts
@@ -39,7 +39,7 @@ const accountKey = "account";
 })
 export class TheirSitesComponent extends PagedTableTemplate<TableRow, Site> {
   constructor(api: ShallowSitesService, route: ActivatedRoute) {
-    // TODO Add missing details
+    // TODO Add missing details https://github.com/QutEcoacoustics/baw-server/issues/406
     super(
       api,
       (sites) =>

--- a/src/app/component/profile/profile.menus.ts
+++ b/src/app/component/profile/profile.menus.ts
@@ -45,12 +45,13 @@ export const myProjectsMenuItem = MenuRoute({
   tooltip: (user) => `Projects ${user.userName} can access`,
 });
 
-export const mySitesMenuItem = MenuLink({
+export const mySitesMenuItem = MenuRoute({
   icon: ["fas", "map-marker-alt"],
   label: "My Sites",
-  predicate: (user) => !!user,
+  parent: myAccountMenuItem,
+  predicate: isLoggedInPredicate,
+  route: myAccountMenuItem.route.add("sites"),
   tooltip: (user) => `Sites ${user.userName} can access`,
-  uri: () => "BROKEN LINK",
 });
 
 export const myBookmarksMenuItem = MenuLink({

--- a/src/app/component/profile/profile.menus.ts
+++ b/src/app/component/profile/profile.menus.ts
@@ -111,12 +111,13 @@ export const theirProjectsMenuItem = MenuRoute({
   tooltip: () => "Projects they can access",
 });
 
-export const theirSitesMenuItem = MenuLink({
+export const theirSitesMenuItem = MenuRoute({
   icon: ["fas", "map-marker-alt"],
   label: "Their Sites",
-  predicate: (user) => !!user,
+  parent: theirProfileMenuItem,
+  predicate: isAdminPredicate,
+  route: theirProfileMenuItem.route.add("sites"),
   tooltip: () => "Sites they can access",
-  uri: () => "BROKEN LINK",
 });
 
 export const theirBookmarksMenuItem = MenuLink({

--- a/src/app/component/profile/profile.module.ts
+++ b/src/app/component/profile/profile.module.ts
@@ -8,6 +8,7 @@ import { TheirProfileComponent } from "./pages/profile/their-profile.component";
 import { MyProjectsComponent } from "./pages/projects/my-projects.component";
 import { TheirProjectsComponent } from "./pages/projects/their-projects.component";
 import { MySitesComponent } from "./pages/sites/my-sites.component";
+import { TheirSitesComponent } from "./pages/sites/their-sites.component";
 import { TheirEditComponent } from "./pages/their-edit/their-edit.component";
 import { myAccountRoute, theirProfileRoute } from "./profile.menus";
 
@@ -21,6 +22,7 @@ const TheirProfileComponents = [
   TheirProfileComponent,
   TheirEditComponent,
   TheirProjectsComponent,
+  TheirSitesComponent,
 ];
 
 const myAccountRoutes = myAccountRoute.compileRoutes(GetRouteConfigForPage);

--- a/src/app/component/profile/profile.module.ts
+++ b/src/app/component/profile/profile.module.ts
@@ -7,6 +7,7 @@ import { MyProfileComponent } from "./pages/profile/my-profile.component";
 import { TheirProfileComponent } from "./pages/profile/their-profile.component";
 import { MyProjectsComponent } from "./pages/projects/my-projects.component";
 import { TheirProjectsComponent } from "./pages/projects/their-projects.component";
+import { MySitesComponent } from "./pages/sites/my-sites.component";
 import { TheirEditComponent } from "./pages/their-edit/their-edit.component";
 import { myAccountRoute, theirProfileRoute } from "./profile.menus";
 
@@ -14,6 +15,7 @@ const MyAccountComponents = [
   MyProfileComponent,
   MyEditComponent,
   MyProjectsComponent,
+  MySitesComponent,
 ];
 const TheirProfileComponents = [
   TheirProfileComponent,

--- a/src/app/models/Site.ts
+++ b/src/app/models/Site.ts
@@ -6,7 +6,7 @@ import {
   Id,
   Ids,
   Param,
-  TimezoneInformation
+  TimezoneInformation,
 } from "../interfaces/apiInterfaces";
 import { AbstractModel } from "./AbstractModel";
 import { Project } from "./Project";
@@ -69,18 +69,17 @@ export class Site extends AbstractModel implements SiteInterface {
 
   toJSON() {
     // TODO Add image, latitude, longitude, timezone
-
     return {
       id: this.id,
       name: this.name,
-      description: this.description
+      description: this.description,
     };
   }
 
-  redirectPath(project: Project): string {
+  redirectPath(project?: Project): string {
     return siteMenuItem.route.format({
-      projectId: project.id,
-      siteId: this.id
+      projectId: project?.id || this.projectIds[0] || -1,
+      siteId: this.id,
     });
   }
 }

--- a/src/app/models/Site.ts
+++ b/src/app/models/Site.ts
@@ -77,8 +77,13 @@ export class Site extends AbstractModel implements SiteInterface {
   }
 
   redirectPath(project?: Project): string {
+    if (!project?.id && this.projectIds.size === 0) {
+      console.error("Site model has no project id, cannot find url.");
+      return "";
+    }
+
     return siteMenuItem.route.format({
-      projectId: project?.id || this.projectIds[0] || -1,
+      projectId: project?.id || this.projectIds[0],
       siteId: this.id,
     });
   }


### PR DESCRIPTION
# User Sites Pages

Created user sites pages. (`their-sites.component.ts` non-functional)

## Issues
Unable to fully implement because of the following issues:

- No route for accessing a users sites
- ShallowSites routes don't exist
- Annotations page does not properly exist
- Sites output does not contain permissions and recent audio uploads

## Closes

Addresses #136 

## Visual Changes

My Sites Page

![image](https://user-images.githubusercontent.com/3955116/79216304-4bc7d800-7e90-11ea-8384-08aabdd0ab5b.png)

Their Sites Page

![image](https://user-images.githubusercontent.com/3955116/79216284-44083380-7e90-11ea-9aa6-a6e757208915.png)
