### PR TITLE
Fix production baw-client linking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "eslint-plugin-import": "^2.23.4",
         "eslint-plugin-jsdoc": "^35.4.3",
         "eslint-plugin-prefer-arrow": "1.2.3",
-        "eslint-plugin-rxjs": "*",
+        "eslint-plugin-rxjs": "latest",
         "eslint-plugin-rxjs-angular": "^1.0.6",
         "faker": "^5.5.3",
         "jasmine-core": "^3.8.0",

--- a/src/app/components/shared/baw-client/baw-client.component.spec.ts
+++ b/src/app/components/shared/baw-client/baw-client.component.spec.ts
@@ -1,9 +1,8 @@
 import { ElementRef } from "@angular/core";
 import { NavigationEnd, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
-import { API_ROOT } from "@helpers/app-initializer/app-initializer";
 import { createComponentFactory, Spectator } from "@ngneat/spectator";
-import { assetRoot } from "@services/config/config.service";
+import { ConfigService } from "@services/config/config.service";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { LoadingModule } from "@shared/loading/loading.module";
 import { assertSpinner } from "@test/helpers/html";
@@ -16,7 +15,7 @@ import { BawClientComponent } from "./baw-client.component";
 describe("BawClientComponent", () => {
   let isFirefox: boolean;
   let events: BehaviorSubject<NavigationEnd>;
-  let apiRoot: string;
+  let config: ConfigService;
   let spec: Spectator<BawClientComponent>;
   const createComponent = createComponentFactory({
     component: BawClientComponent,
@@ -24,7 +23,8 @@ describe("BawClientComponent", () => {
   });
 
   function bawClientSource(route: string) {
-    return `${websiteHttpUrl}${assetRoot}/old-client/#${route}`;
+    const { oldClientOrigin, oldClientDir } = config.endpoints;
+    return `${oldClientOrigin}${oldClientDir}${route}`;
   }
 
   function getIframe(): HTMLIFrameElement {
@@ -55,7 +55,7 @@ describe("BawClientComponent", () => {
     events = undefined;
     spec = createComponent({ detectChanges: false });
     isFirefox = spec.inject(DeviceDetectorService).browser === "Firefox";
-    apiRoot = spec.inject(API_ROOT);
+    config = spec.inject(ConfigService);
   });
 
   afterEach(() => {

--- a/src/app/components/shared/baw-client/baw-client.component.spec.ts
+++ b/src/app/components/shared/baw-client/baw-client.component.spec.ts
@@ -1,7 +1,10 @@
 import { ElementRef } from "@angular/core";
 import { NavigationEnd, Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { API_ROOT } from "@helpers/app-initializer/app-initializer";
 import { createComponentFactory, Spectator } from "@ngneat/spectator";
+import { assetRoot } from "@services/config/config.service";
+import { MockAppConfigModule } from "@services/config/configMock.module";
 import { LoadingModule } from "@shared/loading/loading.module";
 import { assertSpinner } from "@test/helpers/html";
 import { websiteHttpUrl } from "@test/helpers/url";
@@ -13,11 +16,16 @@ import { BawClientComponent } from "./baw-client.component";
 describe("BawClientComponent", () => {
   let isFirefox: boolean;
   let events: BehaviorSubject<NavigationEnd>;
+  let apiRoot: string;
   let spec: Spectator<BawClientComponent>;
   const createComponent = createComponentFactory({
     component: BawClientComponent,
-    imports: [LoadingModule, RouterTestingModule],
+    imports: [LoadingModule, RouterTestingModule, MockAppConfigModule],
   });
+
+  function bawClientSource(route: string) {
+    return `${websiteHttpUrl}${assetRoot}/old-client/#${route}`;
+  }
 
   function getIframe(): HTMLIFrameElement {
     return spec.query("iframe");
@@ -36,7 +44,7 @@ describe("BawClientComponent", () => {
 
     if (!events) {
       events = new BehaviorSubject(event);
-      spec.component["router"] = ({ url, events } as Partial<Router>) as Router;
+      spec.component["router"] = { url, events } as Partial<Router> as Router;
     } else {
       events.next(event);
     }
@@ -47,6 +55,7 @@ describe("BawClientComponent", () => {
     events = undefined;
     spec = createComponent({ detectChanges: false });
     isFirefox = spec.inject(DeviceDetectorService).browser === "Firefox";
+    apiRoot = spec.inject(API_ROOT);
   });
 
   afterEach(() => {
@@ -81,24 +90,24 @@ describe("BawClientComponent", () => {
     });
 
     it("should update iframe height on height calculation", () => {
-      const dummyIFrame: ElementRef<HTMLIFrameElement> = ({
+      const dummyIFrame: ElementRef<HTMLIFrameElement> = {
         nativeElement: {
           style: { height: undefined },
           contentDocument: { body: { scrollHeight: 10000 } },
         },
-      } as Partial<ElementRef<HTMLIFrameElement>>) as any;
+      } as Partial<ElementRef<HTMLIFrameElement>> as any;
       spec.component["iframeRef"] = dummyIFrame;
       spec.component.updateIframeSize();
       expect(dummyIFrame.nativeElement.style.height).toBe("10050px");
     });
 
     it("should not infinitely update iframe height on height calculation", () => {
-      const dummyIFrame: ElementRef<HTMLIFrameElement> = ({
+      const dummyIFrame: ElementRef<HTMLIFrameElement> = {
         nativeElement: {
           style: { height: undefined },
           contentDocument: { body: { scrollHeight: 10000 } },
         },
-      } as Partial<ElementRef<HTMLIFrameElement>>) as any;
+      } as Partial<ElementRef<HTMLIFrameElement>> as any;
       spec.component["iframeRef"] = dummyIFrame;
       spec.component.updateIframeSize();
       spec.component.updateIframeSize();
@@ -145,10 +154,7 @@ describe("BawClientComponent", () => {
     it("should pass url to old client in iframe", () => {
       navigate("/home");
       spec.detectChanges();
-
-      expect(getIframe().src).toBe(
-        websiteHttpUrl + "/assets/old-client/#/home"
-      );
+      expect(getIframe().src).toBe(bawClientSource("/home"));
     });
 
     it("should pass updated url parameters to old client on change", () => {
@@ -156,10 +162,7 @@ describe("BawClientComponent", () => {
       spec.detectChanges();
       navigate("/house");
       spec.detectChanges();
-
-      expect(getIframe().src).toBe(
-        websiteHttpUrl + "/assets/old-client/#/house"
-      );
+      expect(getIframe().src).toBe(bawClientSource("/house"));
     });
   });
 });

--- a/src/app/components/shared/baw-client/baw-client.component.spec.ts
+++ b/src/app/components/shared/baw-client/baw-client.component.spec.ts
@@ -6,7 +6,6 @@ import { ConfigService } from "@services/config/config.service";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { LoadingModule } from "@shared/loading/loading.module";
 import { assertSpinner } from "@test/helpers/html";
-import { websiteHttpUrl } from "@test/helpers/url";
 import { DeviceDetectorService } from "ngx-device-detector";
 import { BehaviorSubject } from "rxjs";
 import { BawClientComponent } from "./baw-client.component";
@@ -23,8 +22,8 @@ describe("BawClientComponent", () => {
   });
 
   function bawClientSource(route: string) {
-    const { oldClientOrigin, oldClientDir } = config.endpoints;
-    return `${oldClientOrigin}${oldClientDir}${route}`;
+    const { oldClientOrigin, oldClientBase } = config.endpoints;
+    return `${oldClientOrigin}${oldClientBase}#${route}`;
   }
 
   function getIframe(): HTMLIFrameElement {

--- a/src/app/components/shared/baw-client/baw-client.component.ts
+++ b/src/app/components/shared/baw-client/baw-client.component.ts
@@ -95,9 +95,11 @@ export class BawClientComponent extends withUnsubscribe() implements OnInit {
   }
 
   protected updateUrl(url: string) {
+    const { oldClientOrigin, oldClientDir } = this.config.endpoints;
+
     // Bypass angular default security
     this.url = this.sanitizer.bypassSecurityTrustResourceUrl(
-      this.config.getBawClientUrl(url)
+      oldClientOrigin + oldClientDir + url
     );
   }
 }

--- a/src/app/components/shared/baw-client/baw-client.component.ts
+++ b/src/app/components/shared/baw-client/baw-client.component.ts
@@ -95,11 +95,11 @@ export class BawClientComponent extends withUnsubscribe() implements OnInit {
   }
 
   protected updateUrl(url: string) {
-    const { oldClientOrigin, oldClientDir } = this.config.endpoints;
+    const { oldClientOrigin, oldClientBase } = this.config.endpoints;
 
     // Bypass angular default security
     this.url = this.sanitizer.bypassSecurityTrustResourceUrl(
-      oldClientOrigin + oldClientDir + url
+      oldClientOrigin + oldClientBase + "#" + url
     );
   }
 }

--- a/src/app/components/shared/form/form.component.spec.ts
+++ b/src/app/components/shared/form/form.component.spec.ts
@@ -317,7 +317,7 @@ describe("FormComponent", () => {
   });
 
   // TODO Add tests for recaptcha
-  describe("Recaptcha", () => {
+  xdescribe("Recaptcha", () => {
     it("should disable submit button while loading recaptcha seed", () => {});
     it("should re-enable submit button when recaptcha seed loaded", () => {});
     it("should display error notification if recaptcha fails to load", () => {});

--- a/src/app/helpers/app-initializer/app-initializer.ts
+++ b/src/app/helpers/app-initializer/app-initializer.ts
@@ -61,7 +61,7 @@ export interface Endpoints {
   clientOrigin: string;
   clientDir: string;
   oldClientOrigin: string;
-  oldClientDir: string;
+  oldClientBase: string;
 }
 
 export interface Keys {

--- a/src/app/helpers/app-initializer/app-initializer.ts
+++ b/src/app/helpers/app-initializer/app-initializer.ts
@@ -60,6 +60,8 @@ export interface Endpoints {
   apiRoot: string;
   clientOrigin: string;
   clientDir: string;
+  oldClientOrigin: string;
+  oldClientDir: string;
 }
 
 export interface Keys {

--- a/src/app/services/config/config.service.ts
+++ b/src/app/services/config/config.service.ts
@@ -1,6 +1,5 @@
 import { Inject, Injectable } from "@angular/core";
 import {
-  API_ROOT,
   Configuration,
   Endpoints,
   isConfiguration,
@@ -23,7 +22,6 @@ export class ConfigService {
 
   public constructor(
     private notification: ToastrService,
-    @Inject(API_ROOT) private apiRoot: string,
     @Inject(IS_SERVER_PLATFORM) private isServer: boolean
   ) {
     if (!isConfiguration(environment, this.isServer)) {

--- a/src/app/services/config/config.service.ts
+++ b/src/app/services/config/config.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from "@angular/core";
 import {
+  API_ROOT,
   Configuration,
   Endpoints,
   isConfiguration,
@@ -22,6 +23,7 @@ export class ConfigService {
 
   public constructor(
     private notification: ToastrService,
+    @Inject(API_ROOT) private apiRoot: string,
     @Inject(IS_SERVER_PLATFORM) private isServer: boolean
   ) {
     if (!isConfiguration(environment, this.isServer)) {
@@ -40,6 +42,11 @@ export class ConfigService {
     }
 
     this._config = new Proxy(environment, {});
+  }
+
+  public getBawClientUrl(route: string): string {
+    // Transform the url into the format required by AngularJS using hash bang
+    return `${this.apiRoot}/listen_to/index.html#${route}`;
   }
 
   /** Get config data */

--- a/src/app/services/config/config.service.ts
+++ b/src/app/services/config/config.service.ts
@@ -44,11 +44,6 @@ export class ConfigService {
     this._config = new Proxy(environment, {});
   }
 
-  public getBawClientUrl(route: string): string {
-    // Transform the url into the format required by AngularJS using hash bang
-    return `${this.apiRoot}/listen_to/index.html#${route}`;
-  }
-
   /** Get config data */
   public get config(): Configuration {
     return this._config;

--- a/src/app/services/config/configMock.service.ts
+++ b/src/app/services/config/configMock.service.ts
@@ -36,7 +36,7 @@ export const testApiConfig = new Configuration({
     clientOrigin: "https://www.testing.com/site",
     clientDir: "/website",
     oldClientOrigin: websiteHttpUrl,
-    oldClientDir: `${assetRoot}/old-client/#`,
+    oldClientBase: `${assetRoot}/old-client/index.html`,
   },
   keys: {
     googleMaps: "<< googleMaps >>",

--- a/src/app/services/config/configMock.service.ts
+++ b/src/app/services/config/configMock.service.ts
@@ -5,14 +5,11 @@ import {
   Keys,
   Settings,
 } from "@helpers/app-initializer/app-initializer";
+import { websiteHttpUrl } from "@test/helpers/url";
 import { assetRoot } from "./config.service";
 
 @Injectable()
 export class AppConfigMockService {
-  public getBawClientUrl(route: string): string {
-    return `${assetRoot}/old-client/#${route}`;
-  }
-
   public get config(): Configuration {
     return new Proxy(testApiConfig, {});
   }
@@ -38,6 +35,8 @@ export const testApiConfig = new Configuration({
     apiRoot: "https://www.testing.com/api",
     clientOrigin: "https://www.testing.com/site",
     clientDir: "/website",
+    oldClientOrigin: websiteHttpUrl,
+    oldClientDir: `${assetRoot}/old-client/#`,
   },
   keys: {
     googleMaps: "<< googleMaps >>",

--- a/src/app/services/config/configMock.service.ts
+++ b/src/app/services/config/configMock.service.ts
@@ -5,9 +5,14 @@ import {
   Keys,
   Settings,
 } from "@helpers/app-initializer/app-initializer";
+import { assetRoot } from "./config.service";
 
 @Injectable()
 export class AppConfigMockService {
+  public getBawClientUrl(route: string): string {
+    return `${assetRoot}/old-client/#${route}`;
+  }
+
   public get config(): Configuration {
     return new Proxy(testApiConfig, {});
   }

--- a/src/app/test/helpers/baw-client.ts
+++ b/src/app/test/helpers/baw-client.ts
@@ -27,8 +27,8 @@ export function validateBawClientPage<Component extends Type<any>>(
   });
 
   function bawClientSource() {
-    const { oldClientOrigin, oldClientDir } = config.endpoints;
-    return oldClientOrigin + oldClientDir + route;
+    const { oldClientOrigin, oldClientBase } = config.endpoints;
+    return oldClientOrigin + oldClientBase + "#" + route;
   }
 
   function getBawClient() {

--- a/src/app/test/helpers/baw-client.ts
+++ b/src/app/test/helpers/baw-client.ts
@@ -6,7 +6,6 @@ import { createRoutingFactory, SpectatorRouting } from "@ngneat/spectator";
 import { ConfigService } from "@services/config/config.service";
 import { BawClientComponent } from "@shared/baw-client/baw-client.component";
 import { SharedModule } from "@shared/shared.module";
-import { websiteHttpUrl } from "./url";
 
 //TODO: OLD-CLIENT REMOVE
 export function validateBawClientPage<Component extends Type<any>>(
@@ -28,7 +27,8 @@ export function validateBawClientPage<Component extends Type<any>>(
   });
 
   function bawClientSource() {
-    return websiteHttpUrl + config.getBawClientUrl(route);
+    const { oldClientOrigin, oldClientDir } = config.endpoints;
+    return oldClientOrigin + oldClientDir + route;
   }
 
   function getBawClient() {

--- a/src/assets/environment.json
+++ b/src/assets/environment.json
@@ -5,7 +5,7 @@
     "clientOrigin": "http://development.ecosounds.org:4200",
     "clientDir": "/",
     "oldClientOrigin": "https://api.staging.ecosounds.org",
-    "oldClientDir": "/listen_to/index.html#"
+    "oldClientBase": "/listen_to/index.html"
   },
   "keys": {
     "googleMaps": "",

--- a/src/assets/environment.json
+++ b/src/assets/environment.json
@@ -3,7 +3,9 @@
     "environment": "development",
     "apiRoot": "https://api.staging.ecosounds.org",
     "clientOrigin": "http://development.ecosounds.org:4200",
-    "clientDir": "/"
+    "clientDir": "/",
+    "oldClientOrigin": "https://api.staging.ecosounds.org",
+    "oldClientDir": "/listen_to/index.html#"
   },
   "keys": {
     "googleMaps": "",


### PR DESCRIPTION
# Fix production baw-client linking

This PR changes the behaviour of the `BawClientComponent` to make it functional with the production versions of workbench-client. Previously baw-client was hosted in the build files of workbench-client, which is incompatible with the deployment environment.  This is related to the following PR: https://github.com/QutEcoacoustics/baw-private/pull/176

## Changes

- Changed url linking iframe of baw-client from assets folder, to api root

## Problems

- Some visual bugs occur during development due to the baw-client dist packages existing on a different domain. A comment has been left in the code to explain this to future developers

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
