### PR TITLE
Reduce nesting on built artifacts

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -77,16 +77,10 @@ jobs:
       - name: Build the workbench client
         run: npm run build
 
-      # https://github.com/marketplace/actions/create-zip-file
-      - name: Zip workbench files
-        uses: montudor/action-zip@v0.1.0
-        with:
-          args: zip -qq -r ./workbench-client.zip ./dist/workbench-client/
-
       - name: Publish build files
         uses: actions/upload-artifact@v2
         with:
-          path: ./workbench-client.zip
+          path: ./dist/workbench-client/
           name: workbench-client
 
   merge:


### PR DESCRIPTION
# Reduce nesting on built artifacts

Converting build workflow from azure pipelines messed up the build artifacts. This PR fixes the build artifact so that the result is a `workbench-client.zip` file which directly contains the build files.

## Issues

Closes #383 