### PR TITLE
Mock services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6620,7 +6620,10 @@
     "full-icu": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
-      "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw=="
+      "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
+      "requires": {
+        "icu4c-data": "^0.64.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -7242,6 +7245,11 @@
       "requires": {
         "postcss": "^7.0.14"
       }
+    },
+    "icu4c-data": {
+      "version": "0.64.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ=="
     },
     "ieee754": {
       "version": "1.1.13",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -6,13 +6,12 @@ import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { SpyObject } from "@ngneat/spectator";
 import { LoadingBarHttpClientModule } from "@ngx-loading-bar/http-client";
-import { BehaviorSubject } from "rxjs";
 import { AppComponent } from "./app.component";
 import { appLibraryImports } from "./app.module";
 import { SharedModule } from "./component/shared/shared.module";
 import { AppConfigService } from "./services/app-config/app-config.service";
-import { SecurityService } from "./services/baw-api/security/security.service";
 import { UserService } from "./services/baw-api/user/user.service";
 
 describe("AppComponent", () => {
@@ -42,14 +41,9 @@ describe("AppComponent", () => {
     router = TestBed.inject(Router);
     env = TestBed.inject(AppConfigService);
     httpMock = TestBed.inject(HttpTestingController);
-    const securityApi = TestBed.inject(SecurityService);
-    const userApi = TestBed.inject(UserService);
+    const userApi = TestBed.inject(UserService) as SpyObject<UserService>;
 
-    spyOn(userApi, "getLocalUser").and.callFake(() => null);
-    spyOn(securityApi, "isLoggedIn").and.callFake(() => false);
-    spyOn(securityApi, "getAuthTrigger").and.callFake(
-      () => new BehaviorSubject(null)
-    );
+    userApi.getLocalUser.and.callFake(() => null);
   });
 
   afterEach(() => {

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -5,6 +5,7 @@ import {
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { LoadingBarHttpClientModule } from "@ngx-loading-bar/http-client";
 import { BehaviorSubject } from "rxjs";
 import { AppComponent } from "./app.component";
@@ -13,7 +14,6 @@ import { SharedModule } from "./component/shared/shared.module";
 import { AppConfigService } from "./services/app-config/app-config.service";
 import { SecurityService } from "./services/baw-api/security/security.service";
 import { UserService } from "./services/baw-api/user/user.service";
-import { testBawServices } from "./test/helpers/testbed";
 
 describe("AppComponent", () => {
   let component: AppComponent;
@@ -30,9 +30,9 @@ describe("AppComponent", () => {
         RouterTestingModule,
         HttpClientTestingModule,
         LoadingBarHttpClientModule,
+        MockBawApiModule,
       ],
       declarations: [AppComponent],
-      providers: [...testBawServices],
     }).compileComponents();
   }));
 

--- a/src/app/app.helper.ts
+++ b/src/app/app.helper.ts
@@ -1,59 +1,12 @@
-import { HTTP_INTERCEPTORS } from "@angular/common/http";
-import { APP_INITIALIZER } from "@angular/core";
-import { serviceProviders } from "@baw-api/ServiceProviders";
 import { FaIconLibrary } from "@fortawesome/angular-fontawesome";
 import { fas } from "@fortawesome/free-solid-svg-icons";
-import { ConfigOption, FormlyFieldConfig } from "@ngx-formly/core";
+import { ConfigOption } from "@ngx-formly/core";
 import {
   formlyInputTypes,
+  formlyValidationMessages,
   formlyWrappers,
 } from "@shared/formly/custom-inputs.module";
 import { GlobalConfig } from "ngx-toastr";
-import { FormTouchedGuard } from "./guards/form/form.guard";
-import {
-  API_CONFIG,
-  API_ROOT,
-  AppInitializer,
-  ASSET_ROOT,
-  CMS_ROOT,
-} from "./helpers/app-initializer/app-initializer";
-import { BawApiInterceptor } from "./services/baw-api/api.interceptor.service";
-
-/**
- * Input min length validation message
- * @param err Error message
- * @param field Formly field
- */
-export function minLengthValidationMessage(_, field: FormlyFieldConfig) {
-  return `Input should have at least ${field.templateOptions.minLength} characters`;
-}
-
-/**
- * Input max length validation message
- * @param err Error message
- * @param field Formly field
- */
-export function maxLengthValidationMessage(_, field: FormlyFieldConfig) {
-  return `This value should be less than ${field.templateOptions.maxLength} characters`;
-}
-
-/**
- * Number input min value validation message
- * @param err Error message
- * @param field Formly field
- */
-export function minValidationMessage(_, field: FormlyFieldConfig) {
-  return `This value should be more than ${field.templateOptions.min}`;
-}
-
-/**
- * Number input max value validation message
- * @param err Error message
- * @param field Formly field
- */
-export function maxValidationMessage(_, field: FormlyFieldConfig) {
-  return `This value should be less than ${field.templateOptions.max}`;
-}
 
 /**
  * Toastr Service global defaults
@@ -70,13 +23,7 @@ export const toastrRoot: Partial<GlobalConfig> = {
 export const formlyRoot: ConfigOption = {
   types: formlyInputTypes,
   wrappers: formlyWrappers,
-  validationMessages: [
-    { name: "required", message: "This field is required" },
-    { name: "minlength", message: minLengthValidationMessage },
-    { name: "maxlength", message: maxLengthValidationMessage },
-    { name: "min", message: minValidationMessage },
-    { name: "max", message: maxValidationMessage },
-  ],
+  validationMessages: formlyValidationMessages,
 };
 
 /**
@@ -86,34 +33,3 @@ export const formlyRoot: ConfigOption = {
 export function fontAwesomeLibraries(library: FaIconLibrary) {
   library.addIconPacks(fas);
 }
-
-/**
- * App providers
- */
-export const providers = [
-  {
-    provide: HTTP_INTERCEPTORS,
-    useClass: BawApiInterceptor,
-    multi: true,
-  },
-  {
-    provide: APP_INITIALIZER,
-    useFactory: AppInitializer.initializerFactory,
-    multi: true,
-    deps: [API_CONFIG],
-  },
-  {
-    provide: API_ROOT,
-    useFactory: AppInitializer.apiRootFactory,
-  },
-  {
-    provide: CMS_ROOT,
-    useFactory: AppInitializer.cmsRootFactory,
-  },
-  {
-    provide: ASSET_ROOT,
-    useFactory: AppInitializer.assetRootFactory,
-  },
-  FormTouchedGuard,
-  ...serviceProviders,
-];

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,13 +3,16 @@ import { NgModule } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
 import { BrowserModule } from "@angular/platform-browser";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { BawApiModule } from "@baw-api/baw-api.module";
+import { GuardModule } from "@guards/guards.module";
 import { NgbModule } from "@ng-bootstrap/ng-bootstrap";
 import { FormlyBootstrapModule } from "@ngx-formly/bootstrap";
 import { FormlyModule } from "@ngx-formly/core";
+import { AppConfigModule } from "@services/app-config/app-config.module";
 import { ToastrModule } from "ngx-toastr";
 import { AppRoutingModule } from "./app-routing.module";
 import { AppComponent } from "./app.component";
-import { formlyRoot, providers, toastrRoot } from "./app.helper";
+import { formlyRoot, toastrRoot } from "./app.helper";
 import { AboutModule } from "./component/about/about.module";
 import { AdminModule } from "./component/admin/admin.module";
 import { DataRequestModule } from "./component/data-request/data-request.module";
@@ -61,10 +64,12 @@ export const appImports = [
   imports: [
     AppRoutingModule,
     HttpClientModule,
+    AppConfigModule,
+    BawApiModule,
+    GuardModule,
     ...appLibraryImports,
     ...appImports,
   ],
-  providers: [...providers],
   bootstrap: [AppComponent],
   entryComponents: [PermissionsShieldComponent],
   exports: [],

--- a/src/app/component/about/pages/contact-us/contact-us.component.spec.ts
+++ b/src/app/component/about/pages/contact-us/contact-us.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { SharedModule } from "@shared/shared.module";
 import { appLibraryImports } from "src/app/app.module";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import { ContactUsComponent } from "./contact-us.component";
 
 describe("ContactUsComponent", () => {
@@ -10,9 +10,8 @@ describe("ContactUsComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule],
+      imports: [...appLibraryImports, SharedModule, MockAppConfigModule],
       declarations: [ContactUsComponent],
-      providers: [...testAppInitializer],
     }).compileComponents();
   }));
 

--- a/src/app/component/about/pages/credits/credits.component.spec.ts
+++ b/src/app/component/about/pages/credits/credits.component.spec.ts
@@ -5,8 +5,8 @@ import {
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AppConfigService } from "@services/app-config/app-config.service";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { SharedModule } from "@shared/shared.module";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import { CreditsComponent } from "./credits.component";
 
 describe("AboutCreditsComponent", () => {
@@ -17,9 +17,13 @@ describe("AboutCreditsComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [SharedModule, HttpClientTestingModule, RouterTestingModule],
+      imports: [
+        SharedModule,
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
+      ],
       declarations: [CreditsComponent],
-      providers: [...testAppInitializer],
     }).compileComponents();
   }));
 

--- a/src/app/component/about/pages/disclaimers/disclaimers.component.spec.ts
+++ b/src/app/component/about/pages/disclaimers/disclaimers.component.spec.ts
@@ -5,8 +5,8 @@ import {
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AppConfigService } from "@services/app-config/app-config.service";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { SharedModule } from "@shared/shared.module";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import { DisclaimersComponent } from "./disclaimers.component";
 
 describe("AboutDisclaimersComponent", () => {
@@ -17,9 +17,13 @@ describe("AboutDisclaimersComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [SharedModule, HttpClientTestingModule, RouterTestingModule],
+      imports: [
+        SharedModule,
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
+      ],
       declarations: [DisclaimersComponent],
-      providers: [...testAppInitializer],
     }).compileComponents();
   }));
 

--- a/src/app/component/about/pages/ethics/ethics.component.spec.ts
+++ b/src/app/component/about/pages/ethics/ethics.component.spec.ts
@@ -5,8 +5,8 @@ import {
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AppConfigService } from "@services/app-config/app-config.service";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { SharedModule } from "@shared/shared.module";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import { EthicsComponent } from "./ethics.component";
 
 describe("AboutEthicsComponent", () => {
@@ -17,9 +17,13 @@ describe("AboutEthicsComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [SharedModule, HttpClientTestingModule, RouterTestingModule],
+      imports: [
+        SharedModule,
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
+      ],
       declarations: [EthicsComponent],
-      providers: [...testAppInitializer],
     }).compileComponents();
   }));
 

--- a/src/app/component/admin/audio-recordings/details/details.component.spec.ts
+++ b/src/app/component/admin/audio-recordings/details/details.component.spec.ts
@@ -13,6 +13,7 @@ import { Site } from "@models/Site";
 import { User } from "@models/User";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateAudioRecording } from "@test/fakes/AudioRecording";
 import { assertDetail, Detail } from "@test/helpers/detail-view";
 import { nStepObservable } from "@test/helpers/general";
@@ -91,10 +92,7 @@ describe("AdminAudioRecordingComponent", () => {
   });
 
   it("should handle error", () => {
-    configureTestingModule(undefined, {
-      status: 401,
-      message: "Unauthorized",
-    } as ApiErrorDetails);
+    configureTestingModule(undefined, generateApiErrorDetails());
     fixture.detectChanges();
     expect(component).toBeTruthy();
   });

--- a/src/app/component/admin/audio-recordings/details/details.component.spec.ts
+++ b/src/app/component/admin/audio-recordings/details/details.component.spec.ts
@@ -2,13 +2,16 @@ import { Injector } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { AccountsService } from "@baw-api/account/accounts.service";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { audioRecordingResolvers } from "@baw-api/audio-recording/audio-recordings.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ACCOUNT, SHALLOW_SITE } from "@baw-api/ServiceTokens";
+import { ShallowSitesService } from "@baw-api/site/sites.service";
 import { AudioRecording } from "@models/AudioRecording";
 import { Site } from "@models/Site";
 import { User } from "@models/User";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { generateAudioRecording } from "@test/fakes/AudioRecording";
 import { assertDetail, Detail } from "@test/helpers/detail-view";
@@ -48,8 +51,12 @@ describe("AdminAudioRecordingComponent", () => {
 
     fixture = TestBed.createComponent(AdminAudioRecordingComponent);
     injector = TestBed.inject(Injector);
-    const accountsApi = TestBed.inject(ACCOUNT.token);
-    const sitesApi = TestBed.inject(SHALLOW_SITE.token);
+    const accountsApi = TestBed.inject(ACCOUNT.token) as SpyObject<
+      AccountsService
+    >;
+    const sitesApi = TestBed.inject(SHALLOW_SITE.token) as SpyObject<
+      ShallowSitesService
+    >;
     component = fixture.componentInstance;
 
     const accountsSubject = new Subject<User>();
@@ -66,8 +73,8 @@ describe("AdminAudioRecordingComponent", () => {
     ]);
 
     // Catch associated models
-    spyOn(accountsApi, "show").and.callFake(() => accountsSubject);
-    spyOn(sitesApi, "show").and.callFake(() => siteSubject);
+    accountsApi.show.and.callFake(() => accountsSubject);
+    sitesApi.show.and.callFake(() => siteSubject);
 
     // Update model to contain injector
     if (model) {

--- a/src/app/component/admin/audio-recordings/details/details.component.spec.ts
+++ b/src/app/component/admin/audio-recordings/details/details.component.spec.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { audioRecordingResolvers } from "@baw-api/audio-recording/audio-recordings.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ACCOUNT, SHALLOW_SITE } from "@baw-api/ServiceTokens";
 import { AudioRecording } from "@models/AudioRecording";
 import { Site } from "@models/Site";
@@ -12,7 +13,7 @@ import { SharedModule } from "@shared/shared.module";
 import { generateAudioRecording } from "@test/fakes/AudioRecording";
 import { assertDetail, Detail } from "@test/helpers/detail-view";
 import { nStepObservable } from "@test/helpers/general";
-import { mockActivatedRoute, testBawServices } from "@test/helpers/testbed";
+import { mockActivatedRoute } from "@test/helpers/testbed";
 import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminAudioRecordingComponent } from "./details.component";
@@ -27,10 +28,14 @@ describe("AdminAudioRecordingComponent", () => {
     error?: ApiErrorDetails
   ) {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [AdminAudioRecordingComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(

--- a/src/app/component/admin/audio-recordings/list/list.component.spec.ts
+++ b/src/app/component/admin/audio-recordings/list/list.component.spec.ts
@@ -1,10 +1,11 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AudioRecordingsService } from "@baw-api/audio-recording/audio-recordings.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { AudioRecording } from "@models/AudioRecording";
 import { SharedModule } from "@shared/shared.module";
+import { generateAudioRecording } from "@test/fakes/AudioRecording";
 import { assertPagination } from "@test/helpers/pagedTableTemplate";
-import { testBawServices } from "@test/helpers/testbed";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminAudioRecordingsComponent } from "./list.component";
 
@@ -16,9 +17,13 @@ describe("AdminAudioRecordingsComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [AdminAudioRecordingsComponent],
-      providers: [...testBawServices],
     }).compileComponents();
   }));
 
@@ -26,22 +31,10 @@ describe("AdminAudioRecordingsComponent", () => {
     fixture = TestBed.createComponent(AdminAudioRecordingsComponent);
     api = TestBed.inject(AudioRecordingsService);
 
-    defaultModel = new AudioRecording({
-      id: 1,
-      siteId: 1,
-      durationSeconds: 3000,
-      recordedDate: "2020-03-09T22:00:50.072+10:00",
-    });
+    defaultModel = new AudioRecording(generateAudioRecording());
     defaultModels = [];
     for (let i = 0; i < 25; i++) {
-      defaultModels.push(
-        new AudioRecording({
-          id: i,
-          siteId: 1,
-          durationSeconds: 3000,
-          recordedDate: "2020-03-09T22:00:50.072+10:00",
-        })
-      );
+      defaultModels.push(new AudioRecording(generateAudioRecording()));
     }
 
     this.defaultModels = defaultModels;

--- a/src/app/component/admin/orphan/details/details.component.spec.ts
+++ b/src/app/component/admin/orphan/details/details.component.spec.ts
@@ -14,6 +14,7 @@ import { Site } from "@models/Site";
 import { User } from "@models/User";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateSite } from "@test/fakes/Site";
 import { assertDetail, Detail } from "@test/helpers/detail-view";
 import { nStepObservable } from "@test/helpers/general";
@@ -90,10 +91,7 @@ describe("AdminOrphanComponent", () => {
   });
 
   it("should handle error", () => {
-    configureTestingModule(undefined, {
-      status: 401,
-      message: "Unauthorized",
-    } as ApiErrorDetails);
+    configureTestingModule(undefined, generateApiErrorDetails());
     fixture.detectChanges();
     expect(component).toBeTruthy();
   });

--- a/src/app/component/admin/orphan/details/details.component.spec.ts
+++ b/src/app/component/admin/orphan/details/details.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ACCOUNT, PROJECT } from "@baw-api/ServiceTokens";
 import { shallowSiteResolvers } from "@baw-api/site/sites.service";
 import { AdminAudioRecordingComponent } from "@component/admin/audio-recordings/details/details.component";
@@ -13,7 +14,7 @@ import { SharedModule } from "@shared/shared.module";
 import { generateSite } from "@test/fakes/Site";
 import { assertDetail, Detail } from "@test/helpers/detail-view";
 import { nStepObservable } from "@test/helpers/general";
-import { mockActivatedRoute, testBawServices } from "@test/helpers/testbed";
+import { mockActivatedRoute } from "@test/helpers/testbed";
 import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminOrphanComponent } from "./details.component";
