### PR TITLE
Project permissions issues

### DIFF
--- a/src/app/app.menus.ts
+++ b/src/app/app.menus.ts
@@ -36,7 +36,7 @@ export const isProjectEditorPredicate = (
   data: any
 ): boolean => {
   const project = (data?.project as ResolvedModel<Project>)?.model;
-  return isAdminPredicate(user) || project?.canEdit;
+  return isAdminPredicate(user) || !!project?.canEdit;
 };
 
 /**

--- a/src/app/app.menus.ts
+++ b/src/app/app.menus.ts
@@ -31,15 +31,12 @@ export const isLoggedInPredicate = (user: SessionUser): boolean => !!user;
  * @param user Session User Data
  * @param data Page Data
  */
-export const isProjectOwnerPredicate = (
+export const isProjectEditorPredicate = (
   user: SessionUser,
   data: any
 ): boolean => {
-  const project: ResolvedModel<Project> = data?.project;
-  return (
-    isLoggedInPredicate(user) &&
-    (isAdminPredicate(user) || user.id === project?.model?.ownerId)
-  );
+  const project = (data?.project as ResolvedModel<Project>)?.model;
+  return isAdminPredicate(user) || project?.canEdit;
 };
 
 /**

--- a/src/app/components/projects/projects.menus.ts
+++ b/src/app/components/projects/projects.menus.ts
@@ -8,7 +8,7 @@ import {
   defaultPermissionsIcon,
   isAdminPredicate,
   isLoggedInPredicate,
-  isProjectOwnerPredicate,
+  isProjectEditorPredicate,
 } from "src/app/app.menus";
 
 /*
@@ -69,7 +69,7 @@ export const editProjectMenuItem = menuRoute({
   icon: defaultEditIcon,
   label: "Edit this project",
   parent: projectMenuItem,
-  predicate: isProjectOwnerPredicate,
+  predicate: isProjectEditorPredicate,
   route: projectMenuItem.route.add("edit"),
   tooltip: () => "Change the details for this project",
 });
@@ -78,7 +78,7 @@ export const editProjectPermissionsMenuItem = menuRoute({
   icon: defaultPermissionsIcon,
   label: "Edit permissions",
   parent: projectMenuItem,
-  predicate: isProjectOwnerPredicate,
+  predicate: isProjectEditorPredicate,
   route: projectMenuItem.route.add("permissions"),
   tooltip: () => "Edit this projects permissions",
 });
@@ -97,7 +97,7 @@ export const deleteProjectMenuItem = menuRoute({
   icon: defaultDeleteIcon,
   label: "Delete Project",
   parent: projectMenuItem,
-  predicate: isProjectOwnerPredicate,
+  predicate: isProjectEditorPredicate,
   route: projectMenuItem.route.add("delete"),
   tooltip: () => "Delete this project",
 });
@@ -106,7 +106,7 @@ export const harvestProjectMenuItem = menuRoute({
   icon: defaultAudioIcon,
   label: "Harvest Data",
   parent: projectMenuItem,
-  predicate: isProjectOwnerPredicate,
+  predicate: isProjectEditorPredicate,
   route: projectMenuItem.route.add("harvest"),
   tooltip: () => "Upload new audio to this project",
 });

--- a/src/app/components/regions/regions.menus.ts
+++ b/src/app/components/regions/regions.menus.ts
@@ -4,7 +4,7 @@ import {
   defaultDeleteIcon,
   defaultEditIcon,
   defaultNewIcon,
-  isProjectOwnerPredicate,
+  isProjectEditorPredicate,
 } from "src/app/app.menus";
 
 export const regionsRoute = projectMenuItem.route.addFeatureModule("regions");
@@ -27,7 +27,7 @@ export const newRegionMenuItem = menuRoute({
   icon: defaultNewIcon,
   label: "New site",
   parent: projectMenuItem,
-  predicate: isProjectOwnerPredicate,
+  predicate: isProjectEditorPredicate,
   route: regionsRoute.add("new"),
   tooltip: () => "Create a new site",
 });
@@ -36,7 +36,7 @@ export const editRegionMenuItem = menuRoute({
   icon: defaultEditIcon,
   label: "Edit this site",
   parent: regionMenuItem,
-  predicate: isProjectOwnerPredicate,
+  predicate: isProjectEditorPredicate,
   route: regionMenuItem.route.add("edit"),
   tooltip: () => "Change the details for this site",
 });
@@ -45,7 +45,7 @@ export const deleteRegionMenuItem = menuRoute({
   icon: defaultDeleteIcon,
   label: "Delete site",
   parent: regionMenuItem,
-  predicate: isProjectOwnerPredicate,
+  predicate: isProjectEditorPredicate,
   route: regionMenuItem.route.add("delete"),
   tooltip: () => "Delete this site",
 });

--- a/src/app/components/shared/menu/menu.module.ts
+++ b/src/app/components/shared/menu/menu.module.ts
@@ -14,18 +14,23 @@ import { PermissionsShieldComponent } from "./permissions-shield/permissions-shi
 import { UserBadgeComponent } from "./user-badge/user-badge.component";
 import { WidgetDirective } from "./widget/widget.directive";
 
+const privateComponents = [
+  MenuButtonComponent,
+  MenuLinkComponent,
+  UserBadgeComponent,
+];
+
+const publicComponents = [
+  MenuComponent,
+  PermissionsShieldComponent,
+  WidgetDirective,
+];
+
 /**
  * Menus Module
  */
 @NgModule({
-  declarations: [
-    MenuButtonComponent,
-    MenuLinkComponent,
-    MenuComponent,
-    PermissionsShieldComponent,
-    UserBadgeComponent,
-    WidgetDirective,
-  ],
+  declarations: [...privateComponents, ...publicComponents],
   imports: [
     CommonModule,
     RouterModule,
@@ -37,6 +42,6 @@ import { WidgetDirective } from "./widget/widget.directive";
     PipesModule,
     DirectivesModule,
   ],
-  exports: [MenuComponent, PermissionsShieldComponent, WidgetDirective],
+  exports: publicComponents,
 })
 export class MenuModule {}

--- a/src/app/components/shared/menu/permissions-shield/permissions-shield.component.ts
+++ b/src/app/components/shared/menu/permissions-shield/permissions-shield.component.ts
@@ -18,12 +18,14 @@ import { WidgetComponent } from "../widget/widget.component";
   selector: "baw-permissions-shield",
   template: `
     <section *ngIf="model" class="pe-3 ps-3 pb-3">
-      <baw-user-badge
-        *ngFor="let badge of badges"
-        [label]="badge.label"
-        [user]="model[badge.userKey]"
-        [timestamp]="badge.timestamp"
-      ></baw-user-badge>
+      <div *ngFor="let badge of badges">
+        <h5 id="label">{{ badge.label }}</h5>
+
+        <baw-user-badge
+          [users]="model[badge.userKey]"
+          [timestamp]="badge.timestamp"
+        ></baw-user-badge>
+      </div>
 
       <ng-container *ngIf="accessLevel">
         <h5 id="access-level-label">Your access level</h5>
@@ -98,9 +100,9 @@ export class PermissionsShieldComponent implements OnInit, WidgetComponent {
         timestampKey: "updatedAt",
       },
       {
-        id: "ownerId",
+        id: "ownerIds",
         label: "Owned By",
-        userKey: "owner",
+        userKey: "owners",
       },
     ].forEach((badge) => {
       if (isInstantiated(model[badge.id])) {

--- a/src/app/components/shared/menu/user-badge/user-badge.component.spec.ts
+++ b/src/app/components/shared/menu/user-badge/user-badge.component.spec.ts
@@ -15,6 +15,7 @@ import { websiteHttpUrl } from "@test/helpers/url";
 import { DateTime } from "luxon";
 import { UserBadgeComponent } from "./user-badge.component";
 
+// TODO Update to validate multiple user badges
 describe("UserBadgeComponent", () => {
   let spec: Spectator<UserBadgeComponent>;
   const createComponent = createComponentFactory({
@@ -29,8 +30,6 @@ describe("UserBadgeComponent", () => {
     ],
   });
 
-  const getLabel = (_spec?: Spectator<any>) =>
-    (spec ?? _spec).query<HTMLHeadingElement>("#label");
   const getGhostUsername = (_spec?: Spectator<any>) =>
     (spec ?? _spec).query<HTMLAnchorElement>("#ghost-username");
   const getUsername = (_spec?: Spectator<any>) =>
@@ -46,7 +45,7 @@ describe("UserBadgeComponent", () => {
     spec = createComponent({
       props: {
         label: "label",
-        user: new User(generateUser()),
+        users: [new User(generateUser())],
         timestamp: DateTime.utc(),
         ...props,
       },
@@ -59,21 +58,15 @@ describe("UserBadgeComponent", () => {
     expect(spec.component).toBeTruthy();
   });
 
-  it("should display label", () => {
-    setup({ label: "custom label" });
-    spec.detectChanges();
-    expect(getLabel().innerText.trim()).toBe("custom label");
-  });
-
   describe("loading", () => {
     it("should display spinner when user is unresolved", () => {
-      setup({ user: UnresolvedModel.one as any });
+      setup({ users: [UnresolvedModel.one as any] });
       spec.detectChanges();
       assertSpinner(spec.fixture, true);
     });
 
     it("should not display spinner when user is resolved", () => {
-      setup({ user: new User(generateUser()) });
+      setup({ users: [new User(generateUser())] });
       spec.detectChanges();
       assertSpinner(spec.fixture, false);
     });
@@ -82,14 +75,14 @@ describe("UserBadgeComponent", () => {
   describe("ghost users", () => {
     it("should display username", () => {
       const user = User.deletedUser;
-      setup({ user });
+      setup({ users: [user] });
       spec.detectChanges();
       expect(getGhostUsername().innerHTML.trim()).toBe(user.userName);
     });
 
     it("should display image", () => {
       const user = User.deletedUser;
-      setup({ user });
+      setup({ users: [user] });
       spec.detectChanges();
       assertImage(
         getImage(),
@@ -102,14 +95,14 @@ describe("UserBadgeComponent", () => {
   describe("single user", () => {
     it("should display username", () => {
       const user = new User(generateUser());
-      setup({ user });
+      setup({ users: [user] });
       spec.detectChanges();
       expect(getUsername().innerHTML.trim()).toBe(user.userName);
     });
 
     it("username should route to user page", () => {
       const user = new User(generateUser());
-      setup({ user });
+      setup({ users: [user] });
       spec.detectChanges();
       assertUrl(getUsername(), user.viewUrl);
     });
@@ -120,7 +113,7 @@ describe("UserBadgeComponent", () => {
         userName: "custom username",
         imageUrls: undefined,
       });
-      setup({ user });
+      setup({ users: [user] });
       spec.detectChanges();
       assertImage(
         getImage(),
@@ -133,7 +126,7 @@ describe("UserBadgeComponent", () => {
       const imageIndex = 1;
       const user = new User({ ...generateUser(), userName: "custom username" });
       user.image[imageIndex].size = ImageSizes.small;
-      setup({ user });
+      setup({ users: [user] });
       spec.detectChanges();
       assertImage(
         getImage(),
@@ -144,7 +137,7 @@ describe("UserBadgeComponent", () => {
 
     it("image should route to user page", () => {
       const user = new User(generateUser());
-      setup({ user });
+      setup({ users: [user] });
       spec.detectChanges();
       assertUrl(getImageWrapper(), user.viewUrl);
     });
@@ -165,9 +158,9 @@ describe("UserBadgeComponent", () => {
 
   it("should detect changes to user", () => {
     const user = new User(generateUser());
-    setup({ user: UnresolvedModel.one as any });
+    setup({ users: [UnresolvedModel.one as any] });
     spec.detectChanges();
-    spec.setInput("user", user);
+    spec.setInput("users", [user]);
     spec.detectChanges();
 
     const username = getUsername(spec);

--- a/src/app/components/shared/menu/user-badge/user-badge.component.ts
+++ b/src/app/components/shared/menu/user-badge/user-badge.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from "@angular/core";
+import { Component, Input, OnChanges } from "@angular/core";
 import { ImageSizes } from "@interfaces/apiInterfaces";
 import { User } from "@models/User";
 import { DateTime } from "luxon";
@@ -10,29 +10,25 @@ import { DateTime } from "luxon";
 @Component({
   selector: "baw-user-badge",
   template: `
-    <!-- Heading -->
-    <h5 id="label">{{ label }}</h5>
+    <div *ngFor="let user of models">
+      <!-- Spinner -->
+      <baw-loading *ngIf="user | isUnresolved"></baw-loading>
 
-    <!-- Spinner -->
-    <baw-loading *ngIf="user | isUnresolved"></baw-loading>
-
-    <!-- User Resolved -->
-    <ng-container *ngIf="!(user | isUnresolved)">
-      <div id="users" class="d-flex mb-1">
+      <!-- User Resolved -->
+      <div *ngIf="!(user | isUnresolved)" id="users" class="d-flex mb-1">
         <!-- User image -->
         <div class="image">
-          <!-- Normal User -->
-          <a
-            *ngIf="!(user | isGhostUser); else userImage"
-            id="imageLink"
-            [bawUrl]="user.viewUrl"
-          >
-            <ng-container *ngTemplateOutlet="userImage"></ng-container>
-          </a>
+          <!-- Add link to non-ghost users -->
+          <ng-container *ngIf="!(user | isGhostUser); else userImage">
+            <a id="imageLink" [bawUrl]="user.viewUrl">
+              <ng-container *ngTemplateOutlet="userImage"></ng-container>
+            </a>
+          </ng-container>
 
-          <!-- Ghost User -->
+          <!-- User Image -->
           <ng-template #userImage>
             <img
+              class="rounded"
               [src]="user.image"
               [alt]="user.userName + ' profile picture'"
               [thumbnail]="thumbnail"
@@ -43,8 +39,8 @@ import { DateTime } from "luxon";
         <!-- User details -->
         <div class="body">
           <!-- Ghost User -->
-          <ng-container *ngIf="user | isGhostUser; else isUser" class="heading">
-            <span id="ghost-username">{{ user.userName }}</span>
+          <ng-container *ngIf="user | isGhostUser; else isUser">
+            <span id="ghost-username" class="heading">{{ user.userName }}</span>
           </ng-container>
 
           <!-- Normal User -->
@@ -65,13 +61,24 @@ import { DateTime } from "luxon";
           </span>
         </div>
       </div>
-    </ng-container>
+    </div>
   `,
   styleUrls: ["./user-badge.component.scss"],
 })
-export class UserBadgeComponent {
+export class UserBadgeComponent implements OnChanges {
   @Input() public label: string;
-  @Input() public user: User;
+  @Input() public users: User | User[];
   @Input() public timestamp?: DateTime;
   public thumbnail = ImageSizes.small;
+  public models: User[];
+
+  public ngOnChanges(): void {
+    if (!this.users) {
+      this.models = [];
+    } else if (this.users instanceof Array) {
+      this.models = this.users;
+    } else {
+      this.models = [this.users];
+    }
+  }
 }

--- a/src/app/components/sites/sites.menus.ts
+++ b/src/app/components/sites/sites.menus.ts
@@ -5,7 +5,7 @@ import {
   defaultDeleteIcon,
   defaultEditIcon,
   defaultNewIcon,
-  isProjectOwnerPredicate,
+  isProjectEditorPredicate,
 } from "src/app/app.menus";
 import { projectMenuItem } from "../projects/projects.menus";
 
@@ -29,7 +29,7 @@ export const newSiteMenuItem = menuRoute({
   icon: defaultNewIcon,
   label: "New site",
   parent: projectMenuItem,
-  predicate: isProjectOwnerPredicate,
+  predicate: isProjectEditorPredicate,
   route: sitesRoute.add("new"),
   tooltip: () => "Create a new site",
 });
@@ -45,7 +45,7 @@ export const editSiteMenuItem = menuRoute({
   icon: defaultEditIcon,
   label: "Edit this site",
   parent: siteMenuItem,
-  predicate: isProjectOwnerPredicate,
+  predicate: isProjectEditorPredicate,
   route: siteMenuItem.route.add("edit"),
   tooltip: () => "Change the details for this site",
 });
@@ -54,7 +54,7 @@ export const siteHarvestMenuItem = menuRoute({
   icon: defaultAudioIcon,
   label: "Harvesting",
   parent: siteMenuItem,
-  predicate: isProjectOwnerPredicate,
+  predicate: isProjectEditorPredicate,
   route: siteMenuItem.route.add("harvest"),
   tooltip: () => "Upload new audio to this site",
 });
@@ -63,7 +63,7 @@ export const deleteSiteMenuItem = menuRoute({
   icon: defaultDeleteIcon,
   label: "Delete site",
   parent: siteMenuItem,
-  predicate: isProjectOwnerPredicate,
+  predicate: isProjectEditorPredicate,
   route: siteMenuItem.route.add("delete"),
   tooltip: () => "Delete this site",
 });

--- a/src/app/models/Project.ts
+++ b/src/app/models/Project.ts
@@ -15,13 +15,7 @@ import {
 import { assetRoot } from "@services/config/config.service";
 import { Card } from "@shared/cards/cards.component";
 import { AbstractModel } from "./AbstractModel";
-import {
-  creator,
-  deleter,
-  hasMany,
-  hasOne,
-  updater,
-} from "./AssociationDecorators";
+import { creator, deleter, hasMany, updater } from "./AssociationDecorators";
 import {
   bawCollection,
   bawDateTime,
@@ -40,7 +34,7 @@ export interface IProject extends HasAllUsers, HasDescription {
   name?: Param;
   imageUrl?: string;
   accessLevel?: AccessLevel;
-  ownerId?: Id;
+  ownerIds?: Ids | Id[];
   siteIds?: Ids | Id[];
   regionIds?: Ids | Id[];
   notes?: Hash;
@@ -73,7 +67,7 @@ export class Project extends AbstractModel<IProject> implements IProject {
   public readonly updatedAt?: DateTimeTimezone;
   @bawDateTime()
   public readonly deletedAt?: DateTimeTimezone;
-  public readonly ownerId?: Id;
+  public readonly ownerIds?: Ids;
   @bawCollection({ persist: true })
   public readonly siteIds?: Ids;
   @bawCollection({ persist: true })
@@ -86,8 +80,8 @@ export class Project extends AbstractModel<IProject> implements IProject {
   public sites?: Site[];
   @hasMany<Project, Region>(SHALLOW_REGION, "regionIds")
   public regions?: Region[];
-  @hasOne<Project, User>(ACCOUNT, "ownerId")
-  public owner?: User;
+  @hasMany<Project, User>(ACCOUNT, "ownerIds")
+  public owners?: User[];
   @creator<Project>()
   public creator?: User;
   @updater<Project>()
@@ -105,6 +99,13 @@ export class Project extends AbstractModel<IProject> implements IProject {
       model: this,
       route: this.viewUrl,
     };
+  }
+
+  /**
+   * Returns true if user has the permissions to edit this model
+   */
+  public get canEdit(): boolean {
+    return [AccessLevel.owner, AccessLevel.writer].includes(this.accessLevel);
   }
 
   public get viewUrl(): string {

--- a/src/app/test/fakes/Project.ts
+++ b/src/app/test/fakes/Project.ts
@@ -8,7 +8,7 @@ export function generateProject(id?: Id): Required<IProject> {
     name: modelData.param(),
     imageUrl: modelData.imageUrl(),
     accessLevel: modelData.accessLevel(),
-    ownerId: modelData.id(),
+    ownerIds: modelData.ids(),
     siteIds: modelData.ids(),
     regionIds: modelData.ids(),
     notes: modelData.notes(),


### PR DESCRIPTION
# Fixed broken project permission issues

There was an issue where users with writer/owner access were not able to access the project/site/point settings.

## Changes

- Added multiple user support to `UserBadgeComponent`
- Renamed `isProjectOwnerPredicate` to `isProjectEditorPredicate`
- Fixed permission checking on `isProjectEditorPredicate`

## Problems

- Didn't add testing for multiple users in `UserBadgeComponent` 

## Visual Changes

### Multiple users in menu

![image](https://user-images.githubusercontent.com/3955116/126450523-cbaa809c-176d-4777-9974-32f3c2b367af.png)

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
