### PR TITLE
Build baw client

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -5,8 +5,71 @@ on:
   pull_request:
 
 jobs:
+  baw-client:
+    name: Build Baw Client
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Baw Client
+        uses: actions/checkout@v2
+        with:
+          repository: QutEcoacoustics/baw-client
+          ref: migration
+
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: Create environment
+        run: |
+          echo '{
+              "environments": {
+                "production": {
+                  "apiRoot": "https://staging.ecosounds.org",
+                  "siteRoot": "http://development.ecosounds.org:4200",
+                  "siteDir": "/assets/old-client/",
+                  "ga": { "trackingId": "" }
+                }
+              },
+              "values": {
+                "keys": { "googleMaps": "" },
+                "brand": {
+                  "name": "<<brand name here>>",
+                  "title": "<<brand name here>> | Acoustic Workbench"
+                },
+                "content": {
+                  "research": {
+                    "header_title": "Custom Menu",
+                    "items": [
+                      {
+                        "innerText": "Example",
+                        "url": "http://www.EXAMPLE.org/awebpage"
+                      }
+                    ]
+                  }
+                }
+              }
+            }' > ./buildConfig/environmentSettings.json
+
+      - name: Read environment
+        run: cat buildConfig/environmentSettings.json
+
+      - name: NPM install
+        run: npm install
+
+      - name: Build
+        run: npm run build -- --production
+
+      - name: Publish build files
+        uses: actions/upload-artifact@v2
+        with:
+          path: bin/
+          name: baw-client
+
   test:
     name: Unit Tests (${{ matrix.os }})
+    needs: baw-client
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -17,12 +80,21 @@ jobs:
           - windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Workbench Client
