### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
-      day: friday
+      interval: daily
       time: "00:00"
       timezone: "Australia/Brisbane"
     allow:


### PR DESCRIPTION
Updated dependabot config so that updates will run daily. This should be safe now that the auto-merger workflow is working properly.