### PR TITLE
Github Actions: Differ file type pattern

### DIFF
--- a/.github/workflows/differ.yml
+++ b/.github/workflows/differ.yml
@@ -12,3 +12,4 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           strip-hash: "\\.(\\w{20})\\."
+          pattern: "dist/**/*.{css,js,json,html}"


### PR DESCRIPTION
# Differ file type pattern

Added file type pattern regex to differ workflow so that non-`.js` files can be tracked. Currently this expands the tracking to the following file types:

- `.css`
- `.js`
- `.json`
- `.html`