+        uses: actions/checkout@v2
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: baw-client
 
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
+
+      - name: Copy baw-client to assets
+        run: cp -r baw-client/* src/assets/old-client
 
       - name: NPM install
         run: npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -12023,11 +12023,6 @@
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
       "dev": true
     },
-    "icu4c-data": {
-      "version": "0.64.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
-      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ=="
-    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11332,10 +11332,7 @@
     "full-icu": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
-      "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "requires": {
-        "icu4c-data": "^0.64.2"
-      }
+      "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw=="
     },
     "function-bind": {
       "version": "1.1.1",

--- a/src/app/components/audio-analysis/pages/details/details.component.spec.ts
+++ b/src/app/components/audio-analysis/pages/details/details.component.spec.ts
@@ -1,23 +1,25 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { AnalysisJobsService } from "@baw-api/analysis/analysis-jobs.service";
+import { audioAnalysesRoute } from "@components/audio-analysis/audio-analysis.menus";
+import { AudioAnalysisModule } from "@components/audio-analysis/audio-analysis.module";
+import { AnalysisJob } from "@models/AnalysisJob";
+import { generateAnalysisJob } from "@test/fakes/AnalysisJob";
+import { validateBawClientPage } from "@test/helpers/baw-client";
+import { BehaviorSubject } from "rxjs";
 import { AudioAnalysisComponent } from "./details.component";
 
-xdescribe("AudioAnalysisComponent", () => {
-  let component: AudioAnalysisComponent;
-  let fixture: ComponentFixture<AudioAnalysisComponent>;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [AudioAnalysisComponent],
-    }).compileComponents();
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AudioAnalysisComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+describe("AudioAnalysisComponent", () => {
+  validateBawClientPage(
+    audioAnalysesRoute,
+    AudioAnalysisComponent,
+    [AudioAnalysisModule],
+    "/audio_analysis/123",
+    "Results are available as they are generated.",
+    (spec) => {
+      const analysisJobApi = spec.inject(AnalysisJobsService);
+      analysisJobApi.show.andCallFake(
+        (modelId) =>
+          new BehaviorSubject(new AnalysisJob(generateAnalysisJob(modelId)))
+      );
+    }
+  );
 });

--- a/src/app/components/audio-analysis/pages/details/details.component.ts
+++ b/src/app/components/audio-analysis/pages/details/details.component.ts
@@ -16,6 +16,7 @@ import { List } from "immutable";
 
 const audioAnalysisKey = "audioAnalysis";
 
+//TODO: OLD-CLIENT REMOVE
 @Component({
   selector: "baw-audio-analysis",
   template: "<baw-client></baw-client>",

--- a/src/app/components/audio-analysis/pages/list/list.component.spec.ts
+++ b/src/app/components/audio-analysis/pages/list/list.component.spec.ts
@@ -1,23 +1,14 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { audioAnalysesRoute } from "@components/audio-analysis/audio-analysis.menus";
+import { AudioAnalysisModule } from "@components/audio-analysis/audio-analysis.module";
+import { validateBawClientPage } from "@test/helpers/baw-client";
 import { AudioAnalysesComponent } from "./list.component";
 
-xdescribe("AudioAnalysesComponent", () => {
-  let component: AudioAnalysesComponent;
-  let fixture: ComponentFixture<AudioAnalysesComponent>;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [AudioAnalysesComponent],
-    }).compileComponents();
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AudioAnalysesComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+describe("AudioAnalysesComponent", () => {
+  validateBawClientPage(
+    audioAnalysesRoute,
+    AudioAnalysesComponent,
+    [AudioAnalysisModule],
+    "/audio_analysis",
+    "This is a list of analysis jobs you have access to."
+  );
 });

--- a/src/app/components/audio-analysis/pages/list/list.component.ts
+++ b/src/app/components/audio-analysis/pages/list/list.component.ts
@@ -7,6 +7,7 @@ import {
 import { PageComponent } from "@helpers/page/pageComponent";
 import { List } from "immutable";
 
+//TODO: OLD-CLIENT REMOVE
 @Component({
   selector: "baw-audio-analyses",
   template: "<baw-client></baw-client>",

--- a/src/app/components/audio-analysis/pages/new/new.component.spec.ts
+++ b/src/app/components/audio-analysis/pages/new/new.component.spec.ts
@@ -1,23 +1,14 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { audioAnalysesRoute } from "@components/audio-analysis/audio-analysis.menus";
+import { AudioAnalysisModule } from "@components/audio-analysis/audio-analysis.module";
+import { validateBawClientPage } from "@test/helpers/baw-client";
 import { NewAudioAnalysisComponent } from "./new.component";
 
-xdescribe("NewAudioAnalysisComponent", () => {
-  let component: NewAudioAnalysisComponent;
-  let fixture: ComponentFixture<NewAudioAnalysisComponent>;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [NewAudioAnalysisComponent],
-    }).compileComponents();
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(NewAudioAnalysisComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+describe("NewAudioAnalysisComponent", () => {
+  validateBawClientPage(
+    audioAnalysesRoute,
+    NewAudioAnalysisComponent,
+    [AudioAnalysisModule],
+    "/audio_analysis/new",
+    "Use this page to select the data to analyze, choose the analysis to run"
+  );
 });

--- a/src/app/components/audio-analysis/pages/new/new.component.ts
+++ b/src/app/components/audio-analysis/pages/new/new.component.ts
@@ -5,6 +5,7 @@ import {
 } from "@components/audio-analysis/audio-analysis.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
 
+//TODO: OLD-CLIENT REMOVE
 @Component({
   selector: "baw-new-audio-analyses",
   template: "<baw-client></baw-client>",

--- a/src/app/components/audio-analysis/pages/results/results.component.spec.ts
+++ b/src/app/components/audio-analysis/pages/results/results.component.spec.ts
@@ -1,23 +1,25 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { AnalysisJobsService } from "@baw-api/analysis/analysis-jobs.service";
+import { audioAnalysesRoute } from "@components/audio-analysis/audio-analysis.menus";
+import { AudioAnalysisModule } from "@components/audio-analysis/audio-analysis.module";
+import { AnalysisJob } from "@models/AnalysisJob";
+import { generateAnalysisJob } from "@test/fakes/AnalysisJob";
+import { validateBawClientPage } from "@test/helpers/baw-client";
+import { BehaviorSubject } from "rxjs";
 import { AudioAnalysisResultsComponent } from "./results.component";
 
-xdescribe("AudioAnalysisResultsComponent", () => {
-  let component: AudioAnalysisResultsComponent;
-  let fixture: ComponentFixture<AudioAnalysisResultsComponent>;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [AudioAnalysisResultsComponent],
-    }).compileComponents();
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AudioAnalysisResultsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+describe("AudioAnalysisResultsComponent", () => {
+  validateBawClientPage(
+    audioAnalysesRoute,
+    AudioAnalysisResultsComponent,
+    [AudioAnalysisModule],
+    "/audio_analysis/123/results",
+    "Results are available as they are generated. There is a basic file explorer below",
+    (spec) => {
+      const analysisJobApi = spec.inject(AnalysisJobsService);
+      analysisJobApi.show.andCallFake(
+        (modelId) =>
+          new BehaviorSubject(new AnalysisJob(generateAnalysisJob(modelId)))
+      );
+    }
+  );
 });

--- a/src/app/components/audio-analysis/pages/results/results.component.ts
+++ b/src/app/components/audio-analysis/pages/results/results.component.ts
@@ -13,6 +13,7 @@ import { List } from "immutable";
 
 const audioAnalysisKey = "audioAnalysis";
 
+//TODO: OLD-CLIENT REMOVE
 @Component({
   selector: "baw-audio-analysis-results",
   template: "<baw-client></baw-client>",

--- a/src/app/components/library/pages/details/details.component.spec.ts
+++ b/src/app/components/library/pages/details/details.component.spec.ts
@@ -1,23 +1,36 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { AudioEventsService } from "@baw-api/audio-event/audio-events.service";
+import { AudioRecordingsService } from "@baw-api/audio-recording/audio-recordings.service";
+import { libraryRoute } from "@components/library/library.menus";
+import { LibraryModule } from "@components/library/library.module";
+import { AudioEvent } from "@models/AudioEvent";
+import { AudioRecording } from "@models/AudioRecording";
+import { generateAudioEvent } from "@test/fakes/AudioEvent";
+import { generateAudioRecording } from "@test/fakes/AudioRecording";
+import { validateBawClientPage } from "@test/helpers/baw-client";
+import { BehaviorSubject } from "rxjs";
 import { AnnotationComponent } from "./details.component";
 
-xdescribe("AnnotationComponent", () => {
-  let component: AnnotationComponent;
-  let fixture: ComponentFixture<AnnotationComponent>;
+describe("AnnotationComponent", () => {
+  validateBawClientPage(
+    libraryRoute,
+    AnnotationComponent,
+    [LibraryModule],
+    "/library/123/audio_events/123",
+    "Annotation",
+    (spec) => {
+      const recordingApi = spec.inject(AudioRecordingsService);
+      const eventsApi = spec.inject(AudioEventsService);
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [AnnotationComponent],
-    }).compileComponents();
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AnnotationComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+      recordingApi.show.andCallFake(
+        (modelId) =>
+          new BehaviorSubject(
+            new AudioRecording(generateAudioRecording(modelId))
+          )
+      );
+      eventsApi.show.andCallFake(
+        (modelId) =>
+          new BehaviorSubject(new AudioEvent(generateAudioEvent(modelId)))
+      );
+    }
+  );
 });

--- a/src/app/components/library/pages/details/details.component.ts
+++ b/src/app/components/library/pages/details/details.component.ts
@@ -1,10 +1,13 @@
 import { Component } from "@angular/core";
+import { audioEventResolvers } from "@baw-api/audio-event/audio-events.service";
+import { audioRecordingResolvers } from "@baw-api/audio-recording/audio-recordings.service";
 import {
   annotationMenuItem,
   annotationsCategory,
 } from "@components/library/library.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
 
+//TODO: OLD-CLIENT REMOVE
 @Component({
   selector: "baw-annotation",
   template: "<baw-client></baw-client>",
@@ -13,6 +16,10 @@ class AnnotationComponent extends PageComponent {}
 
 AnnotationComponent.linkComponentToPageInfo({
   category: annotationsCategory,
+  resolvers: {
+    audioRecording: audioRecordingResolvers.show,
+    audioEvent: audioEventResolvers.show,
+  },
 }).andMenuRoute(annotationMenuItem);
 
 export { AnnotationComponent };

--- a/src/app/components/library/pages/list/list.component.spec.ts
+++ b/src/app/components/library/pages/list/list.component.spec.ts
@@ -1,23 +1,14 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { libraryRoute } from "@components/library/library.menus";
+import { LibraryModule } from "@components/library/library.module";
+import { validateBawClientPage } from "@test/helpers/baw-client";
 import { LibraryComponent } from "./list.component";
 
-xdescribe("LibraryComponent", () => {
-  let component: LibraryComponent;
-  let fixture: ComponentFixture<LibraryComponent>;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [LibraryComponent],
-    }).compileComponents();
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(LibraryComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+describe("LibraryComponent", () => {
+  validateBawClientPage(
+    libraryRoute,
+    LibraryComponent,
+    [LibraryModule],
+    "/library",
+    "Annotation Library"
+  );
 });

--- a/src/app/components/library/pages/list/list.component.ts
+++ b/src/app/components/library/pages/list/list.component.ts
@@ -5,6 +5,7 @@ import {
 } from "@components/library/library.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
 
+//TODO: OLD-CLIENT REMOVE
 @Component({
   selector: "baw-library",
   template: "<baw-client></baw-client>",

--- a/src/app/components/listen/pages/details/details.component.spec.ts
+++ b/src/app/components/listen/pages/details/details.component.spec.ts
@@ -1,23 +1,28 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { AudioRecordingsService } from "@baw-api/audio-recording/audio-recordings.service";
+import { listenRoute } from "@components/listen/listen.menus";
+import { ListenModule } from "@components/listen/listen.module";
+import { AudioRecording } from "@models/AudioRecording";
+import { generateAudioRecording } from "@test/fakes/AudioRecording";
+import { validateBawClientPage } from "@test/helpers/baw-client";
+import { BehaviorSubject } from "rxjs";
 import { ListenRecordingComponent } from "./details.component";
 
-xdescribe("ListenRecordingComponent", () => {
-  let component: ListenRecordingComponent;
-  let fixture: ComponentFixture<ListenRecordingComponent>;
+describe("ListenRecordingComponent", () => {
+  validateBawClientPage(
+    listenRoute,
+    ListenRecordingComponent,
+    [ListenModule],
+    "/listen/123",
+    "Download from this item",
+    (spec) => {
+      const recordingApi = spec.inject(AudioRecordingsService);
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ListenRecordingComponent],
-    }).compileComponents();
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ListenRecordingComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+      recordingApi.show.andCallFake(
+        (modelId) =>
+          new BehaviorSubject(
+            new AudioRecording(generateAudioRecording(modelId))
+          )
+      );
+    }
+  );
 });

--- a/src/app/components/listen/pages/details/details.component.ts
+++ b/src/app/components/listen/pages/details/details.component.ts
@@ -1,10 +1,12 @@
 import { Component } from "@angular/core";
+import { audioRecordingResolvers } from "@baw-api/audio-recording/audio-recordings.service";
 import {
   listenCategory,
   listenRecordingMenuItem,
 } from "@components/listen/listen.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
 
+//TODO: OLD-CLIENT REMOVE
 @Component({
   selector: "baw-listen-recording",
   template: "<baw-client></baw-client>",
@@ -14,6 +16,7 @@ class ListenRecordingComponent extends PageComponent {}
 ListenRecordingComponent.linkComponentToPageInfo({
   category: listenCategory,
   fullscreen: true,
+  resolvers: { audioRecording: audioRecordingResolvers.show },
 }).andMenuRoute(listenRecordingMenuItem);
 
 export { ListenRecordingComponent };

--- a/src/app/components/listen/pages/list/list.component.spec.ts
+++ b/src/app/components/listen/pages/list/list.component.spec.ts
@@ -1,23 +1,14 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { listenRoute } from "@components/listen/listen.menus";
+import { ListenModule } from "@components/listen/listen.module";
+import { validateBawClientPage } from "@test/helpers/baw-client";
 import { ListenComponent } from "./list.component";
 
-xdescribe("ListenComponent", () => {
-  let component: ListenComponent;
-  let fixture: ComponentFixture<ListenComponent>;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ListenComponent],
-    }).compileComponents();
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ListenComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+describe("ListenComponent", () => {
+  validateBawClientPage(
+    listenRoute,
+    ListenComponent,
+    [ListenModule],
+    "/listen",
+    "Recent Audio Recordings"
+  );
 });

--- a/src/app/components/listen/pages/list/list.component.ts
+++ b/src/app/components/listen/pages/list/list.component.ts
@@ -5,6 +5,7 @@ import {
 } from "@components/listen/listen.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
 
+//TODO: OLD-CLIENT REMOVE
 @Component({
   selector: "baw-listen",
   template: "<baw-client></baw-client>",

--- a/src/app/components/projects/site-card/site-card.component.spec.ts
+++ b/src/app/components/projects/site-card/site-card.component.spec.ts
@@ -195,7 +195,6 @@ describe("SiteCardComponent", () => {
           spec.detectChanges();
           await recordingPromise;
           spec.detectChanges();
-          debugger;
           assertLink(getLinks().noAudio, "No Audio");
         });
 

--- a/src/app/components/shared/baw-client/baw-client.component.ts
+++ b/src/app/components/shared/baw-client/baw-client.component.ts
@@ -7,6 +7,7 @@ import { assetRoot } from "@services/config/config.service";
 import { interval } from "rxjs";
 import { filter, takeUntil } from "rxjs/operators";
 
+//TODO: OLD-CLIENT REMOVE
 @Component({
   selector: "baw-client",
   template: `

--- a/src/app/components/visualize/pages/details/details.component.spec.ts
+++ b/src/app/components/visualize/pages/details/details.component.spec.ts
@@ -1,23 +1,14 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { visualizeRoute } from "@components/visualize/visualize.menus";
+import { VisualizeModule } from "@components/visualize/visualize.module";
+import { validateBawClientPage } from "@test/helpers/baw-client";
 import { VisualizeComponent } from "./details.component";
 
 describe("VisualizeComponent", () => {
-  let component: VisualizeComponent;
-  let fixture: ComponentFixture<VisualizeComponent>;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [VisualizeComponent],
-    }).compileComponents();
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(VisualizeComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
+  validateBawClientPage(
+    visualizeRoute,
+    VisualizeComponent,
+    [VisualizeModule],
+    "/visualize",
+    "Audio distribution"
+  );
 });

--- a/src/app/components/visualize/pages/details/details.component.ts
+++ b/src/app/components/visualize/pages/details/details.component.ts
@@ -5,6 +5,7 @@ import {
 } from "@components/visualize/visualize.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
 
+//TODO: OLD-CLIENT REMOVE
 @Component({
   selector: "baw-visualize",
   template: "<baw-client></baw-client>",

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -75,7 +75,6 @@ export class User extends AbstractModel implements IUser {
   public readonly kind = "User";
   @bawPersistAttr
   public readonly id?: Id;
-  @bawPersistAttr
   public readonly email?: string;
   @bawPersistAttr
   public readonly userName?: UserName;

--- a/src/app/services/baw-api/api.interceptor.service.spec.ts
+++ b/src/app/services/baw-api/api.interceptor.service.spec.ts
@@ -1,55 +1,44 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { HttpClient, HttpClientModule, HttpParams } from "@angular/common/http";
-import {
-  HttpClientTestingModule,
-  HttpTestingController,
-} from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
+import { TestRequest } from "@angular/common/http/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { SecurityService } from "@baw-api/security/security.service";
+import { API_ROOT } from "@helpers/app-initializer/app-initializer";
 import { SessionUser } from "@models/User";
+import {
+  createHttpFactory,
+  HttpMethod,
+  SpectatorHttp,
+} from "@ngneat/spectator";
 import { ConfigService } from "@services/config/config.service";
-import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
+import { generateApiErrorResponse } from "@test/fakes/ApiErrorDetails";
 import { generateSessionUser } from "@test/fakes/User";
+import { noop } from "rxjs";
+import { ApiResponse } from "./baw-api.service";
 import {
   apiErrorInfoDetails,
   shouldNotFail,
   shouldNotSucceed,
 } from "./baw-api.service.spec";
 
-// TODO Add tests for CMS
-// TODO Add tests to validate cookies are added to requests
 describe("BawApiInterceptor", () => {
-  let api: SecurityService;
+  let apiRoot: string;
   let http: HttpClient;
   let config: ConfigService;
-  let httpMock: HttpTestingController;
-  let apiRoot: string;
+  let spec: SpectatorHttp<SecurityService>;
+  const createService = createHttpFactory({
+    service: SecurityService,
+    imports: [HttpClientModule, MockBawApiModule],
+  });
 
-  function errorResponse(
-    url: string,
-    status: number,
-    statusText: string,
-    error: any
-  ) {
-    const req = httpMock.expectOne(url);
-    req.flush(
-      {
-        meta: {
-          status,
-          message: statusText,
-          error,
-        },
-        data: null,
-      },
-      { status, statusText }
-    );
+  function getPath(path: string) {
+    return apiRoot + path;
   }
 
   function setLoggedIn(authToken?: string) {
-    spyOn(api, "isLoggedIn").and.callFake(() => true);
-    spyOn(api, "getLocalUser").and.callFake(() =>
+    spyOn(spec.service, "isLoggedIn").and.callFake(() => true);
+    spyOn(spec.service, "getLocalUser").and.callFake(() =>
       authToken
         ? new SessionUser({ ...generateSessionUser(), authToken })
         : new SessionUser(generateSessionUser())
@@ -57,126 +46,126 @@ describe("BawApiInterceptor", () => {
   }
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [HttpClientModule, HttpClientTestingModule, MockBawApiModule],
-    });
-
-    api = TestBed.inject(SecurityService);
-    http = TestBed.inject(HttpClient);
-    httpMock = TestBed.inject(HttpTestingController);
-    config = TestBed.inject(ConfigService);
-
-    apiRoot = config.environment.apiRoot;
-  });
-
-  afterEach(() => {
-    httpMock.verify();
+    spec = createService();
+    http = spec.inject(HttpClient);
+    config = spec.inject(ConfigService);
+    apiRoot = spec.inject(API_ROOT);
   });
 
   describe("error handling", () => {
+    function convertErrorResponseToDetails(
+      response: ApiResponse<null>
+    ): ApiErrorDetails {
+      return {
+        status: response.meta.status,
+        message: response.meta.error.details,
+        info: response.meta.error.info,
+      };
+    }
+
     it("should handle api error response", () => {
+      const error = generateApiErrorResponse("Unauthorized", {
+        message: "Incorrect user name",
+      });
+
       http
-        .get<any>(apiRoot + "/brokenapiroute")
-        .subscribe(shouldNotSucceed, (err: ApiErrorDetails) => {
-          expect(err).toEqual(
-            generateApiErrorDetails("Unauthorized", {
-              message: "Incorrect user name",
-              info: undefined,
-            })
-          );
+        .get(getPath("/brokenapiroute"))
+        .subscribe(shouldNotSucceed, (err) => {
+          expect(err).toEqual(convertErrorResponseToDetails(error));
         });
 
-      errorResponse(apiRoot + "/brokenapiroute", 401, "Unauthorized", {
-        details: "Incorrect user name",
+      spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET).flush(error, {
+        status: error.meta.status,
+        statusText: error.meta.message,
       });
     });
 
     it("should handle api error response with info", () => {
+      const error = generateApiErrorResponse("Unprocessable Entity", {
+        info: apiErrorInfoDetails.info,
+      });
+
       http
-        .get<any>(apiRoot + "/brokenapiroute")
-        .subscribe(shouldNotSucceed, (err: ApiErrorDetails) => {
-          expect(err).toEqual(
-            generateApiErrorDetails("Unprocessable Entity", {
-              info: apiErrorInfoDetails.info,
-            })
-          );
+        .get(getPath("/brokenapiroute"))
+        .subscribe(shouldNotSucceed, (err) => {
+          expect(err).toEqual(convertErrorResponseToDetails(error));
         });
 
-      errorResponse(apiRoot + "/brokenapiroute", 422, "Unprocessable Entity", {
-        details: "Record could not be saved",
-        info: apiErrorInfoDetails.info,
+      spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET).flush(error, {
+        status: error.meta.status,
+        statusText: error.meta.message,
       });
     });
 
     it("should handle http error response", () => {
       http
-        .get<any>(apiRoot + "/brokenapiroute")
-        .subscribe(shouldNotSucceed, (err: ApiErrorDetails) => {
+        .get(getPath("/brokenapiroute"))
+        .subscribe(shouldNotSucceed, (err) => {
           expect(err).toEqual({
             status: 404,
             message: `Http failure response for ${apiRoot}/brokenapiroute: 404 Page Not Found`,
           });
         });
 
-      const req = httpMock.expectOne(apiRoot + "/brokenapiroute");
-      req.flush({}, { status: 404, statusText: "Page Not Found" });
+      spec
+        .expectOne(getPath("/brokenapiroute"), HttpMethod.GET)
+        .flush({}, { status: 404, statusText: "Page Not Found" });
     });
   });
 
   describe("non baw api traffic", () => {
-    const noop = () => {};
-
     describe("outgoing data", () => {
-      it("should not set accept header", () => {
-        http.get<any>("https://brokenlink").subscribe(noop, noop, noop);
+      function makeRequest() {
+        http.get("https://brokenlink").subscribe(noop, noop);
+        return spec.expectOne("https://brokenlink", HttpMethod.GET);
+      }
 
-        const req = httpMock.expectOne("https://brokenlink");
+      it("should not set accept header", () => {
+        const req = makeRequest();
         expect(req.request.headers.has("Accept")).toBeFalsy();
       });
 
       it("should not set Authorization header when not logged in", () => {
-        http.get<any>("https://brokenlink").subscribe(noop, noop, noop);
-
-        const req = httpMock.expectOne("https://brokenlink");
+        const req = makeRequest();
         expect(req.request.headers.has("Authorization")).toBeFalsy();
       });
 
       it("should not set Authorization header when logged in", () => {
         setLoggedIn();
-        http.get<any>("https://brokenlink").subscribe(noop, noop, noop);
-
-        const req = httpMock.expectOne("https://brokenlink");
+        const req = makeRequest();
         expect(req.request.headers.has("Authorization")).toBeFalsy();
       });
 
       it("should not set content-type header", () => {
-        http.get<any>("https://brokenlink").subscribe(noop, noop, noop);
-
-        const req = httpMock.expectOne("https://brokenlink");
+        const req = makeRequest();
         expect(req.request.headers.has("Content-Type")).toBeFalsy();
       });
 
       it("should not convert into snake case for GET requests", () => {
-        const params = new HttpParams().set("shouldNotConvert", "true");
-
         http
-          .get<any>("https://brokenlink/brokenapiroute", { params })
-          .subscribe(noop, noop, noop);
-
-        const req = httpMock.expectOne(
-          "https://brokenlink/brokenapiroute?shouldNotConvert=true"
-        );
-        expect(req).toBeTruthy();
+          .get("https://brokenlink/brokenapiroute", {
+            params: new HttpParams().set("shouldNotConvert", "true"),
+          })
+          .subscribe(noop, noop);
+        expect(
+          spec.expectOne(
+            "https://brokenlink/brokenapiroute?shouldNotConvert=true",
+            HttpMethod.GET
+          )
+        ).toBeInstanceOf(TestRequest);
       });
 
       it("should not convert into snake case for POST requests", () => {
         http
-          .post<any>("https://brokenlink/brokenapiroute", {
+          .post("https://brokenlink/brokenapiroute", {
             shouldNotConvert: true,
           })
-          .subscribe(noop, noop, noop);
+          .subscribe(noop, noop);
 
-        const req = httpMock.expectOne("https://brokenlink/brokenapiroute");
+        const req = spec.expectOne(
+          "https://brokenlink/brokenapiroute",
+          HttpMethod.POST
+        );
         expect(req.request.body).toEqual({ shouldNotConvert: true });
       });
     });
@@ -184,92 +173,103 @@ describe("BawApiInterceptor", () => {
     describe("incoming data", () => {
       it("should not convert into camel case for GET requests", () => {
         http
-          .get<any>("https://brokenlink/brokenapiroute")
-          .subscribe((response) => {
-            expect(response).toBeTruthy();
-            expect(response).toEqual({ dummy_response: true });
-          }, shouldNotFail);
-
-        const req = httpMock.expectOne("https://brokenlink/brokenapiroute");
-        req.flush({ dummy_response: true });
+          .get("https://brokenlink/brokenapiroute")
+          .subscribe(
+            (response) => expect(response).toEqual({ dummy_response: true }),
+            shouldNotFail
+          );
+        spec
+          .expectOne("https://brokenlink/brokenapiroute", HttpMethod.GET)
+          .flush({ dummy_response: true });
       });
 
       it("should not convert into camel case for POST requests", () => {
         http
-          .post<any>("https://brokenlink/brokenapiroute", {})
-          .subscribe((response) => {
-            expect(response).toBeTruthy();
-            expect(response).toEqual({ dummy_response: true });
-          }, shouldNotFail);
-
-        const req = httpMock.expectOne("https://brokenlink/brokenapiroute");
-        req.flush({ dummy_response: true });
+          .post("https://brokenlink/brokenapiroute", {})
+          .subscribe(
+            (response) => expect(response).toEqual({ dummy_response: true }),
+            shouldNotFail
+          );
+        spec
+          .expectOne("https://brokenlink/brokenapiroute", HttpMethod.POST)
+          .flush({ dummy_response: true });
       });
     });
   });
 
   describe("baw api traffic", () => {
-    const noop = () => {};
-
     describe("outgoing data", () => {
       it("should set accept header", () => {
-        http.get<any>(apiRoot + "/brokenapiroute").subscribe(noop, noop, noop);
-
-        const req = httpMock.expectOne(apiRoot + "/brokenapiroute");
-        expect(req.request.headers.has("Accept")).toBeTruthy();
+        http.get(getPath("/brokenapiroute")).subscribe(noop, noop);
+        const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
         expect(req.request.headers.get("Accept")).toBe("application/json");
       });
 
-      it("should set content-type header", () => {
-        http.get<any>(apiRoot + "/brokenapiroute").subscribe(noop, noop, noop);
+      it("should not set accept header on non json requests", () => {
+        http
+          .get(getPath("/brokenapiroute"), { responseType: "text" })
+          .subscribe(noop, noop);
+        const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
+        expect(req.request.headers.get("Accept")).not.toBe("application/json");
+      });
 
-        const req = httpMock.expectOne(apiRoot + "/brokenapiroute");
-        expect(req.request.headers.has("Content-Type")).toBeTruthy();
+      it("should set content-type header", () => {
+        http.get(getPath("/brokenapiroute")).subscribe(noop, noop);
+        const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
         expect(req.request.headers.get("Content-Type")).toBe(
           "application/json"
         );
       });
 
-      it("should convert into snake case for GET requests", () => {
-        const params = new HttpParams().set("shouldConvert", "true");
-
+      it("should not set content-type header on non json requests", () => {
         http
-          .get<any>(apiRoot + "/brokenapiroute", {
-            params,
-          })
-          .subscribe(noop, noop, noop);
-
-        const req = httpMock.expectOne(
-          apiRoot + "/brokenapiroute?should_convert=true"
+          .get(getPath("/brokenapiroute"), { responseType: "text" })
+          .subscribe(noop, noop);
+        const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
+        expect(req.request.headers.get("Content-Type")).not.toBe(
+          "application/json"
         );
-        expect(req).toBeTruthy();
+      });
+
+      it("should set cookies", () => {
+        http.get(getPath("/brokenapiroute")).subscribe(noop, noop);
+        const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
+        expect(req.request.withCredentials).toBeTrue();
+      });
+
+      it("should convert into snake case for GET requests", () => {
+        http
+          .get(getPath("/brokenapiroute"), {
+            params: new HttpParams().set("shouldConvert", "true"),
+          })
+          .subscribe(noop, noop);
+
+        expect(
+          spec.expectOne(
+            getPath("/brokenapiroute?should_convert=true"),
+            HttpMethod.GET
+          )
+        ).toBeInstanceOf(TestRequest);
       });
 
       it("should convert into snake case for POST requests", () => {
         http
-          .post<any>(apiRoot + "/brokenapiroute", {
-            shouldConvert: true,
-          })
-          .subscribe(noop, noop, noop);
-
-        const req = httpMock.expectOne(apiRoot + "/brokenapiroute");
+          .post(getPath("/brokenapiroute"), { shouldConvert: true })
+          .subscribe(noop, noop);
+        const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.POST);
         expect(req.request.body).toEqual({ should_convert: true });
       });
 
       it("should not attach Authorization when unauthenticated", () => {
-        http.get<any>(apiRoot + "/brokenapiroute").subscribe(noop, noop, noop);
-
-        const req = httpMock.expectOne(apiRoot + "/brokenapiroute");
+        http.get(getPath("/brokenapiroute")).subscribe(noop, noop);
+        const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
         expect(req.request.headers.has("Authorization")).toBeFalsy();
       });
 
       it("should attach Authorization when authenticated", () => {
         setLoggedIn("xxxxxxxxxxxxxxxxxxxx");
-
-        http.get<any>(apiRoot + "/brokenapiroute").subscribe(noop, noop, noop);
-
-        const req = httpMock.expectOne(apiRoot + "/brokenapiroute");
-        expect(req.request.headers.has("Authorization")).toBeTruthy();
+        http.get(getPath("/brokenapiroute")).subscribe(noop, noop);
+        const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
         expect(req.request.headers.get("Authorization")).toBe(
           'Token token="xxxxxxxxxxxxxxxxxxxx"'
         );
@@ -278,25 +278,29 @@ describe("BawApiInterceptor", () => {
 
     describe("incoming data", () => {
       it("should convert into camel case for GET requests", () => {
-        http.get<any>(apiRoot + "/brokenapiroute").subscribe((response) => {
-          expect(response).toBeTruthy();
-          expect(response).toEqual({ dummyResponse: true });
-        }, shouldNotFail);
+        http
+          .get(getPath("/brokenapiroute"))
+          .subscribe(
+            (response) => expect(response).toEqual({ dummyResponse: true }),
+            shouldNotFail
+          );
 
-        const req = httpMock.expectOne(apiRoot + "/brokenapiroute");
-        req.flush({ dummy_response: true });
+        spec
+          .expectOne(getPath("/brokenapiroute"), HttpMethod.GET)
+          .flush({ dummy_response: true });
       });
 
       it("should convert incoming data from baw api into camel case for POST requests", () => {
         http
-          .post<any>(apiRoot + "/brokenapiroute", {})
-          .subscribe((response) => {
-            expect(response).toBeTruthy();
-            expect(response).toEqual({ dummyResponse: true });
-          }, shouldNotFail);
+          .post(getPath("/brokenapiroute"), {})
+          .subscribe(
+            (response) => expect(response).toEqual({ dummyResponse: true }),
+            shouldNotFail
+          );
 
-        const req = httpMock.expectOne(apiRoot + "/brokenapiroute");
-        req.flush({ dummy_response: true });
+        spec
+          .expectOne(getPath("/brokenapiroute"), HttpMethod.POST)
+          .flush({ dummy_response: true });
       });
     });
   });

--- a/src/app/services/baw-api/api.interceptor.service.ts
+++ b/src/app/services/baw-api/api.interceptor.service.ts
@@ -46,8 +46,8 @@ export class BawApiInterceptor implements HttpInterceptor {
       return next.handle(request);
     }
 
-    // Don't add these headers to requests to cms service
-    if (request.responseType !== "text") {
+    // Only set these headers if this is a json request
+    if (request.responseType === "json") {
       request = request.clone({
         setHeaders: {
           // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/app/services/baw-api/baw-api.service.ts
+++ b/src/app/services/baw-api/baw-api.service.ts
@@ -237,7 +237,10 @@ export abstract class BawApiService<Model extends AbstractModel> {
    * @param path API path
    */
   protected httpGet(path: string): Observable<ApiResponse<Model | Model[]>> {
-    return this.http.get<ApiResponse<Model>>(this.getPath(path));
+    return this.http.get<ApiResponse<Model>>(this.getPath(path), {
+      // Set responseType for interceptor
+      responseType: "json",
+    });
   }
 
   /**
@@ -247,7 +250,10 @@ export abstract class BawApiService<Model extends AbstractModel> {
    * @param path API path
    */
   protected httpDelete(path: string): Observable<ApiResponse<Model | void>> {
-    return this.http.delete<ApiResponse<null>>(this.getPath(path));
+    return this.http.delete<ApiResponse<null>>(this.getPath(path), {
+      // Set responseType for interceptor
+      responseType: "json",
+    });
   }
 
   /**
@@ -258,7 +264,10 @@ export abstract class BawApiService<Model extends AbstractModel> {
    * @param body Request body
    */
   protected httpPost(path: string, body?: any): Observable<ApiResponse<Model>> {
-    return this.http.post<ApiResponse<Model>>(this.getPath(path), body);
+    return this.http.post<ApiResponse<Model>>(this.getPath(path), body, {
+      // Set responseType for interceptor
+      responseType: "json",
+    });
   }
 
   /**
@@ -272,7 +281,10 @@ export abstract class BawApiService<Model extends AbstractModel> {
     path: string,
     body?: any
   ): Observable<ApiResponse<Model>> {
-    return this.http.patch<ApiResponse<Model>>(this.getPath(path), body);
+    return this.http.patch<ApiResponse<Model>>(this.getPath(path), body, {
+      // Set responseType for interceptor
+      responseType: "json",
+    });
   }
 
   /**
@@ -310,6 +322,15 @@ export abstract class BawApiService<Model extends AbstractModel> {
   }
 
   /**
+   * Concatenates path with apiRoot to form a full URL.
+   *
+   * @param path Path fragment beginning with a `/`
+   */
+  protected getPath(path: string): string {
+    return this.apiRoot + path;
+  }
+
+  /**
    * Modify a base filter to add an association to another model/group of models
    *
    * @param filters Base Filters
@@ -339,15 +360,6 @@ export abstract class BawApiService<Model extends AbstractModel> {
         },
       },
     };
-  }
-
-  /**
-   * Concatenates path with apiRoot to form a full URL.
-   *
-   * @param path Path fragment
-   */
-  private getPath(path: string): string {
-    return this.apiRoot + path;
   }
 }
 