@@ -25,10 +26,14 @@ describe("AdminOrphanComponent", () => {
 
   function configureTestingModule(model: Site, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [AdminAudioRecordingComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(

--- a/src/app/component/admin/orphan/details/details.component.spec.ts
+++ b/src/app/component/admin/orphan/details/details.component.spec.ts
@@ -2,14 +2,17 @@ import { Injector } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { AccountsService } from "@baw-api/account/accounts.service";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { ProjectsService } from "@baw-api/project/projects.service";
 import { ACCOUNT, PROJECT } from "@baw-api/ServiceTokens";
 import { shallowSiteResolvers } from "@baw-api/site/sites.service";
 import { AdminAudioRecordingComponent } from "@component/admin/audio-recordings/details/details.component";
 import { Project } from "@models/Project";
 import { Site } from "@models/Site";
 import { User } from "@models/User";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { generateSite } from "@test/fakes/Site";
 import { assertDetail, Detail } from "@test/helpers/detail-view";
@@ -46,8 +49,12 @@ describe("AdminOrphanComponent", () => {
 
     fixture = TestBed.createComponent(AdminOrphanComponent);
     injector = TestBed.inject(Injector);
-    const accountsApi = TestBed.inject(ACCOUNT.token);
-    const projectsApi = TestBed.inject(PROJECT.token);
+    const accountsApi = TestBed.inject(ACCOUNT.token) as SpyObject<
+      AccountsService
+    >;
+    const projectsApi = TestBed.inject(PROJECT.token) as SpyObject<
+      ProjectsService
+    >;
     component = fixture.componentInstance;
 
     const accountsSubject = new Subject<User>();
@@ -65,8 +72,8 @@ describe("AdminOrphanComponent", () => {
     ]);
 
     // Catch associated models
-    spyOn(accountsApi, "show").and.callFake(() => accountsSubject);
-    spyOn(projectsApi, "filter").and.callFake(() => projectsSubject);
+    accountsApi.show.and.callFake(() => accountsSubject);
+    projectsApi.filter.and.callFake(() => projectsSubject);
 
     // Update model to contain injector
     if (model) {

--- a/src/app/component/admin/orphan/list/list.component.spec.ts
+++ b/src/app/component/admin/orphan/list/list.component.spec.ts
@@ -1,10 +1,11 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ShallowSitesService } from "@baw-api/site/sites.service";
 import { Site } from "@models/Site";
 import { SharedModule } from "@shared/shared.module";
+import { generateSite } from "@test/fakes/Site";
 import { assertPagination } from "@test/helpers/pagedTableTemplate";
-import { testBawServices } from "@test/helpers/testbed";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminOrphansComponent } from "./list.component";
 
@@ -17,8 +18,12 @@ describe("AdminOrphansComponent", () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [AdminOrphansComponent],
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
-      providers: [...testBawServices],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
     }).compileComponents();
   }));
 
@@ -26,18 +31,10 @@ describe("AdminOrphansComponent", () => {
     fixture = TestBed.createComponent(AdminOrphansComponent);
     api = TestBed.inject(ShallowSitesService);
 
-    defaultModel = new Site({
-      id: 1,
-      name: "custom site",
-    });
+    defaultModel = new Site(generateSite());
     defaultModels = [];
     for (let i = 0; i < 25; i++) {
-      defaultModels.push(
-        new Site({
-          id: i,
-          name: "site " + i,
-        })
-      );
+      defaultModels.push(new Site(generateSite()));
     }
 
     this.defaultModels = defaultModels;

--- a/src/app/component/admin/scripts/details/details.component.spec.ts
+++ b/src/app/component/admin/scripts/details/details.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { scriptResolvers } from "@baw-api/script/scripts.service";
 import { ACCOUNT } from "@baw-api/ServiceTokens";
 import { Script } from "@models/Script";
@@ -11,7 +12,7 @@ import { SharedModule } from "@shared/shared.module";
 import { generateScript } from "@test/fakes/Script";
 import { assertDetail, Detail } from "@test/helpers/detail-view";
 import { nStepObservable } from "@test/helpers/general";
-import { mockActivatedRoute, testBawServices } from "@test/helpers/testbed";
+import { mockActivatedRoute } from "@test/helpers/testbed";
 import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminScriptComponent } from "./details.component";
@@ -23,10 +24,14 @@ describe("ScriptComponent", () => {
 
   function configureTestingModule(model: Script, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [AdminScriptComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(

--- a/src/app/component/admin/scripts/details/details.component.spec.ts
+++ b/src/app/component/admin/scripts/details/details.component.spec.ts
@@ -2,12 +2,14 @@ import { Injector } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { AccountsService } from "@baw-api/account/accounts.service";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { scriptResolvers } from "@baw-api/script/scripts.service";
 import { ACCOUNT } from "@baw-api/ServiceTokens";
 import { Script } from "@models/Script";
 import { User } from "@models/User";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { generateScript } from "@test/fakes/Script";
 import { assertDetail, Detail } from "@test/helpers/detail-view";
@@ -44,7 +46,9 @@ describe("ScriptComponent", () => {
 
     fixture = TestBed.createComponent(AdminScriptComponent);
     injector = TestBed.inject(Injector);
-    const accountsApi = TestBed.inject(ACCOUNT.token);
+    const accountsApi = TestBed.inject(ACCOUNT.token) as SpyObject<
+      AccountsService
+    >;
     component = fixture.componentInstance;
 
     const subject = new Subject<User>();
@@ -52,7 +56,7 @@ describe("ScriptComponent", () => {
       subject,
       () => new User({ id: 1, userName: "custom username" })
     );
-    spyOn(accountsApi, "show").and.callFake(() => subject);
+    accountsApi.show.and.callFake(() => subject);
 
     // Update model to contain injector
     if (model) {

--- a/src/app/component/admin/scripts/details/details.component.spec.ts
+++ b/src/app/component/admin/scripts/details/details.component.spec.ts
@@ -11,6 +11,7 @@ import { Script } from "@models/Script";
 import { User } from "@models/User";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateScript } from "@test/fakes/Script";
 import { assertDetail, Detail } from "@test/helpers/detail-view";
 import { nStepObservable } from "@test/helpers/general";
@@ -73,10 +74,7 @@ describe("ScriptComponent", () => {
   });
 
   it("should handle error", () => {
-    configureTestingModule(undefined, {
-      status: 401,
-      message: "Unauthorized",
-    } as ApiErrorDetails);
+    configureTestingModule(undefined, generateApiErrorDetails());
     fixture.detectChanges();
     expect(component).toBeTruthy();
   });

--- a/src/app/component/admin/scripts/edit/edit.component.spec.ts
+++ b/src/app/component/admin/scripts/edit/edit.component.spec.ts
@@ -10,6 +10,7 @@ import {
 import { Script } from "@models/Script";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateScript } from "@test/fakes/Script";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { mockActivatedRoute } from "@test/helpers/testbed";
@@ -21,13 +22,12 @@ import { AdminScriptsEditComponent } from "./edit.component";
 describe("AdminScriptsEditComponent", () => {
   let api: SpyObject<ScriptsService>;
   let component: AdminScriptsEditComponent;
-  let defaultError: ApiErrorDetails;
   let defaultModel: Script;
   let fixture: ComponentFixture<AdminScriptsEditComponent>;
   let notifications: ToastrService;
   let router: Router;
 
-  function configureTestingModule(model: Script, error: ApiErrorDetails) {
+  function configureTestingModule(model: Script, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       imports: [
         ...appLibraryImports,
@@ -62,27 +62,23 @@ describe("AdminScriptsEditComponent", () => {
 
   beforeEach(() => {
     defaultModel = new Script(generateScript());
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
   });
 
   xdescribe("form", () => {});
 
   describe("component", () => {
     it("should create", () => {
-      configureTestingModule(defaultModel, undefined);
+      configureTestingModule(defaultModel);
       expect(component).toBeTruthy();
     });
 
     it("should handle script error", () => {
-      configureTestingModule(undefined, defaultError);
+      configureTestingModule(undefined, generateApiErrorDetails());
       assertResolverErrorHandling(fixture);
     });
 
     it("should call api", () => {
-      configureTestingModule(defaultModel, undefined);
+      configureTestingModule(defaultModel);
       api.update.and.callFake(() => new Subject());
       component.submit({});
       expect(api.update).toHaveBeenCalled();

--- a/src/app/component/admin/scripts/edit/edit.component.spec.ts
+++ b/src/app/component/admin/scripts/edit/edit.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import {
   scriptResolvers,
   ScriptsService,
@@ -9,7 +10,7 @@ import {
 import { Script } from "@models/Script";
 import { SharedModule } from "@shared/shared.module";
 import { assertResolverErrorHandling } from "@test/helpers/html";
-import { mockActivatedRoute, testBawServices } from "@test/helpers/testbed";
+import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminScriptsEditComponent } from "./edit.component";
@@ -25,10 +26,14 @@ describe("AdminScriptsEditComponent", () => {
 
   function configureTestingModule(model: Script, error: ApiErrorDetails) {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [AdminScriptsEditComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(

--- a/src/app/component/admin/scripts/edit/edit.component.spec.ts
+++ b/src/app/component/admin/scripts/edit/edit.component.spec.ts
@@ -8,15 +8,18 @@ import {
   ScriptsService,
 } from "@baw-api/script/scripts.service";
 import { Script } from "@models/Script";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateScript } from "@test/fakes/Script";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
+import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminScriptsEditComponent } from "./edit.component";
 
 describe("AdminScriptsEditComponent", () => {
-  let api: ScriptsService;
+  let api: SpyObject<ScriptsService>;
   let component: AdminScriptsEditComponent;
   let defaultError: ApiErrorDetails;
   let defaultModel: Script;
@@ -45,7 +48,7 @@ describe("AdminScriptsEditComponent", () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(AdminScriptsEditComponent);
-    api = TestBed.inject(ScriptsService);
+    api = TestBed.inject(ScriptsService) as SpyObject<ScriptsService>;
     router = TestBed.inject(Router);
     notifications = TestBed.inject(ToastrService);
     component = fixture.componentInstance;
@@ -58,10 +61,7 @@ describe("AdminScriptsEditComponent", () => {
   }
 
   beforeEach(() => {
-    defaultModel = new Script({
-      id: 1,
-      name: "Script",
-    });
+    defaultModel = new Script(generateScript());
     defaultError = {
       status: 401,
       message: "Unauthorized",
@@ -83,7 +83,7 @@ describe("AdminScriptsEditComponent", () => {
 
     it("should call api", () => {
       configureTestingModule(defaultModel, undefined);
-      spyOn(api, "update").and.callThrough();
+      api.update.and.callFake(() => new Subject());
       component.submit({});
       expect(api.update).toHaveBeenCalled();
     });

--- a/src/app/component/admin/scripts/list/list.component.spec.ts
+++ b/src/app/component/admin/scripts/list/list.component.spec.ts
@@ -1,10 +1,11 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ScriptsService } from "@baw-api/script/scripts.service";
 import { Script } from "@models/Script";
 import { SharedModule } from "@shared/shared.module";
+import { generateScript } from "@test/fakes/Script";
 import { assertPagination } from "@test/helpers/pagedTableTemplate";
-import { testBawServices } from "@test/helpers/testbed";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminScriptsComponent } from "./list.component";
 
@@ -17,8 +18,12 @@ describe("AdminScriptsComponent", () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [AdminScriptsComponent],
-      imports: [SharedModule, RouterTestingModule, ...appLibraryImports],
-      providers: [...testBawServices],
+      imports: [
+        SharedModule,
+        RouterTestingModule,
+        ...appLibraryImports,
+        MockBawApiModule,
+      ],
     }).compileComponents();
   }));
 
@@ -26,22 +31,10 @@ describe("AdminScriptsComponent", () => {
     fixture = TestBed.createComponent(AdminScriptsComponent);
     api = TestBed.inject(ScriptsService);
 
-    defaultModel = new Script({
-      id: 1,
-      name: "script",
-      version: 0.1,
-      executableCommand: "command",
-    });
+    defaultModel = new Script(generateScript());
     defaultModels = [];
     for (let i = 0; i < 25; i++) {
-      defaultModels.push(
-        new Script({
-          id: i,
-          name: "script " + i,
-          version: 0.1,
-          executableCommand: "command",
-        })
-      );
+      defaultModels.push(new Script(generateScript(i)));
     }
 
     this.defaultModels = defaultModels;

--- a/src/app/component/admin/scripts/new/new.component.spec.ts
+++ b/src/app/component/admin/scripts/new/new.component.spec.ts
@@ -1,9 +1,9 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ScriptsService } from "@baw-api/script/scripts.service";
 import { SharedModule } from "@shared/shared.module";
-import { testBawServices } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminScriptsNewComponent } from "./new.component";
@@ -17,9 +17,13 @@ describe("AdminScriptsNewComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [AdminScriptsNewComponent],
-      providers: [...testBawServices],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AdminScriptsNewComponent);

--- a/src/app/component/admin/scripts/new/new.component.spec.ts
+++ b/src/app/component/admin/scripts/new/new.component.spec.ts
@@ -3,13 +3,15 @@ import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ScriptsService } from "@baw-api/script/scripts.service";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { ToastrService } from "ngx-toastr";
+import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminScriptsNewComponent } from "./new.component";
 
 describe("AdminScriptsNewComponent", () => {
-  let api: ScriptsService;
+  let api: SpyObject<ScriptsService>;
   let component: AdminScriptsNewComponent;
   let fixture: ComponentFixture<AdminScriptsNewComponent>;
   let notifications: ToastrService;
@@ -27,7 +29,7 @@ describe("AdminScriptsNewComponent", () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(AdminScriptsNewComponent);
-    api = TestBed.inject(ScriptsService);
+    api = TestBed.inject(ScriptsService) as SpyObject<ScriptsService>;
     router = TestBed.inject(Router);
     notifications = TestBed.inject(ToastrService);
     component = fixture.componentInstance;
@@ -47,7 +49,7 @@ describe("AdminScriptsNewComponent", () => {
     });
 
     it("should call api", () => {
-      spyOn(api, "create").and.callThrough();
+      api.create.and.callFake(() => new Subject());
       component.submit({});
       expect(api.create).toHaveBeenCalled();
     });

--- a/src/app/component/admin/tag-group/delete/delete.component.spec.ts
+++ b/src/app/component/admin/tag-group/delete/delete.component.spec.ts
@@ -10,6 +10,8 @@ import {
 import { TagGroup } from "@models/TagGroup";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
+import { generateTagGroup } from "@test/fakes/TagGroup";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
@@ -21,13 +23,12 @@ import { AdminTagGroupsDeleteComponent } from "./delete.component";
 describe("AdminTagGroupsDeleteComponent", () => {
   let api: SpyObject<TagGroupsService>;
   let component: AdminTagGroupsDeleteComponent;
-  let defaultError: ApiErrorDetails;
   let defaultTagGroup: TagGroup;
   let fixture: ComponentFixture<AdminTagGroupsDeleteComponent>;
   let notifications: ToastrService;
   let router: Router;
 
-  function configureTestingModule(tagGroup: TagGroup, error: ApiErrorDetails) {
+  function configureTestingModule(model: TagGroup, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       imports: [
         ...appLibraryImports,
@@ -41,7 +42,7 @@ describe("AdminTagGroupsDeleteComponent", () => {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
             { tagGroup: tagGroupResolvers.show },
-            { tagGroup: { model: tagGroup, error } }
+            { tagGroup: { model, error } }
           ),
         },
       ],
@@ -61,44 +62,36 @@ describe("AdminTagGroupsDeleteComponent", () => {
   }
 
   beforeEach(() => {
-    defaultTagGroup = new TagGroup({
-      id: 1,
-      groupIdentifier: "Group Identifier",
-      tagId: 1,
-    });
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
+    defaultTagGroup = new TagGroup(generateTagGroup());
   });
 
   describe("form", () => {
     it("should have no fields", () => {
-      configureTestingModule(defaultTagGroup, undefined);
+      configureTestingModule(defaultTagGroup);
       expect(component.fields).toEqual([]);
     });
   });
 
   describe("component", () => {
     it("should create", () => {
-      configureTestingModule(defaultTagGroup, undefined);
+      configureTestingModule(defaultTagGroup);
       expect(component).toBeTruthy();
     });
 
     it("should handle tag group error", () => {
-      configureTestingModule(undefined, defaultError);
+      configureTestingModule(undefined, generateApiErrorDetails());
       assertResolverErrorHandling(fixture);
     });
 
     it("should call api", () => {
-      configureTestingModule(defaultTagGroup, undefined);
+      configureTestingModule(defaultTagGroup);
       api.destroy.and.callFake(() => new Subject());
       component.submit({});
       expect(api.destroy).toHaveBeenCalled();
     });
 
     it("should redirect to tag group list", () => {
-      configureTestingModule(defaultTagGroup, undefined);
+      configureTestingModule(defaultTagGroup);
       api.destroy.and.callFake(() => new BehaviorSubject<void>(null));
 
       component.submit({});

--- a/src/app/component/admin/tag-group/delete/delete.component.spec.ts
+++ b/src/app/component/admin/tag-group/delete/delete.component.spec.ts
@@ -8,17 +8,18 @@ import {
   TagGroupsService,
 } from "@baw-api/tag/tag-group.service";
 import { TagGroup } from "@models/TagGroup";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { adminTagGroupsMenuItem } from "../tag-group.menus";
 import { AdminTagGroupsDeleteComponent } from "./delete.component";
 
 describe("AdminTagGroupsDeleteComponent", () => {
-  let api: TagGroupsService;
+  let api: SpyObject<TagGroupsService>;
   let component: AdminTagGroupsDeleteComponent;
   let defaultError: ApiErrorDetails;
   let defaultTagGroup: TagGroup;
@@ -47,7 +48,7 @@ describe("AdminTagGroupsDeleteComponent", () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(AdminTagGroupsDeleteComponent);
-    api = TestBed.inject(TagGroupsService);
+    api = TestBed.inject(TagGroupsService) as SpyObject<TagGroupsService>;
     router = TestBed.inject(Router);
     notifications = TestBed.inject(ToastrService);
     component = fixture.componentInstance;
@@ -91,14 +92,14 @@ describe("AdminTagGroupsDeleteComponent", () => {
 
     it("should call api", () => {
       configureTestingModule(defaultTagGroup, undefined);
-      spyOn(api, "destroy").and.callThrough();
+      api.destroy.and.callFake(() => new Subject());
       component.submit({});
       expect(api.destroy).toHaveBeenCalled();
     });
 
     it("should redirect to tag group list", () => {
       configureTestingModule(defaultTagGroup, undefined);
-      spyOn(api, "destroy").and.callFake(() => new BehaviorSubject<void>(null));
+      api.destroy.and.callFake(() => new BehaviorSubject<void>(null));
 
       component.submit({});
       expect(router.navigateByUrl).toHaveBeenCalledWith(

--- a/src/app/component/admin/tag-group/delete/delete.component.spec.ts
+++ b/src/app/component/admin/tag-group/delete/delete.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import {
   tagGroupResolvers,
   TagGroupsService,
@@ -9,7 +10,7 @@ import {
 import { TagGroup } from "@models/TagGroup";
 import { SharedModule } from "@shared/shared.module";
 import { assertResolverErrorHandling } from "@test/helpers/html";
-import { mockActivatedRoute, testBawServices } from "@test/helpers/testbed";
+import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
@@ -27,22 +28,19 @@ describe("AdminTagGroupsDeleteComponent", () => {
 
   function configureTestingModule(tagGroup: TagGroup, error: ApiErrorDetails) {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [AdminTagGroupsDeleteComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
-            {
-              tagGroup: tagGroupResolvers.show,
-            },
-            {
-              tagGroup: {
-                model: tagGroup,
-                error,
-              },
-            }
+            { tagGroup: tagGroupResolvers.show },
+            { tagGroup: { model: tagGroup, error } }
           ),
         },
       ],

--- a/src/app/component/admin/tag-group/edit/edit.component.spec.ts
+++ b/src/app/component/admin/tag-group/edit/edit.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import {
   tagGroupResolvers,
   TagGroupsService,
@@ -9,7 +10,7 @@ import {
 import { TagGroup } from "@models/TagGroup";
 import { SharedModule } from "@shared/shared.module";
 import { assertResolverErrorHandling } from "@test/helpers/html";
-import { mockActivatedRoute, testBawServices } from "@test/helpers/testbed";
+import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminTagGroupsEditComponent } from "./edit.component";
@@ -25,22 +26,19 @@ describe("AdminTagGroupsEditComponent", () => {
 
   function configureTestingModule(tagGroup: TagGroup, error: ApiErrorDetails) {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [AdminTagGroupsEditComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
-            {
-              tagGroup: tagGroupResolvers.show,
-            },
-            {
-              tagGroup: {
-                model: tagGroup,
-                error,
-              },
-            }
+            { tagGroup: tagGroupResolvers.show },
+            { tagGroup: { model: tagGroup, error } }
           ),
         },
       ],

--- a/src/app/component/admin/tag-group/edit/edit.component.spec.ts
+++ b/src/app/component/admin/tag-group/edit/edit.component.spec.ts
@@ -8,15 +8,17 @@ import {
   TagGroupsService,
 } from "@baw-api/tag/tag-group.service";
 import { TagGroup } from "@models/TagGroup";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
+import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminTagGroupsEditComponent } from "./edit.component";
 
 describe("AdminTagGroupsEditComponent", () => {
-  let api: TagGroupsService;
+  let api: SpyObject<TagGroupsService>;
   let component: AdminTagGroupsEditComponent;
   let defaultError: ApiErrorDetails;
   let defaultTagGroup: TagGroup;
@@ -45,7 +47,7 @@ describe("AdminTagGroupsEditComponent", () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(AdminTagGroupsEditComponent);
-    api = TestBed.inject(TagGroupsService);
+    api = TestBed.inject(TagGroupsService) as SpyObject<TagGroupsService>;
     router = TestBed.inject(Router);
     notifications = TestBed.inject(ToastrService);
     component = fixture.componentInstance;
@@ -84,7 +86,7 @@ describe("AdminTagGroupsEditComponent", () => {
 
     it("should call api", () => {
       configureTestingModule(defaultTagGroup, undefined);
-      spyOn(api, "update").and.callThrough();
+      api.update.and.callFake(() => new Subject());
       component.submit({});
       expect(api.update).toHaveBeenCalled();
     });

--- a/src/app/component/admin/tag-group/edit/edit.component.spec.ts
+++ b/src/app/component/admin/tag-group/edit/edit.component.spec.ts
@@ -10,6 +10,8 @@ import {
 import { TagGroup } from "@models/TagGroup";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
+import { generateTagGroup } from "@test/fakes/TagGroup";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
@@ -20,13 +22,12 @@ import { AdminTagGroupsEditComponent } from "./edit.component";
 describe("AdminTagGroupsEditComponent", () => {
   let api: SpyObject<TagGroupsService>;
   let component: AdminTagGroupsEditComponent;
-  let defaultError: ApiErrorDetails;
   let defaultTagGroup: TagGroup;
   let fixture: ComponentFixture<AdminTagGroupsEditComponent>;
   let notifications: ToastrService;
   let router: Router;
 
-  function configureTestingModule(tagGroup: TagGroup, error: ApiErrorDetails) {
+  function configureTestingModule(model: TagGroup, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       imports: [
         ...appLibraryImports,
@@ -40,7 +41,7 @@ describe("AdminTagGroupsEditComponent", () => {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
             { tagGroup: tagGroupResolvers.show },
-            { tagGroup: { model: tagGroup, error } }
+            { tagGroup: { model, error } }
           ),
         },
       ],
@@ -60,32 +61,24 @@ describe("AdminTagGroupsEditComponent", () => {
   }
 
   beforeEach(() => {
-    defaultTagGroup = new TagGroup({
-      id: 1,
-      groupIdentifier: "Group Identifier",
-      tagId: 1,
-    });
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
+    defaultTagGroup = new TagGroup(generateTagGroup());
   });
 
   xdescribe("form", () => {});
 
   describe("component", () => {
     it("should create", () => {
-      configureTestingModule(defaultTagGroup, undefined);
+      configureTestingModule(defaultTagGroup);
       expect(component).toBeTruthy();
     });
 
     it("should handle tag group error", () => {
-      configureTestingModule(undefined, defaultError);
+      configureTestingModule(undefined, generateApiErrorDetails());
       assertResolverErrorHandling(fixture);
     });
 
     it("should call api", () => {
-      configureTestingModule(defaultTagGroup, undefined);
+      configureTestingModule(defaultTagGroup);
       api.update.and.callFake(() => new Subject());
       component.submit({});
       expect(api.update).toHaveBeenCalled();

--- a/src/app/component/admin/tag-group/list/list.component.spec.ts
+++ b/src/app/component/admin/tag-group/list/list.component.spec.ts
@@ -1,10 +1,11 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { TagGroupsService } from "@baw-api/tag/tag-group.service";
 import { TagGroup } from "@models/TagGroup";
 import { SharedModule } from "@shared/shared.module";
+import { generateTagGroup } from "@test/fakes/TagGroup";
 import { assertPagination } from "@test/helpers/pagedTableTemplate";
-import { testBawServices } from "@test/helpers/testbed";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminTagGroupsComponent } from "./list.component";
 
@@ -17,8 +18,12 @@ describe("AdminTagGroupsComponent", () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [AdminTagGroupsComponent],
-      imports: [SharedModule, RouterTestingModule, ...appLibraryImports],
-      providers: [...testBawServices],
+      imports: [
+        SharedModule,
+        RouterTestingModule,
+        ...appLibraryImports,
+        MockBawApiModule,
+      ],
     }).compileComponents();
   }));
 
@@ -26,20 +31,10 @@ describe("AdminTagGroupsComponent", () => {
     fixture = TestBed.createComponent(AdminTagGroupsComponent);
     api = TestBed.inject(TagGroupsService);
 
-    defaultModel = new TagGroup({
-      id: 1,
-      tagId: 1,
-      groupIdentifier: "",
-    });
+    defaultModel = new TagGroup(generateTagGroup());
     defaultModels = [];
     for (let i = 0; i < 25; i++) {
-      defaultModels.push(
-        new TagGroup({
-          id: 1,
-          tagId: 1,
-          groupIdentifier: "",
-        })
-      );
+      defaultModels.push(new TagGroup(generateTagGroup()));
     }
 
     this.defaultModels = defaultModels;

--- a/src/app/component/admin/tag-group/new/new.component.spec.ts
+++ b/src/app/component/admin/tag-group/new/new.component.spec.ts
@@ -1,9 +1,10 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { TagGroupsService } from "@baw-api/tag/tag-group.service";
 import { SharedModule } from "@shared/shared.module";
-import { mockActivatedRoute, testBawServices } from "@test/helpers/testbed";
+import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminTagGroupsNewComponent } from "./new.component";
@@ -20,10 +21,14 @@ describe("AdminTagGroupsNewComponent", () => {
   describe("component", () => {
     beforeEach(async(() => {
       TestBed.configureTestingModule({
-        imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+        imports: [
+          ...appLibraryImports,
+          SharedModule,
+          RouterTestingModule,
+          MockBawApiModule,
+        ],
         declarations: [AdminTagGroupsNewComponent],
         providers: [
-          ...testBawServices,
           {
             provide: ActivatedRoute,
             useClass: mockActivatedRoute(),

--- a/src/app/component/admin/tag-group/new/new.component.spec.ts
+++ b/src/app/component/admin/tag-group/new/new.component.spec.ts
@@ -3,14 +3,16 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { TagGroupsService } from "@baw-api/tag/tag-group.service";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
+import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminTagGroupsNewComponent } from "./new.component";
 
 describe("AdminTagGroupsNewComponent", () => {
-  let api: TagGroupsService;
+  let api: SpyObject<TagGroupsService>;
   let component: AdminTagGroupsNewComponent;
   let fixture: ComponentFixture<AdminTagGroupsNewComponent>;
   let notifications: ToastrService;
@@ -39,7 +41,7 @@ describe("AdminTagGroupsNewComponent", () => {
 
     beforeEach(() => {
       fixture = TestBed.createComponent(AdminTagGroupsNewComponent);
-      api = TestBed.inject(TagGroupsService);
+      api = TestBed.inject(TagGroupsService) as SpyObject<TagGroupsService>;
       router = TestBed.inject(Router);
       notifications = TestBed.inject(ToastrService);
       component = fixture.componentInstance;
@@ -56,7 +58,7 @@ describe("AdminTagGroupsNewComponent", () => {
     });
 
     it("should call api", () => {
-      spyOn(api, "create").and.callThrough();
+      api.create.and.callFake(() => new Subject());
       component.submit({});
       expect(api.create).toHaveBeenCalled();
     });

--- a/src/app/component/admin/tags/delete/delete.component.spec.ts
+++ b/src/app/component/admin/tags/delete/delete.component.spec.ts
@@ -7,6 +7,7 @@ import { tagResolvers, TagsService } from "@baw-api/tag/tags.service";
 import { Tag } from "@models/Tag";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateTag } from "@test/fakes/Tag";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { mockActivatedRoute } from "@test/helpers/testbed";
@@ -19,13 +20,12 @@ import { AdminTagsDeleteComponent } from "./delete.component";
 describe("AdminTagsDeleteComponent", () => {
   let api: SpyObject<TagsService>;
   let component: AdminTagsDeleteComponent;
-  let defaultError: ApiErrorDetails;
   let defaultTag: Tag;
   let fixture: ComponentFixture<AdminTagsDeleteComponent>;
   let notifications: ToastrService;
   let router: Router;
 
-  function configureTestingModule(tag: Tag, tagError: ApiErrorDetails) {
+  function configureTestingModule(model: Tag, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       imports: [
         ...appLibraryImports,
@@ -39,7 +39,7 @@ describe("AdminTagsDeleteComponent", () => {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
             { tag: tagResolvers.show },
-            { tag: { model: tag, error: tagError } }
+            { tag: { model, error } }
           ),
         },
       ],
@@ -60,39 +60,35 @@ describe("AdminTagsDeleteComponent", () => {
 
   beforeEach(() => {
     defaultTag = new Tag(generateTag());
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
   });
 
   describe("form", () => {
     it("should have no fields", () => {
-      configureTestingModule(defaultTag, undefined);
+      configureTestingModule(defaultTag);
       expect(component.fields).toEqual([]);
     });
   });
 
   describe("component", () => {
     it("should create", () => {
-      configureTestingModule(defaultTag, undefined);
+      configureTestingModule(defaultTag);
       expect(component).toBeTruthy();
     });
 
     it("should handle tag error", () => {
-      configureTestingModule(undefined, defaultError);
+      configureTestingModule(undefined, generateApiErrorDetails());
       assertResolverErrorHandling(fixture);
     });
 
     it("should call api", () => {
-      configureTestingModule(defaultTag, undefined);
+      configureTestingModule(defaultTag);
       api.destroy.and.callFake(() => new Subject());
       component.submit({});
       expect(api.destroy).toHaveBeenCalled();
     });
 
     it("should redirect to tag list", () => {
-      configureTestingModule(defaultTag, undefined);
+      configureTestingModule(defaultTag);
       api.destroy.and.callFake(() => new BehaviorSubject<void>(null));
 
       component.submit({});

--- a/src/app/component/admin/tags/delete/delete.component.spec.ts
+++ b/src/app/component/admin/tags/delete/delete.component.spec.ts
@@ -5,17 +5,19 @@ import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { tagResolvers, TagsService } from "@baw-api/tag/tags.service";
 import { Tag } from "@models/Tag";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateTag } from "@test/fakes/Tag";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { adminTagsMenuItem } from "../tags.menus";
 import { AdminTagsDeleteComponent } from "./delete.component";
 
 describe("AdminTagsDeleteComponent", () => {
-  let api: TagsService;
+  let api: SpyObject<TagsService>;
   let component: AdminTagsDeleteComponent;
   let defaultError: ApiErrorDetails;
   let defaultTag: Tag;
@@ -44,7 +46,7 @@ describe("AdminTagsDeleteComponent", () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(AdminTagsDeleteComponent);
-    api = TestBed.inject(TagsService);
+    api = TestBed.inject(TagsService) as SpyObject<TagsService>;
     router = TestBed.inject(Router);
     notifications = TestBed.inject(ToastrService);
     component = fixture.componentInstance;
@@ -57,10 +59,7 @@ describe("AdminTagsDeleteComponent", () => {
   }
 
   beforeEach(() => {
-    defaultTag = new Tag({
-      id: 1,
-      text: "Tag",
-    });
+    defaultTag = new Tag(generateTag());
     defaultError = {
       status: 401,
       message: "Unauthorized",
@@ -87,14 +86,14 @@ describe("AdminTagsDeleteComponent", () => {
 
     it("should call api", () => {
       configureTestingModule(defaultTag, undefined);
-      spyOn(api, "destroy").and.callThrough();
+      api.destroy.and.callFake(() => new Subject());
       component.submit({});
       expect(api.destroy).toHaveBeenCalled();
     });
 
     it("should redirect to tag list", () => {
       configureTestingModule(defaultTag, undefined);
-      spyOn(api, "destroy").and.callFake(() => new BehaviorSubject<void>(null));
+      api.destroy.and.callFake(() => new BehaviorSubject<void>(null));
 
       component.submit({});
       expect(router.navigateByUrl).toHaveBeenCalledWith(

--- a/src/app/component/admin/tags/delete/delete.component.spec.ts
+++ b/src/app/component/admin/tags/delete/delete.component.spec.ts
@@ -2,11 +2,12 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { tagResolvers, TagsService } from "@baw-api/tag/tags.service";
 import { Tag } from "@models/Tag";
 import { SharedModule } from "@shared/shared.module";
 import { assertResolverErrorHandling } from "@test/helpers/html";
-import { mockActivatedRoute, testBawServices } from "@test/helpers/testbed";
+import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
@@ -24,22 +25,19 @@ describe("AdminTagsDeleteComponent", () => {
 
   function configureTestingModule(tag: Tag, tagError: ApiErrorDetails) {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [AdminTagsDeleteComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
-            {
-              tag: tagResolvers.show,
-            },
-            {
-              tag: {
-                model: tag,
-                error: tagError,
-              },
-            }
+            { tag: tagResolvers.show },
+            { tag: { model: tag, error: tagError } }
           ),
         },
       ],

--- a/src/app/component/admin/tags/edit/edit.component.spec.ts
+++ b/src/app/component/admin/tags/edit/edit.component.spec.ts
@@ -5,15 +5,18 @@ import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { tagResolvers, TagsService } from "@baw-api/tag/tags.service";
 import { Tag, TagType } from "@models/Tag";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateTag } from "@test/fakes/Tag";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
+import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminTagsEditComponent } from "./edit.component";
 
 describe("AdminTagsEditComponent", () => {
-  let api: TagsService;
+  let api: SpyObject<TagsService>;
   let component: AdminTagsEditComponent;
   let defaultError: ApiErrorDetails;
   let defaultTag: Tag;
@@ -54,7 +57,7 @@ describe("AdminTagsEditComponent", () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(AdminTagsEditComponent);
-    api = TestBed.inject(TagsService);
+    api = TestBed.inject(TagsService) as SpyObject<TagsService>;
     router = TestBed.inject(Router);
     notifications = TestBed.inject(ToastrService);
     component = fixture.componentInstance;
@@ -67,10 +70,7 @@ describe("AdminTagsEditComponent", () => {
   }
 
   beforeEach(() => {
-    defaultTag = new Tag({
-      id: 1,
-      text: "Tag",
-    });
+    defaultTag = new Tag(generateTag());
     defaultTagTypes = [
       new TagType({
         name: "common_name",
@@ -107,7 +107,7 @@ describe("AdminTagsEditComponent", () => {
 
     it("should call api", () => {
       configureTestingModule(defaultTag, undefined, defaultTagTypes, undefined);
-      spyOn(api, "update").and.callThrough();
+      api.update.and.callFake(() => new Subject());
       component.submit({});
       expect(api.update).toHaveBeenCalled();
     });

--- a/src/app/component/admin/tags/edit/edit.component.spec.ts
+++ b/src/app/component/admin/tags/edit/edit.component.spec.ts
@@ -2,11 +2,12 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { tagResolvers, TagsService } from "@baw-api/tag/tags.service";
 import { Tag, TagType } from "@models/Tag";
 import { SharedModule } from "@shared/shared.module";
 import { assertResolverErrorHandling } from "@test/helpers/html";
-import { mockActivatedRoute, testBawServices } from "@test/helpers/testbed";
+import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminTagsEditComponent } from "./edit.component";
@@ -28,10 +29,14 @@ describe("AdminTagsEditComponent", () => {
     tagTypesError: ApiErrorDetails
   ) {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [AdminTagsEditComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
@@ -40,14 +45,8 @@ describe("AdminTagsEditComponent", () => {
               typeOfTags: tagResolvers.tagTypes,
             },
             {
-              tag: {
-                model: tag,
-                error: tagError,
-              },
-              tagTypes: {
-                model: tagTypes,
-                error: tagTypesError,
-              },
+              tag: { model: tag, error: tagError },
+              tagTypes: { model: tagTypes, error: tagTypesError },
             }
           ),
         },

--- a/src/app/component/admin/tags/edit/edit.component.spec.ts
+++ b/src/app/component/admin/tags/edit/edit.component.spec.ts
@@ -7,6 +7,7 @@ import { tagResolvers, TagsService } from "@baw-api/tag/tags.service";
 import { Tag, TagType } from "@models/Tag";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateTag } from "@test/fakes/Tag";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { mockActivatedRoute } from "@test/helpers/testbed";
@@ -18,7 +19,6 @@ import { AdminTagsEditComponent } from "./edit.component";
 describe("AdminTagsEditComponent", () => {
   let api: SpyObject<TagsService>;
   let component: AdminTagsEditComponent;
-  let defaultError: ApiErrorDetails;
   let defaultTag: Tag;
   let defaultTagTypes: TagType[];
   let fixture: ComponentFixture<AdminTagsEditComponent>;
@@ -76,10 +76,6 @@ describe("AdminTagsEditComponent", () => {
         name: "common_name",
       }),
     ];
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
   });
 
   xdescribe("form", () => {});
@@ -93,7 +89,7 @@ describe("AdminTagsEditComponent", () => {
     it("should handle tag error", () => {
       configureTestingModule(
         undefined,
-        defaultError,
+        generateApiErrorDetails(),
         defaultTagTypes,
         undefined
       );
@@ -101,7 +97,12 @@ describe("AdminTagsEditComponent", () => {
     });
 
     it("should handle tag types error", () => {
-      configureTestingModule(defaultTag, undefined, undefined, defaultError);
+      configureTestingModule(
+        defaultTag,
+        undefined,
+        undefined,
+        generateApiErrorDetails()
+      );
       assertResolverErrorHandling(fixture);
     });
 

--- a/src/app/component/admin/tags/list/list.component.spec.ts
+++ b/src/app/component/admin/tags/list/list.component.spec.ts
@@ -1,10 +1,11 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { TagsService } from "@baw-api/tag/tags.service";
 import { Tag } from "@models/Tag";
 import { SharedModule } from "@shared/shared.module";
+import { generateTag } from "@test/fakes/Tag";
 import { assertPagination } from "@test/helpers/pagedTableTemplate";
-import { testBawServices } from "@test/helpers/testbed";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminTagsComponent } from "./list.component";
 
@@ -16,9 +17,13 @@ describe("AdminTagsComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [AdminTagsComponent],
-      providers: [...testBawServices],
     }).compileComponents();
   }));
 
@@ -26,24 +31,10 @@ describe("AdminTagsComponent", () => {
     fixture = TestBed.createComponent(AdminTagsComponent);
     api = TestBed.inject(TagsService);
 
-    defaultModel = new Tag({
-      id: 1,
-      text: "tag",
-      isTaxanomic: false,
-      retired: false,
-      typeOfTag: "common",
-    });
+    defaultModel = new Tag(generateTag());
     defaultModels = [];
     for (let i = 0; i < 25; i++) {
-      defaultModels.push(
-        new Tag({
-          id: i,
-          text: "tag " + i,
-          isTaxanomic: false,
-          retired: false,
-          typeOfTag: "common",
-        })
-      );
+      defaultModels.push(new Tag(generateTag(i)));
     }
 
     this.defaultModels = defaultModels;

--- a/src/app/component/admin/tags/new/new.component.spec.ts
+++ b/src/app/component/admin/tags/new/new.component.spec.ts
@@ -2,11 +2,12 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { tagResolvers, TagsService } from "@baw-api/tag/tags.service";
 import { TagType } from "@models/Tag";
 import { SharedModule } from "@shared/shared.module";
 import { assertResolverErrorHandling } from "@test/helpers/html";
-import { mockActivatedRoute, testBawServices } from "@test/helpers/testbed";
+import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminTagsNewComponent } from "./new.component";
@@ -25,22 +26,19 @@ describe("AdminTagsNewComponent", () => {
     tagTypesError: ApiErrorDetails
   ) {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [AdminTagsNewComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
-            {
-              typeOfTags: tagResolvers.tagTypes,
-            },
-            {
-              tagTypes: {
-                model: tagTypes,
-                error: tagTypesError,
-              },
-            }
+            { typeOfTags: tagResolvers.tagTypes },
+            { tagTypes: { model: tagTypes, error: tagTypesError } }
           ),
         },
       ],

--- a/src/app/component/admin/tags/new/new.component.spec.ts
+++ b/src/app/component/admin/tags/new/new.component.spec.ts
@@ -7,6 +7,7 @@ import { tagResolvers, TagsService } from "@baw-api/tag/tags.service";
 import { TagType } from "@models/Tag";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
@@ -17,16 +18,12 @@ import { AdminTagsNewComponent } from "./new.component";
 describe("AdminTagsNewComponent", () => {
   let api: SpyObject<TagsService>;
   let component: AdminTagsNewComponent;
-  let defaultError: ApiErrorDetails;
   let defaultTagTypes: TagType[];
   let fixture: ComponentFixture<AdminTagsNewComponent>;
   let notifications: ToastrService;
   let router: Router;
 
-  function configureTestingModule(
-    tagTypes: TagType[],
-    tagTypesError: ApiErrorDetails
-  ) {
+  function configureTestingModule(model: TagType[], error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       imports: [
         ...appLibraryImports,
@@ -40,7 +37,7 @@ describe("AdminTagsNewComponent", () => {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
             { typeOfTags: tagResolvers.tagTypes },
-            { tagTypes: { model: tagTypes, error: tagTypesError } }
+            { tagTypes: { model, error } }
           ),
         },
       ],
@@ -65,27 +62,23 @@ describe("AdminTagsNewComponent", () => {
         name: "common_name",
       }),
     ];
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
   });
 
   xdescribe("form", () => {});
 
   describe("component", () => {
     it("should create", () => {
-      configureTestingModule(defaultTagTypes, undefined);
+      configureTestingModule(defaultTagTypes);
       expect(component).toBeTruthy();
     });
 
     it("should handle tag types error", () => {
-      configureTestingModule(undefined, defaultError);
+      configureTestingModule(undefined, generateApiErrorDetails());
       assertResolverErrorHandling(fixture);
     });
 
     it("should call api", () => {
-      configureTestingModule(defaultTagTypes, undefined);
+      configureTestingModule(defaultTagTypes);
       api.create.and.callFake(() => new Subject());
       component.submit({});
       expect(api.create).toHaveBeenCalled();

--- a/src/app/component/admin/tags/new/new.component.spec.ts
+++ b/src/app/component/admin/tags/new/new.component.spec.ts
@@ -5,15 +5,17 @@ import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { tagResolvers, TagsService } from "@baw-api/tag/tags.service";
 import { TagType } from "@models/Tag";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
+import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminTagsNewComponent } from "./new.component";
 
 describe("AdminTagsNewComponent", () => {
-  let api: TagsService;
+  let api: SpyObject<TagsService>;
   let component: AdminTagsNewComponent;
   let defaultError: ApiErrorDetails;
   let defaultTagTypes: TagType[];
@@ -45,7 +47,7 @@ describe("AdminTagsNewComponent", () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(AdminTagsNewComponent);
-    api = TestBed.inject(TagsService);
+    api = TestBed.inject(TagsService) as SpyObject<TagsService>;
     router = TestBed.inject(Router);
     notifications = TestBed.inject(ToastrService);
     component = fixture.componentInstance;
@@ -84,7 +86,7 @@ describe("AdminTagsNewComponent", () => {
 
     it("should call api", () => {
       configureTestingModule(defaultTagTypes, undefined);
-      spyOn(api, "create").and.callThrough();
+      api.create.and.callFake(() => new Subject());
       component.submit({});
       expect(api.create).toHaveBeenCalled();
     });

--- a/src/app/component/admin/users/list/list.component.spec.ts
+++ b/src/app/component/admin/users/list/list.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AccountsService } from "@baw-api/account/accounts.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { User } from "@models/User";
 import { SharedModule } from "@shared/shared.module";
 import { assertRoute } from "@test/helpers/html";
@@ -10,7 +11,6 @@ import {
   getDatatableCells,
   getDatatableRows,
 } from "@test/helpers/pagedTableTemplate";
-import { testBawServices } from "@test/helpers/testbed";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminUserListComponent } from "./list.component";
 
@@ -23,8 +23,12 @@ describe("AdminUserListComponent", () => {
   beforeEach(async(function () {
     TestBed.configureTestingModule({
       declarations: [AdminUserListComponent],
-      imports: [SharedModule, RouterTestingModule, ...appLibraryImports],
-      providers: [...testBawServices],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
     }).compileComponents();
   }));
 

--- a/src/app/component/data-request/data-request.component.spec.ts
+++ b/src/app/component/data-request/data-request.component.spec.ts
@@ -5,9 +5,9 @@ import {
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AppConfigService } from "@services/app-config/app-config.service";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { SharedModule } from "@shared/shared.module";
 import { appLibraryImports } from "src/app/app.module";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import { DataRequestComponent } from "./data-request.component";
 
 describe("DataRequestComponent", () => {
@@ -23,9 +23,9 @@ describe("DataRequestComponent", () => {
         SharedModule,
         HttpClientTestingModule,
         RouterTestingModule,
+        MockAppConfigModule,
       ],
       declarations: [DataRequestComponent],
-      providers: [...testAppInitializer],
     }).compileComponents();
   }));
 

--- a/src/app/component/home/home.component.spec.ts
+++ b/src/app/component/home/home.component.spec.ts
@@ -10,17 +10,18 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ProjectsService } from "@baw-api/project/projects.service";
 import { SecurityService } from "@baw-api/security/security.service";
 import { Project } from "@models/Project";
+import { SpyObject } from "@ngneat/spectator";
 import { AppConfigService } from "@services/app-config/app-config.service";
 import { SharedModule } from "@shared/shared.module";
 import { generateProject } from "@test/fakes/Project";
 import { nStepObservable } from "@test/helpers/general";
 import { assertRoute } from "@test/helpers/html";
-import { BehaviorSubject, Subject } from "rxjs";
+import { Subject } from "rxjs";
 import { HomeComponent } from "./home.component";
 
 describe("HomeComponent", () => {
   let httpMock: HttpTestingController;
-  let projectApi: ProjectsService;
+  let projectApi: SpyObject<ProjectsService>;
   let securityApi: SecurityService;
   let component: HomeComponent;
   let env: AppConfigService;
@@ -41,7 +42,7 @@ describe("HomeComponent", () => {
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
     httpMock = TestBed.inject(HttpTestingController);
-    projectApi = TestBed.inject(ProjectsService);
+    projectApi = TestBed.inject(ProjectsService) as SpyObject<ProjectsService>;
     securityApi = TestBed.inject(SecurityService);
     env = TestBed.inject(AppConfigService);
 
@@ -60,10 +61,7 @@ describe("HomeComponent", () => {
   it("should load cms", async () => {
     const subject = new Subject<Project[]>();
     const promise = nStepObservable(subject, () => []);
-    spyOn(projectApi, "filter").and.callFake(() => subject);
-    spyOn(securityApi, "getAuthTrigger").and.callFake(
-      () => new BehaviorSubject(null)
-    );
+    projectApi.filter.and.callFake(() => subject);
 
     await promise;
     fixture.detectChanges();
@@ -90,10 +88,7 @@ describe("HomeComponent", () => {
         () => (projects ? projects : error),
         !projects
       );
-      spyOn(projectApi, "filter").and.callFake(() => subject);
-      spyOn(securityApi, "getAuthTrigger").and.callFake(
-        () => new BehaviorSubject(null)
-      );
+      projectApi.filter.and.callFake(() => subject);
 
       fixture.detectChanges();
       await promise;

--- a/src/app/component/home/home.component.spec.ts
+++ b/src/app/component/home/home.component.spec.ts
@@ -6,6 +6,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { Filters } from "@baw-api/baw-api.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ProjectsService } from "@baw-api/project/projects.service";
 import { SecurityService } from "@baw-api/security/security.service";
 import { Project } from "@models/Project";
@@ -15,7 +16,6 @@ import { generateProject } from "@test/fakes/Project";
 import { nStepObservable } from "@test/helpers/general";
 import { assertRoute } from "@test/helpers/html";
 import { BehaviorSubject, Subject } from "rxjs";
-import { testBawServices } from "src/app/test/helpers/testbed";
 import { HomeComponent } from "./home.component";
 
 describe("HomeComponent", () => {
@@ -30,8 +30,12 @@ describe("HomeComponent", () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [HomeComponent],
-      imports: [SharedModule, HttpClientTestingModule, RouterTestingModule],
-      providers: testBawServices,
+      imports: [
+        SharedModule,
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(HomeComponent);

--- a/src/app/component/home/home.component.spec.ts
+++ b/src/app/component/home/home.component.spec.ts
@@ -13,6 +13,7 @@ import { Project } from "@models/Project";
 import { SpyObject } from "@ngneat/spectator";
 import { AppConfigService } from "@services/app-config/app-config.service";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateProject } from "@test/fakes/Project";
 import { nStepObservable } from "@test/helpers/general";
 import { assertRoute } from "@test/helpers/html";
@@ -125,7 +126,7 @@ describe("HomeComponent", () => {
     });
 
     it("should handle filter error", async () => {
-      await setupComponent(undefined, { status: 404, message: "Not Found" });
+      await setupComponent(undefined, generateApiErrorDetails());
       expect(getCardImages().length).toBe(0);
       expect(getButton()).toBeTruthy();
     });

--- a/src/app/component/profile/pages/bookmarks/my-bookmarks.component.spec.ts
+++ b/src/app/component/profile/pages/bookmarks/my-bookmarks.component.spec.ts
@@ -2,12 +2,13 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { BookmarksService } from "@baw-api/bookmark/bookmarks.service";
 import { userResolvers } from "@baw-api/user/user.service";
 import { User } from "@models/User";
 import { SharedModule } from "@shared/shared.module";
 import { assertResolverErrorHandling } from "@test/helpers/html";
-import { mockActivatedRoute, testBawServices } from "@test/helpers/testbed";
+import { mockActivatedRoute } from "@test/helpers/testbed";
 import { MyProjectsComponent } from "../projects/my-projects.component";
 import { MyBookmarksComponent } from "./my-bookmarks.component";
 
@@ -21,9 +22,8 @@ describe("MyBookmarksComponent", () => {
   function configureTestingModule(model?: User, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       declarations: [MyProjectsComponent],
-      imports: [SharedModule, RouterTestingModule],
+      imports: [SharedModule, RouterTestingModule, MockBawApiModule],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(

--- a/src/app/component/profile/pages/bookmarks/my-bookmarks.component.spec.ts
+++ b/src/app/component/profile/pages/bookmarks/my-bookmarks.component.spec.ts
@@ -8,6 +8,7 @@ import { userResolvers } from "@baw-api/user/user.service";
 import { User } from "@models/User";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateUser } from "@test/fakes/User";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { mockActivatedRoute } from "@test/helpers/testbed";
@@ -19,7 +20,6 @@ describe("MyBookmarksComponent", () => {
   let api: SpyObject<BookmarksService>;
   let component: MyBookmarksComponent;
   let defaultUser: User;
-  let defaultError: ApiErrorDetails;
   let fixture: ComponentFixture<MyBookmarksComponent>;
 
   function configureTestingModule(model?: User, error?: ApiErrorDetails) {
@@ -46,7 +46,6 @@ describe("MyBookmarksComponent", () => {
 
   beforeEach(() => {
     defaultUser = new User(generateUser());
-    defaultError = { status: 401, message: "Unauthorized" };
   });
 
   it("should create", () => {
@@ -66,7 +65,7 @@ describe("MyBookmarksComponent", () => {
   });
 
   it("should handle user error", () => {
-    configureTestingModule(undefined, defaultError);
+    configureTestingModule(undefined, generateApiErrorDetails());
     fixture.detectChanges();
     expect(component).toBeTruthy();
 

--- a/src/app/component/profile/pages/bookmarks/my-bookmarks.component.spec.ts
+++ b/src/app/component/profile/pages/bookmarks/my-bookmarks.component.spec.ts
@@ -6,14 +6,17 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { BookmarksService } from "@baw-api/bookmark/bookmarks.service";
 import { userResolvers } from "@baw-api/user/user.service";
 import { User } from "@models/User";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateUser } from "@test/fakes/User";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { mockActivatedRoute } from "@test/helpers/testbed";
+import { Subject } from "rxjs";
 import { MyProjectsComponent } from "../projects/my-projects.component";
 import { MyBookmarksComponent } from "./my-bookmarks.component";
 
 describe("MyBookmarksComponent", () => {
-  let api: BookmarksService;
+  let api: SpyObject<BookmarksService>;
   let component: MyBookmarksComponent;
   let defaultUser: User;
   let defaultError: ApiErrorDetails;
@@ -35,12 +38,14 @@ describe("MyBookmarksComponent", () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(MyBookmarksComponent);
-    api = TestBed.inject(BookmarksService);
+    api = TestBed.inject(BookmarksService) as SpyObject<BookmarksService>;
     component = fixture.componentInstance;
+
+    api.filter.and.callFake(() => new Subject());
   }
 
   beforeEach(() => {
-    defaultUser = new User({ id: 1, userName: "username" });
+    defaultUser = new User(generateUser());
     defaultError = { status: 401, message: "Unauthorized" };
   });
 
@@ -52,7 +57,7 @@ describe("MyBookmarksComponent", () => {
 
   it("should display username in title", () => {
     configureTestingModule(
-      new User({ ...defaultUser, userName: "custom username" })
+      new User({ ...generateUser(), userName: "custom username" })
     );
     fixture.detectChanges();
 

--- a/src/app/component/profile/pages/bookmarks/their-bookmarks.component.spec.ts
+++ b/src/app/component/profile/pages/bookmarks/their-bookmarks.component.spec.ts
@@ -8,6 +8,7 @@ import { BookmarksService } from "@baw-api/bookmark/bookmarks.service";
 import { User } from "@models/User";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateUser } from "@test/fakes/User";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { mockActivatedRoute } from "@test/helpers/testbed";
@@ -19,7 +20,6 @@ describe("TheirBookmarksComponent", () => {
   let api: SpyObject<BookmarksService>;
   let component: TheirBookmarksComponent;
   let defaultUser: User;
-  let defaultError: ApiErrorDetails;
   let fixture: ComponentFixture<TheirBookmarksComponent>;
 
   function configureTestingModule(model?: User, error?: ApiErrorDetails) {
@@ -46,7 +46,6 @@ describe("TheirBookmarksComponent", () => {
 
   beforeEach(() => {
     defaultUser = new User(generateUser());
-    defaultError = { status: 401, message: "Unauthorized" };
   });
 
   it("should create", () => {
@@ -66,7 +65,7 @@ describe("TheirBookmarksComponent", () => {
   });
 
   it("should handle user error", () => {
-    configureTestingModule(undefined, defaultError);
+    configureTestingModule(undefined, generateApiErrorDetails());
     fixture.detectChanges();
     expect(component).toBeTruthy();
 

--- a/src/app/component/profile/pages/bookmarks/their-bookmarks.component.spec.ts
+++ b/src/app/component/profile/pages/bookmarks/their-bookmarks.component.spec.ts
@@ -6,14 +6,17 @@ import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { BookmarksService } from "@baw-api/bookmark/bookmarks.service";
 import { User } from "@models/User";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateUser } from "@test/fakes/User";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { mockActivatedRoute } from "@test/helpers/testbed";
+import { Subject } from "rxjs";
 import { MyProjectsComponent } from "../projects/my-projects.component";
 import { TheirBookmarksComponent } from "./their-bookmarks.component";
 
 describe("TheirBookmarksComponent", () => {
-  let api: BookmarksService;
+  let api: SpyObject<BookmarksService>;
   let component: TheirBookmarksComponent;
   let defaultUser: User;
   let defaultError: ApiErrorDetails;
@@ -35,12 +38,14 @@ describe("TheirBookmarksComponent", () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(TheirBookmarksComponent);
-    api = TestBed.inject(BookmarksService);
+    api = TestBed.inject(BookmarksService) as SpyObject<BookmarksService>;
     component = fixture.componentInstance;
+
+    api.filter.and.callFake(() => new Subject());
   }
 
   beforeEach(() => {
-    defaultUser = new User({ id: 1, userName: "username" });
+    defaultUser = new User(generateUser());
     defaultError = { status: 401, message: "Unauthorized" };
   });
 
@@ -52,7 +57,7 @@ describe("TheirBookmarksComponent", () => {
 
   it("should display username in title", () => {
     configureTestingModule(
-      new User({ ...defaultUser, userName: "custom username" })
+      new User({ ...generateUser(), userName: "custom username" })
     );
     fixture.detectChanges();
 

--- a/src/app/component/profile/pages/bookmarks/their-bookmarks.component.spec.ts
+++ b/src/app/component/profile/pages/bookmarks/their-bookmarks.component.spec.ts
@@ -3,11 +3,12 @@ import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { accountResolvers } from "@baw-api/account/accounts.service";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { BookmarksService } from "@baw-api/bookmark/bookmarks.service";
 import { User } from "@models/User";
 import { SharedModule } from "@shared/shared.module";
 import { assertResolverErrorHandling } from "@test/helpers/html";
-import { mockActivatedRoute, testBawServices } from "@test/helpers/testbed";
+import { mockActivatedRoute } from "@test/helpers/testbed";
 import { MyProjectsComponent } from "../projects/my-projects.component";
 import { TheirBookmarksComponent } from "./their-bookmarks.component";
 
@@ -21,9 +22,8 @@ describe("TheirBookmarksComponent", () => {
   function configureTestingModule(model?: User, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       declarations: [MyProjectsComponent],
-      imports: [SharedModule, RouterTestingModule],
+      imports: [SharedModule, RouterTestingModule, MockBawApiModule],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(

--- a/src/app/component/profile/pages/my-edit/my-edit.component.spec.ts
+++ b/src/app/component/profile/pages/my-edit/my-edit.component.spec.ts
@@ -6,6 +6,7 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { userResolvers, UserService } from "@baw-api/user/user.service";
 import { User } from "@models/User";
 import { SharedModule } from "@shared/shared.module";
+import { generateUser } from "@test/fakes/User";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { appLibraryImports } from "src/app/app.module";
 import { MyEditComponent } from "./my-edit.component";
@@ -14,10 +15,9 @@ describe("MyProfileEditComponent", () => {
   let api: UserService;
   let component: MyEditComponent;
   let fixture: ComponentFixture<MyEditComponent>;
-  let defaultError: ApiErrorDetails;
   let defaultUser: User;
 
-  function configureTestingModule(user: User, error: ApiErrorDetails) {
+  function configureTestingModule(model: User, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       imports: [
         ...appLibraryImports,
@@ -31,7 +31,7 @@ describe("MyProfileEditComponent", () => {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
             { user: userResolvers.show },
-            { user: { model: user, error } }
+            { user: { model, error } }
           ),
         },
       ],
@@ -45,18 +45,12 @@ describe("MyProfileEditComponent", () => {
   }
 
   beforeEach(() => {
-    defaultUser = new User({
-      id: 1,
-      userName: "Username",
-    });
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
+    // TODO Handle image urls
+    defaultUser = new User({ ...generateUser(), imageUrls: undefined });
   });
 
   it("should create", () => {
-    configureTestingModule(defaultUser, undefined);
+    configureTestingModule(defaultUser);
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/component/profile/pages/my-edit/my-edit.component.spec.ts
+++ b/src/app/component/profile/pages/my-edit/my-edit.component.spec.ts
@@ -2,10 +2,11 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { userResolvers, UserService } from "@baw-api/user/user.service";
 import { User } from "@models/User";
 import { SharedModule } from "@shared/shared.module";
-import { mockActivatedRoute, testBawServices } from "@test/helpers/testbed";
+import { mockActivatedRoute } from "@test/helpers/testbed";
 import { appLibraryImports } from "src/app/app.module";
 import { MyEditComponent } from "./my-edit.component";
 
@@ -18,22 +19,19 @@ describe("MyProfileEditComponent", () => {
 
   function configureTestingModule(user: User, error: ApiErrorDetails) {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [MyEditComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
-            {
-              user: userResolvers.show,
-            },
-            {
-              user: {
-                model: user,
-                error,
-              },
-            }
+            { user: userResolvers.show },
+            { user: { model: user, error } }
           ),
         },
       ],

--- a/src/app/component/profile/pages/profile/my-profile.component.spec.ts
+++ b/src/app/component/profile/pages/profile/my-profile.component.spec.ts
@@ -4,9 +4,16 @@ import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { BookmarksService } from "@baw-api/bookmark/bookmarks.service";
+import { ProjectsService } from "@baw-api/project/projects.service";
+import { ShallowSitesService } from "@baw-api/site/sites.service";
+import { TagsService } from "@baw-api/tag/tags.service";
 import { userResolvers } from "@baw-api/user/user.service";
 import { User } from "@models/User";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateUser } from "@test/fakes/User";
+import { Subject } from "rxjs";
 import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { MyProfileComponent } from "./my-profile.component";
 
@@ -37,15 +44,28 @@ describe("MyProfileComponent", () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(MyProfileComponent);
+    const projectApi = TestBed.inject(ProjectsService) as SpyObject<
+      ProjectsService
+    >;
+    const tagApi = TestBed.inject(TagsService) as SpyObject<TagsService>;
+    const bookmarkApi = TestBed.inject(BookmarksService) as SpyObject<
+      BookmarksService
+    >;
+    const siteApi = TestBed.inject(ShallowSitesService) as SpyObject<
+      ShallowSitesService
+    >;
     component = fixture.componentInstance;
+
+    projectApi.list.and.callFake(() => new Subject());
+    tagApi.list.and.callFake(() => new Subject());
+    bookmarkApi.list.and.callFake(() => new Subject());
+    siteApi.list.and.callFake(() => new Subject());
+
     fixture.detectChanges();
   }
 
   beforeEach(() => {
-    defaultUser = new User({
-      id: 1,
-      userName: "Username",
-    });
+    defaultUser = new User(generateUser());
     defaultError = {
       status: 401,
       message: "Unauthorized",

--- a/src/app/component/profile/pages/profile/my-profile.component.spec.ts
+++ b/src/app/component/profile/pages/profile/my-profile.component.spec.ts
@@ -3,13 +3,11 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { userResolvers } from "@baw-api/user/user.service";
 import { User } from "@models/User";
 import { SharedModule } from "@shared/shared.module";
-import {
-  mockActivatedRoute,
-  testBawServices,
-} from "src/app/test/helpers/testbed";
+import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { MyProfileComponent } from "./my-profile.component";
 
 describe("MyProfileComponent", () => {
@@ -20,22 +18,19 @@ describe("MyProfileComponent", () => {
 
   function configureTestingModule(user: User, error: ApiErrorDetails) {
     TestBed.configureTestingModule({
-      imports: [SharedModule, HttpClientTestingModule, RouterTestingModule],
+      imports: [
+        SharedModule,
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [MyProfileComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
-            {
-              user: userResolvers.show,
-            },
-            {
-              user: {
-                model: user,
-                error,
-              },
-            }
+            { user: userResolvers.show },
+            { user: { model: user, error } }
           ),
         },
       ],

--- a/src/app/component/profile/pages/profile/my-profile.component.spec.ts
+++ b/src/app/component/profile/pages/profile/my-profile.component.spec.ts
@@ -20,10 +20,9 @@ import { MyProfileComponent } from "./my-profile.component";
 describe("MyProfileComponent", () => {
   let component: MyProfileComponent;
   let fixture: ComponentFixture<MyProfileComponent>;
-  let defaultError: ApiErrorDetails;
   let defaultUser: User;
 
-  function configureTestingModule(user: User, error: ApiErrorDetails) {
+  function configureTestingModule(model: User, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       imports: [
         SharedModule,
@@ -37,7 +36,7 @@ describe("MyProfileComponent", () => {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
             { user: userResolvers.show },
-            { user: { model: user, error } }
+            { user: { model, error } }
           ),
         },
       ],
@@ -66,14 +65,10 @@ describe("MyProfileComponent", () => {
 
   beforeEach(() => {
     defaultUser = new User(generateUser());
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
   });
 
   it("should create", () => {
-    configureTestingModule(defaultUser, undefined);
+    configureTestingModule(defaultUser);
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/component/profile/pages/profile/their-profile.component.spec.ts
+++ b/src/app/component/profile/pages/profile/their-profile.component.spec.ts
@@ -7,16 +7,16 @@ import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { User } from "@models/User";
 import { SharedModule } from "@shared/shared.module";
+import { generateUser } from "@test/fakes/User";
 import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { TheirProfileComponent } from "./their-profile.component";
 
 xdescribe("TheirProfileComponent", () => {
   let component: TheirProfileComponent;
   let fixture: ComponentFixture<TheirProfileComponent>;
-  let defaultError: ApiErrorDetails;
   let defaultUser: User;
 
-  function configureTestingModule(user: User, error: ApiErrorDetails) {
+  function configureTestingModule(model: User, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       imports: [
         SharedModule,
@@ -30,7 +30,7 @@ xdescribe("TheirProfileComponent", () => {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
             { account: accountResolvers.show },
-            { account: { model: user, error } }
+            { account: { model, error } }
           ),
         },
       ],
@@ -42,18 +42,11 @@ xdescribe("TheirProfileComponent", () => {
   }
 
   beforeEach(() => {
-    defaultUser = new User({
-      id: 1,
-      userName: "Username",
-    });
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
+    defaultUser = new User(generateUser());
   });
 
   it("should create", () => {
-    configureTestingModule(defaultUser, undefined);
+    configureTestingModule(defaultUser);
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/component/profile/pages/profile/their-profile.component.spec.ts
+++ b/src/app/component/profile/pages/profile/their-profile.component.spec.ts
@@ -4,12 +4,10 @@ import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { accountResolvers } from "@baw-api/account/accounts.service";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { User } from "@models/User";
 import { SharedModule } from "@shared/shared.module";
-import {
-  mockActivatedRoute,
-  testBawServices,
-} from "src/app/test/helpers/testbed";
+import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { TheirProfileComponent } from "./their-profile.component";
 
 xdescribe("TheirProfileComponent", () => {
@@ -20,22 +18,19 @@ xdescribe("TheirProfileComponent", () => {
 
   function configureTestingModule(user: User, error: ApiErrorDetails) {
     TestBed.configureTestingModule({
-      imports: [SharedModule, HttpClientTestingModule, RouterTestingModule],
+      imports: [
+        SharedModule,
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [TheirProfileComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
-            {
-              account: accountResolvers.show,
-            },
-            {
-              account: {
-                model: user,
-                error,
-              },
-            }
+            { account: accountResolvers.show },
+            { account: { model: user, error } }
           ),
         },
       ],

--- a/src/app/component/profile/pages/projects/my-projects.component.spec.ts
+++ b/src/app/component/profile/pages/projects/my-projects.component.spec.ts
@@ -9,6 +9,7 @@ import { IProject, Project } from "@models/Project";
 import { User } from "@models/User";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateProject } from "@test/fakes/Project";
 import { generateUser } from "@test/fakes/User";
 import { BehaviorSubject } from "rxjs";
@@ -23,7 +24,6 @@ describe("MyProjectsComponent", () => {
   let api: SpyObject<ProjectsService>;
   let component: MyProjectsComponent;
   let defaultUser: User;
-  let defaultError: ApiErrorDetails;
   let fixture: ComponentFixture<MyProjectsComponent>;
 
   function configureTestingModule(model?: User, error?: ApiErrorDetails) {
@@ -66,16 +66,15 @@ describe("MyProjectsComponent", () => {
       },
     });
 
-    api.filter.and.callFake(() => {
-      return new BehaviorSubject<Project[]>([project]);
-    });
+    api.filter.and.callFake(
+      () => new BehaviorSubject<Project[]>([project])
+    );
 
     return project;
   }
 
   beforeEach(() => {
     defaultUser = new User(generateUser());
-    defaultError = { status: 401, message: "Unauthorized" };
   });
 
   it("should create", () => {
@@ -97,7 +96,7 @@ describe("MyProjectsComponent", () => {
   });
 
   it("should handle user error", () => {
-    configureTestingModule(undefined, defaultError);
+    configureTestingModule(undefined, generateApiErrorDetails());
     setProject();
     fixture.detectChanges();
     expect(component).toBeTruthy();

--- a/src/app/component/profile/pages/projects/my-projects.component.spec.ts
+++ b/src/app/component/profile/pages/projects/my-projects.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ProjectsService } from "@baw-api/project/projects.service";
 import { userResolvers } from "@baw-api/user/user.service";
 import { IProject, Project } from "@models/Project";
@@ -12,10 +13,7 @@ import {
   assertResolverErrorHandling,
   assertRoute,
 } from "src/app/test/helpers/html";
-import {
-  mockActivatedRoute,
-  testBawServices,
-} from "src/app/test/helpers/testbed";
+import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { MyProjectsComponent } from "./my-projects.component";
 
 describe("MyProjectsComponent", () => {
@@ -28,9 +26,8 @@ describe("MyProjectsComponent", () => {
   function configureTestingModule(model?: User, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       declarations: [MyProjectsComponent],
-      imports: [SharedModule, RouterTestingModule],
+      imports: [SharedModule, RouterTestingModule, MockBawApiModule],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(

--- a/src/app/component/profile/pages/sites/my-sites.component.spec.ts
+++ b/src/app/component/profile/pages/sites/my-sites.component.spec.ts
@@ -9,6 +9,7 @@ import { ISite, Site } from "@models/Site";
 import { User } from "@models/User";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateSite } from "@test/fakes/Site";
 import { generateUser } from "@test/fakes/User";
 import { BehaviorSubject } from "rxjs";
@@ -23,7 +24,6 @@ describe("MySitesComponent", () => {
   let api: SpyObject<ShallowSitesService>;
   let component: MySitesComponent;
   let defaultUser: User;
-  let defaultError: ApiErrorDetails;
   let fixture: ComponentFixture<MySitesComponent>;
 
   function configureTestingModule(model?: User, error?: ApiErrorDetails) {
@@ -75,7 +75,6 @@ describe("MySitesComponent", () => {
 
   beforeEach(() => {
     defaultUser = new User(generateUser());
-    defaultError = { status: 401, message: "Unauthorized" };
   });
 
   it("should create", () => {
@@ -97,7 +96,7 @@ describe("MySitesComponent", () => {
   });
 
   it("should handle user error", () => {
-    configureTestingModule(undefined, defaultError);
+    configureTestingModule(undefined, generateApiErrorDetails());
     setSite();
     fixture.detectChanges();
     expect(component).toBeTruthy();

--- a/src/app/component/profile/pages/sites/my-sites.component.spec.ts
+++ b/src/app/component/profile/pages/sites/my-sites.component.spec.ts
@@ -7,7 +7,10 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ShallowSitesService } from "@baw-api/site/sites.service";
 import { ISite, Site } from "@models/Site";
 import { User } from "@models/User";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateSite } from "@test/fakes/Site";
+import { generateUser } from "@test/fakes/User";
 import { BehaviorSubject } from "rxjs";
 import {
   assertResolverErrorHandling,
@@ -17,7 +20,7 @@ import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { MySitesComponent } from "./my-sites.component";
 
 describe("MySitesComponent", () => {
-  let api: ShallowSitesService;
+  let api: SpyObject<ShallowSitesService>;
   let component: MySitesComponent;
   let defaultUser: User;
   let defaultError: ApiErrorDetails;
@@ -39,25 +42,54 @@ describe("MySitesComponent", () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(MySitesComponent);
-    api = TestBed.inject(ShallowSitesService);
+    api = TestBed.inject(ShallowSitesService) as SpyObject<ShallowSitesService>;
     component = fixture.componentInstance;
   }
 
+  function setSite(data?: ISite): Site {
+    if (!data) {
+      api.filter.and.callFake(() => {
+        return new BehaviorSubject<Site[]>([]);
+      });
+      return;
+    }
+
+    const site = new Site({ ...generateSite(), ...data });
+    site.addMetadata({
+      status: 200,
+      message: "OK",
+      paging: {
+        page: 1,
+        items: 25,
+        total: 1,
+        maxPage: 1,
+      },
+    });
+
+    api.filter.and.callFake(() => {
+      return new BehaviorSubject<Site[]>([site]);
+    });
+
+    return site;
+  }
+
   beforeEach(() => {
-    defaultUser = new User({ id: 1, userName: "username" });
+    defaultUser = new User(generateUser());
     defaultError = { status: 401, message: "Unauthorized" };
   });
 
   it("should create", () => {
     configureTestingModule(defaultUser);
+    setSite();
     fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
   it("should display username in title", () => {
     configureTestingModule(
-      new User({ ...defaultUser, userName: "custom username" })
+      new User({ ...generateUser(), userName: "custom username" })
     );
+    setSite();
     fixture.detectChanges();
 
     const title = fixture.nativeElement.querySelector("small");
@@ -66,6 +98,7 @@ describe("MySitesComponent", () => {
 
   it("should handle user error", () => {
     configureTestingModule(undefined, defaultError);
+    setSite();
     fixture.detectChanges();
     expect(component).toBeTruthy();
 
@@ -73,26 +106,6 @@ describe("MySitesComponent", () => {
   });
 
   describe("table", () => {
-    function setSite(data: ISite) {
-      const site = new Site({ id: 1, name: "site", ...data });
-      site.addMetadata({
-        status: 200,
-        message: "OK",
-        paging: {
-          page: 1,
-          items: 25,
-          total: 1,
-          maxPage: 1,
-        },
-      });
-
-      spyOn(api, "filter").and.callFake(() => {
-        return new BehaviorSubject<Site[]>([site]);
-      });
-
-      return site;
-    }
-
     function getCells(): NodeListOf<HTMLDivElement> {
       return fixture.nativeElement.querySelectorAll("datatable-body-cell");
     }

--- a/src/app/component/profile/pages/sites/my-sites.component.spec.ts
+++ b/src/app/component/profile/pages/sites/my-sites.component.spec.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { accountResolvers } from "@baw-api/account/accounts.service";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ShallowSitesService } from "@baw-api/site/sites.service";
 import { ISite, Site } from "@models/Site";
 import { User } from "@models/User";
@@ -12,10 +13,7 @@ import {
   assertResolverErrorHandling,
   assertRoute,
 } from "src/app/test/helpers/html";
-import {
-  mockActivatedRoute,
-  testBawServices,
-} from "src/app/test/helpers/testbed";
+import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { MySitesComponent } from "./my-sites.component";
 
 describe("MySitesComponent", () => {
@@ -28,9 +26,8 @@ describe("MySitesComponent", () => {
   function configureTestingModule(model?: User, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       declarations: [MySitesComponent],
-      imports: [SharedModule, RouterTestingModule],
+      imports: [SharedModule, RouterTestingModule, MockBawApiModule],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(

--- a/src/app/component/profile/pages/their-edit/their-edit.component.spec.ts
+++ b/src/app/component/profile/pages/their-edit/their-edit.component.spec.ts
@@ -13,10 +13,9 @@ import { TheirEditComponent } from "./their-edit.component";
 describe("TheirProfileEditComponent", () => {
   let component: TheirEditComponent;
   let fixture: ComponentFixture<TheirEditComponent>;
-  let defaultError: ApiErrorDetails;
   let defaultUser: User;
 
-  function configureTestingModule(user: User, error: ApiErrorDetails) {
+  function configureTestingModule(model: User, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       imports: [
         ...appLibraryImports,
@@ -30,7 +29,7 @@ describe("TheirProfileEditComponent", () => {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
             { account: accountResolvers.show },
-            { account: { model: user, error } }
+            { account: { model, error } }
           ),
         },
       ],
@@ -47,14 +46,10 @@ describe("TheirProfileEditComponent", () => {
       id: 1,
       userName: "Username",
     });
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
   });
 
   it("should create", () => {
-    configureTestingModule(defaultUser, undefined);
+    configureTestingModule(defaultUser);
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/component/profile/pages/their-edit/their-edit.component.spec.ts
+++ b/src/app/component/profile/pages/their-edit/their-edit.component.spec.ts
@@ -3,13 +3,11 @@ import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { accountResolvers } from "@baw-api/account/accounts.service";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { User } from "@models/User";
 import { SharedModule } from "@shared/shared.module";
 import { appLibraryImports } from "src/app/app.module";
-import {
-  mockActivatedRoute,
-  testBawServices,
-} from "src/app/test/helpers/testbed";
+import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { TheirEditComponent } from "./their-edit.component";
 
 describe("TheirProfileEditComponent", () => {
@@ -20,22 +18,19 @@ describe("TheirProfileEditComponent", () => {
 
   function configureTestingModule(user: User, error: ApiErrorDetails) {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [TheirEditComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
-            {
-              account: accountResolvers.show,
-            },
-            {
-              account: {
-                model: user,
-                error,
-              },
-            }
+            { account: accountResolvers.show },
+            { account: { model: user, error } }
           ),
         },
       ],

--- a/src/app/component/projects/pages/assign/assign.component.spec.ts
+++ b/src/app/component/projects/pages/assign/assign.component.spec.ts
@@ -4,15 +4,18 @@ import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { projectResolvers } from "@baw-api/project/projects.service";
-import { SitesService } from "@baw-api/site/sites.service";
+import { ShallowSitesService } from "@baw-api/site/sites.service";
 import { Project } from "@models/Project";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateProject } from "@test/fakes/Project";
+import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { AssignComponent } from "./assign.component";
 
 describe("AssignComponent", () => {
-  let api: SitesService;
+  let api: SpyObject<ShallowSitesService>;
   let component: AssignComponent;
   let defaultError: ApiErrorDetails;
   let defaultProject: Project;
@@ -43,16 +46,14 @@ describe("AssignComponent", () => {
 
     fixture = TestBed.createComponent(AssignComponent);
     component = fixture.componentInstance;
-    api = TestBed.inject(SitesService);
+    api = TestBed.inject(ShallowSitesService) as SpyObject<ShallowSitesService>;
+    api.filter.and.callFake(() => new Subject());
 
     fixture.detectChanges();
   }
 
   beforeEach(() => {
-    defaultProject = new Project({
-      id: 1,
-      name: "Project",
-    });
+    defaultProject = new Project(generateProject());
     defaultError = {
       status: 401,
       message: "Unauthorized",

--- a/src/app/component/projects/pages/assign/assign.component.spec.ts
+++ b/src/app/component/projects/pages/assign/assign.component.spec.ts
@@ -17,14 +17,10 @@ import { AssignComponent } from "./assign.component";
 describe("AssignComponent", () => {
   let api: SpyObject<ShallowSitesService>;
   let component: AssignComponent;
-  let defaultError: ApiErrorDetails;
   let defaultProject: Project;
   let fixture: ComponentFixture<AssignComponent>;
 
-  function configureTestingModule(
-    project: Project,
-    projectError: ApiErrorDetails
-  ) {
+  function configureTestingModule(model: Project, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       imports: [
         ...appLibraryImports,
@@ -38,7 +34,7 @@ describe("AssignComponent", () => {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
             { project: projectResolvers.show },
-            { project: { model: project, error: projectError } }
+            { project: { model, error } }
           ),
         },
       ],
@@ -54,14 +50,10 @@ describe("AssignComponent", () => {
 
   beforeEach(() => {
     defaultProject = new Project(generateProject());
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
   });
 
   it("should create", () => {
-    configureTestingModule(defaultProject, undefined);
+    configureTestingModule(defaultProject);
     expect(component).toBeTruthy();
   });
 

--- a/src/app/component/projects/pages/assign/assign.component.spec.ts
+++ b/src/app/component/projects/pages/assign/assign.component.spec.ts
@@ -2,15 +2,13 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { SitesService } from "@baw-api/site/sites.service";
 import { Project } from "@models/Project";
 import { SharedModule } from "@shared/shared.module";
 import { appLibraryImports } from "src/app/app.module";
-import {
-  mockActivatedRoute,
-  testBawServices,
-} from "src/app/test/helpers/testbed";
+import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { AssignComponent } from "./assign.component";
 
 describe("AssignComponent", () => {
@@ -25,22 +23,19 @@ describe("AssignComponent", () => {
     projectError: ApiErrorDetails
   ) {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [AssignComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
-            {
-              project: projectResolvers.show,
-            },
-            {
-              project: {
-                model: project,
-                error: projectError,
-              },
-            }
+            { project: projectResolvers.show },
+            { project: { model: project, error: projectError } }
           ),
         },
       ],

--- a/src/app/component/projects/pages/assign/assign.component.ts
+++ b/src/app/component/projects/pages/assign/assign.component.ts
@@ -1,7 +1,6 @@
-import { Component, OnInit } from "@angular/core";
+import { Component } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { projectResolvers } from "@baw-api/project/projects.service";
-import { ResolvedModel } from "@baw-api/resolver-common";
 import { ShallowSitesService } from "@baw-api/site/sites.service";
 import {
   assignSiteMenuItem,

--- a/src/app/component/projects/pages/delete/delete.component.spec.ts
+++ b/src/app/component/projects/pages/delete/delete.component.spec.ts
@@ -9,16 +9,18 @@ import {
 } from "@baw-api/project/projects.service";
 import { projectsMenuItem } from "@component/projects/projects.menus";
 import { Project } from "@models/Project";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateProject } from "@test/fakes/Project";
 import { ToastrService } from "ngx-toastr";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { assertResolverErrorHandling } from "src/app/test/helpers/html";
 import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { DeleteComponent } from "./delete.component";
 
 describe("ProjectsDeleteComponent", () => {
-  let api: ProjectsService;
+  let api: SpyObject<ProjectsService>;
   let component: DeleteComponent;
   let defaultError: ApiErrorDetails;
   let defaultProject: Project;
@@ -52,7 +54,7 @@ describe("ProjectsDeleteComponent", () => {
     fixture = TestBed.createComponent(DeleteComponent);
     component = fixture.componentInstance;
     router = TestBed.inject(Router);
-    api = TestBed.inject(ProjectsService);
+    api = TestBed.inject(ProjectsService) as SpyObject<ProjectsService>;
     notifications = TestBed.inject(ToastrService);
 
     spyOn(notifications, "success").and.stub();
@@ -63,10 +65,7 @@ describe("ProjectsDeleteComponent", () => {
   }
 
   beforeEach(() => {
-    defaultProject = new Project({
-      id: 1,
-      name: "Project",
-    });
+    defaultProject = new Project(generateProject());
     defaultError = {
       status: 401,
       message: "Unauthorized",
@@ -93,14 +92,14 @@ describe("ProjectsDeleteComponent", () => {
 
     it("should call api", () => {
       configureTestingModule(defaultProject, undefined);
-      spyOn(api, "destroy").and.callThrough();
+      api.destroy.and.callFake(() => new Subject());
       component.submit({});
       expect(api.destroy).toHaveBeenCalled();
     });
 
     it("should redirect to projects", () => {
       configureTestingModule(defaultProject, undefined);
-      spyOn(api, "destroy").and.callFake(() => new BehaviorSubject<void>(null));
+      api.destroy.and.callFake(() => new BehaviorSubject<void>(null));
 
       component.submit({});
       expect(router.navigateByUrl).toHaveBeenCalledWith(

--- a/src/app/component/projects/pages/delete/delete.component.spec.ts
+++ b/src/app/component/projects/pages/delete/delete.component.spec.ts
@@ -11,6 +11,7 @@ import { projectsMenuItem } from "@component/projects/projects.menus";
 import { Project } from "@models/Project";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateProject } from "@test/fakes/Project";
 import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject, Subject } from "rxjs";
@@ -22,16 +23,12 @@ import { DeleteComponent } from "./delete.component";
 describe("ProjectsDeleteComponent", () => {
   let api: SpyObject<ProjectsService>;
   let component: DeleteComponent;
-  let defaultError: ApiErrorDetails;
   let defaultProject: Project;
   let fixture: ComponentFixture<DeleteComponent>;
   let notifications: ToastrService;
   let router: Router;
 
-  function configureTestingModule(
-    project: Project,
-    projectError: ApiErrorDetails
-  ) {
+  function configureTestingModule(model: Project, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       imports: [
         ...appLibraryImports,
@@ -45,7 +42,7 @@ describe("ProjectsDeleteComponent", () => {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
             { project: projectResolvers.show },
-            { project: { model: project, error: projectError } }
+            { project: { model, error } }
           ),
         },
       ],
@@ -66,39 +63,35 @@ describe("ProjectsDeleteComponent", () => {
 
   beforeEach(() => {
     defaultProject = new Project(generateProject());
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
   });
 
   describe("form", () => {
     it("should have no fields", () => {
-      configureTestingModule(defaultProject, undefined);
+      configureTestingModule(defaultProject);
       expect(component.fields).toEqual([]);
     });
   });
 
   describe("component", () => {
     it("should create", () => {
-      configureTestingModule(defaultProject, undefined);
+      configureTestingModule(defaultProject);
       expect(component).toBeTruthy();
     });
 
     it("should handle project error", () => {
-      configureTestingModule(undefined, defaultError);
+      configureTestingModule(undefined, generateApiErrorDetails());
       assertResolverErrorHandling(fixture);
     });
 
     it("should call api", () => {
-      configureTestingModule(defaultProject, undefined);
+      configureTestingModule(defaultProject);
       api.destroy.and.callFake(() => new Subject());
       component.submit({});
       expect(api.destroy).toHaveBeenCalled();
     });
 
     it("should redirect to projects", () => {
-      configureTestingModule(defaultProject, undefined);
+      configureTestingModule(defaultProject);
       api.destroy.and.callFake(() => new BehaviorSubject<void>(null));
 
       component.submit({});

--- a/src/app/component/projects/pages/delete/delete.component.spec.ts
+++ b/src/app/component/projects/pages/delete/delete.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import {
   projectResolvers,
   ProjectsService,
@@ -13,10 +14,7 @@ import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { assertResolverErrorHandling } from "src/app/test/helpers/html";
-import {
-  mockActivatedRoute,
-  testBawServices,
-} from "src/app/test/helpers/testbed";
+import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { DeleteComponent } from "./delete.component";
 
 describe("ProjectsDeleteComponent", () => {
@@ -33,22 +31,19 @@ describe("ProjectsDeleteComponent", () => {
     projectError: ApiErrorDetails
   ) {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [DeleteComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
-            {
-              project: projectResolvers.show,
-            },
-            {
-              project: {
-                model: project,
-                error: projectError,
-              },
-            }
+            { project: projectResolvers.show },
+            { project: { model: project, error: projectError } }
           ),
         },
       ],

--- a/src/app/component/projects/pages/details/details.component.spec.ts
+++ b/src/app/component/projects/pages/details/details.component.spec.ts
@@ -10,6 +10,8 @@ import { Project } from "@models/Project";
 import { Site } from "@models/Site";
 import { MockMapComponent } from "@shared/map/mapMock.component";
 import { SharedModule } from "@shared/shared.module";
+import { generateProject } from "@test/fakes/Project";
+import { generateSite } from "@test/fakes/Site";
 import { assertImage } from "@test/helpers/html";
 import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { DetailsComponent } from "./details.component";
@@ -52,7 +54,7 @@ describe("ProjectDetailsComponent", () => {
   }
 
   beforeEach(() => {
-    defaultProject = new Project({ id: 1, name: "Project" });
+    defaultProject = new Project(generateProject());
     defaultSites = [];
     defaultError = { status: 401, message: "Unauthorized" };
   });
@@ -89,8 +91,8 @@ describe("ProjectDetailsComponent", () => {
   describe("Project", () => {
     it("should display project name", () => {
       const project = new Project({
-        id: 1,
-        name: "Test project",
+        ...generateProject(),
+        name: "Test Project",
       });
 
       configureTestingModule(project, undefined, defaultSites, undefined);
@@ -98,13 +100,14 @@ describe("ProjectDetailsComponent", () => {
 
       const title = fixture.nativeElement.querySelector("h1");
       expect(title).toBeTruthy();
-      expect(title.innerText).toBe("Test project");
+      expect(title.innerText).toBe("Test Project");
     });
 
     it("should display default project image", () => {
       const project = new Project({
-        id: 1,
-        name: "Test project",
+        ...generateProject(),
+        name: "Test Project",
+        imageUrl: undefined,
       });
 
       configureTestingModule(project, undefined, defaultSites, undefined);
@@ -114,14 +117,14 @@ describe("ProjectDetailsComponent", () => {
       assertImage(
         image,
         `http://${window.location.host}/assets/images/project/project_span4.png`,
-        "Test project image"
+        "Test Project image"
       );
     });
 
     it("should display custom project image", () => {
       const project = new Project({
-        id: 1,
-        name: "Test project",
+        ...generateProject(),
+        name: "Test Project",
         imageUrl: "http://brokenlink/",
       });
 
@@ -129,13 +132,12 @@ describe("ProjectDetailsComponent", () => {
       fixture.detectChanges();
 
       const image = fixture.nativeElement.querySelector("img");
-      assertImage(image, "http://brokenlink/", "Test project image");
+      assertImage(image, "http://brokenlink/", "Test Project image");
     });
 
     it("should display description", () => {
       const project = new Project({
-        id: 1,
-        name: "Test project",
+        ...generateProject(),
         description: "A test project",
       });
 
@@ -165,11 +167,7 @@ describe("ProjectDetailsComponent", () => {
     });
 
     it("should display single site", fakeAsync(() => {
-      const site = new Site({
-        id: 1,
-        name: "Site",
-        description: "A sample site",
-      });
+      const site = new Site(generateSite());
 
       configureTestingModule(defaultProject, undefined, [site], undefined);
       fixture.detectChanges();
@@ -179,11 +177,7 @@ describe("ProjectDetailsComponent", () => {
     }));
 
     it("should display single site with name", fakeAsync(() => {
-      const site = new Site({
-        id: 1,
-        name: "Custom Site",
-        description: "A sample site",
-      });
+      const site = new Site({ ...generateSite(), name: "Custom Site" });
 
       configureTestingModule(defaultProject, undefined, [site], undefined);
       fixture.detectChanges();
@@ -194,18 +188,7 @@ describe("ProjectDetailsComponent", () => {
     }));
 
     it("should display multiple sites", fakeAsync(() => {
-      const sites = [
-        new Site({
-          id: 1,
-          name: "Site 1",
-          description: "A sample site",
-        }),
-        new Site({
-          id: 2,
-          name: "Site 2",
-          description: "A sample site",
-        }),
-      ];
+      const sites = [new Site(generateSite()), new Site(generateSite())];
 
       configureTestingModule(defaultProject, undefined, sites, undefined);
       fixture.detectChanges();
@@ -216,16 +199,8 @@ describe("ProjectDetailsComponent", () => {
 
     it("should display multiple sites in order", fakeAsync(() => {
       const sites = [
-        new Site({
-          id: 1,
-          name: "Site 1",
-          description: "A sample site",
-        }),
-        new Site({
-          id: 2,
-          name: "Site 2",
-          description: "A sample site",
-        }),
+        new Site({ ...generateSite(1), name: "Site 1" }),
+        new Site({ ...generateSite(2), name: "Site 2" }),
       ];
 
       configureTestingModule(defaultProject, undefined, sites, undefined);
@@ -254,42 +229,20 @@ describe("ProjectDetailsComponent", () => {
     });
 
     it("should display google maps with pin for single site", () => {
-      const site = new Site({
-        id: 1,
-        name: "Site",
-        description: "A sample site",
-        locationObfuscated: true,
-        customLatitude: 0,
-        customLongitude: 1,
-      });
+      const site = new Site(generateSite());
 
       configureTestingModule(defaultProject, undefined, [site], undefined);
       fixture.detectChanges();
 
       const googleMaps = fixture.nativeElement.querySelector("baw-map");
       expect(googleMaps).toBeTruthy();
-      expect(googleMaps.querySelector("p").innerText).toBe("Lat: 0 Long: 1");
+      expect(googleMaps.querySelector("p").innerText).toBe(
+        `Lat: ${site.getLatitude()} Long: ${site.getLongitude()}`
+      );
     });
 
     it("should display google maps with pins for multiple sites", () => {
-      const sites = [
-        new Site({
-          id: 1,
-          name: "Site",
-          description: "A sample site",
-          locationObfuscated: true,
-          customLatitude: 0,
-          customLongitude: 1,
-        }),
-        new Site({
-          id: 2,
-          name: "Site",
-          description: "A sample site",
-          locationObfuscated: true,
-          customLatitude: 2,
-          customLongitude: 3,
-        }),
-      ];
+      const sites = [new Site(generateSite()), new Site(generateSite())];
 
       configureTestingModule(defaultProject, undefined, sites, undefined);
       fixture.detectChanges();
@@ -298,8 +251,12 @@ describe("ProjectDetailsComponent", () => {
       const output = googleMaps.querySelectorAll("p");
       expect(googleMaps).toBeTruthy();
       expect(output.length).toBe(2);
-      expect(output[0].innerText).toBe("Lat: 0 Long: 1");
-      expect(output[1].innerText).toBe("Lat: 2 Long: 3");
+      expect(output[0].innerText).toBe(
+        `Lat: ${sites[0].getLatitude()} Long: ${sites[0].getLongitude()}`
+      );
+      expect(output[1].innerText).toBe(
+        `Lat: ${sites[1].getLatitude()} Long: ${sites[1].getLongitude()}`
+      );
     });
   });
 });

--- a/src/app/component/projects/pages/details/details.component.spec.ts
+++ b/src/app/component/projects/pages/details/details.component.spec.ts
@@ -10,6 +10,7 @@ import { Project } from "@models/Project";
 import { Site } from "@models/Site";
 import { MockMapComponent } from "@shared/map/mapMock.component";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
 import { assertImage } from "@test/helpers/html";
@@ -21,7 +22,6 @@ describe("ProjectDetailsComponent", () => {
   let fixture: ComponentFixture<DetailsComponent>;
   let defaultProject: Project;
   let defaultSites: Site[];
-  let defaultError: ApiErrorDetails;
 
   function configureTestingModule(
     project: Project,
@@ -56,7 +56,6 @@ describe("ProjectDetailsComponent", () => {
   beforeEach(() => {
     defaultProject = new Project(generateProject());
     defaultSites = [];
-    defaultError = { status: 401, message: "Unauthorized" };
   });
 
   it("should create", () => {
@@ -67,7 +66,12 @@ describe("ProjectDetailsComponent", () => {
 
   describe("Error Handling", () => {
     it("should handle failed project model", () => {
-      configureTestingModule(undefined, defaultError, defaultSites, undefined);
+      configureTestingModule(
+        undefined,
+        generateApiErrorDetails(),
+        defaultSites,
+        undefined
+      );
       fixture.detectChanges();
 
       const body = fixture.nativeElement;
@@ -79,7 +83,7 @@ describe("ProjectDetailsComponent", () => {
         defaultProject,
         undefined,
         undefined,
-        defaultError
+        generateApiErrorDetails()
       );
       fixture.detectChanges();
 

--- a/src/app/component/projects/pages/details/details.component.spec.ts
+++ b/src/app/component/projects/pages/details/details.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, fakeAsync, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { siteResolvers } from "@baw-api/site/sites.service";
 import { SiteCardComponent } from "@component/projects/site-card/site-card.component";
@@ -10,10 +11,7 @@ import { Site } from "@models/Site";
 import { MockMapComponent } from "@shared/map/mapMock.component";
 import { SharedModule } from "@shared/shared.module";
 import { assertImage } from "@test/helpers/html";
-import {
-  mockActivatedRoute,
-  testBawServices,
-} from "src/app/test/helpers/testbed";
+import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { DetailsComponent } from "./details.component";
 
 describe("ProjectDetailsComponent", () => {
@@ -30,10 +28,9 @@ describe("ProjectDetailsComponent", () => {
     sitesError: ApiErrorDetails
   ) {
     TestBed.configureTestingModule({
-      imports: [SharedModule, RouterTestingModule],
+      imports: [SharedModule, RouterTestingModule, MockBawApiModule],
       declarations: [MockMapComponent, SiteCardComponent, DetailsComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(

--- a/src/app/component/projects/pages/edit/edit.component.spec.ts
+++ b/src/app/component/projects/pages/edit/edit.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import {
   projectResolvers,
   ProjectsService,
@@ -9,11 +10,7 @@ import { Project } from "@models/Project";
 import { generateProject } from "@test/fakes/Project";
 import { testFormlyFields } from "@test/helpers/formly";
 import { assertResolverErrorHandling } from "@test/helpers/html";
-import {
-  mockActivatedRoute,
-  testBawServices,
-  testFormImports,
-} from "@test/helpers/testbed";
+import { mockActivatedRoute, testFormImports } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { Subject } from "rxjs";
 import { fields } from "../../project.schema.json";
@@ -33,10 +30,9 @@ describe("ProjectsEditComponent", () => {
     projectError: ApiErrorDetails
   ) {
     TestBed.configureTestingModule({
-      imports: testFormImports,
+      imports: [...testFormImports, MockBawApiModule],
       declarations: [EditComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(

--- a/src/app/component/projects/pages/edit/edit.component.spec.ts
+++ b/src/app/component/projects/pages/edit/edit.component.spec.ts
@@ -7,6 +7,7 @@ import {
   ProjectsService,
 } from "@baw-api/project/projects.service";
 import { Project } from "@models/Project";
+import { SpyObject } from "@ngneat/spectator";
 import { generateProject } from "@test/fakes/Project";
 import { testFormlyFields } from "@test/helpers/formly";
 import { assertResolverErrorHandling } from "@test/helpers/html";
@@ -17,7 +18,7 @@ import { fields } from "../../project.schema.json";
 import { EditComponent } from "./edit.component";
 
 describe("ProjectsEditComponent", () => {
-  let api: ProjectsService;
+  let api: SpyObject<ProjectsService>;
   let component: EditComponent;
   let defaultError: ApiErrorDetails;
   let defaultProject: Project;
@@ -46,7 +47,7 @@ describe("ProjectsEditComponent", () => {
     fixture = TestBed.createComponent(EditComponent);
     component = fixture.componentInstance;
     router = TestBed.inject(Router);
-    api = TestBed.inject(ProjectsService);
+    api = TestBed.inject(ProjectsService) as SpyObject<ProjectsService>;
     notifications = TestBed.inject(ToastrService);
 
     spyOn(notifications, "success").and.stub();
@@ -102,14 +103,14 @@ describe("ProjectsEditComponent", () => {
 
     it("should call api", () => {
       configureTestingModule(defaultProject, undefined);
-      spyOn(api, "update").and.callThrough();
+      api.update.and.callFake(() => new Subject());
       component.submit({});
       expect(api.update).toHaveBeenCalled();
     });
 
     it("should handle general error", () => {
       configureTestingModule(defaultProject, undefined);
-      spyOn(api, "update").and.callFake(() => {
+      api.update.and.callFake(() => {
         const subject = new Subject<Project>();
 
         subject.error({
@@ -129,7 +130,7 @@ describe("ProjectsEditComponent", () => {
 
     it("should handle duplicate project name", () => {
       configureTestingModule(defaultProject, undefined);
-      spyOn(api, "update").and.callFake(() => {
+      api.update.and.callFake(() => {
         const subject = new Subject<Project>();
 
         subject.error({
@@ -138,10 +139,10 @@ describe("ProjectsEditComponent", () => {
           info: {
             name: ["has already been taken"],
             image: [],
-            image_file_name: [],
-            image_file_size: [],
-            image_content_type: [],
-            image_updated_at: [],
+            imageFileName: [],
+            imageFileSize: [],
+            imageContentType: [],
+            imageUpdatedAt: [],
           },
         } as ApiErrorDetails);
 

--- a/src/app/component/projects/pages/edit/edit.component.spec.ts
+++ b/src/app/component/projects/pages/edit/edit.component.spec.ts
@@ -8,6 +8,7 @@ import {
 } from "@baw-api/project/projects.service";
 import { Project } from "@models/Project";
 import { SpyObject } from "@ngneat/spectator";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateProject } from "@test/fakes/Project";
 import { testFormlyFields } from "@test/helpers/formly";
 import { assertResolverErrorHandling } from "@test/helpers/html";
@@ -20,16 +21,12 @@ import { EditComponent } from "./edit.component";
 describe("ProjectsEditComponent", () => {
   let api: SpyObject<ProjectsService>;
   let component: EditComponent;
-  let defaultError: ApiErrorDetails;
   let defaultProject: Project;
   let fixture: ComponentFixture<EditComponent>;
   let notifications: ToastrService;
   let router: Router;
 
-  function configureTestingModule(
-    project: Project,
-    projectError: ApiErrorDetails
-  ) {
+  function configureTestingModule(model: Project, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       imports: [...testFormImports, MockBawApiModule],
       declarations: [EditComponent],
@@ -38,7 +35,7 @@ describe("ProjectsEditComponent", () => {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
             { project: projectResolvers.show },
-            { project: { model: project, error: projectError } }
+            { project: { model, error } }
           ),
         },
       ],
@@ -59,7 +56,6 @@ describe("ProjectsEditComponent", () => {
 
   beforeEach(() => {
     defaultProject = new Project(generateProject());
-    defaultError = { status: 401, message: "Unauthorized" };
   });
 
   describe("form", () => {
@@ -92,37 +88,35 @@ describe("ProjectsEditComponent", () => {
 
   describe("component", () => {
     it("should create", () => {
-      configureTestingModule(defaultProject, undefined);
+      configureTestingModule(defaultProject);
       expect(component).toBeTruthy();
     });
 
     it("should handle project error", () => {
-      configureTestingModule(undefined, defaultError);
+      configureTestingModule(undefined, generateApiErrorDetails());
       assertResolverErrorHandling(fixture);
     });
 
     it("should call api", () => {
-      configureTestingModule(defaultProject, undefined);
+      configureTestingModule(defaultProject);
       api.update.and.callFake(() => new Subject());
       component.submit({});
       expect(api.update).toHaveBeenCalled();
     });
 
     it("should handle general error", () => {
-      configureTestingModule(defaultProject, undefined);
+      configureTestingModule(defaultProject);
       api.update.and.callFake(() => {
         const subject = new Subject<Project>();
-
-        subject.error({
-          message: "Sign in to access this feature.",
-          info: 401,
-        } as ApiErrorDetails);
-
+        subject.error(
+          generateApiErrorDetails("Unauthorized", {
+            message: "Sign in to access this feature.",
+          })
+        );
         return subject;
       });
 
       component.submit(defaultProject);
-
       expect(notifications.error).toHaveBeenCalledWith(
         "Sign in to access this feature."
       );
@@ -132,19 +126,11 @@ describe("ProjectsEditComponent", () => {
       configureTestingModule(defaultProject, undefined);
       api.update.and.callFake(() => {
         const subject = new Subject<Project>();
-
-        subject.error({
-          message: "Record could not be saved",
-          status: 422,
-          info: {
-            name: ["has already been taken"],
-            image: [],
-            imageFileName: [],
-            imageFileSize: [],
-            imageContentType: [],
-            imageUpdatedAt: [],
-          },
-        } as ApiErrorDetails);
+        subject.error(
+          generateApiErrorDetails("Unprocessable Entity", {
+            info: { name: ["has already been taken"] },
+          })
+        );
 
         return subject;
       });

--- a/src/app/component/projects/pages/list/list.component.spec.ts
+++ b/src/app/component/projects/pages/list/list.component.spec.ts
@@ -7,14 +7,15 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { Project } from "@models/Project";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
+import { generateProject } from "@test/fakes/Project";
 import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { ListComponent } from "./list.component";
 
 describe("ProjectsListComponent", () => {
   let fixture: ComponentFixture<ListComponent>;
-  let defaultError: ApiErrorDetails;
 
-  function configureTestingModule(projects: Project[], error: ApiErrorDetails) {
+  function configureTestingModule(model: Project[], error: ApiErrorDetails) {
     TestBed.configureTestingModule({
       imports: [
         SharedModule,
@@ -27,15 +28,8 @@ describe("ProjectsListComponent", () => {
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
-            {
-              projects: projectResolvers.list,
-            },
-            {
-              projects: {
-                model: projects,
-                error,
-              },
-            }
+            { projects: projectResolvers.list },
+            { projects: { model, error } }
           ),
         },
       ],
@@ -56,13 +50,6 @@ describe("ProjectsListComponent", () => {
     expect(card.querySelector(".card-text").innerText.trim()).toBe(description);
   }
 
-  beforeEach(() => {
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
-  });
-
   it("should handle zero projects", () => {
     const projects = [];
     configureTestingModule(projects, undefined);
@@ -76,12 +63,7 @@ describe("ProjectsListComponent", () => {
   });
 
   it("should display single project card", () => {
-    const projects = [
-      new Project({
-        id: 1,
-        name: "Custom Project",
-      }),
-    ];
+    const projects = [new Project(generateProject())];
     configureTestingModule(projects, undefined);
     fixture.detectChanges();
 
@@ -90,25 +72,17 @@ describe("ProjectsListComponent", () => {
   });
 
   it("should display single project card with title", () => {
-    const projects = [
-      new Project({
-        id: 1,
-        name: "Custom Project",
-      }),
-    ];
+    const projects = [new Project(generateProject())];
     configureTestingModule(projects, undefined);
     fixture.detectChanges();
 
     const cards = getCards();
-    assertCardTitle(cards[0], "Custom Project");
+    assertCardTitle(cards[0], projects[0].name);
   });
 
   it("should display single project card with default description", () => {
     const projects = [
-      new Project({
-        id: 1,
-        name: "Custom Project",
-      }),
+      new Project({ ...generateProject(), description: undefined }),
     ];
     configureTestingModule(projects, undefined);
     fixture.detectChanges();
@@ -118,34 +92,19 @@ describe("ProjectsListComponent", () => {
   });
 
   it("should display single project card with custom description", () => {
-    const projects = [
-      new Project({
-        id: 1,
-        name: "Custom Project",
-        description: "Custom Description",
-      }),
-    ];
+    const projects = [new Project(generateProject())];
     configureTestingModule(projects, undefined);
     fixture.detectChanges();
 
     const cards = getCards();
-    assertCardDescription(cards[0], "Custom Description");
+    assertCardDescription(cards[0], projects[0].description);
   });
 
   it("should display multiple project cards", () => {
     const projects = [
-      new Project({
-        id: 1,
-        name: "Project 1",
-      }),
-      new Project({
-        id: 2,
-        name: "Project 2",
-      }),
-      new Project({
-        id: 3,
-        name: "Project 3",
-      }),
+      new Project(generateProject()),
+      new Project(generateProject()),
+      new Project(generateProject()),
     ];
     configureTestingModule(projects, undefined);
     fixture.detectChanges();
@@ -156,18 +115,9 @@ describe("ProjectsListComponent", () => {
 
   it("should display multiple project cards in order", () => {
     const projects = [
-      new Project({
-        id: 1,
-        name: "Project 1",
-      }),
-      new Project({
-        id: 2,
-        name: "Project 2",
-      }),
-      new Project({
-        id: 3,
-        name: "Project 3",
-      }),
+      new Project({ ...generateProject(), name: "Project 1" }),
+      new Project({ ...generateProject(), name: "Project 2" }),
+      new Project({ ...generateProject(), name: "Project 3" }),
     ];
     configureTestingModule(projects, undefined);
     fixture.detectChanges();
@@ -179,7 +129,7 @@ describe("ProjectsListComponent", () => {
   });
 
   it("should handle failed projects model", () => {
-    configureTestingModule(undefined, defaultError);
+    configureTestingModule(undefined, generateApiErrorDetails());
     fixture.detectChanges();
 
     const body = fixture.nativeElement;

--- a/src/app/component/projects/pages/list/list.component.spec.ts
+++ b/src/app/component/projects/pages/list/list.component.spec.ts
@@ -3,13 +3,11 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { Project } from "@models/Project";
 import { SharedModule } from "@shared/shared.module";
-import {
-  mockActivatedRoute,
-  testBawServices,
-} from "src/app/test/helpers/testbed";
+import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { ListComponent } from "./list.component";
 
 describe("ProjectsListComponent", () => {
@@ -18,10 +16,14 @@ describe("ProjectsListComponent", () => {
 
   function configureTestingModule(projects: Project[], error: ApiErrorDetails) {
     TestBed.configureTestingModule({
-      imports: [SharedModule, HttpClientModule, RouterTestingModule],
+      imports: [
+        SharedModule,
+        HttpClientModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [ListComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(

--- a/src/app/component/projects/pages/new/new.component.spec.ts
+++ b/src/app/component/projects/pages/new/new.component.spec.ts
@@ -5,6 +5,7 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ProjectsService } from "@baw-api/project/projects.service";
 import { Project } from "@models/Project";
 import { SpyObject } from "@ngneat/spectator";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { testFormlyFields } from "@test/helpers/formly";
 import { mockActivatedRoute, testFormImports } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
@@ -105,20 +106,11 @@ describe("ProjectsNewComponent", () => {
     it("should handle duplicate project name", () => {
       api.create.and.callFake(() => {
         const subject = new Subject<Project>();
-
-        subject.error({
-          message: "Record could not be saved",
-          status: 422,
-          info: {
-            name: ["has already been taken"],
-            image: [],
-            imageFileName: [],
-            imageFileSize: [],
-            imageContentType: [],
-            imageUpdatedAt: [],
-          },
-        } as ApiErrorDetails);
-
+        subject.error(
+          generateApiErrorDetails("Unprocessable Entity", {
+            info: { name: ["has already been taken"] },
+          })
+        );
         return subject;
       });
 

--- a/src/app/component/projects/pages/new/new.component.spec.ts
+++ b/src/app/component/projects/pages/new/new.component.spec.ts
@@ -4,6 +4,7 @@ import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ProjectsService } from "@baw-api/project/projects.service";
 import { Project } from "@models/Project";
+import { SpyObject } from "@ngneat/spectator";
 import { testFormlyFields } from "@test/helpers/formly";
 import { mockActivatedRoute, testFormImports } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
@@ -12,7 +13,7 @@ import { fields } from "../../project.schema.json";
 import { NewComponent } from "./new.component";
 
 describe("ProjectsNewComponent", () => {
-  let api: ProjectsService;
+  let api: SpyObject<ProjectsService>;
   let component: NewComponent;
   let fixture: ComponentFixture<NewComponent>;
   let notifications: ToastrService;
@@ -60,7 +61,7 @@ describe("ProjectsNewComponent", () => {
       }).compileComponents();
 
       fixture = TestBed.createComponent(NewComponent);
-      api = TestBed.inject(ProjectsService);
+      api = TestBed.inject(ProjectsService) as SpyObject<ProjectsService>;
       router = TestBed.inject(Router);
       notifications = TestBed.inject(ToastrService);
       component = fixture.componentInstance;
@@ -77,13 +78,13 @@ describe("ProjectsNewComponent", () => {
     });
 
     it("should call api", () => {
-      spyOn(api, "create").and.callThrough();
+      api.create.and.callFake(() => new Subject());
       component.submit({});
       expect(api.create).toHaveBeenCalled();
     });
 
     it("should handle general error", () => {
-      spyOn(api, "create").and.callFake(() => {
+      api.create.and.callFake(() => {
         const subject = new Subject<Project>();
 
         subject.error({
@@ -102,7 +103,7 @@ describe("ProjectsNewComponent", () => {
     });
 
     it("should handle duplicate project name", () => {
-      spyOn(api, "create").and.callFake(() => {
+      api.create.and.callFake(() => {
         const subject = new Subject<Project>();
 
         subject.error({

--- a/src/app/component/projects/pages/new/new.component.spec.ts
+++ b/src/app/component/projects/pages/new/new.component.spec.ts
@@ -1,14 +1,11 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ProjectsService } from "@baw-api/project/projects.service";
 import { Project } from "@models/Project";
 import { testFormlyFields } from "@test/helpers/formly";
-import {
-  mockActivatedRoute,
-  testBawServices,
-  testFormImports,
-} from "@test/helpers/testbed";
+import { mockActivatedRoute, testFormImports } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { Subject } from "rxjs";
 import { fields } from "../../project.schema.json";
@@ -52,10 +49,9 @@ describe("ProjectsNewComponent", () => {
   describe("component", () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: testFormImports,
+        imports: [...testFormImports, MockBawApiModule],
         declarations: [NewComponent],
         providers: [
-          ...testBawServices,
           {
             provide: ActivatedRoute,
             useClass: mockActivatedRoute(),

--- a/src/app/component/projects/pages/permissions/permissions.component.spec.ts
+++ b/src/app/component/projects/pages/permissions/permissions.component.spec.ts
@@ -9,6 +9,7 @@ import {
 } from "@baw-api/project/projects.service";
 import { Project } from "@models/Project";
 import { SharedModule } from "@shared/shared.module";
+import { generateProject } from "@test/fakes/Project";
 import { appLibraryImports } from "src/app/app.module";
 import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { PermissionsComponent } from "./permissions.component";
@@ -16,14 +17,10 @@ import { PermissionsComponent } from "./permissions.component";
 describe("PermissionsComponent", () => {
   let api: ProjectsService;
   let component: PermissionsComponent;
-  let defaultError: ApiErrorDetails;
   let defaultProject: Project;
   let fixture: ComponentFixture<PermissionsComponent>;
 
-  function configureTestingModule(
-    project: Project,
-    projectError: ApiErrorDetails
-  ) {
+  function configureTestingModule(model: Project, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       imports: [
         ...appLibraryImports,
@@ -36,15 +33,8 @@ describe("PermissionsComponent", () => {
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
-            {
-              project: projectResolvers.show,
-            },
-            {
-              project: {
-                model: project,
-                error: projectError,
-              },
-            }
+            { project: projectResolvers.show },
+            { project: { model, error } }
           ),
         },
       ],
@@ -58,18 +48,11 @@ describe("PermissionsComponent", () => {
   }
 
   beforeEach(() => {
-    defaultProject = new Project({
-      id: 1,
-      name: "Project",
-    });
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
+    defaultProject = new Project(generateProject());
   });
 
   it("should create", () => {
-    configureTestingModule(defaultProject, undefined);
+    configureTestingModule(defaultProject);
     expect(component).toBeTruthy();
   });
 

--- a/src/app/component/projects/pages/permissions/permissions.component.spec.ts
+++ b/src/app/component/projects/pages/permissions/permissions.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import {
   projectResolvers,
   ProjectsService,
@@ -9,10 +10,7 @@ import {
 import { Project } from "@models/Project";
 import { SharedModule } from "@shared/shared.module";
 import { appLibraryImports } from "src/app/app.module";
-import {
-  mockActivatedRoute,
-  testBawServices,
-} from "src/app/test/helpers/testbed";
+import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { PermissionsComponent } from "./permissions.component";
 
 describe("PermissionsComponent", () => {
@@ -27,10 +25,14 @@ describe("PermissionsComponent", () => {
     projectError: ApiErrorDetails
   ) {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [PermissionsComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(

--- a/src/app/component/projects/pages/request/request.component.spec.ts
+++ b/src/app/component/projects/pages/request/request.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import {
   projectResolvers,
   ProjectsService,
@@ -9,10 +10,7 @@ import {
 import { Project } from "@models/Project";
 import { SharedModule } from "@shared/shared.module";
 import { appLibraryImports } from "src/app/app.module";
-import {
-  mockActivatedRoute,
-  testBawServices,
-} from "src/app/test/helpers/testbed";
+import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { RequestComponent } from "./request.component";
 
 describe("ProjectsRequestComponent", () => {
@@ -27,10 +25,14 @@ describe("ProjectsRequestComponent", () => {
     projectError: ApiErrorDetails
   ) {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [RequestComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(

--- a/src/app/component/projects/pages/request/request.component.spec.ts
+++ b/src/app/component/projects/pages/request/request.component.spec.ts
@@ -19,14 +19,10 @@ import { RequestComponent } from "./request.component";
 describe("ProjectsRequestComponent", () => {
   let api: SpyObject<ProjectsService>;
   let component: RequestComponent;
-  let defaultError: ApiErrorDetails;
   let defaultProject: Project;
   let fixture: ComponentFixture<RequestComponent>;
 
-  function configureTestingModule(
-    project: Project,
-    projectError: ApiErrorDetails
-  ) {
+  function configureTestingModule(model: Project, error?: ApiErrorDetails) {
     TestBed.configureTestingModule({
       imports: [
         ...appLibraryImports,
@@ -40,7 +36,7 @@ describe("ProjectsRequestComponent", () => {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
             { project: projectResolvers.show },
-            { project: { model: project, error: projectError } }
+            { project: { model, error } }
           ),
         },
       ],
@@ -57,14 +53,10 @@ describe("ProjectsRequestComponent", () => {
 
   beforeEach(() => {
     defaultProject = new Project(generateProject());
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
   });
 
   it("should create", () => {
-    configureTestingModule(defaultProject, undefined);
+    configureTestingModule(defaultProject);
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/component/projects/pages/request/request.component.spec.ts
+++ b/src/app/component/projects/pages/request/request.component.spec.ts
@@ -8,13 +8,16 @@ import {
   ProjectsService,
 } from "@baw-api/project/projects.service";
 import { Project } from "@models/Project";
+import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateProject } from "@test/fakes/Project";
+import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { RequestComponent } from "./request.component";
 
 describe("ProjectsRequestComponent", () => {
-  let api: ProjectsService;
+  let api: SpyObject<ProjectsService>;
   let component: RequestComponent;
   let defaultError: ApiErrorDetails;
   let defaultProject: Project;
@@ -36,15 +39,8 @@ describe("ProjectsRequestComponent", () => {
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(
-            {
-              project: projectResolvers.show,
-            },
-            {
-              project: {
-                model: project,
-                error: projectError,
-              },
-            }
+            { project: projectResolvers.show },
+            { project: { model: project, error: projectError } }
           ),
         },
       ],
@@ -52,16 +48,15 @@ describe("ProjectsRequestComponent", () => {
 
     fixture = TestBed.createComponent(RequestComponent);
     component = fixture.componentInstance;
-    api = TestBed.inject(ProjectsService);
+    api = TestBed.inject(ProjectsService) as SpyObject<ProjectsService>;
+
+    api.list.and.callFake(() => new Subject());
 
     fixture.detectChanges();
   }
 
   beforeEach(() => {
-    defaultProject = new Project({
-      id: 1,
-      name: "Project",
-    });
+    defaultProject = new Project(generateProject());
     defaultError = {
       status: 401,
       message: "Unauthorized",

--- a/src/app/component/projects/site-card/site-card.component.spec.ts
+++ b/src/app/component/projects/site-card/site-card.component.spec.ts
@@ -1,12 +1,12 @@
 import { ComponentFixture, fakeAsync, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { Project } from "@models/Project";
 import { Site } from "@models/Site";
 import { SharedModule } from "@shared/shared.module";
 import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
 import { assertImage } from "@test/helpers/html";
-import { testBawServices } from "@test/helpers/testbed";
 import { SiteCardComponent } from "./site-card.component";
 
 describe("SiteCardComponent", () => {
@@ -15,9 +15,8 @@ describe("SiteCardComponent", () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SharedModule, RouterTestingModule],
+      imports: [SharedModule, RouterTestingModule, MockBawApiModule],
       declarations: [SiteCardComponent],
-      providers: testBawServices,
     }).compileComponents();
 
     fixture = TestBed.createComponent(SiteCardComponent);

--- a/src/app/component/report-problem/report-problem.component.spec.ts
+++ b/src/app/component/report-problem/report-problem.component.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { SharedModule } from "@shared/shared.module";
-import { testAppInitializer } from "@test/helpers/testbed";
 import { appLibraryImports } from "src/app/app.module";
 import { ReportProblemComponent } from "./report-problem.component";
 
@@ -10,9 +10,8 @@ describe("ReportProblemComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule],
+      imports: [...appLibraryImports, SharedModule, MockAppConfigModule],
       declarations: [ReportProblemComponent],
-      providers: [...testAppInitializer],
     }).compileComponents();
   }));
 

--- a/src/app/component/security/pages/confirm-account/confirm-account.component.spec.ts
+++ b/src/app/component/security/pages/confirm-account/confirm-account.component.spec.ts
@@ -1,8 +1,9 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { FormComponent } from "@shared/form/form.component";
 import { ToastrService } from "ngx-toastr";
 import { testFormlyFields } from "src/app/test/helpers/formly";
-import { testBawServices, testFormImports } from "src/app/test/helpers/testbed";
+import { testFormImports } from "src/app/test/helpers/testbed";
 import { ConfirmPasswordComponent } from "./confirm-account.component";
 import { fields } from "./confirm-account.schema.json";
 
@@ -28,9 +29,8 @@ describe("ConfirmPasswordComponent", () => {
   describe("component", () => {
     beforeEach(async(() => {
       TestBed.configureTestingModule({
-        imports: testFormImports,
+        imports: [...testFormImports, MockBawApiModule],
         declarations: [ConfirmPasswordComponent, FormComponent],
-        providers: testBawServices,
       }).compileComponents();
     }));
 

--- a/src/app/component/security/pages/login/login.component.spec.ts
+++ b/src/app/component/security/pages/login/login.component.spec.ts
@@ -9,6 +9,7 @@ import {
 import { createRoutingFactory, SpectatorRouting } from "@ngneat/spectator";
 import { testApiConfig } from "@services/app-config/appConfigMock.service";
 import { FormComponent } from "@shared/form/form.component";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { testFormlyFields } from "@test/helpers/formly";
 import { nStepObservable } from "@test/helpers/general";
 import { testFormImports } from "@test/helpers/testbed";
@@ -49,11 +50,14 @@ describe("LoginComponent New", () => {
 
   function setLoginError() {
     const subject = new Subject<void>();
-    const error: ApiErrorDetails = {
-      status: 401,
-      message: "Incorrect user name, email, or password.",
-    };
-    const promise = nStepObservable(subject, () => error, true);
+    const promise = nStepObservable(
+      subject,
+      () =>
+        generateApiErrorDetails("Unauthorized", {
+          message: "Incorrect user name, email, or password.",
+        }),
+      true
+    );
     spyOn(api, "signIn").and.callFake(() => subject);
     return promise;
   }

--- a/src/app/component/security/pages/login/login.component.spec.ts
+++ b/src/app/component/security/pages/login/login.component.spec.ts
@@ -1,6 +1,7 @@
 import { Location } from "@angular/common";
 import { Router } from "@angular/router";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import {
   LoginDetails,
   SecurityService,
@@ -10,7 +11,7 @@ import { testApiConfig } from "@services/app-config/appConfigMock.service";
 import { FormComponent } from "@shared/form/form.component";
 import { testFormlyFields } from "@test/helpers/formly";
 import { nStepObservable } from "@test/helpers/general";
-import { testBawServices, testFormImports } from "@test/helpers/testbed";
+import { testFormImports } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { Subject } from "rxjs";
 import { LoginComponent } from "./login.component";
@@ -23,9 +24,8 @@ describe("LoginComponent New", () => {
   let spectator: SpectatorRouting<LoginComponent>;
   const createComponent = createRoutingFactory({
     component: LoginComponent,
-    imports: testFormImports,
+    imports: [...testFormImports, MockBawApiModule],
     declarations: [FormComponent],
-    providers: testBawServices,
     mocks: [ToastrService],
     stubsEnabled: true,
   });

--- a/src/app/component/security/pages/register/register.component.spec.ts
+++ b/src/app/component/security/pages/register/register.component.spec.ts
@@ -1,10 +1,11 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { SecurityService } from "@baw-api/security/security.service";
 import { FormComponent } from "@shared/form/form.component";
 import { WIPComponent } from "@shared/wip/wip.component";
 import { ToastrService } from "ngx-toastr";
 import { testFormlyFields } from "src/app/test/helpers/formly";
-import { testBawServices, testFormImports } from "src/app/test/helpers/testbed";
+import { testFormImports } from "src/app/test/helpers/testbed";
 import { RegisterComponent } from "./register.component";
 import { fields } from "./register.schema.json";
 
@@ -51,9 +52,8 @@ describe("RegisterComponent", () => {
   describe("component", () => {
     beforeEach(async(() => {
       TestBed.configureTestingModule({
-        imports: testFormImports,
+        imports: [...testFormImports, MockBawApiModule],
         declarations: [RegisterComponent, FormComponent, WIPComponent],
-        providers: testBawServices,
       }).compileComponents();
     }));
 

--- a/src/app/component/security/pages/reset-password/reset-password.component.spec.ts
+++ b/src/app/component/security/pages/reset-password/reset-password.component.spec.ts
@@ -1,8 +1,9 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { FormComponent } from "@shared/form/form.component";
 import { ToastrService } from "ngx-toastr";
 import { testFormlyFields } from "src/app/test/helpers/formly";
-import { testBawServices, testFormImports } from "src/app/test/helpers/testbed";
+import { testFormImports } from "src/app/test/helpers/testbed";
 import { ResetPasswordComponent } from "./reset-password.component";
 import { fields } from "./reset-password.schema.json";
 
@@ -28,9 +29,8 @@ describe("ResetPasswordComponent", () => {
   describe("component", () => {
     beforeEach(async(() => {
       TestBed.configureTestingModule({
-        imports: testFormImports,
+        imports: [...testFormImports, MockBawApiModule],
         declarations: [ResetPasswordComponent, FormComponent],
-        providers: testBawServices,
       }).compileComponents();
     }));
 

--- a/src/app/component/security/pages/unlock-account/unlock-account.component.spec.ts
+++ b/src/app/component/security/pages/unlock-account/unlock-account.component.spec.ts
@@ -1,8 +1,9 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { FormComponent } from "@shared/form/form.component";
 import { ToastrService } from "ngx-toastr";
 import { testFormlyFields } from "src/app/test/helpers/formly";
-import { testBawServices, testFormImports } from "src/app/test/helpers/testbed";
+import { testFormImports } from "src/app/test/helpers/testbed";
 import { UnlockAccountComponent } from "./unlock-account.component";
 import { fields } from "./unlock-account.schema.json";
 
@@ -28,9 +29,8 @@ describe("UnlockAccountComponent", () => {
   describe("component", () => {
     beforeEach(async(() => {
       TestBed.configureTestingModule({
-        imports: testFormImports,
+        imports: [...testFormImports, MockBawApiModule],
         declarations: [UnlockAccountComponent, FormComponent],
-        providers: testBawServices,
       }).compileComponents();
     }));
 

--- a/src/app/component/send-audio/send-audio.component.spec.ts
+++ b/src/app/component/send-audio/send-audio.component.spec.ts
@@ -5,8 +5,8 @@ import {
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AppConfigService } from "@services/app-config/app-config.service";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { SharedModule } from "@shared/shared.module";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import { SendAudioComponent } from "./send-audio.component";
 
 describe("SendAudioComponent", () => {
@@ -18,9 +18,13 @@ describe("SendAudioComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [SharedModule, HttpClientTestingModule, RouterTestingModule],
+      imports: [
+        SharedModule,
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
+      ],
       declarations: [SendAudioComponent],
-      providers: [...testAppInitializer],
     }).compileComponents();
   }));
 

--- a/src/app/component/shared/action-menu/action-menu.component.spec.ts
+++ b/src/app/component/shared/action-menu/action-menu.component.spec.ts
@@ -2,8 +2,8 @@ import { HttpClientModule } from "@angular/common/http";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { List } from "immutable";
-import { BehaviorSubject } from "rxjs";
 import { PageInfoInterface } from "src/app/helpers/page/pageInfo";
 import {
   AnyMenuItem,
@@ -15,7 +15,7 @@ import {
 } from "src/app/interfaces/menusInterfaces";
 import { StrongRoute } from "src/app/interfaces/strongRoute";
 import { assertIcon, assertTooltip } from "src/app/test/helpers/html";
-import { testBawServices } from "src/app/test/helpers/testbed";
+import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { SharedModule } from "../shared.module";
 import { ActionMenuComponent } from "./action-menu.component";
 
@@ -54,19 +54,19 @@ describe("ActionMenuComponent", () => {
   }
 
   function createTestBed(params: any, data: PageInfoInterface) {
-    class MockActivatedRoute {
-      public data = new BehaviorSubject<PageInfoInterface>(data);
-      public snapshot = {
-        params,
-      };
-    }
-
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, HttpClientModule, SharedModule],
+      imports: [
+        RouterTestingModule,
+        HttpClientModule,
+        SharedModule,
+        MockBawApiModule,
+      ],
       declarations: [ActionMenuComponent],
       providers: [
-        ...testBawServices,
-        { provide: ActivatedRoute, useClass: MockActivatedRoute },
+        {
+          provide: ActivatedRoute,
+          useClass: mockActivatedRoute(undefined, data, params),
+        },
       ],
     }).compileComponents();
     fixture = TestBed.createComponent(ActionMenuComponent);

--- a/src/app/component/shared/cards/card-image/card-image.component.spec.ts
+++ b/src/app/component/shared/cards/card-image/card-image.component.spec.ts
@@ -1,12 +1,12 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { AuthenticatedImageModule } from "@directives/image/image.module";
 import { Id, ImageUrl } from "@interfaces/apiInterfaces";
 import { AbstractModel } from "@models/AbstractModel";
 import { createComponentFactory, Spectator } from "@ngneat/spectator";
 import { modelData } from "@test/helpers/faker";
 import { assertHref, assertImage, assertRoute } from "@test/helpers/html";
-import { testBawServices } from "@test/helpers/testbed";
 import { Card } from "../cards.component";
 import { CardImageComponent } from "./card-image.component";
 
@@ -32,8 +32,8 @@ describe("CardImageComponent", () => {
       HttpClientTestingModule,
       RouterTestingModule,
       AuthenticatedImageModule,
+      MockBawApiModule,
     ],
-    providers: testBawServices,
   });
 
   beforeEach(() => {

--- a/src/app/component/shared/cards/cards.component.spec.ts
+++ b/src/app/component/shared/cards/cards.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { AuthenticatedImageModule } from "@directives/image/image.module";
 import {
   createComponentFactory,
@@ -9,7 +10,6 @@ import {
   SpectatorOptions,
 } from "@ngneat/spectator";
 import { modelData } from "@test/helpers/faker";
-import { testBawServices } from "@test/helpers/testbed";
 import { List } from "immutable";
 import { CardImageComponent } from "./card-image/card-image.component";
 import { CardImageMockModel } from "./card-image/card-image.component.spec";
@@ -26,8 +26,8 @@ describe("CardsComponent", () => {
       HttpClientTestingModule,
       RouterTestingModule,
       AuthenticatedImageModule,
+      MockBawApiModule,
     ],
-    providers: testBawServices,
   };
   const createComponent = createComponentFactory(options);
   const createHost = createHostFactory(options);

--- a/src/app/component/shared/cms/cms.component.spec.ts
+++ b/src/app/component/shared/cms/cms.component.spec.ts
@@ -4,11 +4,11 @@ import {
 } from "@angular/common/http/testing";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { SecurityService } from "@baw-api/security/security.service";
 import { assertSpinner } from "@test/helpers/html";
 import { SessionUser } from "src/app/models/User";
 import { AppConfigService } from "src/app/services/app-config/app-config.service";
-import { testBawServices } from "src/app/test/helpers/testbed";
 import { SharedModule } from "../shared.module";
 import { CmsComponent } from "./cms.component";
 
@@ -21,9 +21,13 @@ describe("CmsComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [SharedModule, HttpClientTestingModule, RouterTestingModule],
+      imports: [
+        SharedModule,
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [CmsComponent],
-      providers: [...testBawServices],
     }).compileComponents();
   }));
 

--- a/src/app/component/shared/detail-view/detail-view.component.spec.ts
+++ b/src/app/component/shared/detail-view/detail-view.component.spec.ts
@@ -1,13 +1,13 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { Injector } from "@angular/core";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { MOCK, MockStandardApiService } from "@baw-api/mock/apiMocks.service";
 import { MockModel as AssociatedModel } from "@baw-api/mock/baseApiMock.service";
 import { Id } from "@interfaces/apiInterfaces";
 import { AbstractModel } from "@models/AbstractModel";
 import { HasMany, HasOne } from "@models/AssociationDecorators";
 import { nStepObservable } from "@test/helpers/general";
-import { testBawServices } from "@test/helpers/testbed";
 import { Subject } from "rxjs";
 import { DetailViewComponent } from "./detail-view.component";
 import { RenderFieldComponent } from "./render-field/render-field.component";
@@ -52,9 +52,8 @@ describe("DetailViewComponent", () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [DetailViewComponent, RenderFieldComponent],
-      imports: [HttpClientTestingModule],
+      imports: [HttpClientTestingModule, MockBawApiModule],
       providers: [
-        ...testBawServices,
         MockStandardApiService,
         { provide: MOCK.token, useExisting: MockStandardApiService },
       ],

--- a/src/app/component/shared/detail-view/render-field/render-field.component.spec.ts
+++ b/src/app/component/shared/detail-view/render-field/render-field.component.spec.ts
@@ -1,12 +1,12 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { AuthenticatedImageModule } from "@directives/image/image.module";
 import { AbstractModel, UnresolvedModel } from "@models/AbstractModel";
 import { CheckboxComponent } from "@shared/checkbox/checkbox.component";
 import { modelData } from "@test/helpers/faker";
 import { assertImage, assertRoute } from "@test/helpers/html";
-import { testBawServices } from "@test/helpers/testbed";
 import { DateTime, Duration } from "luxon";
 import { BehaviorSubject, Subject } from "rxjs";
 import { RenderFieldComponent } from "./render-field.component";
@@ -54,8 +54,8 @@ describe("RenderFieldComponent", () => {
         RouterTestingModule,
         AuthenticatedImageModule,
         HttpClientTestingModule,
+        MockBawApiModule,
       ],
-      providers: testBawServices,
     }).compileComponents();
   }));
 

--- a/src/app/component/shared/error-handler/error-handler.component.spec.ts
+++ b/src/app/component/shared/error-handler/error-handler.component.spec.ts
@@ -1,8 +1,8 @@
 import { ChangeDetectorRef, Component, OnInit } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import { SharedModule } from "../shared.module";
 import { ErrorHandlerComponent } from "./error-handler.component";
 
@@ -66,9 +66,8 @@ describe("ErrorHandlerComponent", () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SharedModule, RouterTestingModule],
+      imports: [SharedModule, RouterTestingModule, MockAppConfigModule],
       declarations: [ErrorHandlerComponent, MockComponent],
-      providers: [...testAppInitializer],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ErrorHandlerComponent);

--- a/src/app/component/shared/error-handler/error-handler.component.spec.ts
+++ b/src/app/component/shared/error-handler/error-handler.component.spec.ts
@@ -1,7 +1,9 @@
 import { ChangeDetectorRef, Component, OnInit } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { apiReturnCodes } from "@baw-api/baw-api.service";
 import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
 import { SharedModule } from "../shared.module";
 import { ErrorHandlerComponent } from "./error-handler.component";
@@ -83,10 +85,9 @@ describe("ErrorHandlerComponent", () => {
   });
 
   it("should handle unauthorized code", () => {
-    component.error = {
-      status: 401,
+    component.error = generateApiErrorDetails("Unauthorized", {
       message: "You need to log in or register before continuing.",
-    } as ApiErrorDetails;
+    });
     fixture.detectChanges();
 
     assertTitle("Unauthorized Access");
@@ -94,10 +95,9 @@ describe("ErrorHandlerComponent", () => {
   });
 
   it("should handle not found code", () => {
-    component.error = {
-      status: 404,
+    component.error = generateApiErrorDetails("Not Found", {
       message: "Could not find the requested item.",
-    } as ApiErrorDetails;
+    });
     fixture.detectChanges();
 
     assertTitle("Not Found");
@@ -105,10 +105,10 @@ describe("ErrorHandlerComponent", () => {
   });
 
   it("should handle zero code", () => {
-    component.error = {
+    component.error = generateApiErrorDetails("Custom", {
       status: 0,
       message: "Unknown error has occurred.",
-    } as ApiErrorDetails;
+    });
     fixture.detectChanges();
 
     assertTitle("Unknown Error");
@@ -116,10 +116,10 @@ describe("ErrorHandlerComponent", () => {
   });
 
   it("should handle unknown code", () => {
-    component.error = {
-      status: -1,
+    component.error = generateApiErrorDetails("Custom", {
+      status: apiReturnCodes.unknown,
       message: "Unknown error has occurred.",
-    } as ApiErrorDetails;
+    });
     fixture.detectChanges();
 
     assertTitle("Unknown Error");
@@ -152,10 +152,11 @@ describe("ErrorHandlerComponent", () => {
       nativeElement
     );
 
-    mockComponent.setError({
-      status: 404,
-      message: "Could not find the requested item.",
-    });
+    mockComponent.setError(
+      generateApiErrorDetails("Not Found", {
+        message: "Could not find the requested item.",
+      })
+    );
     mockFixture.detectChanges();
 
     assertTitle("Not Found", nativeElement);

--- a/src/app/component/shared/footer/footer.component.spec.ts
+++ b/src/app/component/shared/footer/footer.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { appLibraryImports } from "src/app/app.module";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import { FooterComponent } from "./footer.component";
 
 describe("FooterComponent", () => {
@@ -10,9 +10,8 @@ describe("FooterComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, RouterTestingModule],
+      imports: [...appLibraryImports, RouterTestingModule, MockAppConfigModule],
       declarations: [FooterComponent],
-      providers: [...testAppInitializer],
     }).compileComponents();
   }));
 

--- a/src/app/component/shared/formly/custom-inputs.module.ts
+++ b/src/app/component/shared/formly/custom-inputs.module.ts
@@ -6,6 +6,7 @@ import { FormlyBootstrapModule } from "@ngx-formly/bootstrap";
 import { FormlyModule } from "@ngx-formly/core";
 import {
   TypeOption,
+  ValidationMessageOption,
   WrapperOption,
 } from "@ngx-formly/core/lib/services/formly.config";
 import { MapModule } from "@shared/map/map.module";
@@ -27,6 +28,30 @@ export const formlyInputTypes: TypeOption[] = [
 
 export const formlyWrappers: WrapperOption[] = [
   { name: "form-field-horizontal", component: FormlyHorizontalWrapper },
+];
+
+export const formlyValidationMessages: ValidationMessageOption[] = [
+  { name: "required", message: "This field is required" },
+  {
+    name: "minlength",
+    message: (_, field) =>
+      `Input should have at least ${field.templateOptions.minLength} characters`,
+  },
+  {
+    name: "maxlength",
+    message: (_, field) =>
+      `This value should be less than ${field.templateOptions.maxLength} characters`,
+  },
+  {
+    name: "min",
+    message: (_, field) =>
+      `This value should be more than ${field.templateOptions.min}`,
+  },
+  {
+    name: "max",
+    message: (_, field) =>
+      `This value should be less than ${field.templateOptions.max}`,
+  },
 ];
 
 const components = [

--- a/src/app/component/shared/header/header.component.spec.ts
+++ b/src/app/component/shared/header/header.component.spec.ts
@@ -7,15 +7,14 @@ import {
 } from "@angular/core/testing";
 import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { SecurityService } from "@baw-api/security/security.service";
-import { generateSessionUser, generateUser } from "@test/fakes/User";
 import { modelData } from "@test/helpers/faker";
 import { assertImage, assertRoute } from "@test/helpers/html";
 import { BehaviorSubject, Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { SessionUser } from "src/app/models/User";
 import { AppConfigService } from "src/app/services/app-config/app-config.service";
-import { testBawServices } from "src/app/test/helpers/testbed";
 import { contactUsMenuItem } from "../../about/about.menus";
 import { adminDashboardMenuItem } from "../../admin/admin.menus";
 import { homeMenuItem } from "../../home/home.menus";
@@ -56,8 +55,8 @@ describe("HeaderComponent", () => {
         SharedModule,
         RouterTestingModule,
         HttpClientTestingModule,
+        MockBawApiModule,
       ],
-      providers: testBawServices,
     }).compileComponents();
   }));
 

--- a/src/app/component/shared/header/header.component.spec.ts
+++ b/src/app/component/shared/header/header.component.spec.ts
@@ -9,6 +9,7 @@ import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { SecurityService } from "@baw-api/security/security.service";
+import { generateSessionUser, generateUser } from "@test/fakes/User";
 import { modelData } from "@test/helpers/faker";
 import { assertImage, assertRoute } from "@test/helpers/html";
 import { BehaviorSubject, Subject } from "rxjs";
@@ -34,13 +35,7 @@ describe("HeaderComponent", () => {
   let router: Router;
 
   function setUser(isLoggedIn: boolean, user?: SessionUser) {
-    if (isLoggedIn) {
-      spyOn(api, "getLocalUser").and.callFake(() => {
-        return user;
-      });
-    }
-
-    spyOn(api, "getAuthTrigger").and.callFake(() => new BehaviorSubject(null));
+    spyOn(api, "getLocalUser").and.callFake(() => (isLoggedIn ? user : null));
   }
 
   beforeEach(async(() => {
@@ -83,36 +78,9 @@ describe("HeaderComponent", () => {
 
   describe("links", () => {
     const userRoles = [
-      {
-        type: "guest",
-        links: {
-          register: true,
-          login: true,
-          profile: false,
-          logout: false,
-          admin: false,
-        },
-      },
-      {
-        type: "logged in",
-        links: {
-          register: false,
-          login: false,
-          profile: true,
-          logout: true,
-          admin: false,
-        },
-      },
-      {
-        type: "admin",
-        links: {
-          register: false,
-          login: false,
-          profile: true,
-          logout: true,
-          admin: true,
-        },
-      },
+      { type: "guest", links: { register: true, login: true } },
+      { type: "logged in", links: { profile: true, logout: true } },
+      { type: "admin", links: { profile: true, logout: true, admin: true } },
     ];
 
     userRoles.forEach((userType) => {
@@ -373,14 +341,7 @@ describe("HeaderComponent", () => {
     it("should redirect to home page when logout successful", fakeAsync(() => {
       setUser(
         true,
-        new SessionUser({
-          id: 1,
-          authToken: "xxxxxxxxxxxxxxx",
-          userName: "custom username",
-          rolesMask: 2,
-          rolesMaskNames: ["user"],
-          lastSeenAt: "2019-12-18T11:16:08.233+10:00",
-        })
+        new SessionUser({ ...generateSessionUser(), ...generateUser() })
       );
       spyOn(api, "signOut").and.callFake(() => {
         const subject = new Subject<void>();
@@ -418,14 +379,7 @@ describe("HeaderComponent", () => {
           count++;
         }
 
-        return new SessionUser({
-          id: 1,
-          authToken: "xxxxxxxxxxxxxxx",
-          userName: "custom username",
-          rolesMask: 2,
-          rolesMaskNames: ["user"],
-          lastSeenAt: "2019-12-18T11:16:08.233+10:00",
-        });
+        return new SessionUser({ ...generateSessionUser(), ...generateUser() });
       });
       fixture.detectChanges();
 
@@ -462,14 +416,7 @@ describe("HeaderComponent", () => {
           count++;
         }
 
-        return new SessionUser({
-          id: 1,
-          authToken: "xxxxxxxxxxxxxxx",
-          userName: "custom username",
-          rolesMask: 2,
-          rolesMaskNames: ["user"],
-          lastSeenAt: "2019-12-18T11:16:08.233+10:00",
-        });
+        return new SessionUser({ ...generateSessionUser(), ...generateUser() });
       });
       fixture.detectChanges();
 

--- a/src/app/component/shared/menu/external-link/external-link.component.spec.ts
+++ b/src/app/component/shared/menu/external-link/external-link.component.spec.ts
@@ -1,9 +1,9 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { MenuLink } from "src/app/interfaces/menusInterfaces";
 import { AppConfigService } from "src/app/services/app-config/app-config.service";
 import { assertIcon, assertTooltip } from "src/app/test/helpers/html";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import { SharedModule } from "../../shared.module";
 import { MenuExternalLinkComponent } from "./external-link.component";
 
@@ -14,9 +14,8 @@ describe("MenuExternalLinkComponent", () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, SharedModule],
+      imports: [RouterTestingModule, SharedModule, MockAppConfigModule],
       declarations: [MenuExternalLinkComponent],
-      providers: [...testAppInitializer],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MenuExternalLinkComponent);

--- a/src/app/component/shared/menu/menu.component.spec.ts
+++ b/src/app/component/shared/menu/menu.component.spec.ts
@@ -3,6 +3,7 @@ import { DebugElement } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { SecurityService } from "@baw-api/security/security.service";
 import { List } from "immutable";
 import {
@@ -14,10 +15,7 @@ import {
 import { StrongRoute } from "src/app/interfaces/strongRoute";
 import { SessionUser } from "src/app/models/User";
 import { assertIcon, assertTooltip, getText } from "src/app/test/helpers/html";
-import {
-  mockActivatedRoute,
-  testBawServices,
-} from "src/app/test/helpers/testbed";
+import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { SharedModule } from "../shared.module";
 import { MenuButtonComponent } from "./button/button.component";
 import { MenuExternalLinkComponent } from "./external-link/external-link.component";
@@ -62,6 +60,7 @@ describe("MenuComponent", () => {
         SharedModule,
         HttpClientModule,
         RouterTestingModule.withRoutes([]),
+        MockBawApiModule,
       ],
       declarations: [
         MenuComponent,
@@ -70,10 +69,9 @@ describe("MenuComponent", () => {
         MenuInternalLinkComponent,
       ],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute({}, data, { attribute: 10 }),
+          useClass: mockActivatedRoute(undefined, data, { attribute: 10 }),
         },
       ],
     }).compileComponents();

--- a/src/app/component/shared/permissions-shield/permissions-shield.component.spec.ts
+++ b/src/app/component/shared/permissions-shield/permissions-shield.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { AccountsService } from "@baw-api/account/accounts.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { siteResolvers } from "@baw-api/site/sites.service";
 import { AbstractModel } from "@models/AbstractModel";
@@ -9,11 +10,7 @@ import { generateSite } from "@test/fakes/Site";
 import { Project } from "src/app/models/Project";
 import { Site } from "src/app/models/Site";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
-import {
-  MockData,
-  MockResolvers,
-  testBawServices,
-} from "src/app/test/helpers/testbed";
+import { MockData, MockResolvers } from "src/app/test/helpers/testbed";
 import { UserBadgeComponent } from "../user-badges/user-badge/user-badge.component";
 import { UserBadgesComponent } from "../user-badges/user-badges.component";
 import { PermissionsShieldComponent } from "./permissions-shield.component";
@@ -24,8 +21,7 @@ describe("PermissionsShieldComponent", () => {
   const createComponent = createRoutingFactory({
     component: PermissionsShieldComponent,
     declarations: [UserBadgesComponent, UserBadgeComponent],
-    imports: [HttpClientTestingModule],
-    providers: testBawServices,
+    imports: [HttpClientTestingModule, MockBawApiModule],
     stubsEnabled: true,
   });
 

--- a/src/app/component/shared/permissions-shield/permissions-shield.component.spec.ts
+++ b/src/app/component/shared/permissions-shield/permissions-shield.component.spec.ts
@@ -1,14 +1,9 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { AccountsService } from "@baw-api/account/accounts.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { siteResolvers } from "@baw-api/site/sites.service";
 import { AbstractModel } from "@models/AbstractModel";
-import {
-  createRoutingFactory,
-  SpectatorRouting,
-  SpyObject,
-} from "@ngneat/spectator";
+import { createRoutingFactory, SpectatorRouting } from "@ngneat/spectator";
 import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
 import { MockComponent } from "ng-mocks";
@@ -21,7 +16,6 @@ import { PermissionsShieldComponent } from "./permissions-shield.component";
 
 describe("PermissionsShieldComponent", () => {
   let spectator: SpectatorRouting<PermissionsShieldComponent>;
-  let api: SpyObject<AccountsService>;
   const createComponent = createRoutingFactory({
     component: PermissionsShieldComponent,
     declarations: [MockComponent(UserBadgesComponent)],
@@ -34,7 +28,6 @@ describe("PermissionsShieldComponent", () => {
   }
 
   function setup(resolvers: MockResolvers, data: MockData) {
-    // TODO Simplify this by mocking UserBadgesComponent
     spectator = createComponent({ data: { resolvers, ...data } });
   }
 

--- a/src/app/component/shared/permissions-shield/permissions-shield.component.spec.ts
+++ b/src/app/component/shared/permissions-shield/permissions-shield.component.spec.ts
@@ -4,23 +4,27 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { siteResolvers } from "@baw-api/site/sites.service";
 import { AbstractModel } from "@models/AbstractModel";
-import { createRoutingFactory, SpectatorRouting } from "@ngneat/spectator";
+import {
+  createRoutingFactory,
+  SpectatorRouting,
+  SpyObject,
+} from "@ngneat/spectator";
 import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
+import { MockComponent } from "ng-mocks";
 import { Project } from "src/app/models/Project";
 import { Site } from "src/app/models/Site";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
 import { MockData, MockResolvers } from "src/app/test/helpers/testbed";
-import { UserBadgeComponent } from "../user-badges/user-badge/user-badge.component";
 import { UserBadgesComponent } from "../user-badges/user-badges.component";
 import { PermissionsShieldComponent } from "./permissions-shield.component";
 
 describe("PermissionsShieldComponent", () => {
   let spectator: SpectatorRouting<PermissionsShieldComponent>;
-  let api: AccountsService;
+  let api: SpyObject<AccountsService>;
   const createComponent = createRoutingFactory({
     component: PermissionsShieldComponent,
-    declarations: [UserBadgesComponent, UserBadgeComponent],
+    declarations: [MockComponent(UserBadgesComponent)],
     imports: [HttpClientTestingModule, MockBawApiModule],
     stubsEnabled: true,
   });
@@ -32,8 +36,6 @@ describe("PermissionsShieldComponent", () => {
   function setup(resolvers: MockResolvers, data: MockData) {
     // TODO Simplify this by mocking UserBadgesComponent
     spectator = createComponent({ data: { resolvers, ...data } });
-    api = spectator.inject(AccountsService);
-    spyOn(api, "show").and.stub();
   }
 
   it("should handle project model", async () => {

--- a/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
+++ b/src/app/component/shared/secondary-menu/secondary-menu.component.spec.ts
@@ -2,6 +2,8 @@ import { HttpClientModule } from "@angular/common/http";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { mockActivatedRoute, MockParams } from "@test/helpers/testbed";
 import { fromJS, List } from "immutable";
 import { BehaviorSubject } from "rxjs";
 import { DefaultMenu } from "src/app/helpers/page/defaultMenus";
@@ -15,7 +17,6 @@ import {
 } from "src/app/interfaces/menusInterfaces";
 import { StrongRoute } from "src/app/interfaces/strongRoute";
 import { assertIcon, assertTooltip } from "src/app/test/helpers/html";
-import { testBawServices } from "src/app/test/helpers/testbed";
 import { homeCategory } from "../../home/home.menus";
 import { SharedModule } from "../shared.module";
 import { SecondaryMenuComponent } from "./secondary-menu.component";
@@ -56,19 +57,20 @@ describe("SecondaryMenuComponent", () => {
     return fixture.nativeElement.querySelectorAll("baw-menu-" + selector);
   }
 
-  function createTestBed(params: any, data: PageInfoInterface) {
-    class MockActivatedRoute {
-      public data = new BehaviorSubject<PageInfoInterface>(data);
-      public snapshot = {
-        params,
-      };
-    }
+  function createTestBed(params: MockParams, data: PageInfoInterface) {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, HttpClientModule, SharedModule],
+      imports: [
+        RouterTestingModule,
+        HttpClientModule,
+        SharedModule,
+        MockBawApiModule,
+      ],
       declarations: [SecondaryMenuComponent],
       providers: [
-        ...testBawServices,
-        { provide: ActivatedRoute, useClass: MockActivatedRoute },
+        {
+          provide: ActivatedRoute,
+          useClass: mockActivatedRoute(undefined, data, params),
+        },
       ],
     }).compileComponents();
     fixture = TestBed.createComponent(SecondaryMenuComponent);

--- a/src/app/component/shared/user-badges/user-badge/user-badge.component.spec.ts
+++ b/src/app/component/shared/user-badges/user-badge/user-badge.component.spec.ts
@@ -1,12 +1,12 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { AuthenticatedImageModule } from "@directives/image/image.module";
 import { ImageSizes } from "@interfaces/apiInterfaces";
 import { createComponentFactory, Spectator } from "@ngneat/spectator";
 import { LoadingModule } from "@shared/loading/loading.module";
 import { generateUser } from "@test/fakes/User";
 import { assertImage, assertRoute, assertSpinner } from "@test/helpers/html";
-import { testBawServices } from "@test/helpers/testbed";
 import { List } from "immutable";
 import { User } from "src/app/models/User";
 import { UserBadgeComponent } from "./user-badge.component";
@@ -20,8 +20,8 @@ describe("UserBadgeComponent", () => {
       HttpClientTestingModule,
       AuthenticatedImageModule,
       LoadingModule,
+      MockBawApiModule,
     ],
-    providers: testBawServices,
   });
 
   const getLabels = (spec?: Spectator<any>) =>

--- a/src/app/component/shared/user-badges/user-badges.component.spec.ts
+++ b/src/app/component/shared/user-badges/user-badges.component.spec.ts
@@ -7,7 +7,11 @@ import { AuthenticatedImageModule } from "@directives/image/image.module";
 import { DateTimeTimezone, Id } from "@interfaces/apiInterfaces";
 import { AbstractModel } from "@models/AbstractModel";
 import { BawDateTime } from "@models/AttributeDecorators";
-import { createComponentFactory, Spectator } from "@ngneat/spectator";
+import {
+  createComponentFactory,
+  Spectator,
+  SpyObject,
+} from "@ngneat/spectator";
 import { LoadingModule } from "@shared/loading/loading.module";
 import { generateUser } from "@test/fakes/User";
 import { modelData } from "@test/helpers/faker";
@@ -39,7 +43,7 @@ export class MockModel extends AbstractModel {
 }
 
 describe("UserBadgesComponent Spec", () => {
-  let api: AccountsService;
+  let api: SpyObject<AccountsService>;
   let spectator: Spectator<UserBadgesComponent>;
   const createComponent = createComponentFactory({
     component: UserBadgesComponent,
@@ -69,7 +73,7 @@ describe("UserBadgesComponent Spec", () => {
       () => (error ? error : user),
       !!error
     );
-    spyOn(api, "show").and.callFake(() => subject);
+    api.show.and.callFake(() => subject);
     return promise;
   }
 
@@ -148,6 +152,7 @@ describe("UserBadgesComponent Spec", () => {
       });
 
       it("should display loading animation", async () => {
+        api.show.and.callFake(() => new Subject());
         spectator.component.ngOnChanges();
         assertSpinner(spectator.fixture, true);
       });
@@ -241,7 +246,7 @@ describe("UserBadgesComponent Spec", () => {
         )
       )
     );
-    spyOn(api, "show").and.callFake(() => subjects[count++]);
+    api.show.and.callFake(() => subjects[count++]);
 
     spectator.setInput(
       "model",

--- a/src/app/component/shared/user-badges/user-badges.component.spec.ts
+++ b/src/app/component/shared/user-badges/user-badges.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AccountsService } from "@baw-api/account/accounts.service";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { AuthenticatedImageModule } from "@directives/image/image.module";
 import { DateTimeTimezone, Id } from "@interfaces/apiInterfaces";
 import { AbstractModel } from "@models/AbstractModel";
@@ -14,7 +15,6 @@ import { nStepObservable } from "@test/helpers/general";
 import { assertSpinner } from "@test/helpers/html";
 import { Subject } from "rxjs";
 import { User } from "src/app/models/User";
-import { testBawServices } from "src/app/test/helpers/testbed";
 import { UserBadgeComponent } from "./user-badge/user-badge.component";
 import { UserBadgesComponent } from "./user-badges.component";
 
@@ -49,8 +49,8 @@ describe("UserBadgesComponent Spec", () => {
       HttpClientTestingModule,
       LoadingModule,
       AuthenticatedImageModule,
+      MockBawApiModule,
     ],
-    providers: testBawServices,
   });
 
   function getUserBadges(): HTMLElement[] {

--- a/src/app/component/shared/user-badges/user-badges.component.spec.ts
+++ b/src/app/component/shared/user-badges/user-badges.component.spec.ts
@@ -13,6 +13,7 @@ import {
   SpyObject,
 } from "@ngneat/spectator";
 import { LoadingModule } from "@shared/loading/loading.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateUser } from "@test/fakes/User";
 import { modelData } from "@test/helpers/faker";
 import { nStepObservable } from "@test/helpers/general";
@@ -128,9 +129,7 @@ describe("UserBadgesComponent Spec", () => {
     },
     {
       title: "Owned By",
-      keys: {
-        ownerId: modelData.id(),
-      },
+      keys: { ownerId: modelData.id() },
     },
   ].forEach((userType) => {
     describe(userType.title + " User Badge", () => {
@@ -191,10 +190,10 @@ describe("UserBadgesComponent Spec", () => {
       });
 
       it("should display badge title on api error", async () => {
-        const promise = interceptApiRequest(undefined, {
-          status: 404,
-          message: "Not Found",
-        });
+        const promise = interceptApiRequest(
+          undefined,
+          generateApiErrorDetails("Not Found")
+        );
         spectator.component.ngOnChanges();
         await promise;
 
@@ -202,10 +201,10 @@ describe("UserBadgesComponent Spec", () => {
       });
 
       it("should display ghost user on api error", async () => {
-        const promise = interceptApiRequest(undefined, {
-          status: 404,
-          message: "Not Found",
-        });
+        const promise = interceptApiRequest(
+          undefined,
+          generateApiErrorDetails("Not Found")
+        );
         spectator.component.ngOnChanges();
         await promise;
 

--- a/src/app/component/shared/wip/wip.component.spec.ts
+++ b/src/app/component/shared/wip/wip.component.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { appLibraryImports } from "src/app/app.module";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import { SharedModule } from "../shared.module";
 import { WIPComponent } from "./wip.component";
 
@@ -10,9 +10,8 @@ describe("WIPComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule],
+      imports: [...appLibraryImports, SharedModule, MockAppConfigModule],
       declarations: [WIPComponent],
-      providers: [...testAppInitializer],
     }).compileComponents();
   }));
 

--- a/src/app/component/sites/pages/delete/delete.component.spec.ts
+++ b/src/app/component/sites/pages/delete/delete.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { siteResolvers, SitesService } from "@baw-api/site/sites.service";
 import { ToastrService } from "ngx-toastr";
@@ -11,10 +12,7 @@ import { Project } from "src/app/models/Project";
 import { Site } from "src/app/models/Site";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
 import { assertResolverErrorHandling } from "src/app/test/helpers/html";
-import {
-  mockActivatedRoute,
-  testBawServices,
-} from "src/app/test/helpers/testbed";
+import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { DeleteComponent } from "./delete.component";
 
 describe("SitesDeleteComponent", () => {
@@ -34,10 +32,14 @@ describe("SitesDeleteComponent", () => {
     siteError: ApiErrorDetails
   ) {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockBawApiModule,
+      ],
       declarations: [DeleteComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(

--- a/src/app/component/sites/pages/delete/delete.component.spec.ts
+++ b/src/app/component/sites/pages/delete/delete.component.spec.ts
@@ -5,6 +5,7 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { siteResolvers, SitesService } from "@baw-api/site/sites.service";
 import { SpyObject } from "@ngneat/spectator";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
 import { ToastrService } from "ngx-toastr";
@@ -21,7 +22,6 @@ import { DeleteComponent } from "./delete.component";
 describe("SitesDeleteComponent", () => {
   let api: SpyObject<SitesService>;
   let component: DeleteComponent;
-  let defaultError: ApiErrorDetails;
   let defaultSite: Site;
   let defaultProject: Project;
   let fixture: ComponentFixture<DeleteComponent>;
@@ -75,10 +75,6 @@ describe("SitesDeleteComponent", () => {
   beforeEach(() => {
     defaultProject = new Project(generateProject());
     defaultSite = new Site(generateSite());
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
   });
 
   describe("form", () => {
@@ -95,7 +91,12 @@ describe("SitesDeleteComponent", () => {
     });
 
     it("should handle project error", () => {
-      configureTestingModule(undefined, defaultError, defaultSite, undefined);
+      configureTestingModule(
+        undefined,
+        generateApiErrorDetails(),
+        defaultSite,
+        undefined
+      );
       assertResolverErrorHandling(fixture);
     });
 
@@ -104,7 +105,7 @@ describe("SitesDeleteComponent", () => {
         defaultProject,
         undefined,
         undefined,
-        defaultError
+        generateApiErrorDetails()
       );
       assertResolverErrorHandling(fixture);
     });

--- a/src/app/component/sites/pages/delete/delete.component.spec.ts
+++ b/src/app/component/sites/pages/delete/delete.component.spec.ts
@@ -4,8 +4,11 @@ import { RouterTestingModule } from "@angular/router/testing";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { siteResolvers, SitesService } from "@baw-api/site/sites.service";
+import { SpyObject } from "@ngneat/spectator";
+import { generateProject } from "@test/fakes/Project";
+import { generateSite } from "@test/fakes/Site";
 import { ToastrService } from "ngx-toastr";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
 import { SharedModule } from "src/app/component/shared/shared.module";
 import { Project } from "src/app/models/Project";
@@ -16,7 +19,7 @@ import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { DeleteComponent } from "./delete.component";
 
 describe("SitesDeleteComponent", () => {
-  let api: SitesService;
+  let api: SpyObject<SitesService>;
   let component: DeleteComponent;
   let defaultError: ApiErrorDetails;
   let defaultSite: Site;
@@ -48,14 +51,8 @@ describe("SitesDeleteComponent", () => {
               site: siteResolvers.show,
             },
             {
-              project: {
-                model: project,
-                error: projectError,
-              },
-              site: {
-                model: site,
-                error: siteError,
-              },
+              project: { model: project, error: projectError },
+              site: { model: site, error: siteError },
             }
           ),
         },
@@ -65,7 +62,7 @@ describe("SitesDeleteComponent", () => {
     fixture = TestBed.createComponent(DeleteComponent);
     component = fixture.componentInstance;
     router = TestBed.inject(Router);
-    api = TestBed.inject(SitesService);
+    api = TestBed.inject(SitesService) as SpyObject<SitesService>;
     notifications = TestBed.inject(ToastrService);
 
     spyOn(notifications, "success").and.stub();
@@ -76,14 +73,8 @@ describe("SitesDeleteComponent", () => {
   }
 
   beforeEach(() => {
-    defaultProject = new Project({
-      id: 1,
-      name: "Project",
-    });
-    defaultSite = new Site({
-      id: 1,
-      name: "Site",
-    });
+    defaultProject = new Project(generateProject());
+    defaultSite = new Site(generateSite());
     defaultError = {
       status: 401,
       message: "Unauthorized",
@@ -120,7 +111,7 @@ describe("SitesDeleteComponent", () => {
 
     it("should call api", () => {
       configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-      spyOn(api, "destroy").and.callThrough();
+      api.destroy.and.callFake(() => new Subject());
       component.submit({});
       expect(api.destroy).toHaveBeenCalled();
     });
@@ -128,7 +119,7 @@ describe("SitesDeleteComponent", () => {
     it("should redirect to projects", () => {
       const spy = spyOnProperty(defaultProject, "viewUrl");
       configureTestingModule(defaultProject, undefined, defaultSite, undefined);
-      spyOn(api, "destroy").and.callFake(() => new BehaviorSubject<void>(null));
+      api.destroy.and.callFake(() => new BehaviorSubject<void>(null));
 
       component.submit({});
       expect(spy).toHaveBeenCalled();

--- a/src/app/component/sites/pages/details/details.component.spec.ts
+++ b/src/app/component/sites/pages/details/details.component.spec.ts
@@ -6,6 +6,7 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { siteResolvers } from "@baw-api/site/sites.service";
 import { MockMapComponent } from "@shared/map/mapMock.component";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
 import { assertImage } from "@test/helpers/html";
@@ -21,7 +22,6 @@ describe("SitesDetailsComponent", () => {
   let fixture: ComponentFixture<DetailsComponent>;
   let defaultProject: Project;
   let defaultSite: Site;
-  let defaultError: ApiErrorDetails;
 
   function configureTestingModule(
     project: Project,
@@ -61,10 +61,6 @@ describe("SitesDetailsComponent", () => {
   beforeEach(() => {
     defaultProject = new Project(generateProject());
     defaultSite = new Site(generateSite());
-    defaultError = {
-      status: 401,
-      message: "Unauthorized",
-    };
   });
 
   it("should create", () => {
@@ -75,7 +71,12 @@ describe("SitesDetailsComponent", () => {
 
   describe("Error Handling", () => {
     it("should handle failed project model", () => {
-      configureTestingModule(undefined, defaultError, defaultSite, undefined);
+      configureTestingModule(
+        undefined,
+        generateApiErrorDetails(),
+        defaultSite,
+        undefined
+      );
       fixture.detectChanges();
 
       const body = fixture.nativeElement;
@@ -87,7 +88,7 @@ describe("SitesDetailsComponent", () => {
         defaultProject,
         undefined,
         undefined,
-        defaultError
+        generateApiErrorDetails()
       );
       fixture.detectChanges();
 

--- a/src/app/component/sites/pages/details/details.component.spec.ts
+++ b/src/app/component/sites/pages/details/details.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { GoogleMapsModule } from "@angular/google-maps";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { siteResolvers } from "@baw-api/site/sites.service";
 import { MockMapComponent } from "@shared/map/mapMock.component";
@@ -12,10 +13,7 @@ import { SharedModule } from "src/app/component/shared/shared.module";
 import { Project } from "src/app/models/Project";
 import { Site } from "src/app/models/Site";
 import { ApiErrorDetails } from "src/app/services/baw-api/api.interceptor.service";
-import {
-  mockActivatedRoute,
-  testBawServices,
-} from "src/app/test/helpers/testbed";
+import { mockActivatedRoute } from "src/app/test/helpers/testbed";
 import { DetailsComponent } from "./details.component";
 
 describe("SitesDetailsComponent", () => {
@@ -32,10 +30,14 @@ describe("SitesDetailsComponent", () => {
     siteError: ApiErrorDetails
   ) {
     TestBed.configureTestingModule({
-      imports: [SharedModule, RouterTestingModule, GoogleMapsModule],
+      imports: [
+        SharedModule,
+        RouterTestingModule,
+        GoogleMapsModule,
+        MockBawApiModule,
+      ],
       declarations: [DetailsComponent, MockMapComponent],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(

--- a/src/app/component/sites/pages/edit/edit.component.spec.ts
+++ b/src/app/component/sites/pages/edit/edit.component.spec.ts
@@ -8,7 +8,11 @@ import {
 } from "@helpers/embedGoogleMaps/embedGoogleMaps";
 import { Project } from "@models/Project";
 import { Site } from "@models/Site";
-import { createRoutingFactory, SpectatorRouting } from "@ngneat/spectator";
+import {
+  createRoutingFactory,
+  SpectatorRouting,
+  SpyObject,
+} from "@ngneat/spectator";
 import { FormComponent } from "@shared/form/form.component";
 import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
@@ -16,7 +20,7 @@ import { testFormlyFields } from "@test/helpers/formly";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { testFormImports } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, Subject } from "rxjs";
 import { fields } from "../../site.base.json";
 import { EditComponent } from "./edit.component";
 
@@ -65,7 +69,7 @@ describe("SitesEditComponent", () => {
   });
 
   describe("component", () => {
-    let api: SitesService;
+    let api: SpyObject<SitesService>;
     let defaultError: ApiErrorDetails;
     let defaultProject: Project;
     let defaultSite: Site;
@@ -116,7 +120,7 @@ describe("SitesEditComponent", () => {
 
     it("should call api", () => {
       setup();
-      spyOn(api, "update").and.callThrough();
+      api.update.and.callFake(() => new Subject());
 
       spectator.component.submit({});
       expect(api.update).toHaveBeenCalled();
@@ -126,7 +130,7 @@ describe("SitesEditComponent", () => {
       setup();
       const site = new Site(generateSite());
       spyOn(site, "getViewUrl").and.stub();
-      spyOn(api, "update").and.callFake(() => new BehaviorSubject<Site>(site));
+      api.update.and.callFake(() => new BehaviorSubject<Site>(site));
 
       spectator.component.submit({});
       expect(site.getViewUrl).toHaveBeenCalledWith(defaultProject);

--- a/src/app/component/sites/pages/edit/edit.component.spec.ts
+++ b/src/app/component/sites/pages/edit/edit.component.spec.ts
@@ -1,4 +1,5 @@
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { siteResolvers, SitesService } from "@baw-api/site/sites.service";
 import {
@@ -13,7 +14,7 @@ import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
 import { testFormlyFields } from "@test/helpers/formly";
 import { assertResolverErrorHandling } from "@test/helpers/html";
-import { testBawServices, testFormImports } from "@test/helpers/testbed";
+import { testFormImports } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject } from "rxjs";
 import { fields } from "../../site.base.json";
@@ -23,9 +24,8 @@ describe("SitesEditComponent", () => {
   let spectator: SpectatorRouting<EditComponent>;
   const createComponent = createRoutingFactory({
     component: EditComponent,
-    imports: testFormImports,
+    imports: [...testFormImports, MockBawApiModule],
     declarations: [FormComponent],
-    providers: testBawServices,
     mocks: [ToastrService],
     stubsEnabled: true,
   });

--- a/src/app/component/sites/pages/edit/edit.component.spec.ts
+++ b/src/app/component/sites/pages/edit/edit.component.spec.ts
@@ -14,6 +14,7 @@ import {
   SpyObject,
 } from "@ngneat/spectator";
 import { FormComponent } from "@shared/form/form.component";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
 import { testFormlyFields } from "@test/helpers/formly";
@@ -70,7 +71,6 @@ describe("SitesEditComponent", () => {
 
   describe("component", () => {
     let api: SpyObject<SitesService>;
-    let defaultError: ApiErrorDetails;
     let defaultProject: Project;
     let defaultSite: Site;
 
@@ -100,7 +100,6 @@ describe("SitesEditComponent", () => {
     beforeEach(() => {
       defaultProject = new Project(generateProject());
       defaultSite = new Site(generateSite());
-      defaultError = { status: 401, message: "Unauthorized" };
     });
 
     it("should create", () => {
@@ -109,12 +108,12 @@ describe("SitesEditComponent", () => {
     });
 
     it("should handle site error", () => {
-      setup(undefined, defaultError);
+      setup(undefined, generateApiErrorDetails());
       assertResolverErrorHandling(spectator.fixture);
     });
 
     it("should handle project error", () => {
-      setup(defaultError);
+      setup(generateApiErrorDetails());
       assertResolverErrorHandling(spectator.fixture);
     });
 

--- a/src/app/component/sites/pages/harvest/harvest.component.spec.ts
+++ b/src/app/component/sites/pages/harvest/harvest.component.spec.ts
@@ -3,9 +3,9 @@ import {
   HttpTestingController,
 } from "@angular/common/http/testing";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { SharedModule } from "src/app/component/shared/shared.module";
 import { AppConfigService } from "src/app/services/app-config/app-config.service";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import { HarvestComponent } from "./harvest.component";
 
 describe("SiteHarvestComponent", () => {
@@ -16,9 +16,8 @@ describe("SiteHarvestComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [SharedModule, HttpClientTestingModule],
+      imports: [SharedModule, HttpClientTestingModule, MockAppConfigModule],
       declarations: [HarvestComponent],
-      providers: [...testAppInitializer],
     }).compileComponents();
   }));
 

--- a/src/app/component/sites/pages/new/new.component.spec.ts
+++ b/src/app/component/sites/pages/new/new.component.spec.ts
@@ -1,4 +1,5 @@
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { SitesService } from "@baw-api/site/sites.service";
 import {
@@ -13,7 +14,7 @@ import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
 import { testFormlyFields } from "@test/helpers/formly";
 import { assertResolverErrorHandling } from "@test/helpers/html";
-import { testBawServices, testFormImports } from "@test/helpers/testbed";
+import { testFormImports } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject } from "rxjs";
 import { fields } from "../../site.base.json";
@@ -23,9 +24,8 @@ describe("SitesNewComponent", () => {
   let spectator: SpectatorRouting<NewComponent>;
   const createComponent = createRoutingFactory({
     component: NewComponent,
-    imports: testFormImports,
+    imports: [...testFormImports, MockBawApiModule],
     declarations: [FormComponent],
-    providers: testBawServices,
     mocks: [ToastrService],
     stubsEnabled: true,
   });

--- a/src/app/component/sites/pages/new/new.component.spec.ts
+++ b/src/app/component/sites/pages/new/new.component.spec.ts
@@ -14,6 +14,7 @@ import {
   SpyObject,
 } from "@ngneat/spectator";
 import { FormComponent } from "@shared/form/form.component";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
 import { testFormlyFields } from "@test/helpers/formly";
@@ -71,7 +72,6 @@ describe("SitesNewComponent", () => {
   describe("component", () => {
     let api: SpyObject<SitesService>;
     let defaultProject: Project;
-    let defaultError: ApiErrorDetails;
 
     function setup(error?: ApiErrorDetails) {
       spectator = createComponent({
@@ -91,7 +91,6 @@ describe("SitesNewComponent", () => {
     afterAll(() => destroyGoogleMaps());
     beforeEach(() => {
       defaultProject = new Project(generateProject());
-      defaultError = { status: 401, message: "Unauthorized" };
     });
 
     it("should create", () => {
@@ -100,7 +99,7 @@ describe("SitesNewComponent", () => {
     });
 
     it("should handle project error", () => {
-      setup(defaultError);
+      setup(generateApiErrorDetails());
       assertResolverErrorHandling(spectator.fixture);
     });
 

--- a/src/app/component/sites/pages/new/new.component.spec.ts
+++ b/src/app/component/sites/pages/new/new.component.spec.ts
@@ -8,7 +8,11 @@ import {
 } from "@helpers/embedGoogleMaps/embedGoogleMaps";
 import { Project } from "@models/Project";
 import { Site } from "@models/Site";
-import { createRoutingFactory, SpectatorRouting } from "@ngneat/spectator";
+import {
+  createRoutingFactory,
+  SpectatorRouting,
+  SpyObject,
+} from "@ngneat/spectator";
 import { FormComponent } from "@shared/form/form.component";
 import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
@@ -16,7 +20,7 @@ import { testFormlyFields } from "@test/helpers/formly";
 import { assertResolverErrorHandling } from "@test/helpers/html";
 import { testFormImports } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, Subject } from "rxjs";
 import { fields } from "../../site.base.json";
 import { NewComponent } from "./new.component";
 
@@ -65,7 +69,7 @@ describe("SitesNewComponent", () => {
   });
 
   describe("component", () => {
-    let api: SitesService;
+    let api: SpyObject<SitesService>;
     let defaultProject: Project;
     let defaultError: ApiErrorDetails;
 
@@ -102,7 +106,7 @@ describe("SitesNewComponent", () => {
 
     it("should call api", () => {
       setup();
-      spyOn(api, "create").and.callThrough();
+      api.create.and.callFake(() => new Subject());
 
       spectator.component.submit({});
       expect(api.create).toHaveBeenCalled();
@@ -112,7 +116,7 @@ describe("SitesNewComponent", () => {
       setup();
       const site = new Site(generateSite());
       spyOn(site, "getViewUrl").and.stub();
-      spyOn(api, "create").and.callFake(() => new BehaviorSubject<Site>(site));
+      api.create.and.callFake(() => new BehaviorSubject<Site>(site));
 
       spectator.component.submit({});
       expect(site.getViewUrl).toHaveBeenCalledWith(defaultProject);

--- a/src/app/component/statistics/pages/statistics.component.spec.ts
+++ b/src/app/component/statistics/pages/statistics.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { appLibraryImports } from "src/app/app.module";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import { SharedModule } from "../../shared/shared.module";
 import { StatisticsComponent } from "./statistics.component";
 
@@ -11,9 +11,13 @@ describe("StatisticsComponent", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [...appLibraryImports, SharedModule, RouterTestingModule],
+      imports: [
+        ...appLibraryImports,
+        SharedModule,
+        RouterTestingModule,
+        MockAppConfigModule,
+      ],
       declarations: [StatisticsComponent],
-      providers: [...testAppInitializer],
     }).compileComponents();
   }));
 

--- a/src/app/directives/image/image.directive.spec.ts
+++ b/src/app/directives/image/image.directive.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { SimpleChange } from "@angular/core";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { SecurityService } from "@baw-api/security/security.service";
 import { ImageSizes, ImageUrl } from "@interfaces/apiInterfaces";
 import { SessionUser } from "@models/User";
@@ -8,7 +9,6 @@ import { testApiConfig } from "@services/app-config/appConfigMock.service";
 import { generateSessionUser } from "@test/fakes/User";
 import { modelData } from "@test/helpers/faker";
 import { assertImage } from "@test/helpers/html";
-import { testBawServices } from "@test/helpers/testbed";
 import {
   AuthenticatedImageDirective,
   image404RelativeSrc,
@@ -19,8 +19,7 @@ describe("ImageDirective", () => {
   const image404Src = `http://${window.location.host}${image404RelativeSrc}`;
   const createDirective = createDirectiveFactory({
     directive: AuthenticatedImageDirective,
-    imports: [HttpClientTestingModule],
-    providers: testBawServices,
+    imports: [HttpClientTestingModule, MockBawApiModule],
   });
 
   function getImage() {

--- a/src/app/guards/guards.module.ts
+++ b/src/app/guards/guards.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from "@angular/core";
+import { FormTouchedGuard } from "./form/form.guard";
+
+@NgModule({
+  providers: [FormTouchedGuard],
+})
+export class GuardModule {}

--- a/src/app/helpers/formTemplate/formTemplate.spec.ts
+++ b/src/app/helpers/formTemplate/formTemplate.spec.ts
@@ -6,6 +6,7 @@ import { AbstractModel } from "@models/AbstractModel";
 import { ApiErrorDetails } from "@services/baw-api/api.interceptor.service";
 import { ResolvedModel } from "@services/baw-api/resolver-common";
 import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import {
   mockActivatedRoute,
   MockData,
@@ -93,7 +94,7 @@ describe("formTemplate", () => {
   }
 
   beforeEach(() => {
-    defaultError = { status: 401, message: "Unauthorized" } as ApiErrorDetails;
+    defaultError = generateApiErrorDetails();
     defaultModel = new MockModel({ id: 1 });
     successResponse = (model) => {
       return new BehaviorSubject<MockModel>(new MockModel(model));
@@ -146,9 +147,7 @@ describe("formTemplate", () => {
     it("should handle single resolver failure", () => {
       configureTestingModule(
         { mockModel: "MockModelResolver" },
-        {
-          mockModel: makeResolvedModel(undefined, defaultError),
-        }
+        { mockModel: makeResolvedModel(undefined, defaultError) }
       );
       fixture.detectChanges();
 
@@ -466,10 +465,9 @@ describe("defaultSuccessMsg", () => {
 
 describe("defaultErrorMsg", () => {
   it("should return error message", () => {
-    const apiError: ApiErrorDetails = {
-      status: 400,
+    const apiError = generateApiErrorDetails("Bad Request", {
       message: "Custom Message",
-    } as ApiErrorDetails;
+    });
 
     expect(defaultErrorMsg(apiError)).toBe("Custom Message");
   });
@@ -477,22 +475,18 @@ describe("defaultErrorMsg", () => {
 
 describe("extendedErrorMsg", () => {
   it("should return error message", () => {
-    const apiError: ApiErrorDetails = {
-      status: 400,
+    const apiError = generateApiErrorDetails("Bad Request", {
       message: "Custom Message",
-    } as ApiErrorDetails;
+    });
 
     expect(extendedErrorMsg(apiError, {})).toBe("Custom Message");
   });
 
   it("should return error message with single info field", () => {
-    const apiError: ApiErrorDetails = {
-      status: 400,
+    const apiError = generateApiErrorDetails("Bad Request", {
       message: "Custom Message",
-      info: {
-        name: "this name already exists",
-      },
-    } as ApiErrorDetails;
+      info: { name: "this name already exists" },
+    });
 
     expect(
       extendedErrorMsg(apiError, {
@@ -502,14 +496,10 @@ describe("extendedErrorMsg", () => {
   });
 
   it("should return error message with multiple info fields", () => {
-    const apiError: ApiErrorDetails = {
-      status: 400,
+    const apiError = generateApiErrorDetails("Bad Request", {
       message: "Custom Message",
-      info: {
-        name: "this name already exists",
-        foo: "bar",
-      },
-    } as ApiErrorDetails;
+      info: { name: "this name already exists", foo: "bar" },
+    });
 
     expect(
       extendedErrorMsg(apiError, {

--- a/src/app/helpers/tableTemplate/pagedTableTemplate.spec.ts
+++ b/src/app/helpers/tableTemplate/pagedTableTemplate.spec.ts
@@ -12,6 +12,7 @@ import { ProjectsService } from "@baw-api/project/projects.service";
 import { Id } from "@interfaces/apiInterfaces";
 import { AbstractModel } from "@models/AbstractModel";
 import { Project } from "@models/Project";
+import { SpyObject } from "@ngneat/spectator";
 import { ApiErrorDetails } from "@services/baw-api/api.interceptor.service";
 import { SharedModule } from "@shared/shared.module";
 import { BehaviorSubject, Subject } from "rxjs";
@@ -55,7 +56,7 @@ class MockComponent extends PagedTableTemplate<
 describe("PagedTableTemplate", () => {
   let component: MockComponent;
   let fixture: ComponentFixture<MockComponent>;
-  let api: ProjectsService;
+  let api: SpyObject<ProjectsService>;
 
   function configureTestingModule(
     resolvers: MockResolvers = {},
@@ -73,12 +74,13 @@ describe("PagedTableTemplate", () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(MockComponent);
-    api = TestBed.inject(ProjectsService);
+    api = TestBed.inject(ProjectsService) as SpyObject<ProjectsService>;
     component = fixture.componentInstance;
   }
 
   it("should create", () => {
     configureTestingModule();
+    api.filter.and.callFake(() => new Subject());
     fixture.detectChanges();
     expect(component).toBeTruthy();
   });
@@ -86,7 +88,7 @@ describe("PagedTableTemplate", () => {
   it("should handle error response", () => {
     configureTestingModule();
     const error = { status: 401, message: "Unauthorized" } as ApiErrorDetails;
-    spyOn(api, "filter").and.callFake(() => {
+    api.filter.and.callFake(() => {
       const subject = new Subject<Project[]>();
       subject.error(error);
       return subject;
@@ -98,7 +100,7 @@ describe("PagedTableTemplate", () => {
 
   describe("resolvers", () => {
     function setProject() {
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         return new BehaviorSubject<Project[]>([]);
       });
     }
@@ -159,7 +161,7 @@ describe("PagedTableTemplate", () => {
 
   describe("rows", () => {
     function setProjects(projects: Project[]) {
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         return new BehaviorSubject<Project[]>(projects);
       });
     }
@@ -230,7 +232,7 @@ describe("PagedTableTemplate", () => {
     });
 
     it("should handle zero models", () => {
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         return new BehaviorSubject<Project[]>([]);
       });
       component.setPage({ offset: 0, count: 1, limit: 25, pageSize: 25 });
@@ -240,7 +242,7 @@ describe("PagedTableTemplate", () => {
     });
 
     it("should handle 0 offset", () => {
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         return new BehaviorSubject<Project[]>([]);
       });
       component.setPage({ offset: 0, count: 1, limit: 25, pageSize: 25 });
@@ -250,7 +252,7 @@ describe("PagedTableTemplate", () => {
     });
 
     it("should handle 1 offset", () => {
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         return new BehaviorSubject<Project[]>([]);
       });
       component.setPage({ offset: 1, count: 26, limit: 25, pageSize: 25 });
@@ -266,7 +268,7 @@ describe("PagedTableTemplate", () => {
     });
 
     it("should handle zero models", () => {
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         return new BehaviorSubject<Project[]>([]);
       });
       fixture.detectChanges();
@@ -287,7 +289,7 @@ describe("PagedTableTemplate", () => {
           total: 25,
         },
       });
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         return new BehaviorSubject<Project[]>([project]);
       });
       component.setPage({ offset: 0, count: 1, limit: 25, pageSize: 25 });
@@ -309,7 +311,7 @@ describe("PagedTableTemplate", () => {
           total: 25,
         },
       });
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         return new BehaviorSubject<Project[]>([project]);
       });
       component.setPage({ offset: 2, count: 51, limit: 25, pageSize: 25 });
@@ -331,7 +333,7 @@ describe("PagedTableTemplate", () => {
           total: 25,
         },
       });
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         return new Subject<Project[]>();
       });
       component.setPage({ offset: 2, count: 51, limit: 25, pageSize: 25 });
@@ -344,7 +346,7 @@ describe("PagedTableTemplate", () => {
   describe("onFilter", () => {
     beforeEach(() => {
       configureTestingModule();
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         return new BehaviorSubject<Project[]>([]);
       });
     });
@@ -435,7 +437,7 @@ describe("PagedTableTemplate", () => {
   describe("onSort", () => {
     beforeEach(() => {
       configureTestingModule();
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         return new BehaviorSubject<Project[]>([]);
       });
     });
@@ -516,7 +518,7 @@ describe("PagedTableTemplate", () => {
     });
 
     it("should handle zero models", () => {
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         return new BehaviorSubject<Project[]>([]);
       });
       fixture.detectChanges();
@@ -538,7 +540,7 @@ describe("PagedTableTemplate", () => {
         },
       });
 
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         return new BehaviorSubject<Project[]>([project]);
       });
       fixture.detectChanges();
@@ -560,7 +562,7 @@ describe("PagedTableTemplate", () => {
         },
       });
 
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         return new BehaviorSubject<Project[]>([project]);
       });
       fixture.detectChanges();
@@ -579,7 +581,7 @@ describe("PagedTableTemplate", () => {
     });
 
     it("should be true while awaiting api response", () => {
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         return new Subject<Project[]>();
       });
       fixture.detectChanges();
@@ -588,7 +590,7 @@ describe("PagedTableTemplate", () => {
     });
 
     it("should be false after success api response", () => {
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         return new BehaviorSubject<Project[]>([]);
       });
       fixture.detectChanges();
@@ -597,7 +599,7 @@ describe("PagedTableTemplate", () => {
     });
 
     it("should be false after error api response", () => {
-      spyOn(api, "filter").and.callFake(() => {
+      api.filter.and.callFake(() => {
         const subject = new Subject<Project[]>();
         subject.error({
           status: 401,

--- a/src/app/helpers/tableTemplate/pagedTableTemplate.spec.ts
+++ b/src/app/helpers/tableTemplate/pagedTableTemplate.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from "@angular/core";
+import { Component } from "@angular/core";
 import {
   ComponentFixture,
   fakeAsync,
@@ -7,19 +7,18 @@ import {
 } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ProjectsService } from "@baw-api/project/projects.service";
 import { Id } from "@interfaces/apiInterfaces";
 import { AbstractModel } from "@models/AbstractModel";
 import { Project } from "@models/Project";
 import { ApiErrorDetails } from "@services/baw-api/api.interceptor.service";
 import { SharedModule } from "@shared/shared.module";
-import { DatatableComponent } from "@swimlane/ngx-datatable";
 import { BehaviorSubject, Subject } from "rxjs";
 import {
   mockActivatedRoute,
   MockData,
   MockResolvers,
-  testBawServices,
 } from "src/app/test/helpers/testbed";
 import { PagedTableTemplate } from "./pagedTableTemplate";
 
@@ -64,9 +63,8 @@ describe("PagedTableTemplate", () => {
   ) {
     TestBed.configureTestingModule({
       declarations: [MockComponent],
-      imports: [SharedModule, RouterTestingModule],
+      imports: [SharedModule, RouterTestingModule, MockBawApiModule],
       providers: [
-        ...testBawServices,
         {
           provide: ActivatedRoute,
           useClass: mockActivatedRoute(resolvers, data),

--- a/src/app/models/AssociationDecorators.spec.ts
+++ b/src/app/models/AssociationDecorators.spec.ts
@@ -6,6 +6,7 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { MOCK, MockStandardApiService } from "@baw-api/mock/apiMocks.service";
 import { MockModel as ChildModel } from "@baw-api/mock/baseApiMock.service";
 import { Id, Ids } from "@interfaces/apiInterfaces";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { nStepObservable } from "@test/helpers/general";
 import { Subject } from "rxjs";
 import { AbstractModel, UnresolvedModel } from "./AbstractModel";
@@ -181,10 +182,10 @@ describe("Association Decorators", () => {
         });
 
         it("should handle error", async () => {
-          const promise = interceptApiRequest(undefined, {
-            status: 401,
-            message: "Unauthorized",
-          });
+          const promise = interceptApiRequest(
+            undefined,
+            generateApiErrorDetails("Unauthorized")
+          );
           const model = createModel({ ids: idsType.empty }, injector);
           await assertModel(promise, model, "childModels", []);
         });
@@ -329,10 +330,10 @@ describe("Association Decorators", () => {
     });
 
     it("should handle error", async () => {
-      const promise = interceptApiRequest(undefined, {
-        status: 401,
-        message: "Unauthorized",
-      });
+      const promise = interceptApiRequest(
+        undefined,
+        generateApiErrorDetails("Unauthorized")
+      );
       const model = createModel({ id: 1 }, injector);
       await assertModel(promise, model, "childModel", null);
     });

--- a/src/app/models/AssociationDecorators.spec.ts
+++ b/src/app/models/AssociationDecorators.spec.ts
@@ -2,12 +2,12 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { Injector } from "@angular/core";
 import { async, TestBed } from "@angular/core/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { MOCK, MockStandardApiService } from "@baw-api/mock/apiMocks.service";
 import { MockModel as ChildModel } from "@baw-api/mock/baseApiMock.service";
 import { Id, Ids } from "@interfaces/apiInterfaces";
 import { nStepObservable } from "@test/helpers/general";
 import { Subject } from "rxjs";
-import { testBawServices } from "../test/helpers/testbed";
 import { AbstractModel, UnresolvedModel } from "./AbstractModel";
 import { HasMany, HasOne } from "./AssociationDecorators";
 
@@ -32,9 +32,8 @@ describe("Association Decorators", () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [HttpClientTestingModule, MockBawApiModule],
       providers: [
-        ...testBawServices,
         MockStandardApiService,
         { provide: MOCK.token, useExisting: MockStandardApiService },
       ],

--- a/src/app/models/AssociationLoadingInComponents.spec.ts
+++ b/src/app/models/AssociationLoadingInComponents.spec.ts
@@ -2,11 +2,11 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { Component, Injector, Input } from "@angular/core";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { MOCK, MockStandardApiService } from "@baw-api/mock/apiMocks.service";
 import { MockModel as AssociatedModel } from "@baw-api/mock/baseApiMock.service";
 import { Id } from "@interfaces/apiInterfaces";
 import { nStepObservable } from "@test/helpers/general";
-import { testBawServices } from "@test/helpers/testbed";
 import { Subject } from "rxjs";
 import { AbstractModel, UnresolvedModel } from "./AbstractModel";
 import { HasMany, HasOne } from "./AssociationDecorators";
@@ -62,9 +62,8 @@ describe("Association Decorators Loading In Components", () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [MockComponent],
-      imports: [HttpClientTestingModule],
+      imports: [HttpClientTestingModule, MockBawApiModule],
       providers: [
-        ...testBawServices,
         MockStandardApiService,
         { provide: MOCK.token, useExisting: MockStandardApiService },
       ],

--- a/src/app/models/AssociationLoadingInComponents.spec.ts
+++ b/src/app/models/AssociationLoadingInComponents.spec.ts
@@ -6,6 +6,7 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { MOCK, MockStandardApiService } from "@baw-api/mock/apiMocks.service";
 import { MockModel as AssociatedModel } from "@baw-api/mock/baseApiMock.service";
 import { Id } from "@interfaces/apiInterfaces";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { nStepObservable } from "@test/helpers/general";
 import { Subject } from "rxjs";
 import { AbstractModel, UnresolvedModel } from "./AbstractModel";
@@ -145,10 +146,10 @@ describe("Association Decorators Loading In Components", () => {
   });
 
   it("should display hasOne error", async () => {
-    const promise = interceptSingleModel(undefined, {
-      status: 404,
-      message: "Not Found",
-    });
+    const promise = interceptSingleModel(
+      undefined,
+      generateApiErrorDetails("Not Found")
+    );
     component.model = new MockModel({ id: 0 }, injector);
     fixture.detectChanges(); // Load childModel
     await promise;
@@ -221,10 +222,9 @@ describe("Association Decorators Loading In Components", () => {
   });
 
   it("should display hasMany error", async () => {
-    const promise = interceptMultipleModels({
-      status: 404,
-      message: "Not Found",
-    });
+    const promise = interceptMultipleModels(
+      generateApiErrorDetails("Not Found")
+    );
     component.model = new MockModel({ id: 0 }, injector);
     component.hasMany = true;
     fixture.detectChanges(); // Load childModel

--- a/src/app/services/app-config/app-config.module.ts
+++ b/src/app/services/app-config/app-config.module.ts
@@ -1,0 +1,43 @@
+import { HTTP_INTERCEPTORS } from "@angular/common/http";
+import { APP_INITIALIZER, NgModule } from "@angular/core";
+import {
+  API_CONFIG,
+  API_ROOT,
+  AppInitializer,
+  ASSET_ROOT,
+  CMS_ROOT,
+} from "@helpers/app-initializer/app-initializer";
+import { BawApiInterceptor } from "@services/baw-api/api.interceptor.service";
+import { ToastrModule } from "ngx-toastr";
+import { AppConfigService } from "./app-config.service";
+
+@NgModule({
+  imports: [ToastrModule],
+  providers: [
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: BawApiInterceptor,
+      multi: true,
+    },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: AppInitializer.initializerFactory,
+      multi: true,
+      deps: [API_CONFIG],
+    },
+    {
+      provide: API_ROOT,
+      useFactory: AppInitializer.apiRootFactory,
+    },
+    {
+      provide: CMS_ROOT,
+      useFactory: AppInitializer.cmsRootFactory,
+    },
+    {
+      provide: ASSET_ROOT,
+      useFactory: AppInitializer.assetRootFactory,
+    },
+    AppConfigService,
+  ],
+})
+export class AppConfigModule {}

--- a/src/app/services/app-config/app-config.module.ts
+++ b/src/app/services/app-config/app-config.module.ts
@@ -1,4 +1,3 @@
-import { HTTP_INTERCEPTORS } from "@angular/common/http";
 import { APP_INITIALIZER, NgModule } from "@angular/core";
 import {
   API_CONFIG,
@@ -7,18 +6,12 @@ import {
   ASSET_ROOT,
   CMS_ROOT,
 } from "@helpers/app-initializer/app-initializer";
-import { BawApiInterceptor } from "@services/baw-api/api.interceptor.service";
 import { ToastrModule } from "ngx-toastr";
 import { AppConfigService } from "./app-config.service";
 
 @NgModule({
   imports: [ToastrModule],
   providers: [
-    {
-      provide: HTTP_INTERCEPTORS,
-      useClass: BawApiInterceptor,
-      multi: true,
-    },
     {
       provide: APP_INITIALIZER,
       useFactory: AppInitializer.initializerFactory,

--- a/src/app/services/app-config/app-configMock.module.ts
+++ b/src/app/services/app-config/app-configMock.module.ts
@@ -1,0 +1,38 @@
+import { NgModule } from "@angular/core";
+import {
+  API_CONFIG,
+  API_ROOT,
+  ASSET_ROOT,
+  CMS_ROOT,
+  Configuration,
+} from "@helpers/app-initializer/app-initializer";
+import { AppConfigService } from "./app-config.service";
+import { AppConfigMockService, testApiConfig } from "./appConfigMock.service";
+
+@NgModule({
+  providers: [
+    {
+      provide: API_ROOT,
+      useValue: testApiConfig.environment.apiRoot,
+    },
+    {
+      provide: CMS_ROOT,
+      useValue: testApiConfig.environment.cmsRoot,
+    },
+    {
+      provide: ASSET_ROOT,
+      useValue: testApiConfig.environment.assetRoot,
+    },
+    {
+      provide: API_CONFIG,
+      useValue: new Promise<Configuration>((resolve) => {
+        resolve(testApiConfig);
+      }),
+    },
+    {
+      provide: AppConfigService,
+      useClass: AppConfigMockService,
+    },
+  ],
+})
+export class MockAppConfigModule {}

--- a/src/app/services/baw-api/ServiceProviders.ts
+++ b/src/app/services/baw-api/ServiceProviders.ts
@@ -1,4 +1,3 @@
-import { AppConfigService } from "@services/app-config/app-config.service";
 import { accountResolvers, AccountsService } from "./account/accounts.service";
 import {
   analysisJobItemResolvers,
@@ -26,26 +25,16 @@ import {
 } from "./dataset/dataset-items.service";
 import { datasetResolvers, DatasetsService } from "./dataset/datasets.service";
 import {
-  MockImmutableApiService,
-  MockNonDestructibleApiService,
-  MockReadAndCreateApiService,
-  MockReadAndUpdateApiService,
-  MockReadonlyApiService,
-  MockShowApiService,
-  MockStandardApiService,
-} from "./mock/apiMocks.service";
-import { MockShallowSitesService } from "./mock/shallowSitesMock.service";
-import {
   progressEventResolvers,
   ProgressEventsService,
 } from "./progress-event/progress-events.service";
 import { projectResolvers, ProjectsService } from "./project/projects.service";
+import { BawProvider } from "./resolver-common";
 import {
   SavedSearchesService,
   savedSearchResolvers,
 } from "./saved-search/saved-searches.service";
 import { scriptResolvers, ScriptsService } from "./script/scripts.service";
-import { SecurityService } from "./security/security.service";
 import * as Tokens from "./ServiceTokens";
 import {
   shallowSiteResolvers,
@@ -76,167 +65,129 @@ const serviceList = [
     serviceToken: Tokens.ACCOUNT,
     service: AccountsService,
     resolvers: accountResolvers,
-    mock: MockStandardApiService,
   },
   {
     serviceToken: Tokens.ANALYSIS_JOB,
     service: AnalysisJobsService,
     resolvers: analysisJobResolvers,
-    mock: MockReadAndUpdateApiService,
   },
   {
     serviceToken: Tokens.ANALYSIS_JOB_ITEM,
     service: AnalysisJobItemsService,
     resolvers: analysisJobItemResolvers,
-    mock: MockReadonlyApiService,
   },
   {
     serviceToken: Tokens.AUDIO_EVENT,
     service: AudioEventsService,
     resolvers: audioEventResolvers,
-    mock: MockStandardApiService,
   },
   {
     serviceToken: Tokens.AUDIO_RECORDING,
     service: AudioRecordingsService,
     resolvers: audioRecordingResolvers,
-    mock: MockReadonlyApiService,
   },
   {
     serviceToken: Tokens.BOOKMARK,
     service: BookmarksService,
     resolvers: bookmarkResolvers,
-    mock: MockStandardApiService,
   },
   {
     serviceToken: Tokens.DATASET,
     service: DatasetsService,
     resolvers: datasetResolvers,
-    mock: MockStandardApiService,
   },
   {
     serviceToken: Tokens.DATASET_ITEM,
     service: DatasetItemsService,
     resolvers: datasetItemResolvers,
-    mock: MockImmutableApiService,
   },
   {
     serviceToken: Tokens.PROGRESS_EVENT,
     service: ProgressEventsService,
     resolvers: progressEventResolvers,
-    mock: MockReadAndCreateApiService,
   },
   {
     serviceToken: Tokens.PROJECT,
     service: ProjectsService,
     resolvers: projectResolvers,
-    mock: MockStandardApiService,
   },
   {
     serviceToken: Tokens.QUESTION,
     service: QuestionsService,
     resolvers: questionResolvers,
-    mock: MockStandardApiService,
   },
   {
     serviceToken: Tokens.SHALLOW_QUESTION,
     service: ShallowQuestionsService,
     resolvers: shallowQuestionResolvers,
-    mock: MockStandardApiService,
   },
   {
     serviceToken: Tokens.RESPONSE,
     service: ResponsesService,
     resolvers: responseResolvers,
-    mock: MockStandardApiService,
   },
   {
     serviceToken: Tokens.SHALLOW_RESPONSE,
     service: ShallowResponsesService,
     resolvers: shallowResponseResolvers,
-    mock: MockStandardApiService,
   },
   {
     serviceToken: Tokens.SAVED_SEARCH,
     service: SavedSearchesService,
     resolvers: savedSearchResolvers,
-    mock: MockImmutableApiService,
   },
   {
     serviceToken: Tokens.SCRIPT,
     service: ScriptsService,
     resolvers: scriptResolvers,
-    mock: MockNonDestructibleApiService,
   },
   {
     serviceToken: Tokens.SITE,
     service: SitesService,
     resolvers: siteResolvers,
-    mock: MockStandardApiService,
   },
   {
     serviceToken: Tokens.SHALLOW_SITE,
     service: ShallowSitesService,
     resolvers: shallowSiteResolvers,
-    mock: MockShallowSitesService,
   },
   {
     serviceToken: Tokens.STUDY,
     service: StudiesService,
     resolvers: studyResolvers,
-    mock: MockStandardApiService,
   },
   {
     serviceToken: Tokens.TAG,
     service: TagsService,
     resolvers: tagResolvers,
-    mock: MockStandardApiService,
   },
   {
     serviceToken: Tokens.TAG_GROUP,
     service: TagGroupsService,
     resolvers: tagGroupResolvers,
-    mock: MockStandardApiService,
   },
   {
     serviceToken: Tokens.TAGGING,
     service: TaggingsService,
     resolvers: taggingResolvers,
-    mock: MockStandardApiService,
   },
   {
     serviceToken: Tokens.USER,
     service: UserService,
     resolvers: userResolvers,
-    mock: MockShowApiService,
   },
 ];
 
-/**
- * Stores all of the service providers, their service tokens, and resolvers
- */
-const serviceProviders: any[] = [AppConfigService, SecurityService];
+const services = serviceList.map(({ service }) => service);
+const serviceTokens = serviceList.map(({ service, serviceToken }) => ({
+  provide: serviceToken.token,
+  useExisting: service,
+}));
+const serviceResolvers: BawProvider[] = [];
+serviceList.forEach(({ resolvers }) => {
+  if (resolvers) {
+    serviceResolvers.push(...resolvers.providers);
+  }
+});
 
-/**
- * Stores all of the service providers, their service tokens, and resolvers using mock classes
- */
-const serviceMockProviders: any[] = [];
-
-for (const service of serviceList) {
-  const providers = [
-    service.service,
-    { provide: service.serviceToken.token, useExisting: service.service },
-    ...(service.resolvers?.providers ?? []),
-  ];
-
-  const mockProviders = [
-    { provide: service.service, useClass: service.mock },
-    { provide: service.serviceToken.token, useClass: service.mock },
-    ...(service.resolvers?.providers ?? []),
-  ];
-
-  serviceProviders.push(...providers);
-  serviceMockProviders.push(...mockProviders);
-}
-
-export { serviceProviders, serviceMockProviders };
+export { services, serviceTokens, serviceResolvers };

--- a/src/app/services/baw-api/account/accounts.service.spec.ts
+++ b/src/app/services/baw-api/account/accounts.service.spec.ts
@@ -2,9 +2,8 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AccountsService } from "@baw-api/account/accounts.service";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { MockBawApiService } from "@baw-api/mock/baseApiMock.service";
 import { User } from "@models/User";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -13,17 +12,16 @@ import {
   validateApiShow,
   validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 
 describe("AccountsService", () => {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        AccountsService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [AccountsService],
     });
 
     this.service = TestBed.inject(AccountsService);

--- a/src/app/services/baw-api/analysis/analysis-job-items.service.spec.ts
+++ b/src/app/services/baw-api/analysis/analysis-job-items.service.spec.ts
@@ -1,26 +1,24 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { MockBawApiService } from "@baw-api/mock/baseApiMock.service";
 import { AnalysisJobItem } from "@models/AnalysisJobItem";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiFilter,
   validateApiList,
   validateApiShow,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import { AnalysisJobItemsService } from "./analysis-job-items.service";
 
 describe("AnalysisJobItemsService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        AnalysisJobItemsService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [AnalysisJobItemsService],
     });
 
     this.service = TestBed.inject(AnalysisJobItemsService);

--- a/src/app/services/baw-api/analysis/analysis-jobs.service.spec.ts
+++ b/src/app/services/baw-api/analysis/analysis-jobs.service.spec.ts
@@ -2,26 +2,24 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AnalysisJob } from "@models/AnalysisJob";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiFilter,
   validateApiList,
   validateApiShow,
   validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
-import { BawApiService } from "../baw-api.service";
-import { MockBawApiService } from "../mock/baseApiMock.service";
 import { AnalysisJobsService } from "./analysis-jobs.service";
 
 describe("AnalysisJobsService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        AnalysisJobsService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [AnalysisJobsService],
     });
 
     this.service = TestBed.inject(AnalysisJobsService);

--- a/src/app/services/baw-api/api-common.ts
+++ b/src/app/services/baw-api/api-common.ts
@@ -163,14 +163,20 @@ export abstract class StandardApi<M extends AbstractModel, P extends any[] = []>
     ApiUpdate<M, P>,
     ApiDestroy<M, P> {
   public abstract list(...urlParameters: P): Observable<M[]>;
-  public abstract filter(filters: Filters<M>, ...urlParameters: P): Observable<M[]>;
+  public abstract filter(
+    filters: Filters<M>,
+    ...urlParameters: P
+  ): Observable<M[]>;
   public abstract show(model: IdOr<M>, ...urlParameters: P): Observable<M>;
   public abstract create(model: M, ...urlParameters: P): Observable<M>;
   public abstract update(
     model: PartialWith<M, "id">,
     ...urlParameters: P
   ): Observable<M>;
-  public abstract destroy(model: IdOr<M>, ...urlParameters: P): Observable<M | void>;
+  public abstract destroy(
+    model: IdOr<M>,
+    ...urlParameters: P
+  ): Observable<M | void>;
 }
 
 /**
@@ -187,10 +193,16 @@ export abstract class ImmutableApi<
     ApiCreate<M, P>,
     ApiDestroy<M, P> {
   public abstract list(...urlParameters: P): Observable<M[]>;
-  public abstract filter(filters: Filters<M>, ...urlParameters: P): Observable<M[]>;
+  public abstract filter(
+    filters: Filters<M>,
+    ...urlParameters: P
+  ): Observable<M[]>;
   public abstract show(model: IdOr<M>, ...urlParameters: P): Observable<M>;
   public abstract create(model: M, ...urlParameters: P): Observable<M>;
-  public abstract destroy(model: IdOr<M>, ...urlParameters: P): Observable<M | void>;
+  public abstract destroy(
+    model: IdOr<M>,
+    ...urlParameters: P
+  ): Observable<M | void>;
 }
 
 /**
@@ -200,7 +212,10 @@ export abstract class ReadonlyApi<M extends AbstractModel, P extends any[] = []>
   extends BawApiService<M>
   implements ApiList<M, P>, ApiFilter<M, P>, ApiShow<M, P> {
   public abstract list(...urlParameters: P): Observable<M[]>;
-  public abstract filter(filters: Filters<M>, ...urlParameters: P): Observable<M[]>;
+  public abstract filter(
+    filters: Filters<M>,
+    ...urlParameters: P
+  ): Observable<M[]>;
   public abstract show(model: IdOr<M>, ...urlParameters: P): Observable<M>;
 }
 
@@ -213,7 +228,10 @@ export abstract class ReadAndCreateApi<
 > extends BawApiService<M>
   implements ApiList<M, P>, ApiFilter<M, P>, ApiShow<M, P>, ApiCreate<M, P> {
   public abstract list(...urlParameters: P): Observable<M[]>;
-  public abstract filter(filters: Filters<M>, ...urlParameters: P): Observable<M[]>;
+  public abstract filter(
+    filters: Filters<M>,
+    ...urlParameters: P
+  ): Observable<M[]>;
   public abstract show(model: IdOr<M>, ...urlParameters: P): Observable<M>;
   public abstract create(model: M, ...urlParameters: P): Observable<M>;
 }
@@ -227,7 +245,10 @@ export abstract class ReadAndUpdateApi<
 > extends BawApiService<M>
   implements ApiList<M, P>, ApiFilter<M, P>, ApiShow<M, P>, ApiUpdate<M, P> {
   public abstract list(...urlParameters: P): Observable<M[]>;
-  public abstract filter(filters: Filters<M>, ...urlParameters: P): Observable<M[]>;
+  public abstract filter(
+    filters: Filters<M>,
+    ...urlParameters: P
+  ): Observable<M[]>;
   public abstract show(model: IdOr<M>, ...urlParameters: P): Observable<M>;
   public abstract update(
     model: PartialWith<M, "id">,
@@ -249,7 +270,10 @@ export abstract class NonDestructibleApi<
     ApiCreate<M, P>,
     ApiUpdate<M, P> {
   public abstract list(...urlParameters: P): Observable<M[]>;
-  public abstract filter(filters: Filters<M>, ...urlParameters: P): Observable<M[]>;
+  public abstract filter(
+    filters: Filters<M>,
+    ...urlParameters: P
+  ): Observable<M[]>;
   public abstract show(model: IdOr<M>, ...urlParameters: P): Observable<M>;
   public abstract create(model: M, ...urlParameters: P): Observable<M>;
   public abstract update(

--- a/src/app/services/baw-api/api.interceptor.service.spec.ts
+++ b/src/app/services/baw-api/api.interceptor.service.spec.ts
@@ -78,6 +78,7 @@ describe("BawApiInterceptor", () => {
           expect(err).toEqual(
             generateApiErrorDetails("Unauthorized", {
               message: "Incorrect user name",
+              info: undefined,
             })
           );
         });
@@ -111,7 +112,6 @@ describe("BawApiInterceptor", () => {
           expect(err).toEqual({
             status: 404,
             message: `Http failure response for ${apiRoot}/brokenapiroute: 404 Page Not Found`,
-            info: undefined,
           });
         });
 

--- a/src/app/services/baw-api/api.interceptor.service.spec.ts
+++ b/src/app/services/baw-api/api.interceptor.service.spec.ts
@@ -5,11 +5,11 @@ import {
 } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { SecurityService } from "@baw-api/security/security.service";
 import { SessionUser } from "@models/User";
 import { AppConfigService } from "@services/app-config/app-config.service";
 import { generateSessionUser } from "@test/fakes/User";
-import { testBawServices } from "src/app/test/helpers/testbed";
 import {
   apiErrorInfoDetails,
   shouldNotFail,
@@ -54,8 +54,7 @@ describe("BawApiInterceptor", () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientModule, HttpClientTestingModule],
-      providers: testBawServices,
+      imports: [HttpClientModule, HttpClientTestingModule, MockBawApiModule],
     });
 
     api = TestBed.inject(SecurityService);

--- a/src/app/services/baw-api/api.interceptor.service.spec.ts
+++ b/src/app/services/baw-api/api.interceptor.service.spec.ts
@@ -9,6 +9,7 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { SecurityService } from "@baw-api/security/security.service";
 import { SessionUser } from "@models/User";
 import { AppConfigService } from "@services/app-config/app-config.service";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateSessionUser } from "@test/fakes/User";
 import {
   apiErrorInfoDetails,
@@ -74,11 +75,11 @@ describe("BawApiInterceptor", () => {
       http
         .get<any>(apiRoot + "/brokenapiroute")
         .subscribe(shouldNotSucceed, (err: ApiErrorDetails) => {
-          expect(err).toEqual({
-            status: 401,
-            message: "Incorrect user name",
-            info: undefined,
-          });
+          expect(err).toEqual(
+            generateApiErrorDetails("Unauthorized", {
+              message: "Incorrect user name",
+            })
+          );
         });
 
       errorResponse(apiRoot + "/brokenapiroute", 401, "Unauthorized", {
@@ -90,11 +91,11 @@ describe("BawApiInterceptor", () => {
       http
         .get<any>(apiRoot + "/brokenapiroute")
         .subscribe(shouldNotSucceed, (err: ApiErrorDetails) => {
-          expect(err).toEqual({
-            status: 422,
-            message: "Record could not be saved",
-            info: apiErrorInfoDetails.info,
-          });
+          expect(err).toEqual(
+            generateApiErrorDetails("Unprocessable Entity", {
+              info: apiErrorInfoDetails.info,
+            })
+          );
         });
 
       errorResponse(apiRoot + "/brokenapiroute", 422, "Unprocessable Entity", {
@@ -110,6 +111,7 @@ describe("BawApiInterceptor", () => {
           expect(err).toEqual({
             status: 404,
             message: `Http failure response for ${apiRoot}/brokenapiroute: 404 Page Not Found`,
+            info: undefined,
           });
         });
 

--- a/src/app/services/baw-api/audio-event/audio-events.service.spec.ts
+++ b/src/app/services/baw-api/audio-event/audio-events.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AudioEvent } from "@models/AudioEvent";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -10,20 +11,17 @@ import {
   validateApiShow,
   validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
-import { BawApiService } from "../baw-api.service";
-import { MockBawApiService } from "../mock/baseApiMock.service";
 import { AudioEventsService } from "./audio-events.service";
 
 describe("AudioEventsService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        AudioEventsService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [AudioEventsService],
     });
 
     this.service = TestBed.inject(AudioEventsService);

--- a/src/app/services/baw-api/audio-recording/audio-recordings.service.spec.ts
+++ b/src/app/services/baw-api/audio-recording/audio-recordings.service.spec.ts
@@ -1,26 +1,24 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { async, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { MockBawApiService } from "@baw-api/mock/baseApiMock.service";
 import { AudioRecording } from "@models/AudioRecording";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiFilter,
   validateApiList,
   validateApiShow,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import { AudioRecordingsService } from "./audio-recordings.service";
 
 describe("AudioRecordingsService", function () {
   beforeEach(async(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        AudioRecordingsService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [AudioRecordingsService],
     });
     this.service = TestBed.inject(AudioRecordingsService);
   }));

--- a/src/app/services/baw-api/baw-api.module.ts
+++ b/src/app/services/baw-api/baw-api.module.ts
@@ -1,12 +1,18 @@
-import { HttpClientModule } from "@angular/common/http";
+import { HttpClientModule, HTTP_INTERCEPTORS } from "@angular/common/http";
 import { NgModule } from "@angular/core";
 import { AppConfigModule } from "../app-config/app-config.module";
+import { BawApiInterceptor } from "./api.interceptor.service";
 import { SecurityService } from "./security/security.service";
 import { serviceResolvers, services, serviceTokens } from "./ServiceProviders";
 
 @NgModule({
   imports: [HttpClientModule, AppConfigModule],
   providers: [
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: BawApiInterceptor,
+      multi: true,
+    },
     SecurityService,
     ...services,
     ...serviceTokens,

--- a/src/app/services/baw-api/baw-api.module.ts
+++ b/src/app/services/baw-api/baw-api.module.ts
@@ -1,0 +1,16 @@
+import { HttpClientModule } from "@angular/common/http";
+import { NgModule } from "@angular/core";
+import { AppConfigModule } from "../app-config/app-config.module";
+import { SecurityService } from "./security/security.service";
+import { serviceResolvers, services, serviceTokens } from "./ServiceProviders";
+
+@NgModule({
+  imports: [HttpClientModule, AppConfigModule],
+  providers: [
+    SecurityService,
+    ...services,
+    ...serviceTokens,
+    ...serviceResolvers,
+  ],
+})
+export class BawApiModule {}

--- a/src/app/services/baw-api/baw-api.service.spec.ts
+++ b/src/app/services/baw-api/baw-api.service.spec.ts
@@ -22,8 +22,8 @@ import { UserService } from "@baw-api/user/user.service";
 import { AbstractModel } from "@models/AbstractModel";
 import { SessionUser } from "@models/User";
 import { AppConfigService } from "@services/app-config/app-config.service";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { BehaviorSubject, Subject } from "rxjs";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import { MockShowApiService } from "./mock/apiMocks.service";
 
 export const shouldNotSucceed = () => {
@@ -189,9 +189,8 @@ describe("BawApiService", () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [HttpClientTestingModule, MockAppConfigModule],
       providers: [
-        ...testAppInitializer,
         BawApiService,
         { provide: SecurityService, useClass: MockSecurityService },
         { provide: UserService, useClass: MockShowApiService },

--- a/src/app/services/baw-api/baw-api.service.spec.ts
+++ b/src/app/services/baw-api/baw-api.service.spec.ts
@@ -23,6 +23,7 @@ import { AbstractModel } from "@models/AbstractModel";
 import { SessionUser } from "@models/User";
 import { AppConfigService } from "@services/app-config/app-config.service";
 import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { BehaviorSubject, Subject } from "rxjs";
 import { MockShowApiService } from "./mock/apiMocks.service";
 
@@ -38,24 +39,22 @@ export const shouldNotComplete = () => {
   fail("Service should not complete");
 };
 
-export const apiErrorDetails: ApiErrorDetails = {
-  status: 401,
-  message: "Unauthorized",
-  info: undefined,
-};
+export const apiErrorDetails = generateApiErrorDetails("Unauthorized");
 
-export const apiErrorInfoDetails: ApiErrorDetails = {
-  status: 422,
-  message: "Record could not be saved",
-  info: {
-    name: ["has already been taken"],
-    image: [],
-    imageFileName: [],
-    imageFileSize: [],
-    imageContentType: [],
-    imageUpdatedAt: [],
-  },
-};
+export const apiErrorInfoDetails = generateApiErrorDetails(
+  "Unprocessable Entity",
+  {
+    message: "Record could not be saved",
+    info: {
+      name: ["has already been taken"],
+      image: [],
+      imageFileName: [],
+      imageFileSize: [],
+      imageContentType: [],
+      imageUpdatedAt: [],
+    },
+  }
+);
 
 describe("BawApiService", () => {
   /**

--- a/src/app/services/baw-api/baw-apiMock.module.ts
+++ b/src/app/services/baw-api/baw-apiMock.module.ts
@@ -1,0 +1,27 @@
+import { HttpClientModule, HTTP_INTERCEPTORS } from "@angular/common/http";
+import { NgModule } from "@angular/core";
+import { MockAppConfigModule } from "../app-config/app-configMock.module";
+import { BawApiInterceptor } from "./api.interceptor.service";
+import { BawApiService, STUB_MODEL_BUILDER } from "./baw-api.service";
+import { MockBawApiService, MockModel } from "./mock/baseApiMock.service";
+import { MockSecurityService } from "./mock/securityMock.service";
+import { SecurityService } from "./security/security.service";
+import { serviceResolvers, services, serviceTokens } from "./ServiceProviders";
+
+@NgModule({
+  imports: [HttpClientModule, MockAppConfigModule],
+  providers: [
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: BawApiInterceptor,
+      multi: true,
+    },
+    { provide: STUB_MODEL_BUILDER, useValue: MockModel },
+    { provide: BawApiService, useClass: MockBawApiService },
+    { provide: SecurityService, useClass: MockSecurityService },
+    ...services,
+    ...serviceTokens,
+    ...serviceResolvers,
+  ],
+})
+export class MockBawApiModule {}

--- a/src/app/services/baw-api/baw-apiMock.module.ts
+++ b/src/app/services/baw-api/baw-apiMock.module.ts
@@ -1,12 +1,66 @@
 import { HttpClientModule, HTTP_INTERCEPTORS } from "@angular/common/http";
-import { NgModule } from "@angular/core";
+import { FactoryProvider, NgModule, Provider } from "@angular/core";
+import { mockProvider } from "@ngneat/spectator";
 import { MockAppConfigModule } from "../app-config/app-configMock.module";
+import { AccountsService } from "./account/accounts.service";
+import { AnalysisJobItemsService } from "./analysis/analysis-job-items.service";
+import { AnalysisJobsService } from "./analysis/analysis-jobs.service";
 import { BawApiInterceptor } from "./api.interceptor.service";
+import { AudioEventsService } from "./audio-event/audio-events.service";
+import { AudioRecordingsService } from "./audio-recording/audio-recordings.service";
 import { BawApiService, STUB_MODEL_BUILDER } from "./baw-api.service";
+import { BookmarksService } from "./bookmark/bookmarks.service";
+import { DatasetItemsService } from "./dataset/dataset-items.service";
+import { DatasetsService } from "./dataset/datasets.service";
 import { MockBawApiService, MockModel } from "./mock/baseApiMock.service";
 import { MockSecurityService } from "./mock/securityMock.service";
+import { ProgressEventsService } from "./progress-event/progress-events.service";
+import { ProjectsService } from "./project/projects.service";
+import { SavedSearchesService } from "./saved-search/saved-searches.service";
+import { ScriptsService } from "./script/scripts.service";
 import { SecurityService } from "./security/security.service";
 import { serviceResolvers, services, serviceTokens } from "./ServiceProviders";
+import { ShallowSitesService, SitesService } from "./site/sites.service";
+import {
+  QuestionsService,
+  ShallowQuestionsService,
+} from "./study/questions.service";
+import {
+  ResponsesService,
+  ShallowResponsesService,
+} from "./study/responses.service";
+import { StudiesService } from "./study/studies.service";
+import { TagGroupsService } from "./tag/tag-group.service";
+import { TaggingsService } from "./tag/taggings.service";
+import { TagsService } from "./tag/tags.service";
+import { UserService } from "./user/user.service";
+
+const mockProviders: Provider[] = [
+  { provide: SecurityService, useClass: MockSecurityService },
+  mockProvider(AccountsService),
+  mockProvider(AnalysisJobsService),
+  mockProvider(AnalysisJobItemsService),
+  mockProvider(AudioEventsService),
+  mockProvider(AudioRecordingsService),
+  mockProvider(BookmarksService),
+  mockProvider(DatasetsService),
+  mockProvider(DatasetItemsService),
+  mockProvider(ProgressEventsService),
+  mockProvider(ProjectsService),
+  mockProvider(QuestionsService),
+  mockProvider(ShallowQuestionsService),
+  mockProvider(ResponsesService),
+  mockProvider(ShallowResponsesService),
+  mockProvider(SavedSearchesService),
+  mockProvider(ScriptsService),
+  mockProvider(SitesService),
+  mockProvider(ShallowSitesService),
+  mockProvider(StudiesService),
+  mockProvider(TagsService),
+  mockProvider(TagGroupsService),
+  mockProvider(TaggingsService),
+  mockProvider(UserService),
+];
 
 @NgModule({
   imports: [HttpClientModule, MockAppConfigModule],
@@ -18,10 +72,10 @@ import { serviceResolvers, services, serviceTokens } from "./ServiceProviders";
     },
     { provide: STUB_MODEL_BUILDER, useValue: MockModel },
     { provide: BawApiService, useClass: MockBawApiService },
-    { provide: SecurityService, useClass: MockSecurityService },
     ...services,
     ...serviceTokens,
     ...serviceResolvers,
+    ...mockProviders,
   ],
 })
 export class MockBawApiModule {}

--- a/src/app/services/baw-api/bookmark/bookmarks.service.spec.ts
+++ b/src/app/services/baw-api/bookmark/bookmarks.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { Bookmark } from "@models/Bookmark";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -10,20 +11,17 @@ import {
   validateApiShow,
   validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
-import { BawApiService } from "../baw-api.service";
-import { MockBawApiService } from "../mock/baseApiMock.service";
 import { BookmarksService } from "./bookmarks.service";
 
 describe("BookmarksService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        BookmarksService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [BookmarksService],
     });
 
     this.service = TestBed.inject(BookmarksService);

--- a/src/app/services/baw-api/dataset/dataset-items.service.spec.ts
+++ b/src/app/services/baw-api/dataset/dataset-items.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { DatasetItem } from "@models/DatasetItem";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -9,20 +10,17 @@ import {
   validateApiList,
   validateApiShow,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
-import { BawApiService } from "../baw-api.service";
-import { MockBawApiService } from "../mock/baseApiMock.service";
 import { DatasetItemsService } from "./dataset-items.service";
 
 describe("DatasetItemsService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        DatasetItemsService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [DatasetItemsService],
     });
 
     this.service = TestBed.inject(DatasetItemsService);

--- a/src/app/services/baw-api/dataset/datasets.service.spec.ts
+++ b/src/app/services/baw-api/dataset/datasets.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { Dataset } from "@models/Dataset";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -10,20 +11,17 @@ import {
   validateApiShow,
   validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
-import { BawApiService } from "../baw-api.service";
-import { MockBawApiService } from "../mock/baseApiMock.service";
 import { DatasetsService } from "./datasets.service";
 
 describe("DatasetsService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        DatasetsService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [DatasetsService],
     });
 
     this.service = TestBed.inject(DatasetsService);

--- a/src/app/services/baw-api/mock/baseApiMock.service.ts
+++ b/src/app/services/baw-api/mock/baseApiMock.service.ts
@@ -16,7 +16,7 @@ export class MockModel extends AbstractModel {
 }
 
 @Injectable()
-export abstract class MockBawApiService {
+export class MockBawApiService {
   constructor() {}
 
   public isLoggedIn() {

--- a/src/app/services/baw-api/progress-event/progress-events.service.spec.ts
+++ b/src/app/services/baw-api/progress-event/progress-events.service.spec.ts
@@ -2,28 +2,24 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ProgressEvent } from "@models/ProgressEvent";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
-  validateApiDestroy,
   validateApiFilter,
   validateApiList,
   validateApiShow,
-  validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
-import { BawApiService } from "../baw-api.service";
-import { MockBawApiService } from "../mock/baseApiMock.service";
 import { ProgressEventsService } from "./progress-events.service";
 
 describe("ProgressEventsService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        ProgressEventsService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [ProgressEventsService],
     });
 
     this.service = TestBed.inject(ProgressEventsService);

--- a/src/app/services/baw-api/project/projects.service.spec.ts
+++ b/src/app/services/baw-api/project/projects.service.spec.ts
@@ -1,10 +1,9 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { MockBawApiService } from "@baw-api/mock/baseApiMock.service";
 import { ProjectsService } from "@baw-api/project/projects.service";
 import { Project } from "@models/Project";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -13,17 +12,16 @@ import {
   validateApiShow,
   validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 
 describe("ProjectsService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        ProjectsService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [ProjectsService],
     });
 
     this.service = TestBed.inject(ProjectsService);

--- a/src/app/services/baw-api/saved-search/saved-searches.service.spec.ts
+++ b/src/app/services/baw-api/saved-search/saved-searches.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { SavedSearch } from "@models/SavedSearch";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -9,20 +10,17 @@ import {
   validateApiList,
   validateApiShow,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
-import { BawApiService } from "../baw-api.service";
-import { MockBawApiService } from "../mock/baseApiMock.service";
 import { SavedSearchesService } from "./saved-searches.service";
 
 describe("SavedSearchesService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        SavedSearchesService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [SavedSearchesService],
     });
 
     this.service = TestBed.inject(SavedSearchesService);

--- a/src/app/services/baw-api/script/scripts.service.spec.ts
+++ b/src/app/services/baw-api/script/scripts.service.spec.ts
@@ -1,28 +1,25 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { async, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { MockBawApiService } from "@baw-api/mock/baseApiMock.service";
 import { ScriptsService } from "@baw-api/script/scripts.service";
 import { Script } from "@models/Script";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
-  validateApiDestroy,
   validateApiFilter,
   validateApiList,
   validateApiShow,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 
 describe("ScriptsService", function () {
   beforeEach(async(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        ScriptsService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [ScriptsService],
     });
     this.service = TestBed.inject(ScriptsService);
   }));

--- a/src/app/services/baw-api/security/security.service.spec.ts
+++ b/src/app/services/baw-api/security/security.service.spec.ts
@@ -10,8 +10,8 @@ import {
 } from "@baw-api/api.interceptor.service";
 import { MockShowApiService } from "@baw-api/mock/apiMocks.service";
 import { ISessionUser, IUser, SessionUser, User } from "@models/User";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { BehaviorSubject, Subject } from "rxjs";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import {
   apiErrorDetails,
   shouldNotComplete,
@@ -51,15 +51,14 @@ describe("SecurityService", () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [HttpClientTestingModule, MockAppConfigModule],
       providers: [
-        ...testAppInitializer,
-        { provide: UserService, useClass: MockShowApiService },
         {
           provide: HTTP_INTERCEPTORS,
           useClass: BawApiInterceptor,
           multi: true,
         },
+        { provide: UserService, useClass: MockShowApiService },
         SecurityService,
       ],
     });

--- a/src/app/services/baw-api/security/security.service.spec.ts
+++ b/src/app/services/baw-api/security/security.service.spec.ts
@@ -11,6 +11,7 @@ import {
 import { MockShowApiService } from "@baw-api/mock/apiMocks.service";
 import { ISessionUser, IUser, SessionUser, User } from "@models/User";
 import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
+import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { BehaviorSubject, Subject } from "rxjs";
 import {
   apiErrorDetails,
@@ -124,11 +125,7 @@ describe("SecurityService", () => {
           return new BehaviorSubject<User>(user);
         } else {
           const subject = new Subject<User>();
-          subject.error({
-            status: 401,
-            message: "Unauthorized",
-            info: undefined,
-          } as ApiErrorDetails);
+          subject.error(generateApiErrorDetails("Unauthorized"));
           return subject;
         }
       });

--- a/src/app/services/baw-api/site/sites-shallow.service.spec.ts
+++ b/src/app/services/baw-api/site/sites-shallow.service.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "src/app/test/helpers/api-common";
 import { ShallowSitesService } from "./sites.service";
 
-xdescribe("ShallowSitesService", function () {
+describe("ShallowSitesService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
       imports: [
@@ -45,4 +45,6 @@ xdescribe("ShallowSitesService", function () {
     5,
     new Site({ id: 5 })
   );
+
+  // TODO Add tests for filterByAccessLevel and Orphans
 });

--- a/src/app/services/baw-api/site/sites-shallow.service.spec.ts
+++ b/src/app/services/baw-api/site/sites-shallow.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { Site } from "@models/Site";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -10,20 +11,17 @@ import {
   validateApiShow,
   validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
-import { BawApiService } from "../baw-api.service";
-import { MockBawApiService } from "../mock/baseApiMock.service";
 import { ShallowSitesService } from "./sites.service";
 
 xdescribe("ShallowSitesService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        ShallowSitesService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [ShallowSitesService],
     });
 
     this.service = TestBed.inject(ShallowSitesService);

--- a/src/app/services/baw-api/site/sites.service.spec.ts
+++ b/src/app/services/baw-api/site/sites.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { Site } from "@models/Site";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -10,20 +11,17 @@ import {
   validateApiShow,
   validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
-import { BawApiService } from "../baw-api.service";
-import { MockBawApiService } from "../mock/baseApiMock.service";
 import { SitesService } from "./sites.service";
 
 describe("SitesService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        SitesService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [SitesService],
     });
 
     this.service = TestBed.inject(SitesService);

--- a/src/app/services/baw-api/site/sites.service.ts
+++ b/src/app/services/baw-api/site/sites.service.ts
@@ -14,23 +14,21 @@ import {
   IdOr,
   IdParam,
   IdParamOptional,
-  New,
   option,
   StandardApi,
 } from "../api-common";
 import { Filters } from "../baw-api.service";
 import { Resolvers } from "../resolver-common";
 
-type Orphans = "orphans";
-const Orphans: Orphans = "orphans";
-function shallowOption(x?: New | Filter | Empty | Orphans) {
-  return x ? x : Empty;
+function orphanOption(x?: Filter | Empty) {
+  return option(x);
 }
 
 const projectId: IdParam<Project> = id;
 const siteId: IdParamOptional<Site> = id;
 const endpoint = stringTemplate`/projects/${projectId}/sites/${siteId}${option}`;
-const endpointShallow = stringTemplate`/sites/${siteId}${shallowOption}`;
+const endpointShallow = stringTemplate`/sites/${siteId}${option}`;
+const endpointOrphan = stringTemplate`/sites/orphans${orphanOption}`;
 
 /**
  * Sites Service.
@@ -113,12 +111,20 @@ export class ShallowSitesService extends StandardApi<Site> {
   public destroy(model: IdOr<Site>): Observable<Site | void> {
     return this.apiDestroy(endpointShallow(model, Empty));
   }
+
+  /**
+   * Retrieve orphaned sites (sites which have no parent projects)
+   */
+  public orphanList(): Observable<Site[]> {
+    return this.apiList(endpointOrphan(Empty));
+  }
+
   /**
    * Retrieve orphaned sites (sites which have no parent projects)
    * @param filters Filters to apply
    */
-  public orphans(filters: Filters<ISite>): Observable<Site[]> {
-    return this.apiFilter(endpointShallow(Empty, Orphans), filters);
+  public orphanFilter(filters: Filters<ISite>): Observable<Site[]> {
+    return this.apiFilter(endpointOrphan(Filter), filters);
   }
 }
 

--- a/src/app/services/baw-api/site/sites.service.ts
+++ b/src/app/services/baw-api/site/sites.service.ts
@@ -2,10 +2,9 @@ import { HttpClient } from "@angular/common/http";
 import { Inject, Injectable, Injector } from "@angular/core";
 import { API_ROOT } from "@helpers/app-initializer/app-initializer";
 import { stringTemplate } from "@helpers/stringTemplate/stringTemplate";
-import { Project } from "@models/Project";
+import type { Project } from "@models/Project";
 import { ISite, Site } from "@models/Site";
 import type { User } from "@models/User";
-import { generateSite } from "@test/fakes/Site";
 import { Observable } from "rxjs";
 import {
   Empty,
@@ -15,17 +14,23 @@ import {
   IdOr,
   IdParam,
   IdParamOptional,
+  New,
   option,
   StandardApi,
 } from "../api-common";
 import { Filters } from "../baw-api.service";
-import { filterMock, showMock } from "../mock/api-commonMock";
 import { Resolvers } from "../resolver-common";
+
+type Orphans = "orphans";
+const Orphans: Orphans = "orphans";
+function shallowOption(x?: New | Filter | Empty | Orphans) {
+  return x ? x : Empty;
+}
 
 const projectId: IdParam<Project> = id;
 const siteId: IdParamOptional<Site> = id;
 const endpoint = stringTemplate`/projects/${projectId}/sites/${siteId}${option}`;
-const endpointShallow = stringTemplate`/sites/${siteId}${option}`;
+const endpointShallow = stringTemplate`/sites/${siteId}${shallowOption}`;
 
 /**
  * Sites Service.
@@ -48,7 +53,6 @@ export class SitesService extends StandardApi<Site, [IdOr<Project>]> {
     filters: Filters<ISite>,
     project: IdOr<Project>
   ): Observable<Site[]> {
-    // TODO https://github.com/QutEcoacoustics/baw-server/issues/437
     return this.apiFilter(endpoint(project, Empty, Filter), filters);
   }
   public show(model: IdOr<Site>, project: IdOr<Project>): Observable<Site> {
@@ -71,7 +75,6 @@ export class SitesService extends StandardApi<Site, [IdOr<Project>]> {
 /**
  * Shallow Sites Service.
  * Handles API routes pertaining to sites.
- * TODO https://github.com/QutEcoacoustics/baw-server/issues/431
  */
 @Injectable()
 export class ShallowSitesService extends StandardApi<Site> {
@@ -84,46 +87,22 @@ export class ShallowSitesService extends StandardApi<Site> {
   }
 
   public list(): Observable<Site[]> {
-    return this.filter({});
-    // return this.apiList(endpointShallow(Empty, Empty));
+    return this.apiList(endpointShallow(Empty, Empty));
   }
   public filter(filters: Filters<ISite>): Observable<Site[]> {
-    return filterMock<Site>(
-      filters,
-      (index) =>
-        new Site(
-          {
-            id: index,
-            name: "PLACEHOLDER SITE",
-            description: "PLACEHOLDER DESCRIPTION",
-            creatorId: 1,
-          },
-          this.injector
-        )
-    );
-    // return this.apiFilter(endpointShallow(Empty, Filter), filters);
+    return this.apiFilter(endpointShallow(Empty, Filter), filters);
   }
   public filterByAccessLevel(
     filters: Filters<ISite>,
     user?: IdOr<User>
   ): Observable<Site[]> {
-    return this.filter(filters);
-    // TODO https://github.com/QutEcoacoustics/baw-server/issues/453
-    /* return this.apiFilter(
+    return this.apiFilter(
       endpointShallow(Empty, Filter),
       user ? filterByForeignKey<Site>(filters, "creatorId", user) : filters
-    ); */
+    );
   }
   public show(model: IdOr<Site>): Observable<Site> {
-    return showMock(
-      model,
-      (index) =>
-        new Site(
-          { ...generateSite(index), name: "EXAMPLE SITE" },
-          this.injector
-        )
-    );
-    // return this.apiShow(endpointShallow(model, Empty));
+    return this.apiShow(endpointShallow(model, Empty));
   }
   public create(model: Site): Observable<Site> {
     return this.apiCreate(endpointShallow(Empty, Empty), model);
@@ -138,16 +117,8 @@ export class ShallowSitesService extends StandardApi<Site> {
    * Retrieve orphaned sites (sites which have no parent projects)
    * @param filters Filters to apply
    */
-  public orphans(filters: Filters<Site>): Observable<Site[]> {
-    // TODO https://github.com/QutEcoacoustics/baw-server/issues/430
-    return filterMock<Site>(
-      filters,
-      (index) =>
-        new Site(
-          { ...generateSite(index), name: "EXAMPLE SITE" },
-          this.injector
-        )
-    );
+  public orphans(filters: Filters<ISite>): Observable<Site[]> {
+    return this.apiFilter(endpointShallow(Empty, Orphans), filters);
   }
 }
 

--- a/src/app/services/baw-api/study/questions-shallow.service.spec.ts
+++ b/src/app/services/baw-api/study/questions-shallow.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { Question } from "@models/Question";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -10,20 +11,17 @@ import {
   validateApiShow,
   validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
-import { BawApiService } from "../baw-api.service";
-import { MockBawApiService } from "../mock/baseApiMock.service";
 import { ShallowQuestionsService } from "./questions.service";
 
 describe("ShallowQuestionsService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        ShallowQuestionsService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [ShallowQuestionsService],
     });
 
     this.service = TestBed.inject(ShallowQuestionsService);

--- a/src/app/services/baw-api/study/questions.service.spec.ts
+++ b/src/app/services/baw-api/study/questions.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { Question } from "@models/Question";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -10,20 +11,17 @@ import {
   validateApiShow,
   validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
-import { BawApiService } from "../baw-api.service";
-import { MockBawApiService } from "../mock/baseApiMock.service";
 import { QuestionsService } from "./questions.service";
 
 describe("QuestionsService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        QuestionsService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [QuestionsService],
     });
 
     this.service = TestBed.inject(QuestionsService);

--- a/src/app/services/baw-api/study/responses-shallow.service.spec.ts
+++ b/src/app/services/baw-api/study/responses-shallow.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { Response } from "@models/Response";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -10,20 +11,17 @@ import {
   validateApiShow,
   validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
-import { BawApiService } from "../baw-api.service";
-import { MockBawApiService } from "../mock/baseApiMock.service";
 import { ShallowResponsesService } from "./responses.service";
 
 describe("ShallowResponsesService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        ShallowResponsesService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [ShallowResponsesService],
     });
 
     this.service = TestBed.inject(ShallowResponsesService);

--- a/src/app/services/baw-api/study/responses.service.spec.ts
+++ b/src/app/services/baw-api/study/responses.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { Response } from "@models/Response";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -10,20 +11,17 @@ import {
   validateApiShow,
   validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
-import { BawApiService } from "../baw-api.service";
-import { MockBawApiService } from "../mock/baseApiMock.service";
 import { ResponsesService } from "./responses.service";
 
 describe("ResponsesService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        ResponsesService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [ResponsesService],
     });
 
     this.service = TestBed.inject(ResponsesService);

--- a/src/app/services/baw-api/study/studies.service.spec.ts
+++ b/src/app/services/baw-api/study/studies.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { Study } from "@models/Study";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -10,20 +11,17 @@ import {
   validateApiShow,
   validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
-import { BawApiService } from "../baw-api.service";
-import { MockBawApiService } from "../mock/baseApiMock.service";
 import { StudiesService } from "./studies.service";
 
 describe("StudiesService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        StudiesService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [StudiesService],
     });
 
     this.service = TestBed.inject(StudiesService);

--- a/src/app/services/baw-api/tag/tag-group.service.spec.ts
+++ b/src/app/services/baw-api/tag/tag-group.service.spec.ts
@@ -1,10 +1,9 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { MockBawApiService } from "@baw-api/mock/baseApiMock.service";
 import { TagGroupsService } from "@baw-api/tag/tag-group.service";
 import { TagGroup } from "@models/TagGroup";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -13,17 +12,16 @@ import {
   validateApiShow,
   validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 
 describe("TagGroupService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        TagGroupsService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [TagGroupsService],
     });
     this.service = TestBed.inject(TagGroupsService);
   });

--- a/src/app/services/baw-api/tag/taggings.service.spec.ts
+++ b/src/app/services/baw-api/tag/taggings.service.spec.ts
@@ -1,9 +1,8 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { MockBawApiService } from "@baw-api/mock/baseApiMock.service";
 import { Tagging } from "@models/Tagging";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -12,18 +11,17 @@ import {
   validateApiShow,
   validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
 import { TaggingsService } from "./taggings.service";
 
 describe("TaggingsService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        TaggingsService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [TaggingsService],
     });
 
     this.service = TestBed.inject(TaggingsService);

--- a/src/app/services/baw-api/tag/tags.service.spec.ts
+++ b/src/app/services/baw-api/tag/tags.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { async, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { Tag } from "@models/Tag";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import {
   validateApiCreate,
   validateApiDestroy,
@@ -10,20 +11,17 @@ import {
   validateApiShow,
   validateApiUpdate,
 } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
-import { BawApiService } from "../baw-api.service";
-import { MockBawApiService } from "../mock/baseApiMock.service";
 import { TagsService } from "./tags.service";
 
 describe("TagsService", function () {
   beforeEach(async(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        TagsService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [TagsService],
     });
     this.service = TestBed.inject(TagsService);
   }));

--- a/src/app/services/baw-api/user/user.service.spec.ts
+++ b/src/app/services/baw-api/user/user.service.spec.ts
@@ -2,21 +2,19 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { User } from "@models/User";
+import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { validateApiShow } from "src/app/test/helpers/api-common";
-import { testAppInitializer } from "src/app/test/helpers/testbed";
-import { BawApiService } from "../baw-api.service";
-import { MockBawApiService } from "../mock/baseApiMock.service";
 import { UserService } from "./user.service";
 
 describe("UserService", function () {
   beforeEach(function () {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule],
-      providers: [
-        ...testAppInitializer,
-        UserService,
-        { provide: BawApiService, useClass: MockBawApiService },
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        MockAppConfigModule,
       ],
+      providers: [UserService],
     });
 
     this.service = TestBed.inject(UserService);

--- a/src/app/test/fakes/ApiErrorDetails.ts
+++ b/src/app/test/fakes/ApiErrorDetails.ts
@@ -1,0 +1,42 @@
+import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { apiReturnCodes } from "@baw-api/baw-api.service";
+
+type HTTPStatus =
+  | "Unauthorized"
+  | "Not Found"
+  | "Bad Request"
+  | "Unprocessable Entity"
+  | "Custom";
+
+export function generateApiErrorDetails(
+  type: HTTPStatus = "Unauthorized",
+  custom?: Partial<ApiErrorDetails>
+): ApiErrorDetails {
+  let status: number;
+  let message: string;
+
+  switch (type) {
+    case "Unauthorized":
+      status = apiReturnCodes.unauthorized;
+      message = type;
+      break;
+    case "Not Found":
+      status = apiReturnCodes.notFound;
+      message = type;
+      break;
+    case "Bad Request":
+      status = apiReturnCodes.badRequest;
+      message = type;
+      break;
+    case "Unprocessable Entity":
+      status = apiReturnCodes.unprocessableEntity;
+      message = "Record could not be saved";
+      break;
+  }
+
+  return {
+    status: custom?.status ?? status ?? apiReturnCodes.unknown,
+    message: custom?.message ?? message ?? "Unknown",
+    info: custom?.info ?? undefined,
+  };
+}

--- a/src/app/test/helpers/pagedTableTemplate.ts
+++ b/src/app/test/helpers/pagedTableTemplate.ts
@@ -53,9 +53,7 @@ export function datatableApiResponse<M extends AbstractModel>(
   };
 
   assignModelMetadata(models, paging);
-  spyOn(api as any, apiAction).and.callFake(
-    () => new BehaviorSubject<M[]>(models)
-  );
+  api[apiAction].and.callFake(() => new BehaviorSubject<M[]>(models));
 }
 
 /**
@@ -83,7 +81,7 @@ export function assertPagination<
       const paging = { page: 1, items: 25, total: 100, maxPage: 4 };
 
       assignModelMetadata(models, paging);
-      spyOn(api as any, apiAction).and.callFake((filter: Filters) => {
+      api[apiAction].and.callFake((filter: Filters) => {
         if (secondRequest) {
           expect(filter).toEqual(expectation);
           done();
@@ -95,7 +93,7 @@ export function assertPagination<
     }
 
     function apiErrorResponse(error: ApiErrorDetails) {
-      spyOn(api as any, apiAction).and.callFake(() => {
+      api[apiAction].and.callFake(() => {
         const subject = new Subject<M[]>();
         subject.error(error);
         return subject;

--- a/src/app/test/helpers/testbed.ts
+++ b/src/app/test/helpers/testbed.ts
@@ -15,7 +15,11 @@ import {
 import { MockSecurityService } from "@baw-api/mock/securityMock.service";
 import { ResolvedModel } from "@baw-api/resolver-common";
 import { SecurityService } from "@baw-api/security/security.service";
-import { serviceMockProviders } from "@baw-api/ServiceProviders";
+import {
+  serviceResolvers,
+  services,
+  serviceTokens,
+} from "@baw-api/ServiceProviders";
 import {
   API_CONFIG,
   API_ROOT,
@@ -24,6 +28,7 @@ import {
   Configuration,
 } from "@helpers/app-initializer/app-initializer";
 import { NgbModule } from "@ng-bootstrap/ng-bootstrap";
+import { mockProvider } from "@ngneat/spectator";
 import { FormlyBootstrapModule } from "@ngx-formly/bootstrap";
 import { FormlyModule } from "@ngx-formly/core";
 import { AppConfigService } from "@services/app-config/app-config.service";
@@ -91,7 +96,6 @@ export const testBawServices = [
   { provide: STUB_MODEL_BUILDER, useValue: MockModel },
   { provide: BawApiService, useClass: MockBawApiService },
   { provide: SecurityService, useClass: MockSecurityService },
-  ...serviceMockProviders,
 ];
 
 /**
@@ -122,9 +126,11 @@ export function mockActivatedRoute(
 export interface MockResolvers {
   [key: string]: string;
 }
+
 export interface MockData {
   [key: string]: ResolvedModel;
 }
+
 export interface MockParams {
   [key: string]: string | number;
 }
@@ -139,12 +145,9 @@ export type HttpClientBody =
   // tslint:disable-next-line: ban-types
   | (string | number | Object | null)[]
   | null;
+
 export interface HttpClientOpts {
-  headers?:
-    | HttpHeaders
-    | {
-        [name: string]: string | string[];
-      };
+  headers?: HttpHeaders | { [name: string]: string | string[] };
   status?: number;
   statusText?: string;
 }

--- a/src/app/test/helpers/testbed.ts
+++ b/src/app/test/helpers/testbed.ts
@@ -15,27 +15,9 @@ import {
 import { MockSecurityService } from "@baw-api/mock/securityMock.service";
 import { ResolvedModel } from "@baw-api/resolver-common";
 import { SecurityService } from "@baw-api/security/security.service";
-import {
-  serviceResolvers,
-  services,
-  serviceTokens,
-} from "@baw-api/ServiceProviders";
-import {
-  API_CONFIG,
-  API_ROOT,
-  ASSET_ROOT,
-  CMS_ROOT,
-  Configuration,
-} from "@helpers/app-initializer/app-initializer";
 import { NgbModule } from "@ng-bootstrap/ng-bootstrap";
-import { mockProvider } from "@ngneat/spectator";
 import { FormlyBootstrapModule } from "@ngx-formly/bootstrap";
 import { FormlyModule } from "@ngx-formly/core";
-import { AppConfigService } from "@services/app-config/app-config.service";
-import {
-  AppConfigMockService,
-  testApiConfig,
-} from "@services/app-config/appConfigMock.service";
 import { LoadingModule } from "@shared/loading/loading.module";
 import { ToastrModule } from "ngx-toastr";
 import { BehaviorSubject } from "rxjs";
@@ -56,38 +38,9 @@ export const testFormImports = [
 ];
 
 /**
- * Create mock initializer values
- */
-export const testAppInitializer = [
-  {
-    provide: API_ROOT,
-    useValue: testApiConfig.environment.apiRoot,
-  },
-  {
-    provide: CMS_ROOT,
-    useValue: testApiConfig.environment.cmsRoot,
-  },
-  {
-    provide: ASSET_ROOT,
-    useValue: testApiConfig.environment.assetRoot,
-  },
-  {
-    provide: API_CONFIG,
-    useValue: new Promise<Configuration>((resolve) => {
-      resolve(testApiConfig);
-    }),
-  },
-  {
-    provide: AppConfigService,
-    useClass: AppConfigMockService,
-  },
-];
-
-/**
  * Mock classes for baw services
  */
 export const testBawServices = [
-  ...testAppInitializer,
   {
     provide: HTTP_INTERCEPTORS,
     useClass: BawApiInterceptor,

--- a/src/app/test/helpers/testbed.ts
+++ b/src/app/test/helpers/testbed.ts
@@ -1,20 +1,12 @@
 import { CommonModule } from "@angular/common";
-import { HttpHeaders, HTTP_INTERCEPTORS } from "@angular/common/http";
+import { HttpHeaders } from "@angular/common/http";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { ReactiveFormsModule } from "@angular/forms";
 import { BrowserModule } from "@angular/platform-browser";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { ActivatedRouteSnapshot, Data, Params } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
-import { BawApiInterceptor } from "@baw-api/api.interceptor.service";
-import { BawApiService, STUB_MODEL_BUILDER } from "@baw-api/baw-api.service";
-import {
-  MockBawApiService,
-  MockModel,
-} from "@baw-api/mock/baseApiMock.service";
-import { MockSecurityService } from "@baw-api/mock/securityMock.service";
 import { ResolvedModel } from "@baw-api/resolver-common";
-import { SecurityService } from "@baw-api/security/security.service";
 import { NgbModule } from "@ng-bootstrap/ng-bootstrap";
 import { FormlyBootstrapModule } from "@ngx-formly/bootstrap";
 import { FormlyModule } from "@ngx-formly/core";
@@ -35,20 +27,6 @@ export const testFormImports = [
   HttpClientTestingModule,
   RouterTestingModule,
   LoadingModule,
-];
-
-/**
- * Mock classes for baw services
- */
-export const testBawServices = [
-  {
-    provide: HTTP_INTERCEPTORS,
-    useClass: BawApiInterceptor,
-    multi: true,
-  },
-  { provide: STUB_MODEL_BUILDER, useValue: MockModel },
-  { provide: BawApiService, useClass: MockBawApiService },
-  { provide: SecurityService, useClass: MockSecurityService },
 ];
 
 /**


### PR DESCRIPTION
# Mocking Services

Created a better method of mocking services for unit tests. Now unit tests can import `MockAppConfigModule` and `MockBawApiModule` when components use any of the included services. This new implementation also takes advantage of the new `ng-mocks` dependency to remove the need for creating mocks for services ahead of time. This means mocks should never be out of sync with services.

## Problems

- New mock services do not provide empty Subjects by default (means some tests had to be updated to return empty Subjects otherwise the component would crash)
