### PR TITLE
StrongRoute QSP

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -90,7 +90,7 @@ jobs:
         run: cat index.html | grep -o "<title>&lt;&lt; brandName &gt;&gt;</title>"
 
       - name: Validate routing
-        run: cat index.html | grep -o "<router-outlet _ngcontent-sc115=\"\"></router-outlet><baw-home _nghost-sc258=\"\">"
+        run: cat index.html | grep -o "<\/router-outlet><baw-home.*<\/baw-home>"
 
   build:
     runs-on: ubuntu-latest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules\\typescript\\lib"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8874,10 +8874,7 @@
     "full-icu": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
-      "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "requires": {
-        "icu4c-data": "^0.64.2"
-      }
+      "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw=="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -9516,11 +9513,6 @@
       "requires": {
         "postcss": "^7.0.14"
       }
-    },
-    "icu4c-data": {
-      "version": "0.64.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
-      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ=="
     },
     "ieee754": {
       "version": "1.2.1",

--- a/src/app/components/about/about.menus.ts
+++ b/src/app/components/about/about.menus.ts
@@ -1,7 +1,7 @@
 import { Category, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
 
-export const aboutRoute = StrongRoute.base.add("about");
+export const aboutRoute = StrongRoute.newRoot().add("about");
 
 export const aboutCategory: Category = {
   icon: ["fas", "info-circle"],

--- a/src/app/components/admin/admin.menus.ts
+++ b/src/app/components/admin/admin.menus.ts
@@ -2,7 +2,7 @@ import { Category, menuLink, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
 import { isAdminPredicate } from "src/app/app.menus";
 
-export const adminRoute = StrongRoute.base.add("admin");
+export const adminRoute = StrongRoute.newRoot().add("admin");
 export const adminCategory: Category = {
   icon: ["fas", "cog"],
   label: "Admin",

--- a/src/app/components/admin/audio-recordings/list/list.component.html
+++ b/src/app/components/admin/audio-recordings/list/list.component.html
@@ -34,7 +34,8 @@
       <ng-template let-value="value" ngx-datatable-cell-template>
         <a
           class="btn btn-sm btn-default mr-2"
-          [routerLink]="detailsPath(value)"
+          [strongRoute]="detailsPath"
+          [routeParams]="{ audioRecordingId: value.id }"
         >
           Details
         </a>

--- a/src/app/components/admin/audio-recordings/list/list.component.ts
+++ b/src/app/components/admin/audio-recordings/list/list.component.ts
@@ -4,7 +4,6 @@ import { adminDashboardMenuItem } from "@components/admin/admin.menus";
 import { adminMenuItemActions } from "@components/admin/dashboard/dashboard.component";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
 import { Id, toRelative } from "@interfaces/apiInterfaces";
-import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { AudioRecording } from "@models/AudioRecording";
 import { List } from "immutable";
 import {
@@ -20,6 +19,7 @@ import {
 class AdminAudioRecordingsComponent
   extends PagedTableTemplate<TableRow, AudioRecording>
   implements OnInit {
+  public detailsPath = adminAudioRecordingMenuItem.route;
   public columns = [
     { name: "Id" },
     { name: "Site" },
@@ -51,17 +51,6 @@ class AdminAudioRecordingsComponent
 
   public ngOnInit(): void {
     this.getPageData();
-  }
-
-  /**
-   * Path to view audio recording details
-   *
-   * @param model Audio Recording
-   */
-  public detailsPath(model: AudioRecording) {
-    return adminAudioRecordingMenuItem.route.format({
-      audioRecordingId: model.id,
-    });
   }
 }
 

--- a/src/app/components/admin/dashboard/dashboard.component.ts
+++ b/src/app/components/admin/dashboard/dashboard.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component } from "@angular/core";
 import { PageComponent } from "@helpers/page/pageComponent";
-import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { List } from "immutable";
 import {
   adminAnalysisJobsMenuItem,
@@ -38,7 +37,7 @@ class AdminDashboardComponent extends PageComponent {}
 
 AdminDashboardComponent.linkComponentToPageInfo({
   category: adminCategory,
-  menus: { actions: List<AnyMenuItem>(adminMenuItemActions) },
+  menus: { actions: List(adminMenuItemActions) },
 }).andMenuRoute(adminDashboardMenuItem);
 
 export { AdminDashboardComponent };

--- a/src/app/components/admin/orphan/list/list.component.html
+++ b/src/app/components/admin/orphan/list/list.component.html
@@ -46,7 +46,8 @@
       <ng-template let-value="value" ngx-datatable-cell-template>
         <a
           class="btn btn-sm btn-default mr-2"
-          [routerLink]="detailsPath(value)"
+          [strongRoute]="detailsPath"
+          [routeParams]="{ siteId: value.id }"
         >
           Details
         </a>

--- a/src/app/components/admin/orphan/list/list.component.ts
+++ b/src/app/components/admin/orphan/list/list.component.ts
@@ -6,7 +6,6 @@ import { adminMenuItemActions } from "@components/admin/dashboard/dashboard.comp
 import { assignSiteMenuItem } from "@components/projects/projects.menus";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
 import { Id } from "@interfaces/apiInterfaces";
-import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { Site } from "@models/Site";
 import { List } from "immutable";
 import {
@@ -22,6 +21,7 @@ import {
 class AdminOrphansComponent
   extends PagedTableTemplate<TableRow, Site>
   implements OnInit {
+  public detailsPath = adminOrphanMenuItem.route;
   public assignSitesLabel = assignSiteMenuItem.label;
 
   public constructor(api: ShallowSitesService) {
@@ -42,10 +42,6 @@ class AdminOrphansComponent
     this.getPageData();
   }
 
-  public detailsPath(site: Site): string {
-    return adminOrphanMenuItem.route.format({ siteId: site.id });
-  }
-
   protected apiAction(filters: Filters) {
     return (this.api as ShallowSitesService).orphanFilter(filters);
   }
@@ -54,10 +50,7 @@ class AdminOrphansComponent
 AdminOrphansComponent.linkComponentToPageInfo({
   category: adminOrphansCategory,
   menus: {
-    actions: List<AnyMenuItem>([
-      adminDashboardMenuItem,
-      ...adminMenuItemActions,
-    ]),
+    actions: List([adminDashboardMenuItem, ...adminMenuItemActions]),
   },
 }).andMenuRoute(adminOrphansMenuItem);
 

--- a/src/app/components/admin/scripts/list/list.component.html
+++ b/src/app/components/admin/scripts/list/list.component.html
@@ -39,7 +39,11 @@
       <ng-template let-column="column" ngx-datatable-header-template>
       </ng-template>
       <ng-template let-value="value" ngx-datatable-cell-template>
-        <a class="btn btn-sm btn-default mr-1" [routerLink]="updatePath(value)">
+        <a
+          class="btn btn-sm btn-default mr-1"
+          [strongRoute]="updatePath"
+          [routeParams]="{ scriptId: value.id }"
+        >
           Update
         </a>
         <a class="btn btn-sm btn-default" [routerLink]="value.viewUrl">

--- a/src/app/components/admin/scripts/list/list.component.ts
+++ b/src/app/components/admin/scripts/list/list.component.ts
@@ -3,7 +3,6 @@ import { ScriptsService } from "@baw-api/script/scripts.service";
 import { adminDashboardMenuItem } from "@components/admin/admin.menus";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
 import { Id } from "@interfaces/apiInterfaces";
-import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { Script } from "@models/Script";
 import { List } from "immutable";
 import {
@@ -32,6 +31,7 @@ class AdminScriptsComponent extends PagedTableTemplate<TableRow, Script> {
     version: "version",
     id: "id",
   };
+  public updatePath = adminEditScriptMenuItem.route;
 
   public constructor(api: ScriptsService) {
     super(api, (scripts) =>
@@ -46,19 +46,12 @@ class AdminScriptsComponent extends PagedTableTemplate<TableRow, Script> {
 
     this.filterKey = "name";
   }
-
-  public updatePath(model: Script): string {
-    return adminEditScriptMenuItem.route.format({ scriptId: model.id });
-  }
 }
 
 AdminScriptsComponent.linkComponentToPageInfo({
   category: adminScriptsCategory,
   menus: {
-    actions: List<AnyMenuItem>([
-      adminDashboardMenuItem,
-      ...adminScriptsMenuItemActions,
-    ]),
+    actions: List([adminDashboardMenuItem, ...adminScriptsMenuItemActions]),
   },
 }).andMenuRoute(adminScriptsMenuItem);
 

--- a/src/app/components/admin/scripts/new/new.component.ts
+++ b/src/app/components/admin/scripts/new/new.component.ts
@@ -5,7 +5,6 @@ import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
-import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { Script } from "@models/Script";
 import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
@@ -57,10 +56,7 @@ class AdminScriptsNewComponent extends FormTemplate<Script> {
 AdminScriptsNewComponent.linkComponentToPageInfo({
   category: adminScriptsCategory,
   menus: {
-    actions: List<AnyMenuItem>([
-      adminScriptsMenuItem,
-      ...adminScriptsMenuItemActions,
-    ]),
+    actions: List([adminScriptsMenuItem, ...adminScriptsMenuItemActions]),
   },
 }).andMenuRoute(adminNewScriptsMenuItem);
 

--- a/src/app/components/admin/tag-group/delete/delete.component.spec.ts
+++ b/src/app/components/admin/tag-group/delete/delete.component.spec.ts
@@ -96,7 +96,7 @@ describe("AdminTagGroupsDeleteComponent", () => {
 
       component.submit({});
       expect(router.navigateByUrl).toHaveBeenCalledWith(
-        adminTagGroupsMenuItem.route.toString()
+        adminTagGroupsMenuItem.route.toRouterLink()
       );
     });
   });

--- a/src/app/components/admin/tag-group/delete/delete.component.ts
+++ b/src/app/components/admin/tag-group/delete/delete.component.ts
@@ -59,7 +59,7 @@ class AdminTagGroupsDeleteComponent
     }
   }
   protected redirectionPath() {
-    return adminTagGroupsMenuItem.route.toString();
+    return adminTagGroupsMenuItem.route.toRouterLink();
   }
 
   protected apiAction(model: Partial<TagGroup>) {

--- a/src/app/components/admin/tag-group/list/list.component.html
+++ b/src/app/components/admin/tag-group/list/list.component.html
@@ -34,10 +34,18 @@
       <ng-template let-column="column" ngx-datatable-header-template>
       </ng-template>
       <ng-template let-value="value" ngx-datatable-cell-template>
-        <a class="btn btn-sm btn-warning mr-1" [routerLink]="[editPath(value)]">
+        <a
+          class="btn btn-sm btn-warning mr-1"
+          [strongRoute]="editPath"
+          [routeParams]="{ tagGroupId: value.id }"
+        >
           Edit
         </a>
-        <a class="btn btn-sm btn-danger" [routerLink]="[deletePath(value)]">
+        <a
+          class="btn btn-sm btn-danger"
+          [strongRoute]="deletePath"
+          [routeParams]="{ tagGroupId: value.id }"
+        >
           Delete
         </a>
       </ng-template>

--- a/src/app/components/admin/tag-group/list/list.component.ts
+++ b/src/app/components/admin/tag-group/list/list.component.ts
@@ -3,7 +3,6 @@ import { TagGroupsService } from "@baw-api/tag/tag-group.service";
 import { adminDashboardMenuItem } from "@components/admin/admin.menus";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
 import { Id } from "@interfaces/apiInterfaces";
-import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { TagGroup } from "@models/TagGroup";
 import { List } from "immutable";
 import {
@@ -28,10 +27,9 @@ export const adminTagGroupMenuItemActions = [
 })
 class AdminTagGroupsComponent extends PagedTableTemplate<TableRow, TagGroup> {
   public columns = [{ name: "Tag" }, { name: "Group" }, { name: "Model" }];
-  public sortKeys = {
-    tag: "tagId",
-    group: "groupIdentifier",
-  };
+  public sortKeys = { tag: "tagId", group: "groupIdentifier" };
+  public editPath = adminEditTagGroupMenuItem.route;
+  public deletePath = adminDeleteTagGroupMenuItem.route;
 
   public constructor(api: TagGroupsService) {
     super(api, (tagGroups) =>
@@ -44,27 +42,12 @@ class AdminTagGroupsComponent extends PagedTableTemplate<TableRow, TagGroup> {
 
     this.filterKey = "groupIdentifier";
   }
-
-  public editPath(tagGroup: TagGroup): string {
-    return adminEditTagGroupMenuItem.route.toRouterLink({
-      tagGroupId: tagGroup.id,
-    });
-  }
-
-  public deletePath(tag: TagGroup): string {
-    return adminDeleteTagGroupMenuItem.route.toRouterLink({
-      tagGroupId: tag.id,
-    });
-  }
 }
 
 AdminTagGroupsComponent.linkComponentToPageInfo({
   category: adminTagGroupsCategory,
   menus: {
-    actions: List<AnyMenuItem>([
-      adminDashboardMenuItem,
-      ...adminTagGroupsMenuItemActions,
-    ]),
+    actions: List([adminDashboardMenuItem, ...adminTagGroupsMenuItemActions]),
   },
 }).andMenuRoute(adminTagGroupsMenuItem);
 

--- a/src/app/components/admin/tag-group/list/list.component.ts
+++ b/src/app/components/admin/tag-group/list/list.component.ts
@@ -46,15 +46,15 @@ class AdminTagGroupsComponent extends PagedTableTemplate<TableRow, TagGroup> {
   }
 
   public editPath(tagGroup: TagGroup): string {
-    return adminEditTagGroupMenuItem.route
-      .toString()
-      .replace(":tagGroupId", tagGroup.id.toString());
+    return adminEditTagGroupMenuItem.route.toRouterLink({
+      tagGroupId: tagGroup.id,
+    });
   }
 
   public deletePath(tag: TagGroup): string {
-    return adminDeleteTagGroupMenuItem.route
-      .toString()
-      .replace(":tagGroupId", tag.id.toString());
+    return adminDeleteTagGroupMenuItem.route.toRouterLink({
+      tagGroupId: tag.id,
+    });
   }
 }
 

--- a/src/app/components/admin/tags/delete/delete.component.spec.ts
+++ b/src/app/components/admin/tags/delete/delete.component.spec.ts
@@ -93,7 +93,7 @@ describe("AdminTagsDeleteComponent", () => {
 
       component.submit({});
       expect(router.navigateByUrl).toHaveBeenCalledWith(
-        adminTagsMenuItem.route.toString()
+        adminTagsMenuItem.route.toRouterLink()
       );
     });
   });

--- a/src/app/components/admin/tags/delete/delete.component.ts
+++ b/src/app/components/admin/tags/delete/delete.component.ts
@@ -56,7 +56,7 @@ class AdminTagsDeleteComponent extends FormTemplate<Tag> implements OnInit {
   }
 
   protected redirectionPath() {
-    return adminTagsMenuItem.route.toString();
+    return adminTagsMenuItem.route.toRouterLink();
   }
 
   protected apiAction(model: Partial<Tag>) {

--- a/src/app/components/admin/tags/list/list.component.html
+++ b/src/app/components/admin/tags/list/list.component.html
@@ -45,10 +45,18 @@
       <ng-template let-column="column" ngx-datatable-header-template>
       </ng-template>
       <ng-template let-value="value" ngx-datatable-cell-template>
-        <a class="btn btn-sm btn-warning mr-1" [routerLink]="[editPath(value)]">
+        <a
+          class="btn btn-sm btn-warning mr-1"
+          [strongRoute]="editPath"
+          [routeParams]="{ tagId: value.id }"
+        >
           Edit
         </a>
-        <a class="btn btn-sm btn-danger" [routerLink]="[deletePath(value)]">
+        <a
+          class="btn btn-sm btn-danger"
+          [strongRoute]="deletePath"
+          [routeParams]="{ tagId: value.id }"
+        >
           Delete
         </a>
       </ng-template>

--- a/src/app/components/admin/tags/list/list.component.ts
+++ b/src/app/components/admin/tags/list/list.component.ts
@@ -2,7 +2,6 @@ import { Component } from "@angular/core";
 import { TagsService } from "@baw-api/tag/tags.service";
 import { adminDashboardMenuItem } from "@components/admin/admin.menus";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
-import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { Tag } from "@models/Tag";
 import { List } from "immutable";
 import {
@@ -34,6 +33,8 @@ class AdminTagsComponent extends PagedTableTemplate<TableRow, Tag> {
     retired: "retired",
     type: "typeOfTag",
   };
+  public editPath = adminEditTagMenuItem.route;
+  public deletePath = adminDeleteTagMenuItem.route;
 
   public constructor(api: TagsService) {
     super(api, (tags) =>
@@ -48,23 +49,12 @@ class AdminTagsComponent extends PagedTableTemplate<TableRow, Tag> {
 
     this.filterKey = "text";
   }
-
-  public editPath(tag: Tag): string {
-    return adminEditTagMenuItem.route.toRouterLink({ tagId: tag.id });
-  }
-
-  public deletePath(tag: Tag): string {
-    return adminDeleteTagMenuItem.route.toRouterLink({ tagId: tag.id });
-  }
 }
 
 AdminTagsComponent.linkComponentToPageInfo({
   category: adminTagsCategory,
   menus: {
-    actions: List<AnyMenuItem>([
-      adminDashboardMenuItem,
-      ...adminTagsMenuItemActions,
-    ]),
+    actions: List([adminDashboardMenuItem, ...adminTagsMenuItemActions]),
   },
 }).andMenuRoute(adminTagsMenuItem);
 

--- a/src/app/components/admin/tags/list/list.component.ts
+++ b/src/app/components/admin/tags/list/list.component.ts
@@ -50,15 +50,11 @@ class AdminTagsComponent extends PagedTableTemplate<TableRow, Tag> {
   }
 
   public editPath(tag: Tag): string {
-    return adminEditTagMenuItem.route
-      .toString()
-      .replace(":tagId", tag.id.toString());
+    return adminEditTagMenuItem.route.toRouterLink({ tagId: tag.id });
   }
 
   public deletePath(tag: Tag): string {
-    return adminDeleteTagMenuItem.route
-      .toString()
-      .replace(":tagId", tag.id.toString());
+    return adminDeleteTagMenuItem.route.toRouterLink({ tagId: tag.id });
   }
 }
 

--- a/src/app/components/admin/users/list/list.component.html
+++ b/src/app/components/admin/users/list/list.component.html
@@ -25,7 +25,7 @@
   >
     <ngx-datatable-column name="User">
       <ng-template let-row="row" let-value="value" ngx-datatable-cell-template>
-        <a [routerLink]="[viewPath(row.account)]">{{ value }}</a>
+        <a [routerLink]="viewPath(row.account)">{{ value }}</a>
       </ng-template>
     </ngx-datatable-column>
     <ngx-datatable-column name="Last Login"> </ngx-datatable-column>
@@ -61,7 +61,8 @@
       <ng-template let-value="value" ngx-datatable-cell-template>
         <a
           class="btn btn-sm btn-warning w-100"
-          [routerLink]="[editPath(value)]"
+          [strongRoute]="editPath"
+          [routeParams]="{ accountId: value.id }"
         >
           Edit
         </a>

--- a/src/app/components/admin/users/list/list.component.spec.ts
+++ b/src/app/components/admin/users/list/list.component.spec.ts
@@ -1,10 +1,13 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AccountsService } from "@baw-api/account/accounts.service";
 import { defaultApiPageSize } from "@baw-api/baw-api.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { theirEditMenuItem } from "@components/profile/profile.menus";
+import { StrongRouteDirective } from "@directives/strongRoute/strong-route.directive";
 import { User } from "@models/User";
+import { createComponentFactory, Spectator } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { generateUser } from "@test/fakes/User";
 import { assertRoute } from "@test/helpers/html";
 import {
   assertPagination,
@@ -12,31 +15,24 @@ import {
   getDatatableCells,
   getDatatableRows,
 } from "@test/helpers/pagedTableTemplate";
-import { appLibraryImports } from "src/app/app.module";
 import { AdminUserListComponent } from "./list.component";
 
 describe("AdminUserListComponent", () => {
   let api: AccountsService;
   let defaultUser: User;
   let defaultUsers: User[];
-  let fixture: ComponentFixture<AdminUserListComponent>;
+  let spec: Spectator<AdminUserListComponent>;
+  const createComponent = createComponentFactory({
+    component: AdminUserListComponent,
+    imports: [SharedModule, RouterTestingModule, MockBawApiModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      declarations: [AdminUserListComponent],
-      imports: [
-        ...appLibraryImports,
-        SharedModule,
-        RouterTestingModule,
-        MockBawApiModule,
-      ],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(AdminUserListComponent);
-    api = TestBed.inject(AccountsService);
+    spec = createComponent({ detectChanges: false });
+    api = spec.inject(AccountsService);
 
     defaultUser = new User({
-      id: 1,
+      ...generateUser(1),
       userName: "username",
       isConfirmed: false,
     });
@@ -44,7 +40,7 @@ describe("AdminUserListComponent", () => {
     for (let i = 0; i < defaultApiPageSize; i++) {
       defaultUsers.push(
         new User({
-          id: i,
+          ...generateUser(i),
           userName: "user " + i,
           isConfirmed: false,
         })
@@ -52,16 +48,14 @@ describe("AdminUserListComponent", () => {
     }
 
     this.defaultModels = defaultUsers;
-    this.fixture = fixture;
+    this.fixture = spec.fixture;
     this.api = api;
   });
 
   it("should display number of users in description using paging data", () => {
     datatableApiResponse<User>(api, [defaultUser], { total: 100, maxPage: 4 });
-    fixture.detectChanges();
-
-    const description = fixture.nativeElement.querySelector("p");
-    expect(description.innerText.trim()).toBe("Displaying 1 of all 100 users.");
+    spec.detectChanges();
+    expect(spec.query("p")).toHaveText("Displaying 1 of all 100 users.");
   });
 
   it("should display number of results in page in description using paging data", () => {
@@ -69,10 +63,8 @@ describe("AdminUserListComponent", () => {
       total: 100,
       maxPage: 4,
     });
-    fixture.detectChanges();
-
-    const description = fixture.nativeElement.querySelector("p");
-    expect(description.innerText.trim()).toBe("Displaying 3 of all 100 users.");
+    spec.detectChanges();
+    expect(spec.query("p")).toHaveText("Displaying 3 of all 100 users.");
   });
 
   assertPagination<User, AccountsService>();
@@ -81,45 +73,45 @@ describe("AdminUserListComponent", () => {
     it("should display username", () => {
       const user = new User({ id: 1, userName: "user 1" });
       datatableApiResponse<User>(api, [user]);
-      fixture.detectChanges();
+      spec.detectChanges();
 
-      const row = getDatatableRows(fixture)[0];
+      const row = getDatatableRows(spec.fixture)[0];
       const usernameCell = getDatatableCells(row)[0];
       expect(usernameCell.innerText.trim()).toBe("user 1");
     });
 
     it("should handle missing last login data", () => {
-      const user = new User({ ...defaultUser, lastSeenAt: undefined });
+      const user = new User({ ...generateUser(), lastSeenAt: undefined });
       datatableApiResponse<User>(api, [user]);
-      fixture.detectChanges();
+      spec.detectChanges();
 
-      const row = getDatatableRows(fixture)[0];
+      const row = getDatatableRows(spec.fixture)[0];
       const lastLoginCell = getDatatableCells(row)[1];
-      expect(lastLoginCell.innerText.trim()).toBe("?");
+      expect(lastLoginCell).toHaveText("?");
     });
 
     it("should call toRelative for lastLogin", () => {
       const user = new User({
-        ...defaultUser,
+        ...generateUser(),
         lastSeenAt: "2020-03-09T22:00:50.072+10:00",
       });
       datatableApiResponse<User>(api, [user]);
       spyOn(user.lastSeenAt, "toRelative").and.callThrough();
-      fixture.detectChanges();
+      spec.detectChanges();
 
       expect(user.lastSeenAt.toRelative).toHaveBeenCalled();
     });
 
     it("should display last login", () => {
       const user = new User({
-        ...defaultUser,
+        ...generateUser(),
         lastSeenAt: "2020-03-09T22:00:50.072+10:00",
       });
       datatableApiResponse<User>(api, [user]);
       spyOn(user.lastSeenAt, "toRelative").and.callFake(() => "testing");
-      fixture.detectChanges();
+      spec.detectChanges();
 
-      const row = getDatatableRows(fixture)[0];
+      const row = getDatatableRows(spec.fixture)[0];
       const lastLoginCell = getDatatableCells(row)[1];
       expect(lastLoginCell.innerText.trim()).toBe("testing");
     });
@@ -127,9 +119,9 @@ describe("AdminUserListComponent", () => {
     it("should display confirmed user", () => {
       const user = new User({ ...defaultUser, isConfirmed: true });
       datatableApiResponse<User>(api, [user]);
-      fixture.detectChanges();
+      spec.detectChanges();
 
-      const row = getDatatableRows(fixture)[0];
+      const row = getDatatableRows(spec.fixture)[0];
       const isConfirmedCell = getDatatableCells(row)[2];
       const checkbox: HTMLInputElement = isConfirmedCell.querySelector(
         "input[type='checkbox']"
@@ -142,9 +134,9 @@ describe("AdminUserListComponent", () => {
     it("should display not confirmed user", () => {
       const user = new User({ ...defaultUser, isConfirmed: false });
       datatableApiResponse<User>(api, [user]);
-      fixture.detectChanges();
+      spec.detectChanges();
 
-      const row = getDatatableRows(fixture)[0];
+      const row = getDatatableRows(spec.fixture)[0];
       const isConfirmedCell = getDatatableCells(row)[2];
       const checkbox: HTMLInputElement = isConfirmedCell.querySelector(
         "input[type='checkbox']"
@@ -156,9 +148,9 @@ describe("AdminUserListComponent", () => {
 
     it("should display edit button", () => {
       datatableApiResponse<User>(api, [defaultUser]);
-      fixture.detectChanges();
+      spec.detectChanges();
 
-      const row = getDatatableRows(fixture)[0];
+      const row = getDatatableRows(spec.fixture)[0];
       const editCell = getDatatableCells(row)[3];
       const editLink = editCell.querySelector("a");
       expect(editLink).toBeTruthy();
@@ -169,9 +161,9 @@ describe("AdminUserListComponent", () => {
     it("should link to user account", () => {
       const user = new User({ id: 5, userName: "username" });
       datatableApiResponse<User>(api, [user]);
-      fixture.detectChanges();
+      spec.detectChanges();
 
-      const row = getDatatableRows(fixture)[0];
+      const row = getDatatableRows(spec.fixture)[0];
       const usernameCell = getDatatableCells(row)[0];
       const userLink = usernameCell.querySelector("a");
       assertRoute(userLink, "/user_accounts/5");
@@ -180,12 +172,11 @@ describe("AdminUserListComponent", () => {
     it("should link to edit user account", () => {
       const user = new User({ id: 5, userName: "username" });
       datatableApiResponse<User>(api, [user]);
-      fixture.detectChanges();
+      spec.detectChanges();
 
-      const row = getDatatableRows(fixture)[0];
-      const editCell = getDatatableCells(row)[3];
-      const editLink = editCell.querySelector("a");
-      assertRoute(editLink, "/user_accounts/5/edit");
+      const editLink = spec.queryLast(StrongRouteDirective);
+      expect(editLink.strongRoute).toEqual(theirEditMenuItem.route);
+      expect(editLink.routeParams).toEqual({ accountId: 5 });
     });
   });
 });

--- a/src/app/components/admin/users/list/list.component.ts
+++ b/src/app/components/admin/users/list/list.component.ts
@@ -62,9 +62,7 @@ class AdminUserListComponent extends PagedTableTemplate<TableRow, User> {
    * @param user User Account
    */
   public editPath(user: User) {
-    return theirEditMenuItem.route
-      .toString()
-      .replace(":accountId", user.id.toString());
+    return theirEditMenuItem.route.toRouterLink({ accountId: user.id });
   }
 }
 

--- a/src/app/components/admin/users/list/list.component.ts
+++ b/src/app/components/admin/users/list/list.component.ts
@@ -11,7 +11,6 @@ import {
   theirProfileMenuItem,
 } from "@components/profile/profile.menus";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
-import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { User } from "@models/User";
 import { List } from "immutable";
 
@@ -28,10 +27,8 @@ class AdminUserListComponent extends PagedTableTemplate<TableRow, User> {
     { name: "Last Login" },
     { name: "Confirmed" },
   ];
-  public sortKeys = {
-    user: "userName",
-    lastLogin: "lastSeenAt",
-  };
+  public sortKeys = { user: "userName", lastLogin: "lastSeenAt" };
+  public editPath = theirEditMenuItem.route;
 
   public constructor(api: AccountsService) {
     super(api, (accounts) =>
@@ -55,25 +52,11 @@ class AdminUserListComponent extends PagedTableTemplate<TableRow, User> {
   public viewPath(user: User) {
     return user.viewUrl;
   }
-
-  /**
-   * Produce the router path to the edit their account page
-   *
-   * @param user User Account
-   */
-  public editPath(user: User) {
-    return theirEditMenuItem.route.toRouterLink({ accountId: user.id });
-  }
 }
 
 AdminUserListComponent.linkComponentToPageInfo({
   category: adminCategory,
-  menus: {
-    actions: List<AnyMenuItem>([
-      adminDashboardMenuItem,
-      ...adminMenuItemActions,
-    ]),
-  },
+  menus: { actions: List([adminDashboardMenuItem, ...adminMenuItemActions]) },
 }).andMenuRoute(adminUserListMenuItem);
 
 export { AdminUserListComponent };

--- a/src/app/components/data-request/data-request.menus.ts
+++ b/src/app/components/data-request/data-request.menus.ts
@@ -3,7 +3,7 @@ import { homeCategory } from "@components/home/home.menus";
 import { Category, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
 
-export const dataRequestRoute = StrongRoute.base.add(
+export const dataRequestRoute = StrongRoute.newRoot().add(
   "data_request",
   (params: Params) => ({
     projectId: params?.projectId,

--- a/src/app/components/data-request/data-request.menus.ts
+++ b/src/app/components/data-request/data-request.menus.ts
@@ -6,6 +6,7 @@ import { StrongRoute } from "@interfaces/strongRoute";
 export const dataRequestRoute = StrongRoute.newRoot().add(
   "data_request",
   (params: Params) => ({
+    userId: params?.userId,
     projectId: params?.projectId,
     regionId: params?.regionId,
     siteId: params?.siteId,

--- a/src/app/components/data-request/data-request.menus.ts
+++ b/src/app/components/data-request/data-request.menus.ts
@@ -1,8 +1,16 @@
+import { Params } from "@angular/router";
 import { homeCategory } from "@components/home/home.menus";
 import { Category, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
 
-export const dataRequestRoute = StrongRoute.base.add("data_request");
+export const dataRequestRoute = StrongRoute.base.add(
+  "data_request",
+  (params: Params) => ({
+    projectId: params?.projectId,
+    regionId: params?.regionId,
+    siteId: params?.siteId,
+  })
+);
 
 export const dataRequestCategory: Category = homeCategory;
 

--- a/src/app/components/error/error.menus.ts
+++ b/src/app/components/error/error.menus.ts
@@ -1,7 +1,7 @@
 import { menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
 
-export const pageNotFoundRoute = StrongRoute.base.add("**");
+export const pageNotFoundRoute = StrongRoute.newRoot().add("**");
 export const pageNotFoundMenuItem = menuRoute({
   icon: ["fas", "exclamation-triangle"],
   label: "Page Not Found",

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -69,7 +69,10 @@
       </p>
       <baw-cards [cards]="projectList">
         <ng-container>
-          <a class="m-auto btn btn-outline-primary" [routerLink]="projectsLink">
+          <a
+            class="m-auto btn btn-outline-primary"
+            [strongRoute]="projectsLink"
+          >
             More Projects
           </a>
         </ng-container>

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -4,7 +4,8 @@ import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { CMS, CmsService } from "@baw-api/cms/cms.service";
 import { ProjectsService } from "@baw-api/project/projects.service";
-import { SecurityService } from "@baw-api/security/security.service";
+import { projectsMenuItem } from "@components/projects/projects.menus";
+import { StrongRouteDirective } from "@directives/strongRoute/strong-route.directive";
 import { Project } from "@models/Project";
 import {
   createComponentFactory,
@@ -17,13 +18,11 @@ import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateProject } from "@test/fakes/Project";
 import { assertCms } from "@test/helpers/api-common";
 import { nStepObservable } from "@test/helpers/general";
-import { assertRoute } from "@test/helpers/html";
 import { BehaviorSubject, Subject } from "rxjs";
 import { HomeComponent } from "./home.component";
 
 describe("HomeComponent", () => {
   let projectApi: SpyObject<ProjectsService>;
-  let securityApi: SpyObject<SecurityService>;
   let cmsService: SpyObject<CmsService>;
   let spectator: Spectator<HomeComponent>;
   const createComponent = createComponentFactory({
@@ -68,7 +67,6 @@ describe("HomeComponent", () => {
   beforeEach(() => {
     spectator = createComponent({ detectChanges: false });
     projectApi = spectator.inject(ProjectsService);
-    securityApi = spectator.inject(SecurityService);
   });
 
   assertCms<HomeComponent>(async () => {
@@ -176,8 +174,10 @@ describe("HomeComponent", () => {
 
       const button = getButton();
       expect(button).toBeTruthy();
-      expect(button.innerText.trim()).toBe("More Projects");
-      assertRoute(button, "/projects");
+      expect(button).toHaveText("More Projects");
+      expect(spectator.queryLast(StrongRouteDirective).strongRoute).toEqual(
+        projectsMenuItem.route
+      );
     });
   });
 });

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -16,7 +16,7 @@ import { homeCategory, homeMenuItem } from "./home.menus";
 })
 class HomeComponent extends PageComponent implements OnInit {
   public page = CMS.home;
-  public projectsLink = projectsMenuItem.route.toRouterLink();
+  public projectsLink = projectsMenuItem.route;
   public projectList: List<Card> = List([]);
 
   public constructor(

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -16,7 +16,7 @@ import { homeCategory, homeMenuItem } from "./home.menus";
 })
 class HomeComponent extends PageComponent implements OnInit {
   public page = CMS.home;
-  public projectsLink = projectsMenuItem.route.toString();
+  public projectsLink = projectsMenuItem.route.toRouterLink();
   public projectList: List<Card> = List([]);
 
   public constructor(

--- a/src/app/components/home/home.menus.ts
+++ b/src/app/components/home/home.menus.ts
@@ -1,7 +1,7 @@
 import { Category, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
 
-export const homeRoute = StrongRoute.base.add("");
+export const homeRoute = StrongRoute.newRoot().add("");
 export const homeCategory: Category = {
   icon: ["fas", "home"],
   label: "Home",

--- a/src/app/components/profile/pages/annotations/annotations.component.html
+++ b/src/app/components/profile/pages/annotations/annotations.component.html
@@ -62,7 +62,7 @@
         <ng-template let-value="value" ngx-datatable-cell-template>
           <a
             class="btn btn-sm btn-primary mr-1"
-            [routerLink]="[value.listenViewUrl]"
+            [routerLink]="value.listenViewUrl"
           >
             Play
           </a>

--- a/src/app/components/profile/pages/bookmarks/bookmarks.component.html
+++ b/src/app/components/profile/pages/bookmarks/bookmarks.component.html
@@ -29,7 +29,7 @@
         [sortable]="false"
       >
         <ng-template let-value="value" ngx-datatable-cell-template>
-          <a [routerLink]="[value.viewUrl]">{{ value.name }}</a>
+          <a [routerLink]="value.viewUrl">{{ value.name }}</a>
         </ng-template>
       </ngx-datatable-column>
       <ngx-datatable-column

--- a/src/app/components/profile/pages/profile/my-profile.component.spec.ts
+++ b/src/app/components/profile/pages/profile/my-profile.component.spec.ts
@@ -7,6 +7,7 @@ import { ProjectsService } from "@baw-api/project/projects.service";
 import { ShallowSitesService } from "@baw-api/site/sites.service";
 import { TagsService } from "@baw-api/tag/tags.service";
 import { dataRequestMenuItem } from "@components/data-request/data-request.menus";
+import { StrongRouteDirective } from "@directives/strongRoute/strong-route.directive";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { AbstractModel } from "@models/AbstractModel";
 import { AudioEvent } from "@models/AudioEvent";
@@ -166,24 +167,21 @@ describe("MyProfileComponent", () => {
     });
 
     it("should link to data request page", () => {
-      const route = dataRequestMenuItem.route.toString();
       setup(defaultUser);
       interceptApiRequests({});
       spec.detectChanges();
-      assertRoute(getAnnotationsLink(), route);
+      expect(spec.query(StrongRouteDirective).strongRoute).toEqual(
+        dataRequestMenuItem.route
+      );
     });
 
     it("should have site id in parameters", () => {
-      const href =
-        websiteHttpUrl +
-        dataRequestMenuItem.route.toString() +
-        "?userId=" +
-        defaultUser.id;
-
       setup(defaultUser);
       interceptApiRequests({});
       spec.detectChanges();
-      assertHref(getAnnotationsLink(), href, true);
+      expect(spec.query(StrongRouteDirective).queryParams).toEqual({
+        userId: defaultUser.id,
+      });
     });
   });
 

--- a/src/app/components/profile/pages/profile/my-profile.component.spec.ts
+++ b/src/app/components/profile/pages/profile/my-profile.component.spec.ts
@@ -34,11 +34,9 @@ import { modelData } from "@test/helpers/faker";
 import { nStepObservable } from "@test/helpers/general";
 import {
   assertErrorHandler,
-  assertHref,
   assertImage,
   assertRoute,
 } from "@test/helpers/html";
-import { websiteHttpUrl } from "@test/helpers/url";
 import { Subject } from "rxjs";
 import { MyProfileComponent } from "./my-profile.component";
 

--- a/src/app/components/profile/pages/profile/my-profile.component.ts
+++ b/src/app/components/profile/pages/profile/my-profile.component.ts
@@ -54,7 +54,7 @@ const userKey = "user";
 class MyProfileComponent
   extends withUnsubscribe(PageComponent)
   implements OnInit {
-  public dataRequest = dataRequestMenuItem;
+  public dataRequest = dataRequestMenuItem.route;
   public lastSeenAt: string;
   public membershipLength: string;
   public tags: Tag[];

--- a/src/app/components/profile/pages/profile/profile.component.html
+++ b/src/app/components/profile/pages/profile/profile.component.html
@@ -34,10 +34,8 @@
                 <!-- Link to download -->
                 <a
                   class="mx-auto text-center"
-                  [routerLink]="dataRequest.route.toRouterLink()"
-                  [queryParams]="
-                    dataRequest.route.queryParams({ userId: user.id })
-                  "
+                  [strongRoute]="dataRequest"
+                  [queryParams]="{ userId: user.id }"
                 >
                   Annotations you've created
                 </a>

--- a/src/app/components/profile/pages/profile/profile.component.html
+++ b/src/app/components/profile/pages/profile/profile.component.html
@@ -34,8 +34,10 @@
                 <!-- Link to download -->
                 <a
                   class="mx-auto text-center"
-                  [routerLink]="dataRequest.route.toString()"
-                  [queryParams]="{ userId: user.id }"
+                  [routerLink]="dataRequest.route.toRouterLink()"
+                  [queryParams]="
+                    dataRequest.route.queryParams({ userId: user.id })
+                  "
                 >
                   Annotations you've created
                 </a>

--- a/src/app/components/profile/pages/projects/projects.component.html
+++ b/src/app/components/profile/pages/projects/projects.component.html
@@ -27,7 +27,7 @@
     >
       <ngx-datatable-column name="Project">
         <ng-template let-value="value" ngx-datatable-cell-template>
-          <a [routerLink]="[value.viewUrl]">{{ value.name }}</a>
+          <a [routerLink]="value.viewUrl">{{ value.name }}</a>
         </ng-template>
       </ngx-datatable-column>
       <ngx-datatable-column

--- a/src/app/components/profile/pages/sites/my-sites.component.spec.ts
+++ b/src/app/components/profile/pages/sites/my-sites.component.spec.ts
@@ -7,6 +7,7 @@ import { ProjectsService } from "@baw-api/project/projects.service";
 import { PROJECT } from "@baw-api/ServiceTokens";
 import { ShallowSitesService } from "@baw-api/site/sites.service";
 import { dataRequestMenuItem } from "@components/data-request/data-request.menus";
+import { StrongRouteDirective } from "@directives/strongRoute/strong-route.directive";
 import { AccessLevel } from "@interfaces/apiInterfaces";
 import { Project } from "@models/Project";
 import { Site } from "@models/Site";
@@ -222,7 +223,7 @@ describe("MySitesComponent", () => {
       }
 
       function getLink() {
-        return getCells()[3].querySelector("a");
+        return spec.queryLast(StrongRouteDirective);
       }
 
       it("should display annotation link", async () => {
@@ -235,20 +236,13 @@ describe("MySitesComponent", () => {
       it("should create annotation link", async () => {
         setup(defaultUser);
         await createTable();
-
-        assertRoute(getLink(), dataRequestMenuItem.route.toString());
+        expect(getLink().strongRoute).toEqual(dataRequestMenuItem.route);
       });
 
       it("should create annotation link query params", async () => {
         setup(defaultUser);
         await createTable();
-
-        const relativePath = dataRequestMenuItem.route.toString();
-        assertHref(
-          getLink(),
-          `${websiteHttpUrl}${relativePath}?siteId=${defaultSite.id}`,
-          true
-        );
+        expect(getLink().queryParams).toEqual({ siteId: defaultSite.id });
       });
     });
   });

--- a/src/app/components/profile/pages/sites/my-sites.component.spec.ts
+++ b/src/app/components/profile/pages/sites/my-sites.component.spec.ts
@@ -23,12 +23,7 @@ import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
 import { generateUser } from "@test/fakes/User";
 import { nStepObservable } from "@test/helpers/general";
-import {
-  assertErrorHandler,
-  assertHref,
-  assertRoute,
-} from "@test/helpers/html";
-import { websiteHttpUrl } from "@test/helpers/url";
+import { assertErrorHandler, assertRoute } from "@test/helpers/html";
 import { BehaviorSubject, Subject } from "rxjs";
 import { MySitesComponent } from "./my-sites.component";
 
@@ -229,7 +224,6 @@ describe("MySitesComponent", () => {
       it("should display annotation link", async () => {
         setup(defaultUser);
         await createTable();
-
         expect(getCells()[3]).toHaveText("Annotation");
       });
 

--- a/src/app/components/profile/pages/sites/my-sites.component.ts
+++ b/src/app/components/profile/pages/sites/my-sites.component.ts
@@ -30,7 +30,7 @@ class MySitesComponent extends PagedTableTemplate<TableRow, Site> {
     { name: "Annotation" },
   ];
   public sortKeys = { site: "name", lastModified: "updatedAt" };
-  public annotationLink = dataRequestMenuItem.route.toRouterLink();
+  public annotationLink = dataRequestMenuItem.route;
   protected api: ShallowSitesService;
 
   public constructor(api: ShallowSitesService, route: ActivatedRoute) {

--- a/src/app/components/profile/pages/sites/my-sites.component.ts
+++ b/src/app/components/profile/pages/sites/my-sites.component.ts
@@ -30,7 +30,7 @@ class MySitesComponent extends PagedTableTemplate<TableRow, Site> {
     { name: "Annotation" },
   ];
   public sortKeys = { site: "name", lastModified: "updatedAt" };
-  public annotationLink = dataRequestMenuItem.route.toString();
+  public annotationLink = dataRequestMenuItem.route.toRouterLink();
   protected api: ShallowSitesService;
 
   public constructor(api: ShallowSitesService, route: ActivatedRoute) {

--- a/src/app/components/profile/pages/sites/sites.component.html
+++ b/src/app/components/profile/pages/sites/sites.component.html
@@ -23,9 +23,7 @@
     >
       <ngx-datatable-column name="Site">
         <ng-template let-value="value" ngx-datatable-cell-template>
-          <a [routerLink]="[value.viewUrl]">
-            {{ value.name }}
-          </a>
+          <a [routerLink]="value.viewUrl">{{ value.name }} </a>
         </ng-template>
       </ngx-datatable-column>
       <ngx-datatable-column name="Last Modified" [width]="150" [maxWidth]="150">
@@ -57,7 +55,7 @@
         <ng-template let-value="value" ngx-datatable-cell-template>
           <a
             class="btn btn-sm btn-default"
-            [routerLink]="[annotationLink]"
+            [strongRoute]="annotationLink"
             [queryParams]="{ siteId: value.id }"
           >
             Annotation

--- a/src/app/components/profile/pages/sites/their-sites.component.spec.ts
+++ b/src/app/components/profile/pages/sites/their-sites.component.spec.ts
@@ -23,12 +23,7 @@ import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
 import { generateUser } from "@test/fakes/User";
 import { nStepObservable } from "@test/helpers/general";
-import {
-  assertErrorHandler,
-  assertHref,
-  assertRoute,
-} from "@test/helpers/html";
-import { websiteHttpUrl } from "@test/helpers/url";
+import { assertErrorHandler, assertRoute } from "@test/helpers/html";
 import { BehaviorSubject, Subject } from "rxjs";
 import { TheirSitesComponent } from "./their-sites.component";
 

--- a/src/app/components/profile/pages/sites/their-sites.component.spec.ts
+++ b/src/app/components/profile/pages/sites/their-sites.component.spec.ts
@@ -7,6 +7,7 @@ import { ProjectsService } from "@baw-api/project/projects.service";
 import { PROJECT } from "@baw-api/ServiceTokens";
 import { ShallowSitesService } from "@baw-api/site/sites.service";
 import { dataRequestMenuItem } from "@components/data-request/data-request.menus";
+import { StrongRouteDirective } from "@directives/strongRoute/strong-route.directive";
 import { AccessLevel } from "@interfaces/apiInterfaces";
 import { Project } from "@models/Project";
 import { Site } from "@models/Site";
@@ -222,33 +223,25 @@ describe("TheirSitesComponent", () => {
       }
 
       function getLink() {
-        return getCells()[3].querySelector("a");
+        return spec.queryLast(StrongRouteDirective);
       }
 
       it("should display annotation link", async () => {
         setup(defaultUser);
         await createTable();
-
         expect(getCells()[3]).toHaveText("Annotation");
       });
 
       it("should create annotation link", async () => {
         setup(defaultUser);
         await createTable();
-
-        assertRoute(getLink(), dataRequestMenuItem.route.toString());
+        expect(getLink().strongRoute).toEqual(dataRequestMenuItem.route);
       });
 
       it("should create annotation link query params", async () => {
         setup(defaultUser);
         await createTable();
-
-        const relativePath = dataRequestMenuItem.route.toString();
-        assertHref(
-          getLink(),
-          `${websiteHttpUrl}${relativePath}?siteId=${defaultSite.id}`,
-          true
-        );
+        expect(getLink().queryParams).toEqual({ siteId: defaultSite.id });
       });
     });
   });

--- a/src/app/components/profile/profile.menus.ts
+++ b/src/app/components/profile/profile.menus.ts
@@ -14,7 +14,7 @@ function getUserName(user: AbstractModel) {
   return user ? (user as User).userName : "unknown";
 }
 
-export const myAccountRoute = StrongRoute.base.add("my_account");
+export const myAccountRoute = StrongRoute.newRoot().add("my_account");
 
 /**
  * My Account Menus
@@ -100,7 +100,7 @@ export const myAnnotationsMenuItem = menuRoute({
 /**
  * Their Profile Menus
  */
-export const theirProfileRoute = StrongRoute.base
+export const theirProfileRoute = StrongRoute.newRoot
   .add("user_accounts")
   .add(":accountId");
 

--- a/src/app/components/profile/profile.menus.ts
+++ b/src/app/components/profile/profile.menus.ts
@@ -100,7 +100,7 @@ export const myAnnotationsMenuItem = menuRoute({
 /**
  * Their Profile Menus
  */
-export const theirProfileRoute = StrongRoute.newRoot
+export const theirProfileRoute = StrongRoute.newRoot()
   .add("user_accounts")
   .add(":accountId");
 

--- a/src/app/components/projects/harvest-complete/harvest-complete.component.html
+++ b/src/app/components/projects/harvest-complete/harvest-complete.component.html
@@ -19,16 +19,13 @@
   <ngx-datatable-column name="Name"></ngx-datatable-column>
   <ngx-datatable-column name="Actions" [sortable]="false">
     <ng-template let-value="value" ngx-datatable-cell-template>
-      <a
-        class="btn btn-sm btn-primary mr-1"
-        [routerLink]="[detailsPath(value)]"
-      >
+      <a class="btn btn-sm btn-primary mr-1" [routerLink]="detailsPath(value)">
         Details
       </a>
-      <a class="btn btn-sm btn-primary mr-1" [routerLink]="[playPath(value)]">
+      <a class="btn btn-sm btn-primary mr-1" [routerLink]="playPath(value)">
         Play
       </a>
-      <a class="btn btn-sm btn-primary" [routerLink]="[visualizePath(value)]">
+      <a class="btn btn-sm btn-primary" [routerLink]="visualizePath(value)">
         Visualize
       </a>
     </ng-template>

--- a/src/app/components/projects/pages/delete/delete.component.spec.ts
+++ b/src/app/components/projects/pages/delete/delete.component.spec.ts
@@ -80,7 +80,7 @@ describe("ProjectsDeleteComponent", () => {
 
       spectator.component.submit({});
       expect(spectator.router.navigateByUrl).toHaveBeenCalledWith(
-        projectsMenuItem.route.toString()
+        projectsMenuItem.route.toRouterLink()
       );
     });
   });

--- a/src/app/components/projects/pages/delete/delete.component.ts
+++ b/src/app/components/projects/pages/delete/delete.component.ts
@@ -14,7 +14,6 @@ import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
-import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
 import { WidgetMenuItem } from "@menu/widgetItem";
 import { Project } from "@models/Project";
@@ -76,7 +75,7 @@ class DeleteComponent extends FormTemplate<Project> implements OnInit {
 DeleteComponent.linkComponentToPageInfo({
   category: projectCategory,
   menus: {
-    actions: List<AnyMenuItem>([projectMenuItem, ...projectMenuItemActions]),
+    actions: List([projectMenuItem, ...projectMenuItemActions]),
     actionsWidget: new WidgetMenuItem(PermissionsShieldComponent, {}),
   },
   resolvers: { [projectKey]: projectResolvers.show },

--- a/src/app/components/projects/pages/delete/delete.component.ts
+++ b/src/app/components/projects/pages/delete/delete.component.ts
@@ -65,7 +65,7 @@ class DeleteComponent extends FormTemplate<Project> implements OnInit {
   }
 
   protected redirectionPath() {
-    return projectsMenuItem.route.toString();
+    return projectsMenuItem.route.toRouterLink();
   }
 
   protected apiAction(model: Partial<Project>) {

--- a/src/app/components/projects/pages/new/new.component.ts
+++ b/src/app/components/projects/pages/new/new.component.ts
@@ -12,7 +12,6 @@ import {
   extendedErrorMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
-import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { Project } from "@models/Project";
 import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
@@ -60,7 +59,7 @@ class NewComponent extends FormTemplate<Project> {
 NewComponent.linkComponentToPageInfo({
   category: projectsCategory,
   menus: {
-    actions: List<AnyMenuItem>([projectsMenuItem, ...projectsMenuItemActions]),
+    actions: List([projectsMenuItem, ...projectsMenuItemActions]),
   },
 }).andMenuRoute(newProjectMenuItem);
 

--- a/src/app/components/projects/projects.menus.ts
+++ b/src/app/components/projects/projects.menus.ts
@@ -14,7 +14,7 @@ import {
 /*
   Projects Category
 */
-export const projectsRoute = StrongRoute.base.add("projects");
+export const projectsRoute = StrongRoute.newRoot().add("projects");
 export const projectsCategory: Category = {
   label: "Projects",
   icon: ["fas", "globe-asia"],

--- a/src/app/components/report-problem/report-problem.menus.ts
+++ b/src/app/components/report-problem/report-problem.menus.ts
@@ -2,7 +2,7 @@ import { homeCategory } from "@components/home/home.menus";
 import { Category, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
 
-export const reportProblemsRoute = StrongRoute.base.add("report_problem");
+export const reportProblemsRoute = StrongRoute.newRoot().add("report_problem");
 
 export const reportProblemsCategory: Category = homeCategory;
 

--- a/src/app/components/security/pages/confirm-account/confirm-account.component.ts
+++ b/src/app/components/security/pages/confirm-account/confirm-account.component.ts
@@ -8,7 +8,6 @@ import {
 } from "@components/security/security.menus";
 import { withFormCheck } from "@guards/form/form.guard";
 import { PageComponent } from "@helpers/page/pageComponent";
-import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { List } from "immutable";
 import { fields } from "./confirm-account.schema.json";
 
@@ -52,7 +51,7 @@ class ConfirmPasswordComponent
 ConfirmPasswordComponent.linkComponentToPageInfo({
   category: securityCategory,
   menus: {
-    actions: List<AnyMenuItem>([
+    actions: List([
       loginMenuItem,
       confirmAccountMenuItem,
       resetPasswordMenuItem,

--- a/src/app/components/security/pages/login/login.component.spec.ts
+++ b/src/app/components/security/pages/login/login.component.spec.ts
@@ -1,6 +1,5 @@
 import { Location } from "@angular/common";
 import { Router } from "@angular/router";
-import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import {
   LoginDetails,
@@ -18,7 +17,7 @@ import { Subject } from "rxjs";
 import { LoginComponent } from "./login.component";
 import { fields } from "./login.schema.json";
 
-describe("LoginComponent New", () => {
+describe("LoginComponent", () => {
   let api: SecurityService;
   let router: Router;
   let location: Location;

--- a/src/app/components/security/pages/login/login.component.ts
+++ b/src/app/components/security/pages/login/login.component.ts
@@ -18,7 +18,6 @@ import {
   defaultErrorMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
-import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
 import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
@@ -135,7 +134,7 @@ class LoginComponent extends FormTemplate<LoginDetails> implements OnInit {
 LoginComponent.linkComponentToPageInfo({
   category: securityCategory,
   menus: {
-    actions: List<AnyMenuItem>([
+    actions: List([
       confirmAccountMenuItem,
       resetPasswordMenuItem,
       unlockAccountMenuItem,

--- a/src/app/components/security/pages/login/login.component.ts
+++ b/src/app/components/security/pages/login/login.component.ts
@@ -108,7 +108,7 @@ class LoginComponent extends FormTemplate<LoginDetails> implements OnInit {
     if (this.redirectBack) {
       this.location.back();
     } else if (this.redirectUrl instanceof StrongRoute) {
-      this.router.navigateByUrl(this.redirectUrl.toString());
+      this.router.navigateByUrl(this.redirectUrl.toRouterLink());
     } else if (this.redirectUrl.startsWith("/")) {
       this.router.navigateByUrl(this.redirectUrl);
     } else {

--- a/src/app/components/security/pages/login/login.component.ts
+++ b/src/app/components/security/pages/login/login.component.ts
@@ -19,6 +19,7 @@ import {
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
 import { AnyMenuItem } from "@interfaces/menusInterfaces";
+import { StrongRoute } from "@interfaces/strongRoute";
 import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
 import { fields } from "./login.schema.json";
@@ -41,7 +42,7 @@ import { fields } from "./login.schema.json";
 class LoginComponent extends FormTemplate<LoginDetails> implements OnInit {
   public fields = fields;
   private redirectBack: boolean;
-  private redirectUrl: string;
+  private redirectUrl: string | StrongRoute;
 
   public constructor(
     @Inject(API_ROOT) private apiRoot: string,
@@ -70,7 +71,7 @@ class LoginComponent extends FormTemplate<LoginDetails> implements OnInit {
       this.notifications.error("You are already logged in.");
     }
 
-    this.redirectUrl = homeMenuItem.route.toString();
+    this.redirectUrl = homeMenuItem.route;
     const noHistory = 1;
     const navigationId =
       (this.location.getState() as any)?.navigationId ?? noHistory;
@@ -78,7 +79,7 @@ class LoginComponent extends FormTemplate<LoginDetails> implements OnInit {
 
     // If no redirect, redirect home
     if (typeof redirect === "boolean" && !redirect) {
-      this.redirectUrl = homeMenuItem.route.toString();
+      this.redirectUrl = homeMenuItem.route;
       return;
     }
 
@@ -106,6 +107,8 @@ class LoginComponent extends FormTemplate<LoginDetails> implements OnInit {
   protected redirectUser() {
     if (this.redirectBack) {
       this.location.back();
+    } else if (this.redirectUrl instanceof StrongRoute) {
+      this.router.navigateByUrl(this.redirectUrl.toString());
     } else if (this.redirectUrl.startsWith("/")) {
       this.router.navigateByUrl(this.redirectUrl);
     } else {

--- a/src/app/components/security/pages/reset-password/reset-password.component.ts
+++ b/src/app/components/security/pages/reset-password/reset-password.component.ts
@@ -8,7 +8,6 @@ import {
 } from "@components/security/security.menus";
 import { withFormCheck } from "@guards/form/form.guard";
 import { PageComponent } from "@helpers/page/pageComponent";
-import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { List } from "immutable";
 import { fields } from "./reset-password.schema.json";
 
@@ -52,7 +51,7 @@ class ResetPasswordComponent
 ResetPasswordComponent.linkComponentToPageInfo({
   category: securityCategory,
   menus: {
-    actions: List<AnyMenuItem>([
+    actions: List([
       loginMenuItem,
       confirmAccountMenuItem,
       resetPasswordMenuItem,

--- a/src/app/components/security/pages/unlock-account/unlock-account.component.ts
+++ b/src/app/components/security/pages/unlock-account/unlock-account.component.ts
@@ -8,7 +8,6 @@ import {
 } from "@components/security/security.menus";
 import { withFormCheck } from "@guards/form/form.guard";
 import { PageComponent } from "@helpers/page/pageComponent";
-import { AnyMenuItem } from "@interfaces/menusInterfaces";
 import { List } from "immutable";
 import { fields } from "./unlock-account.schema.json";
 
@@ -52,7 +51,7 @@ class UnlockAccountComponent
 UnlockAccountComponent.linkComponentToPageInfo({
   category: securityCategory,
   menus: {
-    actions: List<AnyMenuItem>([
+    actions: List([
       loginMenuItem,
       confirmAccountMenuItem,
       resetPasswordMenuItem,

--- a/src/app/components/security/security.menus.ts
+++ b/src/app/components/security/security.menus.ts
@@ -2,7 +2,7 @@ import { Category, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
 import { defaultUserIcon, isGuestPredicate } from "src/app/app.menus";
 
-export const securityRoute = StrongRoute.base.add("security");
+export const securityRoute = StrongRoute.newRoot().add("security");
 
 export const securityCategory: Category = {
   icon: defaultUserIcon,

--- a/src/app/components/send-audio/send-audio.menus.ts
+++ b/src/app/components/send-audio/send-audio.menus.ts
@@ -2,7 +2,7 @@ import { homeCategory } from "@components/home/home.menus";
 import { Category, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
 
-export const sendAudioRoute = StrongRoute.base.add("send_audio");
+export const sendAudioRoute = StrongRoute.newRoot().add("send_audio");
 export const sendAudioCategory: Category = homeCategory;
 export const sendAudioMenuItem = menuRoute({
   icon: ["fas", "envelope"],

--- a/src/app/components/shared/action-menu/action-menu.component.spec.ts
+++ b/src/app/components/shared/action-menu/action-menu.component.spec.ts
@@ -22,7 +22,7 @@ import { ActionMenuComponent } from "./action-menu.component";
 describe("ActionMenuComponent", () => {
   let component: ActionMenuComponent;
   let fixture: ComponentFixture<ActionMenuComponent>;
-  const defaultRoute = StrongRoute.base.add("/");
+  const defaultRoute = StrongRoute.newRoot().add("/");
   const defaultSelfLink = menuRoute({
     label: "Self Label",
     icon: ["fas", "question-circle"],
@@ -75,7 +75,7 @@ describe("ActionMenuComponent", () => {
 
   describe("category", () => {
     it("should display custom title", () => {
-      const route = StrongRoute.base.add("/");
+      const route = StrongRoute.newRoot().add("/");
 
       createTestBed({}, {
         pageRoute: menuRoute({
@@ -101,7 +101,7 @@ describe("ActionMenuComponent", () => {
     });
 
     it("should display custom icon", () => {
-      const route = StrongRoute.base.add("/");
+      const route = StrongRoute.newRoot().add("/");
 
       createTestBed({}, {
         pageRoute: menuRoute({
@@ -127,7 +127,7 @@ describe("ActionMenuComponent", () => {
     });
 
     it("should display default title", () => {
-      const route = StrongRoute.base.add("/");
+      const route = StrongRoute.newRoot().add("/");
 
       createTestBed({}, {
         pageRoute: menuRoute({
@@ -148,7 +148,7 @@ describe("ActionMenuComponent", () => {
     });
 
     it("should display default icon", () => {
-      const route = StrongRoute.base.add("/");
+      const route = StrongRoute.newRoot().add("/");
 
       createTestBed({}, {
         pageRoute: menuRoute({
@@ -171,7 +171,7 @@ describe("ActionMenuComponent", () => {
 
   describe("links", () => {
     it("should handle undefined links", () => {
-      const route = StrongRoute.base.add("/");
+      const route = StrongRoute.newRoot().add("/");
 
       createTestBed({}, {
         pageRoute: menuRoute({
@@ -199,7 +199,7 @@ describe("ActionMenuComponent", () => {
     });
 
     it("should handle no links", () => {
-      const route = StrongRoute.base.add("/");
+      const route = StrongRoute.newRoot().add("/");
 
       createTestBed({}, {
         pageRoute: menuRoute({
@@ -227,7 +227,7 @@ describe("ActionMenuComponent", () => {
     });
 
     it("should handle mixed links", () => {
-      const route = StrongRoute.base.add("/");
+      const route = StrongRoute.newRoot().add("/");
 
       createTestBed({}, {
         pageRoute: menuRoute({

--- a/src/app/components/shared/action-menu/action-menu.component.spec.ts
+++ b/src/app/components/shared/action-menu/action-menu.component.spec.ts
@@ -22,7 +22,7 @@ import { ActionMenuComponent } from "./action-menu.component";
 describe("ActionMenuComponent", () => {
   let component: ActionMenuComponent;
   let fixture: ComponentFixture<ActionMenuComponent>;
-  const defaultRoute = StrongRoute.newRoot().add("/");
+  const defaultRoute = StrongRoute.newRoot().add("");
   const defaultSelfLink = menuRoute({
     label: "Self Label",
     icon: ["fas", "question-circle"],
@@ -75,7 +75,7 @@ describe("ActionMenuComponent", () => {
 
   describe("category", () => {
     it("should display custom title", () => {
-      const route = StrongRoute.newRoot().add("/");
+      const route = StrongRoute.newRoot().add("");
 
       createTestBed({}, {
         pageRoute: menuRoute({
@@ -101,7 +101,7 @@ describe("ActionMenuComponent", () => {
     });
 
     it("should display custom icon", () => {
-      const route = StrongRoute.newRoot().add("/");
+      const route = StrongRoute.newRoot().add("");
 
       createTestBed({}, {
         pageRoute: menuRoute({
@@ -127,7 +127,7 @@ describe("ActionMenuComponent", () => {
     });
 
     it("should display default title", () => {
-      const route = StrongRoute.newRoot().add("/");
+      const route = StrongRoute.newRoot().add("");
 
       createTestBed({}, {
         pageRoute: menuRoute({
@@ -148,7 +148,7 @@ describe("ActionMenuComponent", () => {
     });
 
     it("should display default icon", () => {
-      const route = StrongRoute.newRoot().add("/");
+      const route = StrongRoute.newRoot().add("");
 
       createTestBed({}, {
         pageRoute: menuRoute({
@@ -171,7 +171,7 @@ describe("ActionMenuComponent", () => {
 
   describe("links", () => {
     it("should handle undefined links", () => {
-      const route = StrongRoute.newRoot().add("/");
+      const route = StrongRoute.newRoot().add("");
 
       createTestBed({}, {
         pageRoute: menuRoute({
@@ -199,7 +199,7 @@ describe("ActionMenuComponent", () => {
     });
 
     it("should handle no links", () => {
-      const route = StrongRoute.newRoot().add("/");
+      const route = StrongRoute.newRoot().add("");
 
       createTestBed({}, {
         pageRoute: menuRoute({
@@ -227,7 +227,7 @@ describe("ActionMenuComponent", () => {
     });
 
     it("should handle mixed links", () => {
-      const route = StrongRoute.newRoot().add("/");
+      const route = StrongRoute.newRoot().add("");
 
       createTestBed({}, {
         pageRoute: menuRoute({

--- a/src/app/components/shared/error-handler/error-handler.component.ts
+++ b/src/app/components/shared/error-handler/error-handler.component.ts
@@ -36,6 +36,6 @@ import { reportProblemMenuItem } from "@components/report-problem/report-problem
 })
 export class ErrorHandlerComponent {
   @Input() public error: ApiErrorDetails;
-  public reportUrl = reportProblemMenuItem.route.toString();
+  public reportUrl = reportProblemMenuItem.route.toRouterLink();
   public apiReturnCodes = apiReturnCodes;
 }

--- a/src/app/components/shared/error-handler/error-handler.component.ts
+++ b/src/app/components/shared/error-handler/error-handler.component.ts
@@ -28,7 +28,7 @@ import { reportProblemMenuItem } from "@components/report-problem/report-problem
       <p>{{ error.message }}</p>
       <p>
         If you continue to encounter this error, please go to the
-        <a [routerLink]="[reportUrl]">Report Problems</a> page and report the
+        <a [strongRoute]="reportProblem">Report Problems</a> page and report the
         issue.
       </p>
     </ng-container>
@@ -36,6 +36,6 @@ import { reportProblemMenuItem } from "@components/report-problem/report-problem
 })
 export class ErrorHandlerComponent {
   @Input() public error: ApiErrorDetails;
-  public reportUrl = reportProblemMenuItem.route.toRouterLink();
+  public reportProblem = reportProblemMenuItem.route;
   public apiReturnCodes = apiReturnCodes;
 }

--- a/src/app/components/shared/footer/footer.component.html
+++ b/src/app/components/shared/footer/footer.component.html
@@ -10,7 +10,7 @@
       <li class="nav-item">
         <a
           class="nav-link"
-          [routerLink]="routes.statistics.route.toString()"
+          [routerLink]="routes.statistics.route.toRouterLink()"
           routerLinkActive="active"
         >
           {{ routes.statistics.label }}
@@ -19,7 +19,7 @@
       <li class="nav-item">
         <a
           class="nav-link"
-          [routerLink]="routes.disclaimers.route.toString()"
+          [routerLink]="routes.disclaimers.route.toRouterLink()"
           routerLinkActive="active"
         >
           {{ routes.disclaimers.label }}
@@ -28,7 +28,7 @@
       <li class="nav-item">
         <a
           class="nav-link"
-          [routerLink]="routes.credits.route.toString()"
+          [routerLink]="routes.credits.route.toRouterLink()"
           routerLinkActive="active"
         >
           {{ routes.credits.label }}
@@ -37,7 +37,7 @@
       <li class="nav-item">
         <a
           class="nav-link"
-          [routerLink]="routes.ethics.route.toString()"
+          [routerLink]="routes.ethics.route.toRouterLink()"
           routerLinkActive="active"
         >
           {{ routes.ethics.label }}
@@ -46,7 +46,7 @@
       <li class="nav-item">
         <a
           class="nav-link"
-          [routerLink]="routes.contactUs.route.toString()"
+          [routerLink]="routes.contactUs.route.toRouterLink()"
           routerLinkActive="active"
         >
           {{ routes.contactUs.label }}

--- a/src/app/components/shared/formly/timezone-input.component.ts
+++ b/src/app/components/shared/formly/timezone-input.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewChild } from "@angular/core";
 import { FormControl } from "@angular/forms";
-import { Potential } from "@helpers/advancedTypes";
+import { Option } from "@helpers/advancedTypes";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { NgbTypeahead } from "@ng-bootstrap/ng-bootstrap";
 import { FieldType } from "@ngx-formly/core";
@@ -126,7 +126,7 @@ export class TimezoneInputComponent extends FieldType implements OnInit {
    *
    * @returns Object containing key and error message if validation fails, else null
    */
-  private timezoneValidator(): Potential<Record<string, string>> {
+  private timezoneValidator(): Option<Record<string, string>> {
     if (!isInstantiated(this.timezone)) {
       if (this.to.required && this.formControl.dirty) {
         return { [this.field.key.toString()]: "You must select a timezone" };

--- a/src/app/components/shared/formly/timezone-input.component.ts
+++ b/src/app/components/shared/formly/timezone-input.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, ViewChild } from "@angular/core";
 import { FormControl } from "@angular/forms";
+import { Potential } from "@helpers/advancedTypes";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { NgbTypeahead } from "@ng-bootstrap/ng-bootstrap";
 import { FieldType } from "@ngx-formly/core";
@@ -125,7 +126,7 @@ export class TimezoneInputComponent extends FieldType implements OnInit {
    *
    * @returns Object containing key and error message if validation fails, else null
    */
-  private timezoneValidator(): Record<string, string> | null {
+  private timezoneValidator(): Potential<Record<string, string>> {
     if (!isInstantiated(this.timezone)) {
       if (this.to.required && this.formControl.dirty) {
         return { [this.field.key.toString()]: "You must select a timezone" };

--- a/src/app/components/shared/header/header-dropdown/header-dropdown.component.spec.ts
+++ b/src/app/components/shared/header/header-dropdown/header-dropdown.component.spec.ts
@@ -110,7 +110,7 @@ describe("HeaderDropdownComponent", () => {
           label: "Custom Label",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          route: StrongRoute.base.add("home"),
+          route: StrongRoute.newRoot().add("home"),
         }),
       ],
     };
@@ -135,13 +135,13 @@ describe("HeaderDropdownComponent", () => {
           label: "Custom Label 1",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          route: StrongRoute.base.add("home"),
+          route: StrongRoute.newRoot().add("home"),
         }),
         menuRoute({
           label: "Custom Label 2",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          route: StrongRoute.base.add("house"),
+          route: StrongRoute.newRoot().add("house"),
         }),
       ],
     };
@@ -227,7 +227,7 @@ describe("HeaderDropdownComponent", () => {
           label: "Custom Label 2",
           icon: ["fas", "home"],
           tooltip: () => "tooltip",
-          route: StrongRoute.base.add("house"),
+          route: StrongRoute.newRoot().add("house"),
         }),
       ],
     };

--- a/src/app/components/shared/header/header-item/header-item.component.spec.ts
+++ b/src/app/components/shared/header/header-item/header-item.component.spec.ts
@@ -29,7 +29,7 @@ describe("HeaderItemComponent", () => {
       label: "Custom Label",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
-      route: StrongRoute.base.add("home"),
+      route: StrongRoute.newRoot().add("home"),
     });
     fixture.detectChanges();
 
@@ -43,7 +43,7 @@ describe("HeaderItemComponent", () => {
       label: "Custom Label",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
-      route: StrongRoute.base.add("home"),
+      route: StrongRoute.newRoot().add("home"),
     });
     fixture.detectChanges();
 
@@ -56,7 +56,7 @@ describe("HeaderItemComponent", () => {
       label: "Custom Label",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
-      route: StrongRoute.base.add("home"),
+      route: StrongRoute.newRoot().add("home"),
     });
     fixture.detectChanges();
 

--- a/src/app/components/shared/header/header.component.html
+++ b/src/app/components/shared/header/header.component.html
@@ -3,7 +3,7 @@
     <!-- Brand Logo -->
     <a
       class="navbar-brand"
-      [routerLink]="routes.home.route.toString()"
+      [routerLink]="routes.home.route.toRouterLink()"
       routerLinkActive="active"
     >
       {{ title }}
@@ -40,7 +40,7 @@
           <a
             id="register-header-link"
             class="nav-link"
-            [routerLink]="routes.register.route.toString()"
+            [routerLink]="routes.register.route.toRouterLink()"
             routerLinkActive="active"
           >
             {{ routes.register.label }}
@@ -50,7 +50,7 @@
           <a
             id="login-header-link"
             class="nav-link"
-            [routerLink]="routes.login.route.toString()"
+            [routerLink]="routes.login.route.toRouterLink()"
             routerLinkActive="active"
           >
             {{ routes.login.label }}
@@ -64,7 +64,7 @@
           <a
             id="admin-settings"
             class="nav-link"
-            [routerLink]="routes.admin.route.toString()"
+            [routerLink]="routes.admin.route.toRouterLink()"
             routerLinkActive="active"
           >
             <fa-icon [icon]="routes.admin.icon"></fa-icon>

--- a/src/app/components/shared/header/header.component.spec.ts
+++ b/src/app/components/shared/header/header.component.spec.ts
@@ -316,8 +316,8 @@ describe("HeaderComponent", () => {
       spec.detectChanges();
 
       getLogoutButton().click();
-      expect(router.navigate).toHaveBeenCalledWith(
-        homeMenuItem.route.toRoute()
+      expect(router.navigateByUrl).toHaveBeenCalledWith(
+        homeMenuItem.route.toRouterLink()
       );
     });
 

--- a/src/app/components/shared/header/header.component.spec.ts
+++ b/src/app/components/shared/header/header.component.spec.ts
@@ -309,7 +309,7 @@ describe("HeaderComponent", () => {
     it("should redirect to home page when logging out if location is undefined", () => {
       setUser(true, defaultUser);
       handleLogout();
-      spyOn(router, "navigate").and.stub();
+      spyOn(router, "navigateByUrl").and.stub();
       spec.component["hasLocationGlobal"] = jasmine
         .createSpy()
         .and.callFake(() => false);

--- a/src/app/components/shared/header/header.component.spec.ts
+++ b/src/app/components/shared/header/header.component.spec.ts
@@ -106,7 +106,7 @@ describe("HeaderComponent", () => {
           spec.detectChanges();
 
           const brand = spec.query<HTMLElement>("a.navbar-brand");
-          assertRoute(brand, homeMenuItem.route.toString());
+          assertRoute(brand, homeMenuItem.route.toRouterLink());
           expect(brand.innerText).toContain(config.values.brand.name);
         });
 
@@ -115,7 +115,7 @@ describe("HeaderComponent", () => {
           spec.detectChanges();
 
           const link = getNavLinks()[0];
-          assertRoute(link, projectsMenuItem.route.toString());
+          assertRoute(link, projectsMenuItem.route.toRouterLink());
           expect(link.innerText).toContain(projectsMenuItem.label);
         });
 
@@ -124,7 +124,7 @@ describe("HeaderComponent", () => {
           spec.detectChanges();
 
           const link = getNavLinks()[2];
-          assertRoute(link, contactUsMenuItem.route.toString());
+          assertRoute(link, contactUsMenuItem.route.toRouterLink());
           expect(link.innerText).toContain(contactUsMenuItem.label);
         });
 
@@ -160,7 +160,7 @@ describe("HeaderComponent", () => {
           const link = spec.query<HTMLElement>("#register-header-link");
 
           if (userType.links.register) {
-            assertRoute(link, registerMenuItem.route.toString());
+            assertRoute(link, registerMenuItem.route.toRouterLink());
             expect(link.innerText).toContain(registerMenuItem.label);
           } else {
             expect(link).toBeFalsy();
@@ -176,7 +176,7 @@ describe("HeaderComponent", () => {
           const link = spec.query<HTMLElement>("#login-header-link");
 
           if (userType.links.login) {
-            assertRoute(link, loginMenuItem.route.toString());
+            assertRoute(link, loginMenuItem.route.toRouterLink());
             expect(link.innerText).toContain(loginMenuItem.label);
           } else {
             expect(link).toBeFalsy();
@@ -192,7 +192,7 @@ describe("HeaderComponent", () => {
           const profile = spec.query<HTMLElement>("#login-widget");
 
           if (userType.links.profile) {
-            assertRoute(profile, myAccountMenuItem.route.toString());
+            assertRoute(profile, myAccountMenuItem.route.toRouterLink());
             expect(profile.innerText.trim()).toBe(defaultUser.userName);
           } else {
             expect(profile).toBeFalsy();
@@ -257,7 +257,7 @@ describe("HeaderComponent", () => {
 
           if (userType.links.admin) {
             expect(settings).toBeTruthy();
-            assertRoute(settings, adminDashboardMenuItem.route.toString());
+            assertRoute(settings, adminDashboardMenuItem.route.toRouterLink());
           } else {
             expect(settings).toBeFalsy();
           }
@@ -344,7 +344,7 @@ describe("HeaderComponent", () => {
       const link = spec.queryAll<HTMLElement>("a.nav-link")[3];
       expect(link).toBeTruthy();
       expect(link.innerText).toContain(registerMenuItem.label);
-      assertRoute(link, registerMenuItem.route.toString());
+      assertRoute(link, registerMenuItem.route.toRouterLink());
     });
 
     // TODO Move to E2E Tests
@@ -370,7 +370,7 @@ describe("HeaderComponent", () => {
       const link = spec.queryAll<HTMLElement>("a.nav-link")[4];
       expect(link).toBeTruthy();
       expect(link.innerText).toContain(loginMenuItem.label);
-      assertRoute(link, loginMenuItem.route.toString());
+      assertRoute(link, loginMenuItem.route.toRouterLink());
     }));
   });
 

--- a/src/app/components/shared/header/header.component.ts
+++ b/src/app/components/shared/header/header.component.ts
@@ -126,7 +126,7 @@ export class HeaderComponent extends withUnsubscribe() implements OnInit {
             this.reloadPage();
           } else {
             // Else just redirect back to home
-            this.router.navigate(homeMenuItem.route.toRoute());
+            this.router.navigateByUrl(homeMenuItem.route.toRouterLink());
           }
         },
       });

--- a/src/app/components/shared/header/header.module.ts
+++ b/src/app/components/shared/header/header.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from "@angular/common";
 import { NgModule } from "@angular/core";
 import { RouterModule } from "@angular/router";
+import { DirectivesModule } from "@directives/directives.module";
 import { AuthenticatedImageModule } from "@directives/image/image.module";
 import { NgbModule } from "@ng-bootstrap/ng-bootstrap";
 import { IconsModule } from "@shared/icons/icons.module";
@@ -18,6 +19,7 @@ import { HeaderComponent } from "./header.component";
     RouterModule,
     NgbModule,
     AuthenticatedImageModule,
+    DirectivesModule,
     IconsModule,
   ],
   exports: [HeaderComponent],

--- a/src/app/components/shared/items/item/item.component.spec.ts
+++ b/src/app/components/shared/items/item/item.component.spec.ts
@@ -113,7 +113,7 @@ describe("ItemComponent", () => {
     component.icon = ["fas", "home"] as IconProp;
     component.name = "Test";
     component.value = "unknown";
-    component.uri = StrongRoute.base.add("home");
+    component.uri = StrongRoute.newRoot().add("home");
 
     fixture.detectChanges();
     const anchor = fixture.nativeElement.querySelector("a");

--- a/src/app/components/shared/items/item/item.component.ts
+++ b/src/app/components/shared/items/item/item.component.ts
@@ -22,23 +22,19 @@ import { StrongRoute } from "@interfaces/strongRoute";
       <!-- Item name -->
       <span id="name">
         <ng-container *ngIf="uri; else plainText">
+          <!-- URI is internal link -->
           <ng-container *ngIf="internalLink; else externalLink">
-            <!-- URI is internal link -->
-            <a [routerLink]="link">
-              {{ name }}
-            </a>
+            <a [routerLink]="link">{{ name }} </a>
           </ng-container>
+
+          <!-- URI is external link -->
           <ng-template #externalLink>
-            <!-- URI is external link -->
-            <a [href]="link">
-              {{ name }}
-            </a>
+            <a [href]="link">{{ name }} </a>
           </ng-template>
         </ng-container>
-        <ng-template #plainText>
-          <!-- No URI -->
-          {{ name }}
-        </ng-template>
+
+        <!-- No URI -->
+        <ng-template #plainText>{{ name }} </ng-template>
       </span>
 
       <!-- Item value -->

--- a/src/app/components/shared/items/item/item.component.ts
+++ b/src/app/components/shared/items/item/item.component.ts
@@ -67,7 +67,7 @@ export class ItemComponent implements OnInit {
 
     if (typeof this.uri === "object") {
       this.internalLink = true;
-      this.link = this.uri.toString();
+      this.link = this.uri.toRouterLink();
     } else {
       const params = this.route.snapshot.params;
 

--- a/src/app/components/shared/menu/external-link/external-link.component.ts
+++ b/src/app/components/shared/menu/external-link/external-link.component.ts
@@ -6,7 +6,7 @@ import {
   OnChanges,
 } from "@angular/core";
 import { API_ROOT } from "@helpers/app-initializer/app-initializer";
-import { MenuLink, menuLink } from "@interfaces/menusInterfaces";
+import { MenuLink } from "@interfaces/menusInterfaces";
 import { Placement } from "@ng-bootstrap/ng-bootstrap";
 
 /**

--- a/src/app/components/shared/menu/internal-link/internal-link.component.spec.ts
+++ b/src/app/components/shared/menu/internal-link/internal-link.component.spec.ts
@@ -72,7 +72,7 @@ describe("MenuInternalLinkComponent", () => {
     defaultLink = menuRoute({
       icon: ["fas", "home"],
       label: "home",
-      route: StrongRoute.base.add("home"),
+      route: StrongRoute.newRoot().add("home"),
       tooltip: () => "tooltip",
     });
   });
@@ -142,7 +142,7 @@ describe("MenuInternalLinkComponent", () => {
         route: "/brokenlink",
         link: menuRoute({
           ...defaultLink,
-          route: StrongRoute.base.add("brokenlink"),
+          route: StrongRoute.newRoot().add("brokenlink"),
         }),
       });
       spec.detectChanges();
@@ -154,7 +154,7 @@ describe("MenuInternalLinkComponent", () => {
         route: "/brokenlink",
         link: menuRoute({
           ...defaultLink,
-          route: StrongRoute.base.add("wronglink"),
+          route: StrongRoute.newRoot().add("wronglink"),
         }),
       });
       spec.detectChanges();

--- a/src/app/components/shared/menu/internal-link/internal-link.component.spec.ts
+++ b/src/app/components/shared/menu/internal-link/internal-link.component.spec.ts
@@ -1,6 +1,7 @@
 import { Location } from "@angular/common";
 import { RouterLink, RouterLinkWithHref } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { StrongRouteDirective } from "@directives/strongRoute/strong-route.directive";
 import { MenuRoute, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
 import { createHostFactory, SpectatorHost } from "@ngneat/spectator";
@@ -137,56 +138,27 @@ describe("MenuInternalLinkComponent", () => {
   });
 
   describe("link", () => {
-    it("should create routerLink", () => {
-      setup({
-        route: "/brokenlink",
-        link: menuRoute({
-          ...defaultLink,
-          route: StrongRoute.newRoot().add("brokenlink"),
-        }),
-      });
+    it("should create router link", () => {
+      const route = StrongRoute.newRoot().add("brokenlink");
+      setup({ link: menuRoute({ ...defaultLink, route }) });
       spec.detectChanges();
-      assertRoute(retrieveLink(), "/brokenlink");
-    });
-
-    it("should not use link route", () => {
-      setup({
-        route: "/brokenlink",
-        link: menuRoute({
-          ...defaultLink,
-          route: StrongRoute.newRoot().add("wronglink"),
-        }),
-      });
-      spec.detectChanges();
-      assertRoute(retrieveLink(), "/brokenlink");
+      expect(spec.query(StrongRouteDirective).strongRoute).toEqual(route);
     });
 
     it("should not highlight link when not active", () => {
-      setup({ route: "/brokenlink" });
+      const route = StrongRoute.newRoot().add("brokenlink");
+      setup({ link: menuRoute({ ...defaultLink, route }) });
       spyOn(location, "path").and.callFake(() => "/customRoute");
       spec.detectChanges();
       assertActive(false);
     });
 
     it("should highlight link when active", () => {
-      setup({ route: "/customRoute" });
+      const route = StrongRoute.newRoot().add("customRoute");
+      setup({ link: menuRoute({ ...defaultLink, route }) });
       spyOn(location, "path").and.callFake(() => "/customRoute");
       spec.detectChanges();
       assertActive(true);
-    });
-
-    it("should handle empty qsp object", () => {
-      setup({ qsp: {} });
-      spec.detectChanges();
-      expect(spec.query(RouterLinkWithHref).queryParams).toEqual({});
-    });
-
-    it("should handle qsp object", () => {
-      setup({ qsp: { test: "value" } });
-      spec.detectChanges();
-      expect(spec.query(RouterLinkWithHref).queryParams).toEqual({
-        test: "value",
-      });
     });
   });
 

--- a/src/app/components/shared/menu/internal-link/internal-link.component.spec.ts
+++ b/src/app/components/shared/menu/internal-link/internal-link.component.spec.ts
@@ -1,4 +1,5 @@
 import { Location } from "@angular/common";
+import { RouterLink } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { MenuRoute, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
@@ -47,6 +48,7 @@ describe("MenuInternalLinkComponent", () => {
         [placement]="placement"
         [tooltip]="tooltip"
         [route]="route"
+        [qsp]="params"
       ></baw-menu-internal-link>
     `,
       {
@@ -57,6 +59,7 @@ describe("MenuInternalLinkComponent", () => {
           placement: "left",
           tooltip: "tooltip",
           route: "/home",
+          qsp: {},
           ...inputs,
         },
       }
@@ -170,6 +173,18 @@ describe("MenuInternalLinkComponent", () => {
       spyOn(location, "path").and.callFake(() => "/customRoute");
       spec.detectChanges();
       assertActive(true);
+    });
+
+    it("should handle empty qsp object", () => {
+      setup({ qsp: {} });
+      spec.detectChanges();
+      expect(spec.query(RouterLink).queryParams).toEqual({});
+    });
+
+    it("should handle qsp object", () => {
+      setup({ qsp: { test: "value" } });
+      spec.detectChanges();
+      expect(spec.query(RouterLink).queryParams).toEqual({ test: "value" });
     });
   });
 

--- a/src/app/components/shared/menu/internal-link/internal-link.component.spec.ts
+++ b/src/app/components/shared/menu/internal-link/internal-link.component.spec.ts
@@ -1,16 +1,10 @@
 import { Location } from "@angular/common";
-import { RouterLink, RouterLinkWithHref } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { StrongRouteDirective } from "@directives/strongRoute/strong-route.directive";
 import { MenuRoute, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
 import { createHostFactory, SpectatorHost } from "@ngneat/spectator";
-import {
-  assertAttribute,
-  assertIcon,
-  assertRoute,
-  assertTooltip,
-} from "@test/helpers/html";
+import { assertAttribute, assertIcon, assertTooltip } from "@test/helpers/html";
 import { SharedModule } from "../../shared.module";
 import { MenuInternalLinkComponent } from "./internal-link.component";
 

--- a/src/app/components/shared/menu/internal-link/internal-link.component.spec.ts
+++ b/src/app/components/shared/menu/internal-link/internal-link.component.spec.ts
@@ -1,5 +1,5 @@
 import { Location } from "@angular/common";
-import { RouterLink } from "@angular/router";
+import { RouterLink, RouterLinkWithHref } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { MenuRoute, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
@@ -48,7 +48,7 @@ describe("MenuInternalLinkComponent", () => {
         [placement]="placement"
         [tooltip]="tooltip"
         [route]="route"
-        [qsp]="params"
+        [qsp]="qsp"
       ></baw-menu-internal-link>
     `,
       {
@@ -178,13 +178,15 @@ describe("MenuInternalLinkComponent", () => {
     it("should handle empty qsp object", () => {
       setup({ qsp: {} });
       spec.detectChanges();
-      expect(spec.query(RouterLink).queryParams).toEqual({});
+      expect(spec.query(RouterLinkWithHref).queryParams).toEqual({});
     });
 
     it("should handle qsp object", () => {
       setup({ qsp: { test: "value" } });
       spec.detectChanges();
-      expect(spec.query(RouterLink).queryParams).toEqual({ test: "value" });
+      expect(spec.query(RouterLinkWithHref).queryParams).toEqual({
+        test: "value",
+      });
     });
   });
 

--- a/src/app/components/shared/menu/internal-link/internal-link.component.ts
+++ b/src/app/components/shared/menu/internal-link/internal-link.component.ts
@@ -5,8 +5,9 @@ import {
   Input,
   OnChanges,
 } from "@angular/core";
-import { Params } from "@angular/router";
+import { ActivatedRoute } from "@angular/router";
 import { MenuRoute } from "@interfaces/menusInterfaces";
+import { StrongRoute } from "@interfaces/strongRoute";
 import { Placement } from "@ng-bootstrap/ng-bootstrap";
 
 /**
@@ -19,8 +20,7 @@ import { Placement } from "@ng-bootstrap/ng-bootstrap";
       <a
         class="nav-link"
         [ngClass]="{ active: active, disabled: disabled }"
-        [routerLink]="route"
-        [queryParams]="qsp"
+        [strongRoute]="this.route"
       >
         <div class="icon"><fa-icon [icon]="link.icon"></fa-icon></div>
         <span id="label">{{ link.label }}</span>
@@ -35,18 +35,23 @@ import { Placement } from "@ng-bootstrap/ng-bootstrap";
 export class MenuInternalLinkComponent implements OnChanges {
   @Input() public id: string;
   @Input() public link: MenuRoute;
-  @Input() public route: string;
-  @Input() public qsp: Params;
+  @Input() public route: StrongRoute;
   @Input() public placement: Placement;
   @Input() public tooltip: string;
   public active: boolean;
   public disabled: boolean;
 
-  public constructor(private location: Location) {}
+  public constructor(
+    private activatedRoute: ActivatedRoute,
+    private location: Location
+  ) {}
 
   public ngOnChanges() {
+    const routeParams = this.activatedRoute.snapshot.params;
+    const currentRoute = this.route.toRouterLink(routeParams);
+
     this.disabled = this.link.disabled;
     this.active =
-      this.route === this.location.path().split("?")[0] || this.disabled;
+      currentRoute === this.location.path().split("?")[0] || this.disabled;
   }
 }

--- a/src/app/components/shared/menu/internal-link/internal-link.component.ts
+++ b/src/app/components/shared/menu/internal-link/internal-link.component.ts
@@ -7,7 +7,6 @@ import {
 } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { MenuRoute } from "@interfaces/menusInterfaces";
-import { StrongRoute } from "@interfaces/strongRoute";
 import { Placement } from "@ng-bootstrap/ng-bootstrap";
 
 /**
@@ -20,7 +19,7 @@ import { Placement } from "@ng-bootstrap/ng-bootstrap";
       <a
         class="nav-link"
         [ngClass]="{ active: active, disabled: disabled }"
-        [strongRoute]="this.route"
+        [strongRoute]="link.route"
       >
         <div class="icon"><fa-icon [icon]="link.icon"></fa-icon></div>
         <span id="label">{{ link.label }}</span>
@@ -35,7 +34,6 @@ import { Placement } from "@ng-bootstrap/ng-bootstrap";
 export class MenuInternalLinkComponent implements OnChanges {
   @Input() public id: string;
   @Input() public link: MenuRoute;
-  @Input() public route: StrongRoute;
   @Input() public placement: Placement;
   @Input() public tooltip: string;
   public active: boolean;
@@ -48,7 +46,7 @@ export class MenuInternalLinkComponent implements OnChanges {
 
   public ngOnChanges() {
     const routeParams = this.activatedRoute.snapshot.params;
-    const currentRoute = this.route.toRouterLink(routeParams);
+    const currentRoute = this.link.route.toRouterLink(routeParams);
 
     this.disabled = this.link.disabled;
     this.active =

--- a/src/app/components/shared/menu/internal-link/internal-link.component.ts
+++ b/src/app/components/shared/menu/internal-link/internal-link.component.ts
@@ -5,7 +5,8 @@ import {
   Input,
   OnChanges,
 } from "@angular/core";
-import { MenuRoute, menuRoute } from "@interfaces/menusInterfaces";
+import { Params } from "@angular/router";
+import { MenuRoute } from "@interfaces/menusInterfaces";
 import { Placement } from "@ng-bootstrap/ng-bootstrap";
 
 /**
@@ -19,6 +20,7 @@ import { Placement } from "@ng-bootstrap/ng-bootstrap";
         class="nav-link"
         [ngClass]="{ active: active, disabled: disabled }"
         [routerLink]="route"
+        [queryParams]="qsp"
       >
         <div class="icon"><fa-icon [icon]="link.icon"></fa-icon></div>
         <span id="label">{{ link.label }}</span>
@@ -34,6 +36,7 @@ export class MenuInternalLinkComponent implements OnChanges {
   @Input() public id: string;
   @Input() public link: MenuRoute;
   @Input() public route: string;
+  @Input() public qsp: Params;
   @Input() public placement: Placement;
   @Input() public tooltip: string;
   public active: boolean;

--- a/src/app/components/shared/menu/menu.component.html
+++ b/src/app/components/shared/menu/menu.component.html
@@ -31,7 +31,6 @@
             [link]="link"
             [placement]="placement"
             [tooltip]="link.tooltip(user)"
-            [route]="link.route"
           >
           </baw-menu-internal-link>
         </ng-container>

--- a/src/app/components/shared/menu/menu.component.html
+++ b/src/app/components/shared/menu/menu.component.html
@@ -31,8 +31,7 @@
             [link]="link"
             [placement]="placement"
             [tooltip]="link.tooltip(user)"
-            [route]="link.route.format(params)"
-            [qsp]="link.route.queryParams(params)"
+            [route]="link.route"
           >
           </baw-menu-internal-link>
         </ng-container>

--- a/src/app/components/shared/menu/menu.component.html
+++ b/src/app/components/shared/menu/menu.component.html
@@ -4,7 +4,7 @@
       <h6 class="nav-link disabled m-0">
         <ng-container *ngIf="title; else linksTitle">
           <fa-icon [icon]="title.icon"></fa-icon>
-          {{ title.label.toUpperCase() }}
+          {{ title.label | uppercase }}
         </ng-container>
         <ng-template #linksTitle>MENU</ng-template>
       </h6>
@@ -32,6 +32,7 @@
             [placement]="placement"
             [tooltip]="link.tooltip(user)"
             [route]="link.route.format(params)"
+            [qsp]="link.route.queryParams(params)"
           >
           </baw-menu-internal-link>
         </ng-container>

--- a/src/app/components/shared/menu/menu.component.spec.ts
+++ b/src/app/components/shared/menu/menu.component.spec.ts
@@ -357,7 +357,7 @@ describe("MenuComponent", () => {
       const params = { attribute: 10 };
       const link = menuRoute({
         ...defaultMenuRoute,
-        route: StrongRoute.newRoot.add("home").add(":attribute"),
+        route: StrongRoute.newRoot().add("home").add(":attribute"),
       });
       setup({ menuType: "action", links: List([link]) }, undefined, params);
       spec.detectChanges();
@@ -374,7 +374,7 @@ describe("MenuComponent", () => {
       const params = { projectId: 5 };
       const link = menuRoute({
         ...defaultMenuRoute,
-        route: StrongRoute.newRoot.add("home", ({ projectId }) => ({
+        route: StrongRoute.newRoot().add("home", ({ projectId }) => ({
           id: projectId,
         })),
       });

--- a/src/app/components/shared/menu/menu.component.spec.ts
+++ b/src/app/components/shared/menu/menu.component.spec.ts
@@ -363,6 +363,25 @@ describe("MenuComponent", () => {
       spec.detectChanges();
       expect(getMenuRoutes()[0].route).toBe("/home/10");
     });
+
+    it("should handle undefined query parameters", () => {
+      setup({ menuType: "action", links: List([defaultMenuRoute]) });
+      spec.detectChanges();
+      expect(getMenuRoutes()[0].qsp).toEqual({});
+    });
+
+    it("should set link query parameters", () => {
+      const params = { projectId: 5 };
+      const link = menuRoute({
+        ...defaultMenuRoute,
+        route: StrongRoute.base.add("home", ({ projectId }) => ({
+          id: projectId,
+        })),
+      });
+      setup({ menuType: "action", links: List([link]) }, undefined, params);
+      spec.detectChanges();
+      expect(getMenuRoutes()[0].qsp).toEqual({ id: 5 });
+    });
   });
 
   describe("item ordering", () => {

--- a/src/app/components/shared/menu/menu.component.spec.ts
+++ b/src/app/components/shared/menu/menu.component.spec.ts
@@ -350,7 +350,7 @@ describe("MenuComponent", () => {
     it("should set link route", () => {
       setup({ menuType: "action", links: List([defaultMenuRoute]) });
       spec.detectChanges();
-      expect(getMenuRoutes()[0].route).toBe(defaultMenuRoute.route.format({}));
+      expect(getMenuRoutes()[0].link.route).toBe(defaultMenuRoute.route);
     });
 
     it("should set link route with parameter", () => {
@@ -361,26 +361,7 @@ describe("MenuComponent", () => {
       });
       setup({ menuType: "action", links: List([link]) }, undefined, params);
       spec.detectChanges();
-      expect(getMenuRoutes()[0].route).toBe("/home/10");
-    });
-
-    it("should handle undefined query parameters", () => {
-      setup({ menuType: "action", links: List([defaultMenuRoute]) });
-      spec.detectChanges();
-      expect(getMenuRoutes()[0].qsp).toEqual({});
-    });
-
-    it("should set link query parameters", () => {
-      const params = { projectId: 5 };
-      const link = menuRoute({
-        ...defaultMenuRoute,
-        route: StrongRoute.newRoot().add("home", ({ projectId }) => ({
-          id: projectId,
-        })),
-      });
-      setup({ menuType: "action", links: List([link]) }, undefined, params);
-      spec.detectChanges();
-      expect(getMenuRoutes()[0].qsp).toEqual({ id: 5 });
+      expect(getMenuRoutes()[0].link.route).toEqual(link.route);
     });
   });
 

--- a/src/app/components/shared/menu/menu.component.spec.ts
+++ b/src/app/components/shared/menu/menu.component.spec.ts
@@ -92,7 +92,7 @@ describe("MenuComponent", () => {
       label: "label",
       icon: ["fas", "home"],
       tooltip: () => "tooltip",
-      route: StrongRoute.base.add("home"),
+      route: StrongRoute.newRoot().add("home"),
     });
   });
 
@@ -357,7 +357,7 @@ describe("MenuComponent", () => {
       const params = { attribute: 10 };
       const link = menuRoute({
         ...defaultMenuRoute,
-        route: StrongRoute.base.add("home").add(":attribute"),
+        route: StrongRoute.newRoot.add("home").add(":attribute"),
       });
       setup({ menuType: "action", links: List([link]) }, undefined, params);
       spec.detectChanges();
@@ -374,7 +374,7 @@ describe("MenuComponent", () => {
       const params = { projectId: 5 };
       const link = menuRoute({
         ...defaultMenuRoute,
-        route: StrongRoute.base.add("home", ({ projectId }) => ({
+        route: StrongRoute.newRoot.add("home", ({ projectId }) => ({
           id: projectId,
         })),
       });

--- a/src/app/components/shared/menu/menu.module.ts
+++ b/src/app/components/shared/menu/menu.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from "@angular/common";
 import { NgModule } from "@angular/core";
 import { RouterModule } from "@angular/router";
+import { DirectivesModule } from "@directives/directives.module";
 import { AuthenticatedImageModule } from "@directives/image/image.module";
 import { NgbModule } from "@ng-bootstrap/ng-bootstrap";
 import { PipesModule } from "@pipes/pipes.module";
@@ -35,6 +36,7 @@ import { WidgetDirective } from "./widget/widget.directive";
     AuthenticatedImageModule,
     LoadingModule,
     PipesModule,
+    DirectivesModule,
   ],
   exports: [MenuComponent, PermissionsShieldComponent, WidgetDirective],
 })

--- a/src/app/components/shared/secondary-menu/secondary-menu.component.spec.ts
+++ b/src/app/components/shared/secondary-menu/secondary-menu.component.spec.ts
@@ -24,7 +24,7 @@ describe("SecondaryMenuComponent", () => {
   let component: SecondaryMenuComponent;
   let fixture: ComponentFixture<SecondaryMenuComponent>;
   let storedDefaultMenu: any;
-  const defaultRoute = StrongRoute.base.add("/");
+  const defaultRoute = StrongRoute.newRoot().add("/");
   const selfLinkCount = 1;
   const defaultPageRouteLink = menuRoute({
     label: "Self Label",
@@ -217,7 +217,7 @@ describe("SecondaryMenuComponent", () => {
     });
 
     it("should handle parent link", () => {
-      const parentRoute = StrongRoute.base.add("home");
+      const parentRoute = StrongRoute.newRoot().add("home");
       const childRoute = parentRoute.add("house");
       const parentLink = menuRoute({
         label: "Parent Label",
@@ -257,7 +257,7 @@ describe("SecondaryMenuComponent", () => {
     });
 
     it("should handle grandparent link", () => {
-      const grandParentRoute = StrongRoute.base.add("home");
+      const grandParentRoute = StrongRoute.newRoot().add("home");
       const parentRoute = grandParentRoute.add("house");
       const childRoute = parentRoute.add("door");
       const grandParentLink = menuRoute({
@@ -310,7 +310,7 @@ describe("SecondaryMenuComponent", () => {
     });
 
     it("should not hide self link if predicate fails", () => {
-      const parentRoute = StrongRoute.base.add("home");
+      const parentRoute = StrongRoute.newRoot().add("home");
       const childRoute = parentRoute.add("house");
       const parentLink = menuRoute({
         label: "Parent Label",
@@ -500,7 +500,7 @@ describe("SecondaryMenuComponent", () => {
 
   describe("default menu", () => {
     it("should handle single link", () => {
-      const homeRoute = StrongRoute.base.add("");
+      const homeRoute = StrongRoute.newRoot().add("");
 
       defaultMenu.contextLinks = List<NavigableMenuItem>([
         menuRoute({
@@ -533,8 +533,8 @@ describe("SecondaryMenuComponent", () => {
     });
 
     it("should handle multiple links", () => {
-      const homeRoute = StrongRoute.base.add("");
-      const projectsRoute = StrongRoute.base.add("projects");
+      const homeRoute = StrongRoute.newRoot().add("");
+      const projectsRoute = StrongRoute.newRoot().add("projects");
 
       defaultMenu.contextLinks = List<NavigableMenuItem>([
         menuRoute({
@@ -578,8 +578,8 @@ describe("SecondaryMenuComponent", () => {
     });
 
     it("should hide duplicate if self link exists in default menu", () => {
-      const homeRoute = StrongRoute.base.add("");
-      const projectsRoute = StrongRoute.base.add("projects");
+      const homeRoute = StrongRoute.newRoot().add("");
+      const projectsRoute = StrongRoute.newRoot().add("projects");
 
       const selfRoute = menuRoute({
         icon: ["fas", "globe-asia"],

--- a/src/app/components/sites/points.menus.ts
+++ b/src/app/components/sites/points.menus.ts
@@ -34,7 +34,6 @@ export const newPointMenuItem = menuRoute({
   tooltip: () => "Create a new point",
 });
 
-// TODO Add site id, region id, and project id to route params
 export const pointAnnotationsMenuItem = menuRoute({
   ...dataRequestMenuItem,
   label: "Download Annotations",

--- a/src/app/components/sites/site/site.component.ts
+++ b/src/app/components/sites/site/site.component.ts
@@ -3,7 +3,6 @@ import { ShallowAudioEventsService } from "@baw-api/audio-event/audio-events.ser
 import { AudioRecordingsService } from "@baw-api/audio-recording/audio-recordings.service";
 import { Direction, Filters } from "@baw-api/baw-api.service";
 import { PageComponent } from "@helpers/page/pageComponent";
-import { AudioEvent, IAudioEvent } from "@models/AudioEvent";
 import { AudioRecording, IAudioRecording } from "@models/AudioRecording";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";

--- a/src/app/components/sites/sites.menus.ts
+++ b/src/app/components/sites/sites.menus.ts
@@ -34,7 +34,6 @@ export const newSiteMenuItem = menuRoute({
   tooltip: () => "Create a new site",
 });
 
-// TODO Add site id and project id to route params
 export const siteAnnotationsMenuItem = menuRoute({
   ...dataRequestMenuItem,
   label: "Download Annotations",

--- a/src/app/components/statistics/statistics.menus.ts
+++ b/src/app/components/statistics/statistics.menus.ts
@@ -2,7 +2,7 @@ import { Category, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
 import { homeCategory } from "../home/home.menus";
 
-export const statisticsRoute = StrongRoute.base.add("website_statistics");
+export const statisticsRoute = StrongRoute.newRoot().add("website_statistics");
 
 export const statisticsCategory: Category = homeCategory;
 

--- a/src/app/directives/directives.module.ts
+++ b/src/app/directives/directives.module.ts
@@ -1,8 +1,9 @@
 import { NgModule } from "@angular/core";
 import { DatatableDirective } from "./datatable/datatable.directive";
 import { AuthenticatedImageModule } from "./image/image.module";
+import { StrongRouteDirective } from "./strongRoute/strong-route.directive";
 
-const directives = [DatatableDirective];
+const directives = [DatatableDirective, StrongRouteDirective];
 
 /**
  * App Shared Directives

--- a/src/app/directives/strongRoute/strong-route.directive.spec.ts
+++ b/src/app/directives/strongRoute/strong-route.directive.spec.ts
@@ -1,9 +1,225 @@
+import {
+  ActivatedRoute,
+  Params,
+  Router,
+  RouterLinkWithHref,
+} from "@angular/router";
+import { RouterTestingModule } from "@angular/router/testing";
+import { RouteParams, StrongRoute } from "@interfaces/strongRoute";
+import { createDirectiveFactory, SpectatorDirective } from "@ngneat/spectator";
+import { websiteHttpUrl } from "@test/helpers/url";
 import { StrongRouteDirective } from "./strong-route.directive";
 
-// TODO Write tests
-/* describe("StrongRouteDirective", () => {
-  it("should create an instance", () => {
-    const directive = new StrongRouteDirective();
-    expect(directive).toBeTruthy();
+describe("StrongRouteDirective", () => {
+  let router: Router;
+  let route: ActivatedRoute;
+  let spec: SpectatorDirective<StrongRouteDirective>;
+  const createDirective = createDirectiveFactory({
+    directive: StrongRouteDirective,
+    imports: [RouterTestingModule],
   });
-}); */
+
+  const createRouterLink = createDirectiveFactory({
+    directive: RouterLinkWithHref,
+    declarations: [StrongRouteDirective],
+    imports: [RouterTestingModule],
+  });
+
+  function assertUrlTree(url: string, queryParams: Params) {
+    expect(spec.directive.urlTree).toEqual(
+      router.createUrlTree([url], {
+        queryParams,
+        relativeTo: route,
+        fragment: spec.directive.fragment,
+        queryParamsHandling: spec.directive.queryParamsHandling,
+        preserveFragment: spec.directive.preserveFragment,
+      })
+    );
+  }
+
+  function assertRoute(url: string) {
+    expect(spec.query<HTMLAnchorElement>("a").href).toBe(websiteHttpUrl + url);
+  }
+
+  function setup(
+    strongRoute: StrongRoute,
+    routeParams?: RouteParams,
+    queryParams?: Params
+  ) {
+    spec = createDirective(
+      `
+        <a
+          [strongRoute]="strongRoute"
+          [routeParams]="routeParams"
+          [queryParams]="queryParams"
+        ></a>
+      `,
+      { hostProps: { strongRoute, routeParams, queryParams } }
+    );
+    router = spec.inject(Router);
+    route = spec.inject(ActivatedRoute);
+  }
+
+  it("should not interfere with routerLink if no [strongRoute]", () => {
+    const spectator = createRouterLink(
+      '<a [routerLink]="link" [queryParams]="params"></a>',
+      { hostProps: { link: "/home", params: { test: "value" } } }
+    );
+    spectator.detectChanges();
+
+    const routerLink = spectator.query(RouterLinkWithHref);
+    expect(routerLink).toBeTruthy();
+    expect(routerLink.href).toBe(websiteHttpUrl + "/home?test=value");
+  });
+
+  // TODO Current implementation does not work with routerLinkActive
+  xit("should not interfere with routerLinkActive", () => {});
+
+  describe("strongRoute", () => {
+    it("should handle undefined strongRoute", () => {
+      setup(undefined);
+      spec.detectChanges();
+      expect(spec.directive).toBeTruthy();
+    });
+
+    it("should handle null strongRoute", () => {
+      setup(null);
+      spec.detectChanges();
+      expect(spec.directive).toBeTruthy();
+    });
+
+    it("should handle root strongRoute", () => {
+      const baseRoute = StrongRoute.newRoot();
+      setup(baseRoute);
+      spec.detectChanges();
+      assertRoute("/");
+    });
+
+    it("should handle strongRoute", () => {
+      const childRoute = StrongRoute.newRoot().add("home");
+      setup(childRoute);
+      spec.detectChanges();
+      assertRoute("/home");
+    });
+  });
+
+  describe("routeParams", () => {
+    it("should handle strongRoute with single parameter", () => {
+      const paramRoute = StrongRoute.newRoot().add(":id");
+      setup(paramRoute, { id: 5 });
+      spec.detectChanges();
+      assertRoute("/5");
+    });
+
+    it("should handle strongRoute with multiple parameters", () => {
+      const paramRoute = StrongRoute.newRoot().add(":type").add(":id");
+      setup(paramRoute, { id: 5, type: "home" });
+      spec.detectChanges();
+      assertRoute("/home/5");
+    });
+  });
+
+  describe("queryParams", () => {
+    it("should handle strongRoute with query parameter", () => {
+      const childRoute = StrongRoute.newRoot().add("home", (params) => ({
+        test: params.test,
+      }));
+      setup(childRoute, undefined, { test: "value" });
+      spec.detectChanges();
+      assertRoute("/home?test=value");
+    });
+
+    it("should handle strongRoute with multiple query parameter", () => {
+      const childRoute = StrongRoute.newRoot().add("home", (params) => ({
+        test: params.test,
+        example: params.example,
+      }));
+      setup(childRoute, undefined, { example: 5, test: "value" });
+      spec.detectChanges();
+      assertRoute("/home?test=value&example=5");
+    });
+
+    // TODO Update this to work through the router instead of bypassing it
+    it("should handle strongRoute with router query parameter", () => {
+      const childRoute = StrongRoute.newRoot().add("home", (params) => ({
+        testing: params.test,
+      }));
+      setup(childRoute);
+      spec.detectChanges();
+      spec.directive["angularRouteParams"] = { test: "value" };
+      assertUrlTree("/home", { testing: "value" });
+    });
+
+    // TODO Update this to work through the router instead of bypassing it
+    it("should handle strongRoute with multiple router query parameter", () => {
+      const childRoute = StrongRoute.newRoot().add("home", (params) => ({
+        testing: params.test,
+        testing2: params.example,
+      }));
+      setup(childRoute);
+      spec.detectChanges();
+      spec.directive["angularRouteParams"] = { example: 5, test: "value" };
+      assertUrlTree("/home", { testing: "value", testing2: 5 });
+    });
+
+    // TODO Update this to work through the router instead of bypassing it
+    it("should combine route query parameters and queryParams", () => {
+      const childRoute = StrongRoute.newRoot().add("home", (params) => ({
+        testing: params.test,
+        testing2: params.example,
+      }));
+      setup(childRoute, undefined, { test: "value" });
+      spec.detectChanges();
+      spec.directive["angularRouteParams"] = { example: 5 };
+      assertUrlTree("/home", { testing: "value", testing2: 5 });
+    });
+  });
+
+  describe("urlTree", () => {
+    it("should create root url tree", () => {
+      const baseRoute = StrongRoute.newRoot();
+      setup(baseRoute);
+      spec.detectChanges();
+      assertUrlTree("/", {});
+    });
+
+    it("should create url tree", () => {
+      const baseRoute = StrongRoute.newRoot().add("home");
+      setup(baseRoute);
+      spec.detectChanges();
+      assertUrlTree("/home", {});
+    });
+
+    // TODO Update this to work through the router instead of bypassing it
+    it("should create url tree with query parameters from router", () => {
+      const childRoute = StrongRoute.newRoot().add("home", (params) => ({
+        testing: params.example,
+      }));
+      setup(childRoute);
+      spec.detectChanges();
+      spec.directive["angularRouteParams"] = { example: 5 };
+      assertUrlTree("/home", { testing: 5 });
+    });
+
+    it("should create url tree with custom query parameters", () => {
+      const childRoute = StrongRoute.newRoot().add("home", (params) => ({
+        testing: params.test,
+      }));
+      setup(childRoute, undefined, { test: "value" });
+      spec.detectChanges();
+      assertUrlTree("/home", { testing: "value" });
+    });
+
+    // TODO Update this to work through the router instead of bypassing it
+    it("should create url tree with with custom and router query parameters", () => {
+      const childRoute = StrongRoute.newRoot().add("home", (params) => ({
+        testing: params.test,
+        testing2: params.example,
+      }));
+      setup(childRoute, undefined, { test: "value" });
+      spec.detectChanges();
+      spec.directive["angularRouteParams"] = { example: 5 };
+      assertUrlTree("/home", { testing: "value", testing2: 5 });
+    });
+  });
+});

--- a/src/app/directives/strongRoute/strong-route.directive.spec.ts
+++ b/src/app/directives/strongRoute/strong-route.directive.spec.ts
@@ -7,7 +7,6 @@ import {
 import { RouterTestingModule } from "@angular/router/testing";
 import { RouteParams, StrongRoute } from "@interfaces/strongRoute";
 import { createDirectiveFactory, SpectatorDirective } from "@ngneat/spectator";
-import { websiteHttpUrl } from "@test/helpers/url";
 import { StrongRouteDirective } from "./strong-route.directive";
 
 // TODO Some tests work by bypassing the angular router. This can be solved by navigating
@@ -73,7 +72,7 @@ describe("StrongRouteDirective", () => {
 
     const routerLink = spectator.query(RouterLinkWithHref);
     expect(routerLink).toBeTruthy();
-    expect(routerLink.href).toBe(websiteHttpUrl + "/home?test=value");
+    expect(routerLink.href).toContain("/home?test=value");
   });
 
   // TODO Current implementation does not work with routerLinkActive

--- a/src/app/directives/strongRoute/strong-route.directive.spec.ts
+++ b/src/app/directives/strongRoute/strong-route.directive.spec.ts
@@ -10,6 +10,10 @@ import { createDirectiveFactory, SpectatorDirective } from "@ngneat/spectator";
 import { websiteHttpUrl } from "@test/helpers/url";
 import { StrongRouteDirective } from "./strong-route.directive";
 
+// TODO Some tests work by bypassing the angular router. This can be solved by navigating
+// to a page with parameters set in the url. This will allow simulating the route changes
+// within the constraints of the testing framework
+
 describe("StrongRouteDirective", () => {
   let router: Router;
   let route: ActivatedRoute;

--- a/src/app/directives/strongRoute/strong-route.directive.spec.ts
+++ b/src/app/directives/strongRoute/strong-route.directive.spec.ts
@@ -82,13 +82,13 @@ describe("StrongRouteDirective", () => {
     it("should handle undefined strongRoute", () => {
       setup(undefined);
       spec.detectChanges();
-      expect(spec.directive).toBeTruthy();
+      expect(spec.directive instanceof StrongRouteDirective).toBeTrue();
     });
 
     it("should handle null strongRoute", () => {
       setup(null);
       spec.detectChanges();
-      expect(spec.directive).toBeTruthy();
+      expect(spec.directive instanceof StrongRouteDirective).toBeTrue();
     });
 
     it("should handle root strongRoute", () => {

--- a/src/app/directives/strongRoute/strong-route.directive.spec.ts
+++ b/src/app/directives/strongRoute/strong-route.directive.spec.ts
@@ -42,7 +42,7 @@ describe("StrongRouteDirective", () => {
   }
 
   function assertRoute(url: string) {
-    expect(spec.query<HTMLAnchorElement>("a").href).toBe(websiteHttpUrl + url);
+    expect(spec.query<HTMLAnchorElement>("a").href).toContain(url);
   }
 
   function setup(

--- a/src/app/directives/strongRoute/strong-route.directive.spec.ts
+++ b/src/app/directives/strongRoute/strong-route.directive.spec.ts
@@ -1,0 +1,8 @@
+import { StrongRouteDirective } from "./strong-route.directive";
+
+describe("StrongRouteDirective", () => {
+  it("should create an instance", () => {
+    const directive = new StrongRouteDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/directives/strongRoute/strong-route.directive.spec.ts
+++ b/src/app/directives/strongRoute/strong-route.directive.spec.ts
@@ -1,8 +1,9 @@
 import { StrongRouteDirective } from "./strong-route.directive";
 
-describe("StrongRouteDirective", () => {
+// TODO Write tests
+/* describe("StrongRouteDirective", () => {
   it("should create an instance", () => {
     const directive = new StrongRouteDirective();
     expect(directive).toBeTruthy();
   });
-});
+}); */

--- a/src/app/directives/strongRoute/strong-route.directive.ts
+++ b/src/app/directives/strongRoute/strong-route.directive.ts
@@ -31,10 +31,7 @@ export class StrongRouteDirective
    * to the StrongRoute.
    */
   @Input() public queryParams: Params;
-
-  /** Points to original classes 'router' */
   private _router: Router;
-  /** Points to original classes 'route' */
   private _route: ActivatedRoute;
   private angularRouteParams: Params;
 

--- a/src/app/directives/strongRoute/strong-route.directive.ts
+++ b/src/app/directives/strongRoute/strong-route.directive.ts
@@ -1,3 +1,4 @@
+import { LocationStrategy } from "@angular/common";
 import { Directive, Input, OnChanges, SimpleChanges } from "@angular/core";
 import {
   ActivatedRoute,
@@ -36,6 +37,14 @@ export class StrongRouteDirective
   /** Points to original classes 'route' */
   private _route: ActivatedRoute;
   private angularRouteParams: Params;
+
+  public constructor(
+    router: Router,
+    route: ActivatedRoute,
+    locationStrategy: LocationStrategy
+  ) {
+    super(router, route, locationStrategy);
+  }
 
   public ngOnChanges(changes: SimpleChanges) {
     if (!this._router || !this._route) {

--- a/src/app/directives/strongRoute/strong-route.directive.ts
+++ b/src/app/directives/strongRoute/strong-route.directive.ts
@@ -55,7 +55,7 @@ export class StrongRouteDirective
         .subscribe((params) => (this.angularRouteParams = params));
     }
 
-    this.routerLink = this.strongRoute.toRouterLink({
+    this.routerLink = this.strongRoute?.toRouterLink({
       ...this.angularRouteParams,
       ...this.routeParams,
     });
@@ -67,7 +67,7 @@ export class StrongRouteDirective
 
     return this._router.createUrlTree(this["commands"], {
       relativeTo: this._route,
-      queryParams: this.strongRoute.queryParams(queryParams),
+      queryParams: this.strongRoute?.queryParams(queryParams) ?? undefined,
       fragment: this.fragment,
       queryParamsHandling: this.queryParamsHandling,
       preserveFragment: this.preserveFragment,

--- a/src/app/directives/strongRoute/strong-route.directive.ts
+++ b/src/app/directives/strongRoute/strong-route.directive.ts
@@ -1,0 +1,67 @@
+import { Directive, Input, OnChanges, SimpleChanges } from "@angular/core";
+import {
+  ActivatedRoute,
+  Params,
+  Router,
+  RouterLinkWithHref,
+  UrlTree,
+} from "@angular/router";
+import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
+import { RouteParams, StrongRoute } from "@interfaces/strongRoute";
+import { takeUntil } from "rxjs/operators";
+
+@Directive({
+  // eslint-disable-next-line @angular-eslint/directive-selector
+  selector: "a[strongRoute]",
+})
+export class StrongRouteDirective
+  extends withUnsubscribe(RouterLinkWithHref)
+  implements OnChanges {
+  @Input() public strongRoute: StrongRoute;
+  /**
+   * Additional route parameters to apply to the StrongRoute. By
+   * default, all of the angular route parameters are already given
+   * to the StrongRoute.
+   */
+  @Input() public routeParams: RouteParams;
+  /**
+   * Additional query parameters to apply to the StrongRoute. By
+   * default, all of the angular route parameters are already given
+   * to the StrongRoute.
+   */
+  @Input() public queryParams: Params;
+
+  /** Points to original classes 'router' */
+  private _router: Router;
+  /** Points to original classes 'route' */
+  private _route: ActivatedRoute;
+  private angularRouteParams: Params;
+
+  public ngOnChanges(changes: SimpleChanges) {
+    if (!this._router || !this._route) {
+      this._router = this["router"];
+      this._route = this["route"];
+      this._route.params
+        .pipe(takeUntil(this.unsubscribe))
+        .subscribe((params) => (this.angularRouteParams = params));
+    }
+
+    this.routerLink = this.strongRoute.toRouterLink({
+      ...this.angularRouteParams,
+      ...this.routeParams,
+    });
+    super.ngOnChanges(changes);
+  }
+
+  public get urlTree(): UrlTree {
+    const queryParams = { ...this.queryParams, ...this.angularRouteParams };
+
+    return this._router.createUrlTree(this["commands"], {
+      relativeTo: this._route,
+      queryParams: this.strongRoute.queryParams(queryParams),
+      fragment: this.fragment,
+      queryParamsHandling: this.queryParamsHandling,
+      preserveFragment: this.preserveFragment,
+    });
+  }
+}

--- a/src/app/helpers/advancedTypes.ts
+++ b/src/app/helpers/advancedTypes.ts
@@ -33,4 +33,4 @@ export type KeysOfType<T, TProp> = {
 }[keyof T];
 
 /** Sets type to either be T or null */
-export type Potential<T> = T | null;
+export type Option<T> = T | null;

--- a/src/app/helpers/advancedTypes.ts
+++ b/src/app/helpers/advancedTypes.ts
@@ -31,3 +31,6 @@ export type MayBeAsync<T> = T | Promise<T>;
 export type KeysOfType<T, TProp> = {
   [P in keyof T]: T[P] extends TProp ? P : never;
 }[keyof T];
+
+/** Sets type to either be T or null */
+export type Potential<T> = T | null;

--- a/src/app/helpers/page/pageComponent.ts
+++ b/src/app/helpers/page/pageComponent.ts
@@ -1,5 +1,6 @@
 import { Type } from "@angular/core";
-import { MenuRoute, menuRoute } from "@interfaces/menusInterfaces";
+import { Potential } from "@helpers/advancedTypes";
+import { MenuRoute } from "@interfaces/menusInterfaces";
 import { withUnsubscribe } from "../unsubscribe/unsubscribe";
 import { IPageInfo, PageInfo } from "./pageInfo";
 
@@ -51,6 +52,8 @@ export class PageComponent extends withUnsubscribe() implements IPageComponent {
  *
  * @param component Angular component or null if not exists
  */
-export function getPageInfo(component: Type<IPageComponent>): PageInfo {
+export function getPageInfo(
+  component: Potential<Type<IPageComponent>>
+): Potential<PageInfo> {
   return (component as IPageComponentStatic)?.pageInfo ?? null;
 }

--- a/src/app/helpers/page/pageComponent.ts
+++ b/src/app/helpers/page/pageComponent.ts
@@ -1,5 +1,5 @@
 import { Type } from "@angular/core";
-import { Potential } from "@helpers/advancedTypes";
+import { Option } from "@helpers/advancedTypes";
 import { MenuRoute } from "@interfaces/menusInterfaces";
 import { withUnsubscribe } from "../unsubscribe/unsubscribe";
 import { IPageInfo, PageInfo } from "./pageInfo";
@@ -53,7 +53,7 @@ export class PageComponent extends withUnsubscribe() implements IPageComponent {
  * @param component Angular component or null if not exists
  */
 export function getPageInfo(
-  component: Potential<Type<IPageComponent>>
-): Potential<PageInfo> {
+  component: Option<Type<IPageComponent>>
+): Option<PageInfo> {
   return (component as IPageComponentStatic)?.pageInfo ?? null;
 }

--- a/src/app/helpers/page/pageRouting.ts
+++ b/src/app/helpers/page/pageRouting.ts
@@ -2,7 +2,7 @@ import { Type } from "@angular/core";
 import { Route } from "@angular/router";
 import { ResolverHandlerComponent } from "@components/error/resolver-handler.component";
 import { FormTouchedGuard } from "@guards/form/form.guard";
-import { Potential } from "@helpers/advancedTypes";
+import { Option } from "@helpers/advancedTypes";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { ActionMenuComponent } from "@shared/action-menu/action-menu.component";
 import { SecondaryMenuComponent } from "@shared/secondary-menu/secondary-menu.component";
@@ -15,9 +15,9 @@ import { getPageInfo, PageComponent } from "./pageComponent";
  * @returns List of routes
  */
 export function getRouteConfigForPage(
-  component: Potential<Type<PageComponent>>,
+  component: Option<Type<PageComponent>>,
   config: Partial<Route>
-): Potential<Route> {
+): Option<Route> {
   const page = getPageInfo(component);
 
   if (!page || !isInstantiated(page.route.name)) {

--- a/src/app/helpers/page/pageRouting.ts
+++ b/src/app/helpers/page/pageRouting.ts
@@ -2,6 +2,7 @@ import { Type } from "@angular/core";
 import { Route } from "@angular/router";
 import { ResolverHandlerComponent } from "@components/error/resolver-handler.component";
 import { FormTouchedGuard } from "@guards/form/form.guard";
+import { Potential } from "@helpers/advancedTypes";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { ActionMenuComponent } from "@shared/action-menu/action-menu.component";
 import { SecondaryMenuComponent } from "@shared/secondary-menu/secondary-menu.component";
@@ -14,13 +15,13 @@ import { getPageInfo, PageComponent } from "./pageComponent";
  * @returns List of routes
  */
 export function getRouteConfigForPage(
-  component: Type<PageComponent>,
+  component: Potential<Type<PageComponent>>,
   config: Partial<Route>
-) {
+): Potential<Route> {
   const page = getPageInfo(component);
 
-  if (!page || !isInstantiated(page.route.fullRoute)) {
-    return;
+  if (!page || !isInstantiated(page.route.name)) {
+    return null;
   }
 
   return {

--- a/src/app/helpers/page/pageRouting.ts
+++ b/src/app/helpers/page/pageRouting.ts
@@ -20,7 +20,7 @@ export function getRouteConfigForPage(
 ): Option<Route> {
   const page = getPageInfo(component);
 
-  if (!page || !isInstantiated(page.route.name)) {
+  if (!page || !isInstantiated(page.route.pathFragment)) {
     return null;
   }
 

--- a/src/app/helpers/tableTemplate/tableTemplate.ts
+++ b/src/app/helpers/tableTemplate/tableTemplate.ts
@@ -1,5 +1,5 @@
 import { Directive, ViewChild } from "@angular/core";
-import { Potential } from "@helpers/advancedTypes";
+import { Option } from "@helpers/advancedTypes";
 import {
   ColumnMode,
   DatatableComponent,
@@ -64,7 +64,7 @@ export abstract class TableTemplate<T> extends PageComponent {
    * @param filter Filter value
    * @param cell Cell value to compare
    */
-  protected checkMatch(filter: string, cell: Potential<string>): boolean {
+  protected checkMatch(filter: string, cell: Option<string>): boolean {
     if (!cell) {
       return false;
     }

--- a/src/app/helpers/tableTemplate/tableTemplate.ts
+++ b/src/app/helpers/tableTemplate/tableTemplate.ts
@@ -1,4 +1,5 @@
 import { Directive, ViewChild } from "@angular/core";
+import { Potential } from "@helpers/advancedTypes";
 import {
   ColumnMode,
   DatatableComponent,
@@ -63,7 +64,7 @@ export abstract class TableTemplate<T> extends PageComponent {
    * @param filter Filter value
    * @param cell Cell value to compare
    */
-  protected checkMatch(filter: string, cell: string | null): boolean {
+  protected checkMatch(filter: string, cell: Potential<string>): boolean {
     if (!cell) {
       return false;
     }

--- a/src/app/helpers/unsubscribe/unsubscribe.ts
+++ b/src/app/helpers/unsubscribe/unsubscribe.ts
@@ -16,6 +16,7 @@ export function withUnsubscribe<T extends Type<any>>(
     public ngOnDestroy() {
       this.unsubscribe.next();
       this.unsubscribe.complete();
+      super.ngOnDestroy?.();
     }
   };
 }

--- a/src/app/interfaces/menusInterfaces.ts
+++ b/src/app/interfaces/menusInterfaces.ts
@@ -223,7 +223,7 @@ export function isExternalLink(menuItem: AnyMenuItem): menuItem is MenuLink {
  * @returns Either full route, or uri
  */
 export function getRoute(link: NavigableMenuItem, params?: Params): string {
-  return isInternalRoute(link) ? link.route.toString() : link.uri(params);
+  return isInternalRoute(link) ? link.route.toRouterLink() : link.uri(params);
 }
 
 /**

--- a/src/app/interfaces/strongRoute.spec.ts
+++ b/src/app/interfaces/strongRoute.spec.ts
@@ -227,7 +227,7 @@ describe("StrongRoute", () => {
       path: string,
       component?: any,
       config: Partial<Route> = {}
-    ) {
+    ): Route {
       return {
         path,
         pathMatch: "full",
@@ -237,7 +237,7 @@ describe("StrongRoute", () => {
     }
 
     it('should compile root ("") route', () => {
-      const routes: Routes = [createRoute(""), createRoute("", MockComponent)];
+      const routes: Routes = [createRoute("", MockComponent)];
       const homeRoute = StrongRoute.base.add("");
       homeRoute.pageComponent = MockComponent;
 
@@ -248,8 +248,8 @@ describe("StrongRoute", () => {
     const parents = [
       {
         title: "Base Route",
-        baseRef: "",
-        parent: () => StrongRoute.base,
+        baseRef: "test/",
+        parent: () => StrongRoute.base.add("test"),
       },
       {
         title: "Feature Module Route",
@@ -289,7 +289,7 @@ describe("StrongRoute", () => {
         });
 
         it("should compile StrongRoute with route", () => {
-          const routes: Routes = [
+          const routes = [
             rootRoute,
             createRoute(parent.baseRef + "home", MockComponent),
           ];
@@ -301,7 +301,7 @@ describe("StrongRoute", () => {
         });
 
         it("should compile StrongRoute with parameter route", () => {
-          const routes: Routes = [
+          const routes = [
             rootRoute,
             createRoute(parent.baseRef + ":id", MockComponent),
           ];
@@ -313,7 +313,7 @@ describe("StrongRoute", () => {
         });
 
         it("should compile StrongRoute with mixed routes", () => {
-          const routes: Routes = [
+          const routes = [
             rootRoute,
             createRoute(parent.baseRef + "home"),
             createRoute(parent.baseRef + "home/:id"),
@@ -327,7 +327,7 @@ describe("StrongRoute", () => {
         });
 
         it("should compile StrongRoute with custom config", () => {
-          const routes: Routes = [
+          const routes = [
             rootRoute,
             createRoute(parent.baseRef + ":id", MockComponent, {
               redirectTo: "/test",
@@ -343,7 +343,7 @@ describe("StrongRoute", () => {
         });
 
         it("should order child StrongRoute routes", () => {
-          const routes: Routes = [
+          const routes = [
             rootRoute,
             createRoute(parent.baseRef + "home"),
             createRoute(parent.baseRef + "home/house"),
@@ -358,7 +358,7 @@ describe("StrongRoute", () => {
         });
 
         it("should order base StrongRoute routes", () => {
-          const routes: Routes = [
+          const routes = [
             rootRoute,
             createRoute(parent.baseRef + "home"),
             createRoute(parent.baseRef + "house"),

--- a/src/app/interfaces/strongRoute.spec.ts
+++ b/src/app/interfaces/strongRoute.spec.ts
@@ -47,6 +47,10 @@ describe("StrongRoute", () => {
     ],
   });
 
+  function assertChildren(route: StrongRoute, children: StrongRoute[]) {
+    expect(route["children"]).toEqual(children);
+  }
+
   beforeEach(() => (baseRoute = StrongRoute.base));
 
   type ToOutput = KeysOfType<StrongRoute, () => string | string[]>;
@@ -144,10 +148,6 @@ describe("StrongRoute", () => {
       });
     });
   });
-
-  function assertChildren(route: StrongRoute, children: StrongRoute[]) {
-    expect(route.children).toEqual(children);
-  }
 
   describe("StrongRoutes", () => {
     const parents = [
@@ -333,7 +333,9 @@ describe("StrongRoute", () => {
               redirectTo: "/test",
             }),
           ];
-          const paramRoute = strongRoute.add(":id", { redirectTo: "/test" });
+          const paramRoute = strongRoute.add(":id", undefined, {
+            redirectTo: "/test",
+          });
           paramRoute.pageComponent = MockComponent;
 
           const compiledRoutes = paramRoute.compileRoutes(callback);
@@ -369,6 +371,22 @@ describe("StrongRoute", () => {
 
           const compiledRoutes = strongRoute.compileRoutes(callback);
           expect(compiledRoutes).toEqual(routes);
+        });
+      });
+    });
+  });
+
+  describe("Query Parameters", () => {
+    ["add", "addFeatureModule"].forEach((funcName) => {
+      describe(funcName, () => {
+        it("should create with empty object with query parameters by default", () => {
+          expect(baseRoute[funcName]("home").queryParams).toEqual({});
+        });
+
+        it("should create with query parameters", () => {
+          expect(
+            baseRoute[funcName]("home", { test: "value" }).queryParams
+          ).toEqual({ test: "value" });
         });
       });
     });

--- a/src/app/interfaces/strongRoute.spec.ts
+++ b/src/app/interfaces/strongRoute.spec.ts
@@ -57,7 +57,7 @@ describe("StrongRoute", () => {
     ngZone = spec.inject(NgZone);
   }
 
-  beforeEach(() => (baseRoute = StrongRoute.base));
+  beforeEach(() => (baseRoute = StrongRoute.newRoot()));
 
   type ToOutput = KeysOfType<StrongRoute, () => string | string[]>;
   (["toString", "toRoute"] as ToOutput[]).forEach((funcName) => {
@@ -153,15 +153,16 @@ describe("StrongRoute", () => {
     const parents = [
       {
         title: "Base Route",
-        parent: () => StrongRoute.base,
+        parent: () => StrongRoute.newRoot(),
       },
       {
         title: "Child Route",
-        parent: () => StrongRoute.base.add("parent"),
+        parent: () => StrongRoute.newRoot().add("parent"),
       },
       {
         title: "Feature Module Route",
-        parent: () => StrongRoute.base.add("test").addFeatureModule("testing"),
+        parent: () =>
+          StrongRoute.newRoot().add("test").addFeatureModule("testing"),
       },
     ];
 
@@ -238,7 +239,7 @@ describe("StrongRoute", () => {
 
     it('should compile root ("") route', () => {
       const routes: Routes = [createRoute("", MockComponent)];
-      const homeRoute = StrongRoute.base.add("");
+      const homeRoute = StrongRoute.newRoot().add("");
       homeRoute.pageComponent = MockComponent;
 
       const compiledRoutes = homeRoute.compileRoutes(callback);
@@ -249,12 +250,13 @@ describe("StrongRoute", () => {
       {
         title: "Base Route",
         baseRef: "test/",
-        parent: () => StrongRoute.base.add("test"),
+        parent: () => StrongRoute.newRoot().add("test"),
       },
       {
         title: "Feature Module Route",
         baseRef: "test/testing/",
-        parent: () => StrongRoute.base.add("test").addFeatureModule("testing"),
+        parent: () =>
+          StrongRoute.newRoot().add("test").addFeatureModule("testing"),
       },
     ];
 

--- a/src/app/interfaces/strongRoute.spec.ts
+++ b/src/app/interfaces/strongRoute.spec.ts
@@ -223,6 +223,28 @@ describe("StrongRoute", () => {
   });
 
   describe("Compile Routes", () => {
+    function createRoute(
+      path: string,
+      component?: any,
+      config: Partial<Route> = {}
+    ) {
+      return {
+        path,
+        pathMatch: "full",
+        children: [{ path: "", component }],
+        ...config,
+      };
+    }
+
+    it('should compile root ("") route', () => {
+      const routes: Routes = [createRoute(""), createRoute("", MockComponent)];
+      const homeRoute = StrongRoute.base.add("");
+      homeRoute.pageComponent = MockComponent;
+
+      const compiledRoutes = homeRoute.compileRoutes(callback);
+      expect(compiledRoutes).toEqual(routes);
+    });
+
     const parents = [
       {
         title: "Base Route",
@@ -246,19 +268,6 @@ describe("StrongRoute", () => {
       describe(parent.title, () => {
         let strongRoute: StrongRoute;
         let rootRoute: Route;
-
-        function createRoute(
-          path: string,
-          component?: any,
-          config: Partial<Route> = {}
-        ) {
-          return {
-            path,
-            pathMatch: "full",
-            children: [{ path: "", component }],
-            ...config,
-          };
-        }
 
         beforeEach(() => {
           strongRoute = parent.parent();

--- a/src/app/interfaces/strongRoute.spec.ts
+++ b/src/app/interfaces/strongRoute.spec.ts
@@ -129,7 +129,7 @@ describe("StrongRoute", () => {
             path:
               parent.baseRef.length > 0
                 ? parent.baseRef.substr(0, parent.baseRef.length - 1)
-                : null,
+                : undefined,
             pathMatch: "full",
             children: [
               {

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -199,7 +199,14 @@ export class StrongRoute {
       const route = callback(current.pageComponent, current.config);
       current.children.forEach(recursiveAdd);
 
-      if (route) {
+      // Ignore root route with no component
+      if (
+        route &&
+        !(
+          route.path === StrongRoute.rootPath &&
+          route.children[0].component === undefined
+        )
+      ) {
         output.push(route);
       }
     };

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -293,7 +293,9 @@ export class StrongRoute {
    * );
    * ```
    *
-   * @param callback Callback function (usually: getRouteConfigForPage)
+   * @param callback Callback function (usually: `getRouteConfigForPage`)
+   * which allows the 'pages' to add extra route data or modifications when
+   * they are set up
    */
   public compileRoutes(callback: RouteConfigCallback): Routes {
     const rootRoute = this.root;

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -1,11 +1,11 @@
 import { Type } from "@angular/core";
 import { Params, Route, Routes } from "@angular/router";
-import { Potential } from "@helpers/advancedTypes";
+import { Option } from "@helpers/advancedTypes";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { PageComponent } from "@helpers/page/pageComponent";
 
 export type RouteConfigCallback = (
-  component: Potential<Type<PageComponent>>,
+  component: Option<Type<PageComponent>>,
   config: Partial<Route>
 ) => Route;
 
@@ -20,7 +20,7 @@ export class StrongRoute {
   private static readonly rootPath = "";
 
   /** Page component associated with this strong route */
-  public pageComponent: Potential<Type<PageComponent>>;
+  public pageComponent: Option<Type<PageComponent>>;
   /** Root strong route of this strong route */
   public readonly root: StrongRoute;
   /** Parent strong route of this strong route */

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -1,5 +1,5 @@
 import { Type } from "@angular/core";
-import { Route, Routes } from "@angular/router";
+import { Params, Route, Routes } from "@angular/router";
 import { Potential } from "@helpers/advancedTypes";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { PageComponent } from "@helpers/page/pageComponent";
@@ -15,7 +15,7 @@ export type RouteConfigCallback = (
  * dynamically create routes for the various page components.
  */
 export class StrongRoute {
-  private static rootPath = "";
+  private static readonly rootPath = "";
 
   /** Page component associated with this strong route */
   public pageComponent: Potential<Type<PageComponent>>;
@@ -25,10 +25,12 @@ export class StrongRoute {
   public readonly parent?: StrongRoute;
   /** Route path/name to add/create in the strong route tree */
   public readonly name?: string;
+  /** Route query parameters */
+  public readonly queryParams?: Params;
   /** Is this strong route a parameter (ie. :siteId) */
-  public readonly isParameter: boolean;
+  private readonly isParameter: boolean;
   /** Children strong routes of this strong route */
-  public readonly children: StrongRoute[] = [];
+  private readonly children: StrongRoute[] = [];
   /** List of parameter strong routes in this strong routes path */
   private readonly parameters: StrongRoute[];
   /** List of parent strong routes (including current strong route) */
@@ -47,11 +49,13 @@ export class StrongRoute {
   private constructor(
     parent: StrongRoute = undefined,
     name: string = StrongRoute.rootPath,
+    qsp: Params = {},
     config: Partial<Route> = {},
     isRoot?: boolean
   ) {
     this.root = this;
     this.name = name;
+    this.queryParams = qsp;
     this.isParameter = name ? name.startsWith(":") : false;
 
     if (parent) {
@@ -85,20 +89,22 @@ export class StrongRoute {
    * Add a child route
    *
    * @param name Route name
+   * @param qsp Route query parameters
    * @param config Additional router configurations
    */
-  public add(name: string, config?: Partial<Route>) {
-    return new StrongRoute(this, name, config);
+  public add(name: string, qsp?: Params, config?: Partial<Route>) {
+    return new StrongRoute(this, name, qsp, config);
   }
 
   /**
    * Add a new feature module route (inherit parent path without recalculating parent routes)
    *
    * @param name Route name
+   * @param qsp Route query parameters
    * @param config Additional router configurations
    */
-  public addFeatureModule(name: string, config?: Partial<Route>) {
-    return new StrongRoute(this, name, config, true);
+  public addFeatureModule(name: string, qsp?: Params, config?: Partial<Route>) {
+    return new StrongRoute(this, name, qsp, config, true);
   }
 
   /**

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -3,7 +3,6 @@ import { Params, Route, Routes } from "@angular/router";
 import { Potential } from "@helpers/advancedTypes";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { PageComponent } from "@helpers/page/pageComponent";
-import { Param } from "./apiInterfaces";
 
 export type RouteConfigCallback = (
   component: Potential<Type<PageComponent>>,
@@ -113,7 +112,7 @@ export class StrongRoute {
   /**
    * Method used for templating a route with parameters.
    * Use this in a template like so:
-   * <a [routerlink]="route.Format({projectId: 1, siteId: 1})" />
+   * <a [routerlink]="route.format({projectId: 1, siteId: 1})" />
    */
   public format(args: { [key: string]: string | number }): string {
     if (!args) {

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -207,7 +207,8 @@ export class StrongRoute {
    */
   public toString(): string {
     // Prevent double '/' at start of route string
-    return this.toRoute().join("/").substr(1);
+    const path = this.toRoute().join("/");
+    return path.length >= 2 ? path.substr(1) : path;
   }
 
   /**

--- a/src/app/models/AnalysisJob.ts
+++ b/src/app/models/AnalysisJob.ts
@@ -106,7 +106,9 @@ export class AnalysisJob extends AbstractModel implements IAnalysisJob {
    * Gets the route path for the admin details page for this model
    */
   public get adminViewUrl(): string {
-    return adminAnalysisJobMenuItem.route.format({ analysisJobId: this.id });
+    return adminAnalysisJobMenuItem.route.toRouterLink({
+      analysisJobId: this.id,
+    });
   }
 }
 

--- a/src/app/models/AssociationLoadingInComponents.spec.ts
+++ b/src/app/models/AssociationLoadingInComponents.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { Component, Injector, Input } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { MOCK, MockStandardApiService } from "@baw-api/mock/apiMocks.service";
@@ -66,7 +67,7 @@ describe("Association Decorators Loading In Components", () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [MockComponent],
-      imports: [HttpClientTestingModule, MockBawApiModule],
+      imports: [RouterTestingModule, MockBawApiModule],
       providers: [
         MockStandardApiService,
         { provide: MOCK.token, useExisting: MockStandardApiService },

--- a/src/app/models/Project.ts
+++ b/src/app/models/Project.ts
@@ -114,6 +114,6 @@ export class Project extends AbstractModel implements IProject {
   }
 
   public get viewUrl(): string {
-    return projectMenuItem.route.format({ projectId: this.id });
+    return projectMenuItem.route.toRouterLink({ projectId: this.id });
   }
 }

--- a/src/app/models/Region.ts
+++ b/src/app/models/Region.ts
@@ -95,7 +95,7 @@ export class Region extends AbstractModel implements IRegion {
   }
 
   public get viewUrl(): string {
-    return regionMenuItem.route.format({
+    return regionMenuItem.route.toRouterLink({
       projectId: this.projectId,
       regionId: this.id,
     });

--- a/src/app/models/Script.ts
+++ b/src/app/models/Script.ts
@@ -71,6 +71,6 @@ export class Script extends AbstractModel implements IScript {
   }
 
   public get viewUrl(): string {
-    return adminScriptMenuItem.route.format({ scriptId: this.id });
+    return adminScriptMenuItem.route.toRouterLink({ scriptId: this.id });
   }
 }

--- a/src/app/models/Site.ts
+++ b/src/app/models/Site.ts
@@ -137,13 +137,13 @@ export class Site extends AbstractModel implements ISite {
 
   public getViewUrl(project: IdOr<Project>): string {
     if (isInstantiated(this.regionId)) {
-      return pointMenuItem.route.format({
+      return pointMenuItem.route.toRouterLink({
         projectId: id(project),
         regionId: this.regionId,
         siteId: this.id,
       });
     } else {
-      return siteMenuItem.route.format({
+      return siteMenuItem.route.toRouterLink({
         projectId: id(project),
         siteId: this.id,
       });

--- a/src/app/models/TagGroup.ts
+++ b/src/app/models/TagGroup.ts
@@ -43,6 +43,6 @@ export class TagGroup extends AbstractModel implements ITagGroup {
   }
 
   public get viewUrl(): string {
-    return adminTagGroupsMenuItem.route.toString();
+    return adminTagGroupsMenuItem.route.toRouterLink();
   }
 }

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -181,7 +181,7 @@ export class SessionUser extends AbstractModel implements ISessionUser {
   }
 
   public get viewUrl(): string {
-    return myAccountMenuItem.route.toString();
+    return myAccountMenuItem.route.toRouterLink();
   }
 }
 

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -128,7 +128,7 @@ export class User extends AbstractModel implements IUser {
   }
 
   public get viewUrl(): string {
-    return theirProfileMenuItem.route.format({ accountId: this.id });
+    return theirProfileMenuItem.route.toRouterLink({ accountId: this.id });
   }
 
   public toString(): string {

--- a/src/app/test/helpers/pagedTableTemplate.ts
+++ b/src/app/test/helpers/pagedTableTemplate.ts
@@ -10,7 +10,9 @@ import { BehaviorSubject, Subject } from "rxjs";
 /**
  * Get all rows from datatable component
  */
-export function getDatatableRows(fixture: ComponentFixture<any>) {
+export function getDatatableRows(
+  fixture: ComponentFixture<any>
+): HTMLElement[] {
   return fixture.nativeElement.querySelectorAll("datatable-body-row");
 }
 
@@ -19,7 +21,7 @@ export function getDatatableRows(fixture: ComponentFixture<any>) {
  *
  * @param row Row to query
  */
-export function getDatatableCells(row: any) {
+export function getDatatableCells(row: any): HTMLElement[] {
   return row.querySelectorAll("datatable-body-cell");
 }
 


### PR DESCRIPTION
# Strong Route Query Parameters

Added tracking of query parameters to the `StrongRoute`. This will allow for links in the action/secondary menus to handle dynamic parameters.

## Changes

- Added query parameters to `StrongRoute`
- Updated `MenuComponent` and `InternalLinkComponent` to handle applying `StrongRoute` query params to the link

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
