### PR TITLE
E2E chrome CI failure

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -39,6 +39,11 @@ jobs:
           brew cask reinstall google-chrome
         if: matrix.os == 'macos-latest'
 
+      - name: Windows Chrome install
+        run: |
+          choco install googlechrome
+        if: matrix.os == 'windows-latest'
+
       - name: NPM install
         run: npm install
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -47,16 +47,6 @@ jobs:
       - name: NPM install
         run: npm install
 
-      - name: Run test suite on chrome
-        run: npm run test:pipeline -- --browsers ChromeHeadless
-
-      - name: Run test suite on firefox
-        run: npm run test:pipeline -- --browsers FirefoxHeadless
-
-      - name: Run test suite on edge
-        run: npm run test:pipeline -- --browsers EdgeHeadless
-        if: matrix.os == 'windows-latest'
-
       - name: Run e2e test suite
         run: npm run e2e
 


### PR DESCRIPTION
CI broke for e2e tests because Chrome is outdated on Mac and Windows VMs