--- a/src/app/services/baw-api/cms/cms.service.ts
+++ b/src/app/services/baw-api/cms/cms.service.ts
@@ -33,8 +33,6 @@ export class CmsService {
 
   public get(cms: CMS): Observable<string> {
     return this.http.get(this.apiRoot + endpoint(cms), {
-      // Set response type so that interceptor can identify this is not
-      // json traffic
       responseType: "text",
     });
   }

--- a/src/app/services/baw-api/security/security.service.spec.ts
+++ b/src/app/services/baw-api/security/security.service.spec.ts
@@ -1,20 +1,24 @@
+import { ok } from "assert";
 import { HTTP_INTERCEPTORS } from "@angular/common/http";
-import {
-  HttpClientTestingModule,
-  HttpTestingController,
-} from "@angular/common/http/testing";
-import { fakeAsync, TestBed } from "@angular/core/testing";
+import { TestRequest } from "@angular/common/http/testing";
 import {
   ApiErrorDetails,
   BawApiInterceptor,
 } from "@baw-api/api.interceptor.service";
 import { MockShowApiService } from "@baw-api/mock/apiMocks.service";
-import { ImageSizes } from "@interfaces/apiInterfaces";
-import { AbstractModel } from "@models/AbstractModel";
-import { ISessionUser, IUser, SessionUser, User } from "@models/User";
+import { Option } from "@helpers/advancedTypes";
+import { SessionUser, User } from "@models/User";
+import {
+  createHttpFactory,
+  HttpMethod,
+  SpectatorHttp,
+} from "@ngneat/spectator";
+import { ConfigService } from "@services/config/config.service";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
-import { BehaviorSubject, Subject } from "rxjs";
+import { generateSessionUser, generateUser } from "@test/fakes/User";
+import { modelData } from "@test/helpers/faker";
+import { BehaviorSubject, noop, Subject } from "rxjs";
 import {
   apiErrorDetails,
   shouldNotComplete,
@@ -24,349 +28,415 @@ import {
 import { UserService } from "../user/user.service";
 import { LoginDetails, SecurityService } from "./security.service";
 
-// TODO Rewrite using spectator
 describe("SecurityService", () => {
-  let service: SecurityService;
-  let userApi: UserService;
-  let httpMock: HttpTestingController;
-  let defaultLoginDetails: LoginDetails;
+  let apiRoot: string;
   let defaultUser: User;
   let defaultSessionUser: SessionUser;
-
-  function createError(
-    func:
-      | "apiList"
-      | "apiFilter"
-      | "apiShow"
-      | "apiCreate"
-      | "apiUpdate"
-      | "apiDestroy",
-    url: string,
-    error: ApiErrorDetails
-  ): void {
-    service[func] = jasmine.createSpy().and.callFake((path: string) => {
-      expect(path).toBe(url);
-      const subject = new Subject();
-      subject.error(error);
-      return subject;
-    });
-  }
+  let defaultLoginDetails: LoginDetails;
+  let defaultError: ApiErrorDetails;
+  let defaultAuthToken: string;
+  let userApi: UserService;
+  let spec: SpectatorHttp<SecurityService>;
+  const createService = createHttpFactory({
+    service: SecurityService,
+    imports: [MockAppConfigModule],
+    providers: [
+      {
+        provide: HTTP_INTERCEPTORS,
+        useClass: BawApiInterceptor,
+        multi: true,
+      },
+      { provide: UserService, useClass: MockShowApiService },
+    ],
+  });
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [
-        {
-          provide: HTTP_INTERCEPTORS,
-          useClass: BawApiInterceptor,
-          multi: true,
-        },
-        { provide: UserService, useClass: MockShowApiService },
-        SecurityService,
-      ],
-    });
+    spec = createService();
+    userApi = spec.inject(UserService);
+    apiRoot = spec.inject(ConfigService).environment.apiRoot;
 
-    service = TestBed.inject(SecurityService);
-    userApi = TestBed.inject(UserService);
-    httpMock = TestBed.inject(HttpTestingController);
-
-    defaultUser = new User({
-      id: 1,
-      userName: "username",
-    });
+    defaultAuthToken = modelData.random.alphaNumeric(20);
+    defaultError = generateApiErrorDetails();
+    defaultUser = new User(generateUser());
     defaultSessionUser = new SessionUser({
-      authToken: "xxxxxxxxxxxxxxx",
-      userName: "username",
+      ...defaultUser,
+      ...generateSessionUser(),
     });
     defaultLoginDetails = new LoginDetails({
-      login: "username",
-      password: "password",
+      login: modelData.internet.userName(),
+      password: modelData.internet.password(),
     });
   });
 
   afterEach(() => {
     localStorage.clear();
-    httpMock.verify();
   });
 
-  describe("Authentication Tracking", () => {
-    it("isLoggedIn should return false initially", () => {
-      expect(service.isLoggedIn()).toBeFalse();
+  describe("initial state", () => {
+    it("isLoggedIn should return false", () => {
+      expect(spec.service.isLoggedIn()).toBeFalse();
     });
 
-    it("getSessionUser should return null initially", () => {
-      expect(service.getLocalUser()).toBeFalsy();
+    it("getSessionUser should return null", () => {
+      expect(spec.service.getLocalUser()).toBeFalsy();
     });
 
-    it("authTrigger should contain default value", () => {
-      const spy = jasmine.createSpy();
-
-      service.getAuthTrigger().subscribe(spy, shouldNotFail, shouldNotComplete);
-
-      expect(spy).toHaveBeenCalledTimes(1);
+    it("authTrigger should return null", (done) => {
+      spec.service.getAuthTrigger().subscribe(
+        (val) => {
+          expect(val).toBeNull();
+          done();
+        },
+        shouldNotFail,
+        shouldNotComplete
+      );
     });
   });
 
   describe("signIn", () => {
-    function createResponse(
-      path: string,
-      details: LoginDetails,
-      model: SessionUser,
-      user?: User
-    ): void {
-      spyOn(service as any, "apiCreate").and.callFake(
-        (createPath: string, createDetails: AbstractModel) => {
-          expect(createPath).toBe(path);
-          expect(createDetails).toEqual(details);
-
-          return new BehaviorSubject<SessionUser>(model);
-        }
-      );
-      spyOn(userApi, "show").and.callFake(() => {
-        if (user) {
-          return new BehaviorSubject<User>(user);
-        } else {
-          const subject = new Subject<User>();
-          subject.error(generateApiErrorDetails("Unauthorized"));
-          return subject;
-        }
-      });
+    function expectLoginFormRequest() {
+      return spec.expectOne(apiRoot + "/my_account/sign_in/", HttpMethod.GET);
     }
 
-    it("should call apiCreate", fakeAsync(() => {
-      createResponse(
-        "/security/",
-        defaultLoginDetails,
-        defaultSessionUser,
-        defaultUser
+    function expectCookieRequest() {
+      return spec.expectOne(apiRoot + "/my_account/sign_in/", HttpMethod.POST);
+    }
+
+    function intercept(
+      req: TestRequest,
+      success: boolean,
+      response: Option<any>,
+      expectation: Option<(req: TestRequest) => void>
+    ) {
+      if (success) {
+        req.flush(response);
+        expectation?.(req);
+      } else {
+        req.flush(
+          { meta: { ...defaultError } },
+          {
+            status: defaultError.status,
+            statusText: defaultError.message,
+          }
+        );
+      }
+      return req;
+    }
+
+    function handleLoginForm(
+      authenticityToken: string,
+      expectation?: (req: TestRequest) => void
+    ) {
+      intercept(
+        expectLoginFormRequest(),
+        !!authenticityToken,
+        `<input name="authenticity_token" value="${authenticityToken}" />`,
+        expectation
       );
-      service.signIn(defaultLoginDetails).subscribe();
-      expect(service["apiCreate"]).toHaveBeenCalledWith(
-        "/security/",
-        defaultLoginDetails
-      );
-    }));
+    }
 
-    it("should handle response", fakeAsync(() => {
-      createResponse(
-        "/security/",
-        defaultLoginDetails,
-        defaultSessionUser,
-        defaultUser
-      );
-      service.signIn(defaultLoginDetails).subscribe(() => {
-        expect(true).toBeTruthy();
-      }, shouldNotFail);
-    }));
+    function handleCookie(
+      success: boolean,
+      expectation?: (req: TestRequest) => void
+    ) {
+      intercept(expectCookieRequest(), success, "<html></html>", expectation);
+    }
 
-    it("should store user", fakeAsync(() => {
-      const userDetails = {
-        id: 1,
-        userName: "username",
-        preferences: {},
-        rolesMask: 1,
-        imageUrls: [
-          { size: "extralarge", url: "path.png", width: 300, height: 300 },
-        ],
-      } as IUser;
-      const authDetails = {
-        authToken: "xxxxxxxxxxxxxxxx",
-        userName: "username",
-      } as ISessionUser;
+    function interceptSessionUser(user: SessionUser, error?: ApiErrorDetails) {
+      const subject = new BehaviorSubject(user);
+      if (!user) {
+        subject.error(error);
+      }
+      spec.service["apiShow"] = jasmine.createSpy().and.callFake(() => subject);
+    }
 
-      const user = new User(userDetails);
-      const session = new SessionUser(authDetails);
-      createResponse("/security/", defaultLoginDetails, session, user);
-      service.signIn(defaultLoginDetails).subscribe(() => {}, shouldNotFail);
+    function interceptUser(user: User, error?: ApiErrorDetails) {
+      const subject = new BehaviorSubject(user);
+      if (!user) {
+        subject.error(error);
+      }
+      spyOn(userApi, "show").and.callFake(() => subject);
+    }
 
-      expect(service.getLocalUser()).toEqual(
-        new SessionUser({
-          id: 1,
-          authToken: "xxxxxxxxxxxxxxxx",
-          userName: "username",
-          preferences: {},
-          rolesMask: 1,
-          imageUrls: [
-            {
-              size: ImageSizes.extraLarge,
-              url: "path.png",
-              width: 300,
-              height: 300,
-            },
-          ],
-        })
-      );
-    }));
+    describe("1st request: Login form", () => {
+      beforeEach(() => {
+        interceptSessionUser(defaultSessionUser);
+        interceptUser(defaultUser);
+      });
 
-    it("should ignore excess user data", () => {
-      const userDetails = {
-        id: 1,
-        email: "test@example.com",
-        userName: "username",
-        signInCount: 1,
-        failedAttempts: 2,
-        preferences: {},
-        isConfirmed: true,
-        imageUrls: [
-          { size: "extralarge", url: "path.png", width: 300, height: 300 },
-        ],
-        rolesMask: 1,
-        rolesMaskNames: ["user"],
-        resetPasswordSentAt: "1970-01-01T00:00:00.000+10:00",
-        rememberCreatedAt: "1970-01-01T00:00:00.000+10:00",
-        currentSignInAt: "1970-01-01T00:00:00.000+10:00",
-        lastSignInAt: "1970-01-01T00:00:00.000+10:00",
-        confirmedAt: "1970-01-01T00:00:00.000+10:00",
-        confirmationSentAt: "1970-01-01T00:00:00.000+10:00",
-        lockedAt: "1970-01-01T00:00:00.000+10:00",
-        createdAt: "1970-01-01T00:00:00.000+10:00",
-        updatedAt: "1970-01-01T00:00:00.000+10:00",
-        lastSeenAt: "1970-01-01T00:00:00.000+10:00",
-      } as IUser;
-      const authDetails = {
-        authToken: "xxxxxxxxxxxxxxxx",
-        userName: "username",
-      } as ISessionUser;
+      it("should request login form", (done) => {
+        spec.service.signIn(defaultLoginDetails).subscribe(noop, shouldNotFail);
 
-      const user = new User(userDetails);
-      const session = new SessionUser(authDetails);
-      createResponse("/security/", defaultLoginDetails, session, user);
-      service.signIn(defaultLoginDetails).subscribe(() => {}, shouldNotFail);
+        handleLoginForm(defaultAuthToken, (req) => {
+          expect(req.request.responseType).toBe("text");
+          expect(req.request.headers.get("Accept")).not.toBe(
+            "application/json"
+          );
+          expect(req.request.headers.get("Content-Type")).not.toBe(
+            "application/json"
+          );
+          expectCookieRequest();
+          done();
+        });
+      });
 
-      expect(service.getLocalUser()).toEqual(
-        new SessionUser({
-          id: 1,
-          userName: "username",
-          rolesMask: 1,
-          preferences: {},
-          authToken: "xxxxxxxxxxxxxxxx",
-          imageUrls: [
-            {
-              size: ImageSizes.extraLarge,
-              url: "path.png",
-              width: 300,
-              height: 300,
-            },
-          ],
-        })
-      );
+      it("should handle login form failure", (done) => {
+        spec.service
+          .signIn(defaultLoginDetails)
+          .subscribe(shouldNotSucceed, (details) => {
+            expect(details).toBeTruthy();
+            done();
+          });
+
+        handleLoginForm(undefined);
+      });
     });
 
-    it("should trigger authTrigger", fakeAsync(() => {
-      const spy = jasmine.createSpy();
-      createResponse(
-        "/security/",
-        defaultLoginDetails,
-        defaultSessionUser,
-        defaultUser
-      );
+    describe("2nd request: Authentication cookies", () => {
+      beforeEach(() => {
+        interceptSessionUser(defaultSessionUser);
+        interceptUser(defaultUser);
+      });
 
-      service.getAuthTrigger().subscribe(spy, shouldNotFail, shouldNotComplete);
-      service.signIn(defaultLoginDetails).subscribe();
+      it("should request api cookie", (done) => {
+        spec.service.signIn(defaultLoginDetails).subscribe(noop, shouldNotFail);
 
-      // Should call auth trigger twice, first time is when the subscription is created
-      expect(spy).toHaveBeenCalledTimes(2);
-    }));
-
-    it("should handle signIn error", fakeAsync(() => {
-      createError("apiCreate", "/security/", apiErrorDetails);
-      service
-        .signIn(defaultLoginDetails)
-        .subscribe(shouldNotSucceed, (err: ApiErrorDetails) => {
-          expect(err).toBeTruthy();
-          expect(err).toEqual(apiErrorDetails);
+        handleLoginForm(defaultAuthToken);
+        handleCookie(true, (req) => {
+          expect(req.request.responseType).toBe("text");
+          expect(req.request.headers.get("Accept")).toBe("text/html");
+          expect(req.request.headers.get("Content-Type")).toBe(
+            "application/x-www-form-urlencoded"
+          );
+          done();
         });
-    }));
+      });
 
-    it("should handle get user error", fakeAsync(() => {
-      createResponse(
-        "/security/",
-        defaultLoginDetails,
-        defaultSessionUser,
-        undefined
-      );
-
-      service
-        .signIn(defaultLoginDetails)
-        .subscribe(shouldNotSucceed, (err: ApiErrorDetails) => {
-          expect(err).toBeTruthy();
-          expect(err).toEqual(apiErrorDetails);
+      it("should request api cookie with login details", (done) => {
+        const details = new LoginDetails({
+          login: "test username",
+          password: "Ex@mp1e_P@55w0rd",
         });
-    }));
+        const authToken = "5efm2plggqiuvyjlghgp";
+        spec.service.signIn(details).subscribe(noop, shouldNotFail);
 
-    it("should trigger authTrigger on error", fakeAsync(() => {
-      const noop = () => {};
-      const spy = jasmine.createSpy();
-      createError("apiCreate", "/security/", apiErrorDetails);
+        handleLoginForm(authToken);
+        handleCookie(true, (req) => {
+          expect(req.request.body).toBe(
+            "user%5Blogin%5D=test+username&" +
+              "user%5Bpassword%5D=Ex%40mp1e_P%4055w0rd&" +
+              "user%5Bremember_me%5D=0&" +
+              "commit=Log%2Bin&" +
+              "authenticity_token=5efm2plggqiuvyjlghgp"
+          );
+          done();
+        });
+      });
 
-      service.getAuthTrigger().subscribe(spy, shouldNotFail, shouldNotComplete);
-      service.signIn(defaultLoginDetails).subscribe(noop, noop);
+      it("should handle api cookie failure", (done) => {
+        spec.service
+          .signIn(defaultLoginDetails)
+          .subscribe(shouldNotSucceed, (details) => {
+            expect(details).toBeTruthy();
+            done();
+          });
 
-      // Should call auth trigger twice, first time is when the subscription is created
-      expect(spy).toHaveBeenCalledTimes(2);
-    }));
+        handleLoginForm(defaultAuthToken);
+        handleCookie(false);
+      });
+    });
+
+    describe("3rd request: Session User details", () => {
+      beforeEach(() => {
+        interceptUser(defaultUser);
+      });
+
+      it("should request session user details", () => {
+        interceptSessionUser(defaultSessionUser);
+        spec.service.signIn(defaultLoginDetails).subscribe(noop, shouldNotFail);
+        handleLoginForm(defaultAuthToken);
+        handleCookie(true);
+        expect(spec.service["apiShow"]).toHaveBeenCalledTimes(1);
+      });
+
+      it("should request session user details with anti cache containing current timestamp", () => {
+        interceptSessionUser(defaultSessionUser);
+        spec.service.signIn(defaultLoginDetails).subscribe(noop, shouldNotFail);
+        handleLoginForm(defaultAuthToken);
+        handleCookie(true);
+
+        // Validate timestamp within 100 ms
+        const timestamp = Math.floor(Date.now() / 100);
+        expect(
+          (spec.service["apiShow"] as jasmine.Spy).calls.mostRecent().args[0]
+        ).toContain("/security/user?antiCache=" + timestamp);
+      });
+
+      it("should handle user details failure", (done) => {
+        interceptSessionUser(undefined, defaultError);
+        spec.service
+          .signIn(defaultLoginDetails)
+          .subscribe(shouldNotSucceed, (details) => {
+            expect(details).toBeTruthy();
+            done();
+          });
+        handleLoginForm(defaultAuthToken);
+        handleCookie(true);
+      });
+    });
+
+    describe("4th request: User details", () => {
+      beforeEach(() => {
+        interceptSessionUser(defaultSessionUser);
+      });
+
+      it("should request user details", () => {
+        interceptUser(defaultUser);
+        spec.service.signIn(defaultLoginDetails).subscribe(noop, shouldNotFail);
+        handleLoginForm(defaultAuthToken);
+        handleCookie(true);
+        expect(userApi.show).toHaveBeenCalledTimes(1);
+      });
+
+      it("should handle user details failure", (done) => {
+        interceptUser(undefined, defaultError);
+        spec.service
+          .signIn(defaultLoginDetails)
+          .subscribe(shouldNotSucceed, (details) => {
+            expect(details).toBeTruthy();
+            done();
+          });
+        handleLoginForm(defaultAuthToken);
+        handleCookie(true);
+      });
+    });
+
+    describe("success", () => {
+      function successfulRequest() {
+        interceptSessionUser(defaultSessionUser);
+        interceptUser(defaultUser);
+        spec.service.signIn(defaultLoginDetails).subscribe(noop, noop);
+        handleLoginForm(defaultAuthToken);
+        handleCookie(true);
+      }
+
+      it("should store session user in local storage", () => {
+        successfulRequest();
+        expect(spec.service.getLocalUser()).toEqual(
+          new SessionUser({
+            ...defaultSessionUser.toJSON(),
+            ...defaultUser.toJSON(),
+          })
+        );
+      });
+      it("should trigger authTrigger", () => {
+        const trigger = spec.service.getAuthTrigger();
+        trigger.subscribe(noop, noop, shouldNotComplete);
+        spyOn(trigger, "next").and.callThrough();
+        expect(trigger.next).toHaveBeenCalledTimes(0);
+        successfulRequest();
+        expect(trigger.next).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("error", () => {
+      function errorRequest() {
+        interceptSessionUser(undefined, defaultError);
+        interceptUser(defaultUser);
+        spec.service.signIn(defaultLoginDetails).subscribe(noop, noop);
+        handleLoginForm(defaultAuthToken);
+        handleCookie(true);
+      }
+
+      it("should clear session user", () => {
+        spec.service["storeLocalUser"](defaultSessionUser);
+        errorRequest();
+        expect(spec.service.getLocalUser()).toBeFalsy();
+      });
+
+      it("should trigger authTrigger", () => {
+        const trigger = spec.service.getAuthTrigger();
+        trigger.subscribe(noop, noop, shouldNotComplete);
+        spyOn(trigger, "next").and.callThrough();
+        expect(trigger.next).toHaveBeenCalledTimes(0);
+        errorRequest();
+        expect(trigger.next).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
   describe("signOut", () => {
     function createSuccess(path: string): void {
-      spyOn(service as any, "apiDestroy").and.callFake(
+      spyOn(spec.service, "apiDestroy" as any).and.callFake(
         (destroyPath: string) => {
           expect(destroyPath).toBe(path);
-
           return new BehaviorSubject<void>(null);
         }
       );
     }
 
-    it("should call apiDestroy", fakeAsync(() => {
+    function createError(url: string, error: ApiErrorDetails): void {
+      spec.service["apiDestroy"] = jasmine
+        .createSpy()
+        .and.callFake((path: string) => {
+          expect(path).toBe(url);
+          const subject = new Subject();
+          subject.error(error);
+          return subject;
+        });
+    }
+
+    it("should call apiDestroy", () => {
       createSuccess("/security/");
-      service.signOut().subscribe();
-      expect(service["apiDestroy"]).toHaveBeenCalledWith("/security/");
-    }));
+      spec.service.signOut().subscribe(noop, noop);
+      expect(spec.service["apiDestroy"]).toHaveBeenCalledWith("/security/");
+    });
 
-    it("should handle response", fakeAsync(() => {
+    it("should handle response", (done) => {
       createSuccess("/security/");
-      service
-        .signOut()
-        .subscribe(() => expect(true).toBeTruthy(), shouldNotFail);
-    }));
+      spec.service.signOut().subscribe(() => {
+        ok(true);
+        done();
+      }, shouldNotFail);
+    });
 
-    it("should clear session user", fakeAsync(() => {
+    it("should clear session user", () => {
       createSuccess("/security/");
-      service.signOut().subscribe(() => {}, shouldNotFail);
+      spec.service.signOut().subscribe(noop, shouldNotFail);
+      expect(spec.service.getLocalUser()).toBeFalsy();
+    });
 
-      expect(service.getLocalUser()).toBeFalsy();
-    }));
-
-    it("should trigger authTrigger", fakeAsync(() => {
+    it("should trigger authTrigger", () => {
       const spy = jasmine.createSpy();
       createSuccess("/security/");
 
-      service.getAuthTrigger().subscribe(spy, shouldNotFail, shouldNotComplete);
-      service.signOut().subscribe();
+      spec.service
+        .getAuthTrigger()
+        .subscribe(spy, shouldNotFail, shouldNotComplete);
+      spec.service.signOut().subscribe();
 
       // Should call auth trigger twice, first time is when the subscription is created
       expect(spy).toHaveBeenCalledTimes(2);
-    }));
+    });
 
-    it("should handle error", fakeAsync(() => {
-      createError("apiDestroy", "/security/", apiErrorDetails);
-      service.signOut().subscribe(shouldNotSucceed, (err: ApiErrorDetails) => {
-        expect(err).toBeTruthy();
+    it("should handle error", () => {
+      createError("/security/", apiErrorDetails);
+      spec.service.signOut().subscribe(shouldNotSucceed, (err) => {
         expect(err).toEqual(apiErrorDetails);
       });
-    }));
+    });
 
-    it("should trigger authTrigger on error", fakeAsync(() => {
-      const noop = () => {};
+    it("should trigger authTrigger on error", () => {
       const spy = jasmine.createSpy();
-      createError("apiDestroy", "/security/", apiErrorDetails);
+      createError("/security/", apiErrorDetails);
 
-      service.getAuthTrigger().subscribe(spy, shouldNotFail, shouldNotComplete);
-      service.signOut().subscribe(noop, noop);
+      spec.service
+        .getAuthTrigger()
+        .subscribe(spy, shouldNotFail, shouldNotComplete);
+      spec.service.signOut().subscribe(noop, noop);
 
       // Should call auth trigger twice, first time is when the subscription is created
       expect(spy).toHaveBeenCalledTimes(2);
-    }));
+    });
   });
 });

--- a/src/app/test/fakes/ApiErrorDetails.ts
+++ b/src/app/test/fakes/ApiErrorDetails.ts
@@ -1,5 +1,5 @@
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
-import { apiReturnCodes } from "@baw-api/baw-api.service";
+import { ApiResponse, apiReturnCodes } from "@baw-api/baw-api.service";
 
 type HTTPStatus =
   | "Unauthorized"
@@ -8,6 +8,13 @@ type HTTPStatus =
   | "Unprocessable Entity"
   | "Custom";
 
+/**
+ * Used to generate a well constructed error object after the interceptor
+ * has intercepted and converted the API response
+ *
+ * @param type Http status type
+ * @param custom Custom error details
+ */
 export function generateApiErrorDetails(
   type: HTTPStatus = "Unauthorized",
   custom?: Partial<ApiErrorDetails>
@@ -38,5 +45,31 @@ export function generateApiErrorDetails(
     status: custom?.status ?? status ?? apiReturnCodes.unknown,
     message: custom?.message ?? message ?? "Unknown",
     info: custom?.info ?? undefined,
+  };
+}
+
+/**
+ * Used to generate a well constructed error object for API responses
+ * that do not conform to the standard
+ *
+ * @param type Http status type
+ * @param custom Custom error details
+ */
+export function generateApiErrorResponse(
+  type: HTTPStatus = "Unauthorized",
+  custom?: Partial<ApiErrorDetails>
+): ApiResponse<null> {
+  const details = generateApiErrorDetails(type, custom);
+
+  return {
+    meta: {
+      status: details.status,
+      message: type,
+      error: {
+        details: custom?.message ?? details.message,
+        info: custom?.info,
+      },
+    },
+    data: null,
   };
 }

--- a/src/app/test/helpers/baw-client.ts
+++ b/src/app/test/helpers/baw-client.ts
@@ -1,0 +1,69 @@
+import { Type } from "@angular/core";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { getRouteConfigForPage } from "@helpers/page/pageRouting";
+import { StrongRoute } from "@interfaces/strongRoute";
+import { createRoutingFactory, SpectatorRouting } from "@ngneat/spectator";
+import { BawClientComponent } from "@shared/baw-client/baw-client.component";
+import { SharedModule } from "@shared/shared.module";
+import { websiteHttpUrl } from "./url";
+
+//TODO: OLD-CLIENT REMOVE
+export function validateBawClientPage<Component extends Type<any>>(
+  routes: StrongRoute,
+  component: Component,
+  modules: any[],
+  route: string,
+  validatePageLoaded: string,
+  interceptApiRequests?: (spec: SpectatorRouting<Component>) => void
+) {
+  let spec: SpectatorRouting<Component>;
+  const compiledRoutes = routes.compileRoutes(getRouteConfigForPage);
+  const createComponent = createRoutingFactory({
+    component,
+    imports: [SharedModule, MockBawApiModule, ...modules],
+    routes: compiledRoutes,
+    stubsEnabled: false,
+  });
+
+  function getBawClient() {
+    return spec.query(BawClientComponent);
+  }
+
+  function waitForLoad() {
+    return new Promise<void>((resolve) =>
+      getBawClient()["iframeRef"].nativeElement.addEventListener("load", () =>
+        resolve()
+      )
+    );
+  }
+
+  function setup(url: string) {
+    spec = createComponent();
+    interceptApiRequests?.(spec);
+    spec.router.navigateByUrl(url);
+    spec.detectChanges();
+  }
+
+  it("should have correct route", async () => {
+    setup(route);
+    await waitForLoad();
+    spec.detectChanges();
+
+    const bawClient = getBawClient();
+    expect(bawClient).toBeTruthy();
+    expect(bawClient["iframeRef"].nativeElement.src).toEqual(
+      `${websiteHttpUrl}/assets/old-client/#${route}`
+    );
+  });
+
+  it("should load page", async () => {
+    setup(route);
+    await waitForLoad();
+    spec.detectChanges();
+
+    const bawClient = getBawClient();
+    expect(
+      bawClient["iframeRef"].nativeElement.contentWindow.document.body
+    ).toContainText(validatePageLoaded);
+  });
+}

--- a/src/test.ts
+++ b/src/test.ts
@@ -16,6 +16,9 @@ getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting()
 );
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+
 // Then we find all the tests.
 const context = require.context("./", true, /\.spec\.ts$/);
 // And load the modules.


### PR DESCRIPTION
# Build Baw Client

Build baw client in github actions, this allows the unit tests to validate that the baw client has been correctly integrated into the project.

## Changes

- Added tests for baw client pages
- Updated actions workflow to build baw client
- Added resolvers to baw client pages so that if the model is not available, we use the projects error page instead of the baw client error handler

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
