### PR TITLE
Config Refinements V2

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -12,6 +12,7 @@ import {
   Configuration,
 } from "@helpers/app-initializer/app-initializer";
 import { ngExpressEngine } from "@nguniversal/express-engine";
+import { assetRoot } from "@services/app-config/app-config.service";
 import express from "express";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
@@ -52,7 +53,7 @@ export function app(path: string): express.Express {
   server.set("views", distFolder);
 
   // special case rendering our settings file - we already have it loaded
-  server.get("/assets/environment.json", (request, response) => {
+  server.get(`${assetRoot}/environment.json`, (request, response) => {
     response.type("application/json");
     response.send(rawConfig);
   });

--- a/src/app/components/about/pages/credits/credits.component.spec.ts
+++ b/src/app/components/about/pages/credits/credits.component.spec.ts
@@ -5,6 +5,7 @@ import {
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AppConfigService } from "@services/app-config/app-config.service";
+import { cmsRoot } from "@services/app-config/app-config.service.spec";
 import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { SharedModule } from "@shared/shared.module";
 import { CreditsComponent } from "./credits.component";
@@ -40,12 +41,12 @@ describe("AboutCreditsComponent", () => {
   });
 
   it("should create", () => {
-    httpMock.expectOne(env.environment.cmsRoot + "/credits.html");
+    httpMock.expectOne(`${cmsRoot}/credits.html`);
     expect(component).toBeTruthy();
   });
 
   it("should load cms", () => {
-    const req = httpMock.expectOne(env.environment.cmsRoot + "/credits.html");
+    const req = httpMock.expectOne(`${cmsRoot}/credits.html`);
 
     req.flush("<h1>Test Header</h1><p>Test Description</p>");
     fixture.detectChanges();

--- a/src/app/components/about/pages/credits/credits.component.ts
+++ b/src/app/components/about/pages/credits/credits.component.ts
@@ -16,7 +16,7 @@ class CreditsComponent extends PageComponent implements OnInit {
   }
 
   public ngOnInit() {
-    this.page = this.env.values.cms.credits;
+    this.page = this.env.getCms("credits");
   }
 }
 

--- a/src/app/components/about/pages/disclaimers/disclaimers.component.spec.ts
+++ b/src/app/components/about/pages/disclaimers/disclaimers.component.spec.ts
@@ -5,6 +5,7 @@ import {
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AppConfigService } from "@services/app-config/app-config.service";
+import { cmsRoot } from "@services/app-config/app-config.service.spec";
 import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { SharedModule } from "@shared/shared.module";
 import { DisclaimersComponent } from "./disclaimers.component";
@@ -40,14 +41,12 @@ describe("AboutDisclaimersComponent", () => {
   });
 
   it("should create", () => {
-    httpMock.expectOne(env.environment.cmsRoot + "/disclaimers.html");
+    httpMock.expectOne(`${cmsRoot}/disclaimers.html`);
     expect(component).toBeTruthy();
   });
 
   it("should load cms", () => {
-    const req = httpMock.expectOne(
-      env.environment.cmsRoot + "/disclaimers.html"
-    );
+    const req = httpMock.expectOne(`${cmsRoot}/disclaimers.html`);
 
     req.flush("<h1>Test Header</h1><p>Test Description</p>");
     fixture.detectChanges();

--- a/src/app/components/about/pages/disclaimers/disclaimers.component.ts
+++ b/src/app/components/about/pages/disclaimers/disclaimers.component.ts
@@ -19,7 +19,7 @@ class DisclaimersComponent extends PageComponent implements OnInit {
   }
 
   public ngOnInit() {
-    this.page = this.env.values.cms.disclaimers;
+    this.page = this.env.getCms("disclaimers");
   }
 }
 

--- a/src/app/components/about/pages/ethics/ethics.component.spec.ts
+++ b/src/app/components/about/pages/ethics/ethics.component.spec.ts
@@ -5,6 +5,7 @@ import {
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AppConfigService } from "@services/app-config/app-config.service";
+import { cmsRoot } from "@services/app-config/app-config.service.spec";
 import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { SharedModule } from "@shared/shared.module";
 import { EthicsComponent } from "./ethics.component";
@@ -40,12 +41,12 @@ describe("AboutEthicsComponent", () => {
   });
 
   it("should create", () => {
-    httpMock.expectOne(env.environment.cmsRoot + "/ethics.html");
+    httpMock.expectOne(`${cmsRoot}/ethics.html`);
     expect(component).toBeTruthy();
   });
 
   it("should load cms", () => {
-    const req = httpMock.expectOne(env.environment.cmsRoot + "/ethics.html");
+    const req = httpMock.expectOne(`${cmsRoot}/ethics.html`);
 
     req.flush("<h1>Test Header</h1><p>Test Description</p>");
     fixture.detectChanges();

--- a/src/app/components/about/pages/ethics/ethics.component.ts
+++ b/src/app/components/about/pages/ethics/ethics.component.ts
@@ -16,7 +16,7 @@ class EthicsComponent extends PageComponent implements OnInit {
   }
 
   public ngOnInit() {
-    this.page = this.env.values.cms.ethics;
+    this.page = this.env.getCms("ethics");
   }
 }
 

--- a/src/app/components/data-request/data-request.component.spec.ts
+++ b/src/app/components/data-request/data-request.component.spec.ts
@@ -5,6 +5,7 @@ import {
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AppConfigService } from "@services/app-config/app-config.service";
+import { cmsRoot } from "@services/app-config/app-config.service.spec";
 import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { SharedModule } from "@shared/shared.module";
 import { appLibraryImports } from "src/app/app.module";
@@ -38,7 +39,7 @@ xdescribe("DataRequestComponent", () => {
   });
 
   it("should create", () => {
-    httpMock.expectOne(env.environment.cmsRoot + "/downloadAnnotations.html");
+    httpMock.expectOne(`${cmsRoot}/downloadAnnotations.html`);
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/components/data-request/data-request.component.ts
+++ b/src/app/components/data-request/data-request.component.ts
@@ -33,7 +33,8 @@ import { fields as annotationFields } from "./download-annotations.schema.json";
     </baw-wip>
   `,
 })
-class DataRequestComponent extends WithFormCheck(PageComponent)
+class DataRequestComponent
+  extends WithFormCheck(PageComponent)
   implements OnInit {
   public annotationLoading: boolean;
   public annotationModel = {};
@@ -48,7 +49,7 @@ class DataRequestComponent extends WithFormCheck(PageComponent)
   }
 
   public ngOnInit() {
-    this.page = this.env.values.cms.downloadAnnotations;
+    this.page = this.env.getCms("downloadAnnotations");
   }
 
   /**

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -12,6 +12,7 @@ import { SecurityService } from "@baw-api/security/security.service";
 import { Project } from "@models/Project";
 import { SpyObject } from "@ngneat/spectator";
 import { AppConfigService } from "@services/app-config/app-config.service";
+import { cmsRoot } from "@services/app-config/app-config.service.spec";
 import { SharedModule } from "@shared/shared.module";
 import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateProject } from "@test/fakes/Project";
@@ -47,7 +48,7 @@ describe("HomeComponent", () => {
     securityApi = TestBed.inject(SecurityService);
     env = TestBed.inject(AppConfigService);
 
-    cmsUrl = env.environment.cmsRoot + "/home.html";
+    cmsUrl = `${cmsRoot}/home.html`;
   });
 
   afterEach(() => {

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -16,9 +16,7 @@ import { homeCategory, homeMenuItem } from "./home.menus";
     <baw-cms [page]="page"></baw-cms>
     <div class="container-fluid" style="background-color: #e9ecef;">
       <section class="container">
-        <h2>
-          Some of the projects you can access
-        </h2>
+        <h2>Some of the projects you can access</h2>
         <p>
           You can browse some public projects and audio recordings without
           logging in. To participate in the analysis work you will need to Log
@@ -52,7 +50,7 @@ class HomeComponent extends PageComponent implements OnInit {
   }
 
   public ngOnInit() {
-    this.page = this.env.values.cms.home;
+    this.page = this.env.getCms("home");
 
     this.securityApi
       .getAuthTrigger()

--- a/src/app/components/projects/pages/details/details.component.spec.ts
+++ b/src/app/components/projects/pages/details/details.component.spec.ts
@@ -8,6 +8,7 @@ import { siteResolvers } from "@baw-api/site/sites.service";
 import { SiteCardComponent } from "@components/projects/site-card/site-card.component";
 import { Project } from "@models/Project";
 import { Site } from "@models/Site";
+import { assetRoot } from "@services/app-config/app-config.service";
 import { MockMapComponent } from "@shared/map/mapMock.component";
 import { SharedModule } from "@shared/shared.module";
 import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
@@ -121,7 +122,7 @@ describe("ProjectDetailsComponent", () => {
       const image = fixture.nativeElement.querySelector("img");
       assertImage(
         image,
-        `${websiteHttpUrl}/assets/images/project/project_span4.png`,
+        `${websiteHttpUrl}${assetRoot}/images/project/project_span4.png`,
         "Test Project image"
       );
     });

--- a/src/app/components/projects/site-card/site-card.component.spec.ts
+++ b/src/app/components/projects/site-card/site-card.component.spec.ts
@@ -3,6 +3,7 @@ import { RouterTestingModule } from "@angular/router/testing";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { Project } from "@models/Project";
 import { Site } from "@models/Site";
+import { assetRoot } from "@services/app-config/app-config.service";
 import { SharedModule } from "@shared/shared.module";
 import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
@@ -64,7 +65,7 @@ describe("SiteCardComponent", () => {
     const image = fixture.nativeElement.querySelector("img#image");
     assertImage(
       image,
-      `${websiteHttpUrl}/assets/images/site/site_span4.png`,
+      `${websiteHttpUrl}${assetRoot}/images/site/site_span4.png`,
       "Test Site alt"
     );
   });

--- a/src/app/components/send-audio/send-audio.component.spec.ts
+++ b/src/app/components/send-audio/send-audio.component.spec.ts
@@ -5,6 +5,7 @@ import {
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AppConfigService } from "@services/app-config/app-config.service";
+import { cmsRoot } from "@services/app-config/app-config.service.spec";
 import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { SharedModule } from "@shared/shared.module";
 import { SendAudioComponent } from "./send-audio.component";
@@ -34,7 +35,7 @@ describe("SendAudioComponent", () => {
     env = TestBed.inject(AppConfigService);
     component = fixture.componentInstance;
 
-    cmsUrl = env.environment.cmsRoot + "/sendAudio.html";
+    cmsUrl = `${cmsRoot}/sendAudio.html`;
 
     fixture.detectChanges();
   });

--- a/src/app/components/send-audio/send-audio.component.ts
+++ b/src/app/components/send-audio/send-audio.component.ts
@@ -20,7 +20,7 @@ class SendAudioComponent extends PageComponent implements OnInit {
   }
 
   public ngOnInit() {
-    this.page = this.env.values.cms.sendAudio;
+    this.page = this.env.getCms("sendAudio");
   }
 }
 

--- a/src/app/components/shared/cards/card-image/card-image.component.spec.ts
+++ b/src/app/components/shared/cards/card-image/card-image.component.spec.ts
@@ -5,6 +5,7 @@ import { AuthenticatedImageModule } from "@directives/image/image.module";
 import { Id, ImageUrl } from "@interfaces/apiInterfaces";
 import { AbstractModel } from "@models/AbstractModel";
 import { createComponentFactory, Spectator } from "@ngneat/spectator";
+import { assetRoot } from "@services/app-config/app-config.service";
 import { modelData } from "@test/helpers/faker";
 import { assertHref, assertImage, assertRoute } from "@test/helpers/html";
 import { websiteHttpUrl } from "@test/helpers/url";
@@ -61,7 +62,7 @@ describe("CardImageComponent", () => {
   });
 
   it("should handle local image", () => {
-    const baseUrl = "/assets/broken_link";
+    const baseUrl = `${assetRoot}/broken_link`;
     spectator.setInput("card", {
       title: "custom title",
       model: new CardImageMockModel({ image: modelData.imageUrls(baseUrl) }),

--- a/src/app/components/shared/cms/cms.component.spec.ts
+++ b/src/app/components/shared/cms/cms.component.spec.ts
@@ -9,6 +9,7 @@ import { SecurityService } from "@baw-api/security/security.service";
 import { SessionUser } from "@models/User";
 import { AppConfigService } from "@services/app-config/app-config.service";
 import { cmsRoot } from "@services/app-config/app-config.service.spec";
+import { generateSessionUser } from "@test/fakes/User";
 import { assertSpinner } from "@test/helpers/html";
 import { SharedModule } from "../shared.module";
 import { CmsComponent } from "./cms.component";
@@ -146,11 +147,9 @@ describe("CmsComponent", () => {
 
   // TODO Re-implement when CMS requests are performed by API
   xit("should request page from api with 'Authorization' header when logged in", () => {
+    const sessionUser = new SessionUser(generateSessionUser());
     spyOn(api, "isLoggedIn").and.callFake(() => true);
-    spyOn(api, "getLocalUser").and.callFake(
-      () =>
-        new SessionUser({ authToken: "xxxxxxxxxxxxxxx", userName: "username" })
-    );
+    spyOn(api, "getLocalUser").and.callFake(() => sessionUser);
 
     component.page = "/testing.html";
     fixture.detectChanges();
@@ -158,7 +157,7 @@ describe("CmsComponent", () => {
     const req = httpMock.expectOne(`${cmsRoot}/testing.html`);
     expect(req.request.headers.has("Authorization")).toBeTruthy();
     expect(req.request.headers.get("Authorization")).toBe(
-      'Token token="xxxxxxxxxxxxxxx"'
+      `Token token="${sessionUser.authToken}"`
     );
   });
 

--- a/src/app/components/shared/cms/cms.component.spec.ts
+++ b/src/app/components/shared/cms/cms.component.spec.ts
@@ -8,6 +8,7 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { SecurityService } from "@baw-api/security/security.service";
 import { SessionUser } from "@models/User";
 import { AppConfigService } from "@services/app-config/app-config.service";
+import { cmsRoot } from "@services/app-config/app-config.service.spec";
 import { assertSpinner } from "@test/helpers/html";
 import { SharedModule } from "../shared.module";
 import { CmsComponent } from "./cms.component";
@@ -47,7 +48,7 @@ describe("CmsComponent", () => {
     component.page = "/testing.html";
     fixture.detectChanges();
 
-    const req = httpMock.expectOne(env.environment.cmsRoot + "/testing.html");
+    const req = httpMock.expectOne(`${cmsRoot}/testing.html`);
 
     expect(req).toBeTruthy();
     expect(req.request.method).toBe("GET");
@@ -59,7 +60,7 @@ describe("CmsComponent", () => {
     component.page = "/new.html";
     fixture.detectChanges();
 
-    const req = httpMock.expectOne(env.environment.cmsRoot + "/new.html");
+    const req = httpMock.expectOne(`${cmsRoot}/new.html`);
 
     expect(req).toBeTruthy();
     expect(req.request.method).toBe("GET");
@@ -71,7 +72,7 @@ describe("CmsComponent", () => {
     component.page = "/testing.html";
     fixture.detectChanges();
 
-    httpMock.expectOne(env.environment.cmsRoot + "/testing.html");
+    httpMock.expectOne(`${cmsRoot}/testing.html`);
     assertSpinner(fixture, true);
   });
 
@@ -81,7 +82,7 @@ describe("CmsComponent", () => {
     component.page = "/testing.html";
     fixture.detectChanges();
 
-    const req = httpMock.expectOne(env.environment.cmsRoot + "/testing.html");
+    const req = httpMock.expectOne(`${cmsRoot}/testing.html`);
     req.flush("<h1>Response</h1><p>Example HTML response from API</p>");
 
     fixture.detectChanges();
@@ -94,7 +95,7 @@ describe("CmsComponent", () => {
     component.page = "/testing.html";
     fixture.detectChanges();
 
-    const req = httpMock.expectOne(env.environment.cmsRoot + "/testing.html");
+    const req = httpMock.expectOne(`${cmsRoot}/testing.html`);
     req.flush("", { status: 404, statusText: "Not Found" });
 
     fixture.detectChanges();
@@ -107,7 +108,7 @@ describe("CmsComponent", () => {
     component.page = "/testing.html";
     fixture.detectChanges();
 
-    const req = httpMock.expectOne(env.environment.cmsRoot + "/testing.html");
+    const req = httpMock.expectOne(`${cmsRoot}/testing.html`);
 
     expect(req.request.responseType).toBeTruthy();
     expect(req.request.responseType).toBe("text");
@@ -119,7 +120,7 @@ describe("CmsComponent", () => {
     component.page = "/testing.html";
     fixture.detectChanges();
 
-    const req = httpMock.expectOne(env.environment.cmsRoot + "/testing.html");
+    const req = httpMock.expectOne(`${cmsRoot}/testing.html`);
     expect(req.request.headers.has("Accept")).toBeFalsy();
   });
 
@@ -129,7 +130,7 @@ describe("CmsComponent", () => {
     component.page = "/testing.html";
     fixture.detectChanges();
 
-    const req = httpMock.expectOne(env.environment.cmsRoot + "/testing.html");
+    const req = httpMock.expectOne(`${cmsRoot}/testing.html`);
     expect(req.request.headers.has("Content-Type")).toBeFalsy();
   });
 
@@ -139,11 +140,12 @@ describe("CmsComponent", () => {
     component.page = "/testing.html";
     fixture.detectChanges();
 
-    const req = httpMock.expectOne(env.environment.cmsRoot + "/testing.html");
+    const req = httpMock.expectOne(`${cmsRoot}/testing.html`);
     expect(req.request.headers.has("Authorization")).toBeFalsy();
   });
 
-  it("should request page from api with 'Authorization' header when logged in", () => {
+  // TODO Re-implement when CMS requests are performed by API
+  xit("should request page from api with 'Authorization' header when logged in", () => {
     spyOn(api, "isLoggedIn").and.callFake(() => true);
     spyOn(api, "getLocalUser").and.callFake(
       () =>
@@ -153,7 +155,7 @@ describe("CmsComponent", () => {
     component.page = "/testing.html";
     fixture.detectChanges();
 
-    const req = httpMock.expectOne(env.environment.cmsRoot + "/testing.html");
+    const req = httpMock.expectOne(`${cmsRoot}/testing.html`);
     expect(req.request.headers.has("Authorization")).toBeTruthy();
     expect(req.request.headers.get("Authorization")).toBe(
       'Token token="xxxxxxxxxxxxxxx"'
@@ -166,7 +168,7 @@ describe("CmsComponent", () => {
     component.page = "/testing.html";
     fixture.detectChanges();
 
-    const req = httpMock.expectOne(env.environment.cmsRoot + "/testing.html");
+    const req = httpMock.expectOne(`${cmsRoot}/testing.html`);
     req.flush("<h1>Response</h1><p>Example HTML response from API</p>");
 
     fixture.detectChanges();
@@ -186,7 +188,7 @@ describe("CmsComponent", () => {
     component.page = "/testing.html";
     fixture.detectChanges();
 
-    const req = httpMock.expectOne(env.environment.cmsRoot + "/testing.html");
+    const req = httpMock.expectOne(`${cmsRoot}/testing.html`);
     req.flush("", { status: 404, statusText: "Not Found" });
 
     const header = fixture.nativeElement.querySelector("h1");
@@ -200,7 +202,7 @@ describe("CmsComponent", () => {
     component.page = "/testing.html";
     fixture.detectChanges();
 
-    const req = httpMock.expectOne(env.environment.cmsRoot + "/testing.html");
+    const req = httpMock.expectOne(`${cmsRoot}/testing.html`);
     req.flush("", { status: 401, statusText: "Unauthorized" });
 
     const header = fixture.nativeElement.querySelector("h1");

--- a/src/app/components/shared/cms/cms.component.ts
+++ b/src/app/components/shared/cms/cms.component.ts
@@ -8,7 +8,7 @@ import {
 } from "@angular/core";
 import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
-import { CMS_ROOT } from "@helpers/app-initializer/app-initializer";
+import { API_ROOT } from "@helpers/app-initializer/app-initializer";
 import { WithUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
 import { takeUntil } from "rxjs/operators";
 
@@ -32,7 +32,7 @@ export class CmsComponent extends WithUnsubscribe() implements OnInit {
   public loading: boolean;
 
   constructor(
-    @Inject(CMS_ROOT) private cmsRoot: string,
+    @Inject(API_ROOT) private apiRoot: string,
     private http: HttpClient,
     private ref: ChangeDetectorRef,
     private sanitizer: DomSanitizer
@@ -43,8 +43,10 @@ export class CmsComponent extends WithUnsubscribe() implements OnInit {
   public ngOnInit() {
     this.loading = true;
 
+    // TODO Replace with API request
     this.http
-      .get(this.cmsRoot + this.page, { responseType: "text" })
+      // .get(this.apiRoot + this.page, { responseType: "text" })
+      .get(`/assets/content${this.page}`, { responseType: "text" })
       .pipe(takeUntil(this.unsubscribe))
       .subscribe(
         (data) => {

--- a/src/app/components/shared/detail-view/render-field/render-field.component.spec.ts
+++ b/src/app/components/shared/detail-view/render-field/render-field.component.spec.ts
@@ -4,6 +4,7 @@ import { RouterTestingModule } from "@angular/router/testing";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { AuthenticatedImageModule } from "@directives/image/image.module";
 import { AbstractModel, UnresolvedModel } from "@models/AbstractModel";
+import { assetRoot } from "@services/app-config/app-config.service";
 import { CheckboxComponent } from "@shared/checkbox/checkbox.component";
 import { modelData } from "@test/helpers/faker";
 import { assertImage, assertRoute } from "@test/helpers/html";
@@ -492,11 +493,11 @@ describe("RenderFieldComponent", () => {
       component["isImage"] = jasmine
         .createSpy()
         .and.callFake((src: string, onload: () => void, __: () => void) => {
-          expect(src).toBe("/assets/test/test.png");
+          expect(src).toBe(`${assetRoot}/test/test.png`);
           onload();
         });
 
-      component.value = "/assets/test/test.png";
+      component.value = `${assetRoot}/test/test.png`;
       fixture.detectChanges();
 
       expect(getValues().length).toBe(1);
@@ -525,13 +526,13 @@ describe("RenderFieldComponent", () => {
           onload();
         });
 
-      component.value = "/assets/test/test.png";
+      component.value = `${assetRoot}/test/test.png`;
       fixture.detectChanges();
 
       const value = getImageValues()[0];
       assertImage(
         value,
-        `${websiteHttpUrl}/assets/test/test.png`,
+        `${websiteHttpUrl}${assetRoot}/test/test.png`,
         "model image alt"
       );
     });

--- a/src/app/components/shared/header/header.component.spec.ts
+++ b/src/app/components/shared/header/header.component.spec.ts
@@ -10,7 +10,10 @@ import { RouterTestingModule } from "@angular/router/testing";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { SecurityService } from "@baw-api/security/security.service";
 import { SessionUser } from "@models/User";
-import { AppConfigService } from "@services/app-config/app-config.service";
+import {
+  AppConfigService,
+  assetRoot,
+} from "@services/app-config/app-config.service";
 import { generateSessionUser, generateUser } from "@test/fakes/User";
 import { modelData } from "@test/helpers/faker";
 import { assertImage, assertRoute } from "@test/helpers/html";
@@ -229,7 +232,7 @@ describe("HeaderComponent", () => {
             const image = profile.querySelector("img");
             assertImage(
               image,
-              `${websiteHttpUrl}/assets/images/user/user_span4.png`,
+              `${websiteHttpUrl}${assetRoot}/images/user/user_span4.png`,
               "Profile Icon"
             );
           }));

--- a/src/app/components/shared/user-badges/user-badge/user-badge.component.spec.ts
+++ b/src/app/components/shared/user-badges/user-badge/user-badge.component.spec.ts
@@ -5,6 +5,7 @@ import { AuthenticatedImageModule } from "@directives/image/image.module";
 import { ImageSizes } from "@interfaces/apiInterfaces";
 import { User } from "@models/User";
 import { createComponentFactory, Spectator } from "@ngneat/spectator";
+import { assetRoot } from "@services/app-config/app-config.service";
 import { LoadingModule } from "@shared/loading/loading.module";
 import { generateUser } from "@test/fakes/User";
 import { assertImage, assertRoute, assertSpinner } from "@test/helpers/html";
@@ -119,7 +120,7 @@ describe("UserBadgeComponent", () => {
       detectChanges();
       assertImage(
         getImages()[0],
-        `${websiteHttpUrl}/assets/images/user/user_span4.png`,
+        `${websiteHttpUrl}${assetRoot}/images/user/user_span4.png`,
         "custom username profile picture"
       );
     });

--- a/src/app/components/sites/pages/details/details.component.spec.ts
+++ b/src/app/components/sites/pages/details/details.component.spec.ts
@@ -9,6 +9,7 @@ import { siteResolvers } from "@baw-api/site/sites.service";
 import { SharedModule } from "@components/shared/shared.module";
 import { Project } from "@models/Project";
 import { Site } from "@models/Site";
+import { assetRoot } from "@services/app-config/app-config.service";
 import { MockMapComponent } from "@shared/map/mapMock.component";
 import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateProject } from "@test/fakes/Project";
@@ -138,7 +139,7 @@ describe("SitesDetailsComponent", () => {
       const image = fixture.nativeElement.querySelector("img");
       assertImage(
         image,
-        `${websiteHttpUrl}/assets/images/site/site_span4.png`,
+        `${websiteHttpUrl}${assetRoot}/images/site/site_span4.png`,
         "Site image"
       );
     });

--- a/src/app/components/sites/pages/harvest/harvest.component.spec.ts
+++ b/src/app/components/sites/pages/harvest/harvest.component.spec.ts
@@ -4,6 +4,7 @@ import {
 } from "@angular/common/http/testing";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { AppConfigService } from "@services/app-config/app-config.service";
+import { cmsRoot } from "@services/app-config/app-config.service.spec";
 import { MockAppConfigModule } from "@services/app-config/app-configMock.module";
 import { SharedModule } from "@shared/shared.module";
 import { HarvestComponent } from "./harvest.component";
@@ -34,12 +35,12 @@ describe("SiteHarvestComponent", () => {
   });
 
   it("should create", () => {
-    httpMock.expectOne(env.environment.cmsRoot + "/harvest.html");
+    httpMock.expectOne(`${cmsRoot}/harvest.html`);
     expect(component).toBeTruthy();
   });
 
   it("should load cms", () => {
-    const req = httpMock.expectOne(env.environment.cmsRoot + "/harvest.html");
+    const req = httpMock.expectOne(`${cmsRoot}/harvest.html`);
 
     req.flush(
       "<h1>Test Header</h1><p class='description'>Test Description</p>"

--- a/src/app/components/sites/pages/harvest/harvest.component.ts
+++ b/src/app/components/sites/pages/harvest/harvest.component.ts
@@ -24,7 +24,7 @@ class HarvestComponent extends PageComponent implements OnInit {
   }
 
   public ngOnInit() {
-    this.page = this.env.values.cms.harvest;
+    this.page = this.env.getCms("harvest");
   }
 }
 

--- a/src/app/directives/image/image.directive.ts
+++ b/src/app/directives/image/image.directive.ts
@@ -9,9 +9,10 @@ import {
 import { SecurityService } from "@baw-api/security/security.service";
 import { API_ROOT } from "@helpers/app-initializer/app-initializer";
 import { ImageSizes, ImageUrl } from "@interfaces/apiInterfaces";
+import { assetRoot } from "@services/app-config/app-config.service";
 import { OrderedSet } from "immutable";
 
-export const image404RelativeSrc = "/assets/images/404.png";
+export const image404RelativeSrc = `${assetRoot}/images/404.png`;
 
 @Directive({
   // Directive applies directly to all image tags instead of being

--- a/src/app/helpers/app-initializer/app-initializer.ts
+++ b/src/app/helpers/app-initializer/app-initializer.ts
@@ -71,6 +71,7 @@ export interface Environment {
   siteRoot: string;
   siteDir: string;
   ga: {
+    domain: string;
     trackingId: string;
   };
 }

--- a/src/app/helpers/app-initializer/app-initializer.ts
+++ b/src/app/helpers/app-initializer/app-initializer.ts
@@ -8,7 +8,6 @@ export let API_CONFIG = new InjectionToken<Promise<Configuration>>(
 );
 export let API_ROOT = new InjectionToken<string>("baw.api.root");
 export let CMS_ROOT = new InjectionToken<string>("baw.cms.root");
-export let ASSET_ROOT = new InjectionToken<string>("baw.asset.root");
 
 /**
  * App Initializer class.
@@ -35,12 +34,6 @@ export class AppInitializer {
 
   public static cmsRootFactory() {
     return isConfiguration(environment) ? environment.environment.cmsRoot : "";
-  }
-
-  public static assetRootFactory() {
-    return isConfiguration(environment)
-      ? environment.environment.assetRoot
-      : "";
   }
 }
 
@@ -81,7 +74,6 @@ export interface Environment {
   siteRoot: string;
   siteDir: string;
   cmsRoot: string;
-  assetRoot: string;
   ga: {
     trackingId: string;
   };

--- a/src/app/helpers/app-initializer/app-initializer.ts
+++ b/src/app/helpers/app-initializer/app-initializer.ts
@@ -28,12 +28,16 @@ export class AppInitializer {
     };
   }
 
+  private static getEnvironmentValue(key: keyof Environment) {
+    return isConfiguration(environment) ? environment?.environment?.[key] : "";
+  }
+
   public static apiRootFactory() {
-    return isConfiguration(environment) ? environment.environment.apiRoot : "";
+    return this.getEnvironmentValue("apiRoot");
   }
 
   public static cmsRootFactory() {
-    return isConfiguration(environment) ? environment.environment.cmsRoot : "";
+    return this.getEnvironmentValue("cmsRoot");
   }
 }
 

--- a/src/app/helpers/app-initializer/app-initializer.ts
+++ b/src/app/helpers/app-initializer/app-initializer.ts
@@ -7,7 +7,6 @@ export let API_CONFIG = new InjectionToken<Promise<Configuration>>(
   "baw.api.config"
 );
 export let API_ROOT = new InjectionToken<string>("baw.api.root");
-export let CMS_ROOT = new InjectionToken<string>("baw.cms.root");
 
 /**
  * App Initializer class.
@@ -28,16 +27,10 @@ export class AppInitializer {
     };
   }
 
-  private static getEnvironmentValue(key: keyof Environment) {
-    return isConfiguration(environment) ? environment?.environment?.[key] : "";
-  }
-
   public static apiRootFactory() {
-    return this.getEnvironmentValue("apiRoot");
-  }
-
-  public static cmsRootFactory() {
-    return this.getEnvironmentValue("cmsRoot");
+    return isConfiguration(environment)
+      ? environment?.environment?.apiRoot
+      : "";
   }
 }
 
@@ -77,7 +70,6 @@ export interface Environment {
   apiRoot: string;
   siteRoot: string;
   siteDir: string;
-  cmsRoot: string;
   ga: {
     trackingId: string;
   };
@@ -117,7 +109,12 @@ export class Configuration implements Configuration {
 export function isConfiguration(
   config: Configuration
 ): config is Configuration {
-  return config.kind === "Configuration";
+  const hasKind = config?.kind === "Configuration";
+  const hasEnvironment = !!config?.environment;
+  const hasValues = !!config?.values;
+  const hasApiRoot = !!config?.environment?.apiRoot;
+
+  return hasKind && hasEnvironment && hasValues && hasApiRoot;
 }
 
 type Links = XOR<HeaderLink, HeaderDropDownLink>;

--- a/src/app/models/AttributeDecorators.spec.ts
+++ b/src/app/models/AttributeDecorators.spec.ts
@@ -1,4 +1,5 @@
 import { Id, Ids, ImageSizes, ImageUrl } from "@interfaces/apiInterfaces";
+import { assetRoot } from "@services/app-config/app-config.service";
 import { modelData } from "@test/helpers/faker";
 import { DateTime, Duration } from "luxon";
 import { AbstractModel } from "./AbstractModel";
@@ -61,7 +62,7 @@ describe("Attribute Decorators", () => {
     beforeEach(() => {
       defaultImageUrls = modelData.imageUrls();
       defaultImageUrl = {
-        url: "/assets/broken_link.png",
+        url: `${assetRoot}/broken_link.png`,
         size: ImageSizes.DEFAULT,
       };
     });

--- a/src/app/models/AttributeDecorators.ts
+++ b/src/app/models/AttributeDecorators.ts
@@ -20,6 +20,7 @@ export function BawImage<T extends AbstractModel>(
   defaultUrl: string,
   opts?: BawDecoratorOptions<T>
 ) {
+  // Retrieve default image and prepend site url if required
   const defaultImage: ImageUrl = { size: ImageSizes.DEFAULT, url: defaultUrl };
 
   function sortImageUrls(a: ImageUrl, b: ImageUrl): number {
@@ -35,7 +36,7 @@ export function BawImage<T extends AbstractModel>(
     return imageASize === imageBSize ? 0 : imageASize > imageBSize ? -1 : 1;
   }
 
-  function hasDefault(images: ImageUrl[]): boolean {
+  function missingDefault(images: ImageUrl[]): boolean {
     return !images.find((image) => image.size === ImageSizes.DEFAULT);
   }
 
@@ -54,9 +55,10 @@ export function BawImage<T extends AbstractModel>(
         output.sort((a, b) => sortImageUrls(a, b));
 
         // Append default image
-        if (hasDefault(output)) {
+        if (missingDefault(output)) {
           output.push(defaultImage);
         }
+
         model[key] = output;
       } else {
         model[key] = [defaultImage];

--- a/src/app/models/Project.ts
+++ b/src/app/models/Project.ts
@@ -9,6 +9,7 @@ import {
   ImageUrl,
   Param,
 } from "@interfaces/apiInterfaces";
+import { assetRoot } from "@services/app-config/app-config.service";
 import { Card } from "@shared/cards/cards.component";
 import { AbstractModel } from "./AbstractModel";
 import { Creator, HasMany, Owner, Updater } from "./AssociationDecorators";
@@ -49,7 +50,7 @@ export class Project extends AbstractModel implements IProject {
   @BawPersistAttr
   public readonly description?: Description;
   public readonly imageUrl?: string;
-  @BawImage<Project>("/assets/images/project/project_span4.png", {
+  @BawImage<Project>(`${assetRoot}/images/project/project_span4.png`, {
     key: "imageUrl",
   })
   public readonly image: ImageUrl[];

--- a/src/app/models/Site.ts
+++ b/src/app/models/Site.ts
@@ -2,6 +2,7 @@ import { Injector } from "@angular/core";
 import { IdOr } from "@baw-api/api-common";
 import { PROJECT } from "@baw-api/ServiceTokens";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
+import { assetRoot } from "@services/app-config/app-config.service";
 import { MapMarkerOption } from "@shared/map/map.component";
 import { siteMenuItem } from "../components/sites/sites.menus";
 import {
@@ -57,7 +58,7 @@ export class Site extends AbstractModel implements ISite {
   public readonly name?: Param;
   @BawPersistAttr
   public readonly imageUrl?: string;
-  @BawImage<Site>("/assets/images/site/site_span4.png", {
+  @BawImage<Site>(`${assetRoot}/images/site/site_span4.png`, {
     key: "imageUrl",
   })
   public readonly image?: ImageUrl[];

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -1,3 +1,4 @@
+import { assetRoot } from "@services/app-config/app-config.service";
 import {
   myAccountMenuItem,
   theirProfileMenuItem,
@@ -56,7 +57,9 @@ export class User extends AbstractModel implements IUser {
   public readonly failedAttempts?: number;
   @BawPersistAttr
   public readonly imageUrls?: ImageUrl[];
-  @BawImage<User>("/assets/images/user/user_span4.png", { key: "imageUrls" })
+  @BawImage<User>(`${assetRoot}/images/user/user_span4.png`, {
+    key: "imageUrls",
+  })
   public readonly image: ImageUrl[];
   @BawPersistAttr
   public readonly preferences?: any;

--- a/src/app/services/app-config/app-config.module.ts
+++ b/src/app/services/app-config/app-config.module.ts
@@ -3,7 +3,6 @@ import {
   API_CONFIG,
   API_ROOT,
   AppInitializer,
-  CMS_ROOT,
 } from "@helpers/app-initializer/app-initializer";
 import { ToastrModule } from "ngx-toastr";
 import { AppConfigService } from "./app-config.service";
@@ -20,10 +19,6 @@ import { AppConfigService } from "./app-config.service";
     {
       provide: API_ROOT,
       useFactory: AppInitializer.apiRootFactory,
-    },
-    {
-      provide: CMS_ROOT,
-      useFactory: AppInitializer.cmsRootFactory,
     },
     AppConfigService,
   ],

--- a/src/app/services/app-config/app-config.module.ts
+++ b/src/app/services/app-config/app-config.module.ts
@@ -3,7 +3,6 @@ import {
   API_CONFIG,
   API_ROOT,
   AppInitializer,
-  ASSET_ROOT,
   CMS_ROOT,
 } from "@helpers/app-initializer/app-initializer";
 import { ToastrModule } from "ngx-toastr";
@@ -25,10 +24,6 @@ import { AppConfigService } from "./app-config.service";
     {
       provide: CMS_ROOT,
       useFactory: AppInitializer.cmsRootFactory,
-    },
-    {
-      provide: ASSET_ROOT,
-      useFactory: AppInitializer.assetRootFactory,
     },
     AppConfigService,
   ],

--- a/src/app/services/app-config/app-config.service.spec.ts
+++ b/src/app/services/app-config/app-config.service.spec.ts
@@ -2,7 +2,6 @@ import { TestBed } from "@angular/core/testing";
 import {
   API_CONFIG,
   API_ROOT,
-  ASSET_ROOT,
   CMS_ROOT,
   Configuration,
 } from "@helpers/app-initializer/app-initializer";
@@ -48,7 +47,6 @@ describe("AppConfigService", () => {
   function configureTestingModule(
     apiRoot: string = testApiConfig.environment.apiRoot,
     cmsRoot: string = testApiConfig.environment.cmsRoot,
-    assetRoot: string = testApiConfig.environment.assetRoot,
     apiConfig: Partial<Configuration> = testApiConfig
   ) {
     TestBed.configureTestingModule({
@@ -61,10 +59,6 @@ describe("AppConfigService", () => {
         {
           provide: CMS_ROOT,
           useValue: cmsRoot,
-        },
-        {
-          provide: ASSET_ROOT,
-          useValue: assetRoot,
         },
         {
           provide: API_CONFIG,
@@ -104,7 +98,7 @@ describe("AppConfigService", () => {
   });
 
   it("should create warning message on failed config", () => {
-    configureTestingModule("", "", "", {});
+    configureTestingModule("", "", {});
 
     expect(toastr.error).toHaveBeenCalledWith(
       "The website is not configured correctly. Try coming back at another time.",

--- a/src/app/services/app-config/app-config.service.spec.ts
+++ b/src/app/services/app-config/app-config.service.spec.ts
@@ -125,7 +125,7 @@ describe("AppConfigService", () => {
     it("should return error page if cms does not exist", () => {
       const config: any = { ...testApiConfig, values: { cms: {} } };
       configureTestingModule(undefined, config);
-      expect(service.getCms("test" as any)).toEqual(`${cmsRoot}/error.html`);
+      expect(service.getCms("test" as any)).toEqual("/error.html");
     });
   });
 });

--- a/src/app/services/app-config/app-config.service.spec.ts
+++ b/src/app/services/app-config/app-config.service.spec.ts
@@ -2,7 +2,6 @@ import { TestBed } from "@angular/core/testing";
 import {
   API_CONFIG,
   API_ROOT,
-  CMS_ROOT,
   Configuration,
 } from "@helpers/app-initializer/app-initializer";
 import { SharedModule } from "@shared/shared.module";
@@ -10,8 +9,13 @@ import { fromJS } from "immutable";
 import { ToastrModule, ToastrService } from "ngx-toastr";
 import { toastrRoot } from "src/app/app.helper";
 import { environment } from "src/environments/environment";
-import { AppConfigService } from "./app-config.service";
+import { AppConfigService, assetRoot } from "./app-config.service";
 import { testApiConfig } from "./appConfigMock.service";
+
+/**
+ * CMS root for resources. This should only be used by tests
+ */
+export const cmsRoot = `${assetRoot}/content`;
 
 describe("AppConfigService", () => {
   let service: AppConfigService;
@@ -46,7 +50,6 @@ describe("AppConfigService", () => {
 
   function configureTestingModule(
     apiRoot: string = testApiConfig.environment.apiRoot,
-    cmsRoot: string = testApiConfig.environment.cmsRoot,
     apiConfig: Partial<Configuration> = testApiConfig
   ) {
     TestBed.configureTestingModule({
@@ -55,10 +58,6 @@ describe("AppConfigService", () => {
         {
           provide: API_ROOT,
           useValue: apiRoot,
-        },
-        {
-          provide: CMS_ROOT,
-          useValue: cmsRoot,
         },
         {
           provide: API_CONFIG,
@@ -98,7 +97,7 @@ describe("AppConfigService", () => {
   });
 
   it("should create warning message on failed config", () => {
-    configureTestingModule("", "", {});
+    configureTestingModule("", {});
 
     expect(toastr.error).toHaveBeenCalledWith(
       "The website is not configured correctly. Try coming back at another time.",

--- a/src/app/services/app-config/app-config.service.spec.ts
+++ b/src/app/services/app-config/app-config.service.spec.ts
@@ -110,4 +110,22 @@ describe("AppConfigService", () => {
       }
     );
   });
+
+  describe("CMS", () => {
+    it("should get cms", () => {
+      const config: any = {
+        ...testApiConfig,
+        values: { cms: { test: "/test.html" } },
+      };
+
+      configureTestingModule(undefined, config);
+      expect(service.getCms("test" as any)).toEqual("/test.html");
+    });
+
+    it("should return error page if cms does not exist", () => {
+      const config: any = { ...testApiConfig, values: { cms: {} } };
+      configureTestingModule(undefined, config);
+      expect(service.getCms("test" as any)).toEqual(`${cmsRoot}/error.html`);
+    });
+  });
 });

--- a/src/app/services/app-config/app-config.service.ts
+++ b/src/app/services/app-config/app-config.service.ts
@@ -66,8 +66,6 @@ export class AppConfigService {
    * @param cms CMS page to retrieve
    */
   public getCms(cms: keyof CMS): string {
-    return this.values.cms?.[cms]
-      ? this.values.cms[cms]
-      : `${assetRoot}/content/error.html`;
+    return this.values.cms?.[cms] ? this.values.cms[cms] : "/error.html";
   }
 }

--- a/src/app/services/app-config/app-config.service.ts
+++ b/src/app/services/app-config/app-config.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@angular/core";
 import {
+  CMS,
   Configuration,
   Environment,
   isConfiguration,
@@ -40,21 +41,33 @@ export class AppConfigService {
   /**
    * Get config data
    */
-  get config(): Configuration {
+  public get config(): Configuration {
     return this._config;
   }
 
   /**
    * Get environment values
    */
-  get environment(): Environment {
+  public get environment(): Environment {
     return this._config.environment;
   }
 
   /**
    * Get config values
    */
-  get values(): Values {
+  public get values(): Values {
     return this._config.values;
+  }
+
+  /**
+   * Retrieve cms url path.
+   * ! This is only a temporary function to handle retrieving
+   * cms paths. It will eventually be replaced by an API call.
+   * @param cms CMS page to retrieve
+   */
+  public getCms(cms: keyof CMS): string {
+    return this.values.cms?.[cms]
+      ? this.values.cms[cms]
+      : `${assetRoot}/content/error.html`;
   }
 }

--- a/src/app/services/app-config/app-config.service.ts
+++ b/src/app/services/app-config/app-config.service.ts
@@ -8,6 +8,8 @@ import {
 import { ToastrService } from "ngx-toastr";
 import { environment } from "src/environments/environment";
 
+export const assetRoot = "/assets";
+
 /**
  * App Config Service.
  * Handles access to the deployment environment.

--- a/src/app/services/app-config/app-configMock.module.ts
+++ b/src/app/services/app-config/app-configMock.module.ts
@@ -2,13 +2,11 @@ import { NgModule } from "@angular/core";
 import {
   API_CONFIG,
   API_ROOT,
-  ASSET_ROOT,
   CMS_ROOT,
   Configuration,
 } from "@helpers/app-initializer/app-initializer";
 import { AppConfigService } from "./app-config.service";
 import { AppConfigMockService, testApiConfig } from "./appConfigMock.service";
-
 @NgModule({
   providers: [
     {
@@ -18,10 +16,6 @@ import { AppConfigMockService, testApiConfig } from "./appConfigMock.service";
     {
       provide: CMS_ROOT,
       useValue: testApiConfig.environment.cmsRoot,
-    },
-    {
-      provide: ASSET_ROOT,
-      useValue: testApiConfig.environment.assetRoot,
     },
     {
       provide: API_CONFIG,

--- a/src/app/services/app-config/app-configMock.module.ts
+++ b/src/app/services/app-config/app-configMock.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from "@angular/core";
 import {
   API_CONFIG,
   API_ROOT,
-  CMS_ROOT,
   Configuration,
 } from "@helpers/app-initializer/app-initializer";
 import { AppConfigService } from "./app-config.service";
@@ -12,10 +11,6 @@ import { AppConfigMockService, testApiConfig } from "./appConfigMock.service";
     {
       provide: API_ROOT,
       useValue: testApiConfig.environment.apiRoot,
-    },
-    {
-      provide: CMS_ROOT,
-      useValue: testApiConfig.environment.cmsRoot,
     },
     {
       provide: API_CONFIG,

--- a/src/app/services/app-config/appConfigMock.service.ts
+++ b/src/app/services/app-config/appConfigMock.service.ts
@@ -30,7 +30,6 @@ export const testApiConfig = new Configuration({
     siteRoot: "https://www.testing.com/site",
     siteDir: "<< siteDir >>",
     cmsRoot: "https://www.testing.com/cms",
-    assetRoot: "/assets",
     ga: {
       trackingId: "<< googleAnalytics >>",
     },

--- a/src/app/services/app-config/appConfigMock.service.ts
+++ b/src/app/services/app-config/appConfigMock.service.ts
@@ -23,9 +23,7 @@ export class AppConfigMockService {
   }
 
   public getCms(cms: keyof CMS): string {
-    return this.values.cms?.[cms]
-      ? this.values.cms[cms]
-      : `${assetRoot}/content/error.html`;
+    return this.values.cms?.[cms] ? this.values.cms[cms] : "/error.html";
   }
 }
 

--- a/src/app/services/app-config/appConfigMock.service.ts
+++ b/src/app/services/app-config/appConfigMock.service.ts
@@ -28,7 +28,7 @@ export const testApiConfig = new Configuration({
     environment: "testing",
     apiRoot: "https://www.testing.com/api",
     siteRoot: "https://www.testing.com/site",
-    siteDir: "<< siteDir >>",
+    siteDir: "/website",
     cmsRoot: "https://www.testing.com/cms",
     ga: {
       trackingId: "<< googleAnalytics >>",

--- a/src/app/services/app-config/appConfigMock.service.ts
+++ b/src/app/services/app-config/appConfigMock.service.ts
@@ -1,23 +1,31 @@
 import { Injectable } from "@angular/core";
 import {
+  CMS,
   Configuration,
   Environment,
   Values,
 } from "@helpers/app-initializer/app-initializer";
 import { version } from "package.json";
+import { assetRoot } from "./app-config.service";
 
 @Injectable()
 export class AppConfigMockService {
-  get config(): Configuration {
+  public get config(): Configuration {
     return new Proxy(testApiConfig, {});
   }
 
-  get environment(): Environment {
+  public get environment(): Environment {
     return new Proxy(testApiConfig.environment, {});
   }
 
-  get values(): Values {
+  public get values(): Values {
     return new Proxy(testApiConfig.values, {});
+  }
+
+  public getCms(cms: keyof CMS): string {
+    return this.values.cms?.[cms]
+      ? this.values.cms[cms]
+      : `${assetRoot}/content/error.html`;
   }
 }
 
@@ -29,7 +37,6 @@ export const testApiConfig = new Configuration({
     apiRoot: "https://www.testing.com/api",
     siteRoot: "https://www.testing.com/site",
     siteDir: "/website",
-    cmsRoot: "https://www.testing.com/cms",
     ga: {
       trackingId: "<< googleAnalytics >>",
     },

--- a/src/app/services/app-config/appConfigMock.service.ts
+++ b/src/app/services/app-config/appConfigMock.service.ts
@@ -38,6 +38,7 @@ export const testApiConfig = new Configuration({
     siteRoot: "https://www.testing.com/site",
     siteDir: "/website",
     ga: {
+      domain: "<< domain >>",
       trackingId: "<< googleAnalytics >>",
     },
   },

--- a/src/app/services/baw-api/api.interceptor.service.ts
+++ b/src/app/services/baw-api/api.interceptor.service.ts
@@ -8,7 +8,7 @@ import {
   HttpResponse,
 } from "@angular/common/http";
 import { Inject, Injectable } from "@angular/core";
-import { API_ROOT, CMS_ROOT } from "@helpers/app-initializer/app-initializer";
+import { API_ROOT } from "@helpers/app-initializer/app-initializer";
 import {
   toCamelCase,
   toSnakeCase,
@@ -27,7 +27,6 @@ import { SecurityService } from "./security/security.service";
 export class BawApiInterceptor implements HttpInterceptor {
   constructor(
     @Inject(API_ROOT) private apiRoot: string,
-    @Inject(CMS_ROOT) private cmsRoot: string,
     public api: SecurityService
   ) {}
 
@@ -42,10 +41,7 @@ export class BawApiInterceptor implements HttpInterceptor {
     request: HttpRequest<any>,
     next: HttpHandler
   ): Observable<HttpEvent<any>> {
-    if (
-      !request.url.includes(this.apiRoot) &&
-      !request.url.includes(this.cmsRoot)
-    ) {
+    if (!request.url.includes(this.apiRoot)) {
       return next.handle(request);
     }
 

--- a/src/assets/content/error.html
+++ b/src/assets/content/error.html
@@ -1,0 +1,7 @@
+<!-- Do not edit or delete this file. It is a default fallback in the case of an error -->
+<h2>Error Loading Content</h2>
+<p>
+  An error has occurred loading a section of this page, please use the
+  <a href="/report_problem">Report Problems</a> feature if this continue to
+  occur.
+</p>

--- a/src/assets/environment.json
+++ b/src/assets/environment.json
@@ -5,7 +5,6 @@
     "siteRoot": "http://localhost:4200",
     "siteDir": "/build/",
     "cmsRoot": "/assets/content",
-    "assetRoot": "/assets",
     "ga": {
       "trackingId": ""
     }

--- a/src/assets/environment.json
+++ b/src/assets/environment.json
@@ -3,8 +3,9 @@
     "environment": "development",
     "apiRoot": "https://staging.ecosounds.org",
     "siteRoot": "http://localhost:4200",
-    "siteDir": "/build/",
+    "siteDir": "/",
     "ga": {
+      "domain": "",
       "trackingId": ""
     }
   },

--- a/src/assets/environment.json
+++ b/src/assets/environment.json
@@ -4,7 +4,6 @@
     "apiRoot": "https://staging.ecosounds.org",
     "siteRoot": "http://localhost:4200",
     "siteDir": "/build/",
-    "cmsRoot": "/assets/content",
     "ga": {
       "trackingId": ""
     }


### PR DESCRIPTION
# Config Refinements

Refined how the configuration file works to match production expectations. This is a re-implementation the previous attempt: https://github.com/QutEcoacoustics/workbench-client/pull/407.

## Changes

- Implemented better error checking/handling for CMS components
- Removed `cmsRoot` and `assetRoot` from app config
- Added `domain` to `ga` config value

## Problems

- Some potential pain points to take this refinement further. Specifically referencing this requested change: https://github.com/QutEcoacoustics/workbench-client/pull/407#issuecomment-678833721
  - The change, as it currently stands, is not possible. This is a limitation in how baw models are created. To achieve the desired result, I would have to use the Inject service to retrieve the `API_ROOT`, `SITE_DIR`, and `SITE_ROOT`. However, the model is not guaranteed to be created with the Inject service attached (ie. In the case of forms which effectively lose this value). If I try to implement this behaviour somewhere else, such as the `AuthenticatedImageDirective`, it will be impossible to determine if the resource is an local asset, or api asset. The best middle ground I can think of, is to either use the current implementation (which works fine and will only mean changing some of the default api outputs, however even those arent required), or to have the model prepend the image url with an identifier such as `local_asset/user_profile.jpg` and `api_asset/user_profile.jpg`, which is then interpreted and replaced by `AuthenticatedImageDirective`.

## Issues

Closes #403 
Closes #402 

## Visual Changes

### New CMS error handling:
![image](https://user-images.githubusercontent.com/3955116/91381999-0ff44480-e86c-11ea-907c-f0087f62349d.png)
