### PR TITLE
General Unit Test Cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "eslint-plugin-import": "^2.24.0",
         "eslint-plugin-jsdoc": "^36.0.7",
         "eslint-plugin-prefer-arrow": "1.2.3",
-        "eslint-plugin-rxjs": "*",
+        "eslint-plugin-rxjs": "latest",
         "eslint-plugin-rxjs-angular": "^1.0.6",
         "faker": "^5.5.3",
         "jasmine-core": "^3.8.0",

--- a/src/app/components/admin/analysis-jobs/details/details.component.spec.ts
+++ b/src/app/components/admin/analysis-jobs/details/details.component.spec.ts
@@ -54,19 +54,18 @@ describe("AdminAnalysisJobComponent", () => {
     const promise = Promise.all([
       nStepObservable(
         accountsSubject,
-        () => new User({ ...generateUser(1), userName: "custom username" })
+        () => new User(generateUser({ id: 1, userName: "custom username" }))
       ),
       nStepObservable(
         scriptsSubject,
-        () => new Script({ ...generateScript(1), name: "custom script" })
+        () => new Script(generateScript({ id: 1, name: "custom script" }))
       ),
       nStepObservable(
         savedSearchesSubject,
         () =>
-          new SavedSearch({
-            ...generateSavedSearch(1),
-            name: "custom saved search",
-          })
+          new SavedSearch(
+            generateSavedSearch({ id: 1, name: "custom saved search" })
+          )
       ),
     ]);
 

--- a/src/app/components/admin/analysis-jobs/list/list.component.spec.ts
+++ b/src/app/components/admin/analysis-jobs/list/list.component.spec.ts
@@ -1,33 +1,27 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AnalysisJobsService } from "@baw-api/analysis/analysis-jobs.service";
 import { defaultApiPageSize } from "@baw-api/baw-api.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { AnalysisJob } from "@models/AnalysisJob";
+import { createComponentFactory, Spectator } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { generateAnalysisJob } from "@test/fakes/AnalysisJob";
 import { assertPagination } from "@test/helpers/pagedTableTemplate";
-import { appLibraryImports } from "src/app/app.module";
 import { AdminAnalysisJobsComponent } from "./list.component";
 
 describe("AdminAnalysisJobsComponent", () => {
   let api: AnalysisJobsService;
   let defaultModels: AnalysisJob[];
-  let fixture: ComponentFixture<AdminAnalysisJobsComponent>;
+  let spec: Spectator<AdminAnalysisJobsComponent>;
+  const createComponent = createComponentFactory({
+    detectChanges: false,
+    component: AdminAnalysisJobsComponent,
+    imports: [SharedModule, RouterTestingModule, MockBawApiModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [
-        ...appLibraryImports,
-        SharedModule,
-        RouterTestingModule,
-        MockBawApiModule,
-      ],
-      declarations: [AdminAnalysisJobsComponent],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(AdminAnalysisJobsComponent);
-    api = TestBed.inject(AnalysisJobsService);
+    spec = createComponent();
+    api = spec.inject(AnalysisJobsService);
 
     defaultModels = [];
     for (let i = 0; i < defaultApiPageSize; i++) {
@@ -35,7 +29,7 @@ describe("AdminAnalysisJobsComponent", () => {
     }
 
     this.defaultModels = defaultModels;
-    this.fixture = fixture;
+    this.fixture = spec.fixture;
     this.api = api;
   });
 

--- a/src/app/components/admin/audio-recordings/details/details.component.spec.ts
+++ b/src/app/components/admin/audio-recordings/details/details.component.spec.ts
@@ -1,17 +1,14 @@
 import { Injector } from "@angular/core";
-import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
-import { AccountsService } from "@baw-api/account/accounts.service";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { audioRecordingResolvers } from "@baw-api/audio-recording/audio-recordings.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ACCOUNT, SHALLOW_SITE } from "@baw-api/ServiceTokens";
-import { ShallowSitesService } from "@baw-api/site/sites.service";
 import { AudioRecording } from "@models/AudioRecording";
 import { Site } from "@models/Site";
 import { User } from "@models/User";
-import { SpyObject } from "@ngneat/spectator";
+import { createComponentFactory, Spectator } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateAudioRecording } from "@test/fakes/AudioRecording";
@@ -19,23 +16,19 @@ import { assertDetail, Detail } from "@test/helpers/detail-view";
 import { nStepObservable } from "@test/helpers/general";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { Subject } from "rxjs";
-import { appLibraryImports } from "src/app/app.module";
 import { AdminAudioRecordingComponent } from "./details.component";
 
 describe("AdminAudioRecordingComponent", () => {
-  let component: AdminAudioRecordingComponent;
-  let fixture: ComponentFixture<AdminAudioRecordingComponent>;
   let injector: Injector;
+  let spec: Spectator<AdminAudioRecordingComponent>;
+  const createComponent = createComponentFactory({
+    component: AdminAudioRecordingComponent,
+    imports: [SharedModule, RouterTestingModule, MockBawApiModule],
+  });
 
   function setup(model: AudioRecording, error?: ApiErrorDetails) {
-    TestBed.configureTestingModule({
-      imports: [
-        ...appLibraryImports,
-        SharedModule,
-        RouterTestingModule,
-        MockBawApiModule,
-      ],
-      declarations: [AdminAudioRecordingComponent],
+    spec = createComponent({
+      detectChanges: false,
       providers: [
         {
           provide: ActivatedRoute,
@@ -45,17 +38,11 @@ describe("AdminAudioRecordingComponent", () => {
           ),
         },
       ],
-    }).compileComponents();
+    });
 
-    fixture = TestBed.createComponent(AdminAudioRecordingComponent);
-    injector = TestBed.inject(Injector);
-    const accountsApi = TestBed.inject(
-      ACCOUNT.token
-    ) as SpyObject<AccountsService>;
-    const sitesApi = TestBed.inject(
-      SHALLOW_SITE.token
-    ) as SpyObject<ShallowSitesService>;
-    component = fixture.componentInstance;
+    injector = spec.inject(Injector);
+    const accountsApi = spec.inject(ACCOUNT.token);
+    const sitesApi = spec.inject(SHALLOW_SITE.token);
 
     const accountsSubject = new Subject<User>();
     const siteSubject = new Subject<Site>();
@@ -84,14 +71,14 @@ describe("AdminAudioRecordingComponent", () => {
 
   it("should create", () => {
     setup(new AudioRecording(generateAudioRecording()));
-    fixture.detectChanges();
-    expect(component).toBeTruthy();
+    spec.detectChanges();
+    expect(spec.component).toBeTruthy();
   });
 
   it("should handle error", () => {
     setup(undefined, generateApiErrorDetails());
-    fixture.detectChanges();
-    expect(component).toBeTruthy();
+    spec.detectChanges();
+    expect(spec.component).toBeTruthy();
   });
 
   describe("details", () => {
@@ -99,10 +86,10 @@ describe("AdminAudioRecordingComponent", () => {
 
     beforeEach(async function () {
       const promise = setup(model);
-      fixture.detectChanges();
+      spec.detectChanges();
       await promise;
-      fixture.detectChanges();
-      this.fixture = fixture;
+      spec.detectChanges();
+      this.fixture = spec.fixture;
     });
 
     const details: Detail[] = [

--- a/src/app/components/admin/audio-recordings/details/details.component.spec.ts
+++ b/src/app/components/admin/audio-recordings/details/details.component.spec.ts
@@ -39,7 +39,7 @@ describe("AdminAudioRecordingComponent", () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute(
+          useValue: mockActivatedRoute(
             { audioRecording: audioRecordingResolvers.show },
             { audioRecording: { model, error } }
           ),

--- a/src/app/components/admin/audio-recordings/list/list.component.spec.ts
+++ b/src/app/components/admin/audio-recordings/list/list.component.spec.ts
@@ -1,33 +1,26 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AudioRecordingsService } from "@baw-api/audio-recording/audio-recordings.service";
 import { defaultApiPageSize } from "@baw-api/baw-api.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { AudioRecording } from "@models/AudioRecording";
+import { createComponentFactory, Spectator } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { generateAudioRecording } from "@test/fakes/AudioRecording";
 import { assertPagination } from "@test/helpers/pagedTableTemplate";
-import { appLibraryImports } from "src/app/app.module";
 import { AdminAudioRecordingsComponent } from "./list.component";
 
 describe("AdminAudioRecordingsComponent", () => {
   let api: AudioRecordingsService;
   let defaultModels: AudioRecording[];
-  let fixture: ComponentFixture<AdminAudioRecordingsComponent>;
+  let spec: Spectator<AdminAudioRecordingsComponent>;
+  const createComponent = createComponentFactory({
+    component: AdminAudioRecordingsComponent,
+    imports: [SharedModule, RouterTestingModule, MockBawApiModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [
-        ...appLibraryImports,
-        SharedModule,
-        RouterTestingModule,
-        MockBawApiModule,
-      ],
-      declarations: [AdminAudioRecordingsComponent],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(AdminAudioRecordingsComponent);
-    api = TestBed.inject(AudioRecordingsService);
+    spec = createComponent({ detectChanges: false });
+    api = spec.inject(AudioRecordingsService);
 
     defaultModels = [];
     for (let i = 0; i < defaultApiPageSize; i++) {
@@ -35,7 +28,7 @@ describe("AdminAudioRecordingsComponent", () => {
     }
 
     this.defaultModels = defaultModels;
-    this.fixture = fixture;
+    this.fixture = spec.fixture;
     this.api = api;
   });
 

--- a/src/app/components/admin/orphan/details/details.component.spec.ts
+++ b/src/app/components/admin/orphan/details/details.component.spec.ts
@@ -97,11 +97,9 @@ describe("AdminOrphanComponent", () => {
   });
 
   describe("details", () => {
-    const model = new Site({
-      ...generateSite(),
-      locationObfuscated: true,
-      projectIds: [1, 2, 3],
-    });
+    const model = new Site(
+      generateSite({ locationObfuscated: true, projectIds: [1, 2, 3] })
+    );
 
     beforeEach(async function () {
       const promise = configureTestingModule(model);

--- a/src/app/components/admin/orphan/details/details.component.spec.ts
+++ b/src/app/components/admin/orphan/details/details.component.spec.ts
@@ -40,7 +40,7 @@ describe("AdminOrphanComponent", () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute(
+          useValue: mockActivatedRoute(
             { site: shallowSiteResolvers.show },
             { site: { model, error } }
           ),

--- a/src/app/components/admin/scripts/details/details.component.spec.ts
+++ b/src/app/components/admin/scripts/details/details.component.spec.ts
@@ -40,7 +40,7 @@ describe("ScriptComponent", () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute(
+          useValue: mockActivatedRoute(
             { script: scriptResolvers.show },
             { script: { model, error } }
           ),

--- a/src/app/components/admin/scripts/edit/edit.component.spec.ts
+++ b/src/app/components/admin/scripts/edit/edit.component.spec.ts
@@ -39,7 +39,7 @@ describe("AdminScriptsEditComponent", () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute(
+          useValue: mockActivatedRoute(
             { script: scriptResolvers.show },
             { script: { model, error } }
           ),

--- a/src/app/components/admin/scripts/list/list.component.spec.ts
+++ b/src/app/components/admin/scripts/list/list.component.spec.ts
@@ -30,8 +30,8 @@ describe("AdminScriptsComponent", () => {
     api = TestBed.inject(ScriptsService);
 
     defaultModels = [];
-    for (let i = 0; i < defaultApiPageSize; i++) {
-      defaultModels.push(new Script(generateScript(i)));
+    for (let id = 0; id < defaultApiPageSize; id++) {
+      defaultModels.push(new Script(generateScript({ id })));
     }
 
     this.defaultModels = defaultModels;

--- a/src/app/components/admin/tag-group/delete/delete.component.spec.ts
+++ b/src/app/components/admin/tag-group/delete/delete.component.spec.ts
@@ -40,7 +40,7 @@ describe("AdminTagGroupsDeleteComponent", () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute(
+          useValue: mockActivatedRoute(
             { tagGroup: tagGroupResolvers.show },
             { tagGroup: { model, error } }
           ),

--- a/src/app/components/admin/tag-group/edit/edit.component.spec.ts
+++ b/src/app/components/admin/tag-group/edit/edit.component.spec.ts
@@ -39,7 +39,7 @@ describe("AdminTagGroupsEditComponent", () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute(
+          useValue: mockActivatedRoute(
             { tagGroup: tagGroupResolvers.show },
             { tagGroup: { model, error } }
           ),

--- a/src/app/components/admin/tag-group/new/new.component.spec.ts
+++ b/src/app/components/admin/tag-group/new/new.component.spec.ts
@@ -33,7 +33,7 @@ describe("AdminTagGroupsNewComponent", () => {
         providers: [
           {
             provide: ActivatedRoute,
-            useClass: mockActivatedRoute(),
+            useValue: mockActivatedRoute(),
           },
         ],
       }).compileComponents();

--- a/src/app/components/admin/tags/delete/delete.component.spec.ts
+++ b/src/app/components/admin/tags/delete/delete.component.spec.ts
@@ -37,7 +37,7 @@ describe("AdminTagsDeleteComponent", () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute(
+          useValue: mockActivatedRoute(
             { tag: tagResolvers.show },
             { tag: { model, error } }
           ),

--- a/src/app/components/admin/tags/edit/edit.component.spec.ts
+++ b/src/app/components/admin/tags/edit/edit.component.spec.ts
@@ -42,7 +42,7 @@ describe("AdminTagsEditComponent", () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute(
+          useValue: mockActivatedRoute(
             {
               tag: tagResolvers.show,
               typeOfTags: tagResolvers.tagTypes,

--- a/src/app/components/admin/tags/list/list.component.spec.ts
+++ b/src/app/components/admin/tags/list/list.component.spec.ts
@@ -30,8 +30,8 @@ describe("AdminTagsComponent", () => {
     api = TestBed.inject(TagsService);
 
     defaultModels = [];
-    for (let i = 0; i < defaultApiPageSize; i++) {
-      defaultModels.push(new Tag(generateTag(i)));
+    for (let id = 0; id < defaultApiPageSize; id++) {
+      defaultModels.push(new Tag(generateTag({ id })));
     }
 
     this.defaultModels = defaultModels;

--- a/src/app/components/admin/tags/new/new.component.spec.ts
+++ b/src/app/components/admin/tags/new/new.component.spec.ts
@@ -35,7 +35,7 @@ describe("AdminTagsNewComponent", () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute(
+          useValue: mockActivatedRoute(
             { typeOfTags: tagResolvers.tagTypes },
             { tagTypes: { model, error } }
           ),

--- a/src/app/components/admin/users/list/list.component.spec.ts
+++ b/src/app/components/admin/users/list/list.component.spec.ts
@@ -31,19 +31,15 @@ describe("AdminUserListComponent", () => {
     spec = createComponent({ detectChanges: false });
     api = spec.inject(AccountsService);
 
-    defaultUser = new User({
-      ...generateUser(1),
-      userName: "username",
-      isConfirmed: false,
-    });
+    defaultUser = new User(
+      generateUser({ id: 1, userName: "username", isConfirmed: false })
+    );
     defaultUsers = [];
-    for (let i = 0; i < defaultApiPageSize; i++) {
+    for (let id = 0; id < defaultApiPageSize; id++) {
       defaultUsers.push(
-        new User({
-          ...generateUser(i),
-          userName: "user " + i,
-          isConfirmed: false,
-        })
+        new User(
+          generateUser({ id, userName: "user " + id, isConfirmed: false })
+        )
       );
     }
 
@@ -81,7 +77,7 @@ describe("AdminUserListComponent", () => {
     });
 
     it("should handle missing last login data", () => {
-      const user = new User({ ...generateUser(), lastSeenAt: undefined });
+      const user = new User(generateUser({ lastSeenAt: undefined }));
       datatableApiResponse<User>(api, [user]);
       spec.detectChanges();
 
@@ -91,10 +87,9 @@ describe("AdminUserListComponent", () => {
     });
 
     it("should call toRelative for lastLogin", () => {
-      const user = new User({
-        ...generateUser(),
-        lastSeenAt: "2020-03-09T22:00:50.072+10:00",
-      });
+      const user = new User(
+        generateUser({ lastSeenAt: "2020-03-09T22:00:50.072+10:00" })
+      );
       datatableApiResponse<User>(api, [user]);
       spyOn(user.lastSeenAt, "toRelative").and.callThrough();
       spec.detectChanges();
@@ -103,10 +98,9 @@ describe("AdminUserListComponent", () => {
     });
 
     it("should display last login", () => {
-      const user = new User({
-        ...generateUser(),
-        lastSeenAt: "2020-03-09T22:00:50.072+10:00",
-      });
+      const user = new User(
+        generateUser({ lastSeenAt: "2020-03-09T22:00:50.072+10:00" })
+      );
       datatableApiResponse<User>(api, [user]);
       spyOn(user.lastSeenAt, "toRelative").and.callFake(() => "testing");
       spec.detectChanges();

--- a/src/app/components/admin/users/list/list.component.spec.ts
+++ b/src/app/components/admin/users/list/list.component.spec.ts
@@ -111,7 +111,7 @@ describe("AdminUserListComponent", () => {
     });
 
     it("should display confirmed user", () => {
-      const user = new User({ ...defaultUser, isConfirmed: true });
+      const user = new User(generateUser({ isConfirmed: true }));
       datatableApiResponse<User>(api, [user]);
       spec.detectChanges();
 
@@ -126,7 +126,7 @@ describe("AdminUserListComponent", () => {
     });
 
     it("should display not confirmed user", () => {
-      const user = new User({ ...defaultUser, isConfirmed: false });
+      const user = new User(generateUser({ isConfirmed: false }));
       datatableApiResponse<User>(api, [user]);
       spec.detectChanges();
 

--- a/src/app/components/audio-analysis/pages/details/details.component.spec.ts
+++ b/src/app/components/audio-analysis/pages/details/details.component.spec.ts
@@ -17,8 +17,8 @@ describe("AudioAnalysisComponent", () => {
     (spec) => {
       const analysisJobApi = spec.inject(AnalysisJobsService);
       analysisJobApi.show.andCallFake(
-        (modelId) =>
-          new BehaviorSubject(new AnalysisJob(generateAnalysisJob(modelId)))
+        (id: number) =>
+          new BehaviorSubject(new AnalysisJob(generateAnalysisJob({ id })))
       );
     }
   );

--- a/src/app/components/audio-analysis/pages/results/results.component.spec.ts
+++ b/src/app/components/audio-analysis/pages/results/results.component.spec.ts
@@ -17,8 +17,8 @@ describe("AudioAnalysisResultsComponent", () => {
     (spec) => {
       const analysisJobApi = spec.inject(AnalysisJobsService);
       analysisJobApi.show.andCallFake(
-        (modelId) =>
-          new BehaviorSubject(new AnalysisJob(generateAnalysisJob(modelId)))
+        (id: number) =>
+          new BehaviorSubject(new AnalysisJob(generateAnalysisJob({ id })))
       );
     }
   );

--- a/src/app/components/library/pages/details/details.component.spec.ts
+++ b/src/app/components/library/pages/details/details.component.spec.ts
@@ -22,14 +22,14 @@ describe("AnnotationComponent", () => {
       const eventsApi = spec.inject(AudioEventsService);
 
       recordingApi.show.andCallFake(
-        (modelId) =>
+        (id: number) =>
           new BehaviorSubject(
-            new AudioRecording(generateAudioRecording(modelId))
+            new AudioRecording(generateAudioRecording({ id }))
           )
       );
       eventsApi.show.andCallFake(
-        (modelId) =>
-          new BehaviorSubject(new AudioEvent(generateAudioEvent(modelId)))
+        (id: number) =>
+          new BehaviorSubject(new AudioEvent(generateAudioEvent({ id })))
       );
     }
   );

--- a/src/app/components/listen/pages/details/details.component.spec.ts
+++ b/src/app/components/listen/pages/details/details.component.spec.ts
@@ -18,9 +18,9 @@ describe("ListenRecordingComponent", () => {
       const recordingApi = spec.inject(AudioRecordingsService);
 
       recordingApi.show.andCallFake(
-        (modelId) =>
+        (id: number) =>
           new BehaviorSubject(
-            new AudioRecording(generateAudioRecording(modelId))
+            new AudioRecording(generateAudioRecording({ id }))
           )
       );
     }

--- a/src/app/components/profile/pages/my-edit/my-edit.component.spec.ts
+++ b/src/app/components/profile/pages/my-edit/my-edit.component.spec.ts
@@ -28,7 +28,7 @@ describe("MyProfileEditComponent", () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute(
+          useValue: mockActivatedRoute(
             { user: userResolvers.show },
             { user: { model, error } }
           ),

--- a/src/app/components/profile/pages/my-edit/my-edit.component.spec.ts
+++ b/src/app/components/profile/pages/my-edit/my-edit.component.spec.ts
@@ -44,7 +44,7 @@ describe("MyProfileEditComponent", () => {
 
   beforeEach(() => {
     // TODO Handle image urls
-    defaultUser = new User({ ...generateUser(), imageUrls: undefined });
+    defaultUser = new User(generateUser({ imageUrls: undefined }));
   });
 
   it("should create", () => {

--- a/src/app/components/profile/pages/profile/my-profile.component.spec.ts
+++ b/src/app/components/profile/pages/profile/my-profile.component.spec.ts
@@ -192,8 +192,7 @@ describe("MyProfileComponent", () => {
     });
 
     it("should handle if user has no last seen at date", () => {
-      const user = new User({ ...generateUser(), lastSeenAt: null });
-
+      const user = new User(generateUser({ lastSeenAt: null }));
       setup(user);
       interceptApiRequests({});
       spec.detectChanges();
@@ -214,8 +213,7 @@ describe("MyProfileComponent", () => {
     });
 
     it("should handle if user has no membership length", () => {
-      const user = new User({ ...generateUser(), createdAt: undefined });
-
+      const user = new User(generateUser({ createdAt: undefined }));
       setup(user);
       interceptApiRequests({});
       spec.detectChanges();

--- a/src/app/components/profile/pages/profile/their-profile.component.spec.ts
+++ b/src/app/components/profile/pages/profile/their-profile.component.spec.ts
@@ -181,8 +181,7 @@ describe("TheirProfileComponent", () => {
     });
 
     it("should handle if user has no last seen at date", () => {
-      const user = new User({ ...generateUser(), lastSeenAt: null });
-
+      const user = new User(generateUser({ lastSeenAt: null }));
       setup(user);
       interceptApiRequests({});
       spec.detectChanges();
@@ -217,8 +216,7 @@ describe("TheirProfileComponent", () => {
     });
 
     it("should handle if user has no membership length", () => {
-      const user = new User({ ...generateUser(), createdAt: undefined });
-
+      const user = new User(generateUser({ createdAt: undefined }));
       setup(user);
       interceptApiRequests({});
       spec.detectChanges();

--- a/src/app/components/profile/pages/sites/my-sites.component.spec.ts
+++ b/src/app/components/profile/pages/sites/my-sites.component.spec.ts
@@ -31,7 +31,6 @@ describe("MySitesComponent", () => {
   let injector: Injector;
   let defaultUser: User;
   let defaultSite: Site;
-  let defaultProject: Project;
   let sitesApi: SpyObject<ShallowSitesService>;
   let projectsApi: SpyObject<ProjectsService>;
   let spec: SpectatorRouting<MySitesComponent>;
@@ -82,7 +81,6 @@ describe("MySitesComponent", () => {
   beforeEach(() => {
     defaultUser = new User(generateUser());
     defaultSite = new Site(generateSite());
-    defaultProject = new Project(generateProject());
   });
 
   it("should create", async () => {
@@ -130,6 +128,17 @@ describe("MySitesComponent", () => {
         const link = getCells()[0].querySelector("a");
         assertUrl(link, defaultSite.viewUrl);
       });
+
+      it("should not display site name link when no projects found", () => {
+        const site = new Site(generateSite({ projectIds: [] }));
+        setup(defaultUser);
+        interceptSiteRequest([site]);
+        interceptProjectRequest([]);
+        spec.detectChanges();
+
+        const link = getCells()[0].querySelector("a");
+        expect(link).toBeFalsy();
+      });
     });
 
     it("should display last modified time", async () => {
@@ -145,8 +154,8 @@ describe("MySitesComponent", () => {
       [AccessLevel.reader, AccessLevel.writer, AccessLevel.owner].forEach(
         (accessLevel) => {
           it(`should display ${accessLevel} permissions`, async () => {
-            const site = new Site({ ...defaultSite, projectIds: [1] });
-            const project = new Project({ ...generateProject(), accessLevel });
+            const site = new Site(generateSite({ projectIds: [1] }));
+            const project = new Project(generateProject({ accessLevel }));
 
             setup(defaultUser);
             interceptSiteRequest([site]);
@@ -161,7 +170,7 @@ describe("MySitesComponent", () => {
       );
 
       it("should display unknown permissions when no projects found", async () => {
-        const site = new Site({ ...defaultSite, projectIds: [] });
+        const site = new Site(generateSite({ projectIds: [] }));
 
         setup(defaultUser);
         interceptSiteRequest([site]);
@@ -174,14 +183,14 @@ describe("MySitesComponent", () => {
       });
 
       it("should prioritize owner level permission if multiple projects", async () => {
-        const site = new Site({ ...defaultSite, projectIds: [1] });
+        const site = new Site(generateSite({ projectIds: [1] }));
 
         setup(defaultUser);
         interceptSiteRequest([site]);
         const projectPromise = interceptProjectRequest([
-          new Project({ ...defaultProject, accessLevel: AccessLevel.reader }),
-          new Project({ ...defaultProject, accessLevel: AccessLevel.owner }),
-          new Project({ ...defaultProject, accessLevel: AccessLevel.writer }),
+          new Project(generateProject({ accessLevel: AccessLevel.reader })),
+          new Project(generateProject({ accessLevel: AccessLevel.owner })),
+          new Project(generateProject({ accessLevel: AccessLevel.writer })),
         ]);
         spec.detectChanges();
         await projectPromise;
@@ -191,14 +200,14 @@ describe("MySitesComponent", () => {
       });
 
       it("should prioritize writer level permission if multiple projects and no owner", async () => {
-        const site = new Site({ ...defaultSite, projectIds: [1] });
+        const site = new Site(generateSite({ projectIds: [1] }));
 
         setup(defaultUser);
         interceptSiteRequest([site]);
         const projectPromise = interceptProjectRequest([
-          new Project({ ...defaultProject, accessLevel: AccessLevel.reader }),
-          new Project({ ...defaultProject, accessLevel: AccessLevel.writer }),
-          new Project({ ...defaultProject, accessLevel: AccessLevel.reader }),
+          new Project(generateProject({ accessLevel: AccessLevel.reader })),
+          new Project(generateProject({ accessLevel: AccessLevel.writer })),
+          new Project(generateProject({ accessLevel: AccessLevel.reader })),
         ]);
         spec.detectChanges();
         await projectPromise;

--- a/src/app/components/profile/pages/sites/my-sites.component.ts
+++ b/src/app/components/profile/pages/sites/my-sites.component.ts
@@ -51,6 +51,10 @@ class MySitesComponent extends PagedTableTemplate<TableRow, Site> {
     return this.models[userKey] as User;
   }
 
+  public hasViewUrl(site: Site): boolean {
+    return site.projectIds.size > 0;
+  }
+
   public resolveHighestAccessLevel(projects: Project[]): string {
     if ((projects ?? []).length === 0) {
       return "Unknown";

--- a/src/app/components/profile/pages/sites/sites.component.html
+++ b/src/app/components/profile/pages/sites/sites.component.html
@@ -23,7 +23,12 @@
     >
       <ngx-datatable-column name="Site">
         <ng-template let-value="value" ngx-datatable-cell-template>
-          <a [bawUrl]="value.viewUrl">{{ value.name }} </a>
+          <ng-container *ngIf="hasViewUrl(value); else siteName">
+            <a [bawUrl]="value.viewUrl">{{ value.name }}</a>
+          </ng-container>
+          <ng-template #siteName>
+            {{ value.name }}
+          </ng-template>
         </ng-template>
       </ngx-datatable-column>
       <ngx-datatable-column name="Last Modified" [width]="150" [maxWidth]="150">

--- a/src/app/components/profile/pages/sites/their-sites.component.spec.ts
+++ b/src/app/components/profile/pages/sites/their-sites.component.spec.ts
@@ -31,7 +31,6 @@ describe("TheirSitesComponent", () => {
   let injector: Injector;
   let defaultUser: User;
   let defaultSite: Site;
-  let defaultProject: Project;
   let sitesApi: SpyObject<ShallowSitesService>;
   let projectsApi: SpyObject<ProjectsService>;
   let spec: SpectatorRouting<TheirSitesComponent>;
@@ -82,7 +81,6 @@ describe("TheirSitesComponent", () => {
   beforeEach(() => {
     defaultUser = new User(generateUser());
     defaultSite = new Site(generateSite());
-    defaultProject = new Project(generateProject());
   });
 
   it("should create", async () => {
@@ -130,6 +128,17 @@ describe("TheirSitesComponent", () => {
         const link = getCells()[0].querySelector("a");
         assertUrl(link, defaultSite.viewUrl);
       });
+
+      it("should not display site name link when no projects found", () => {
+        const site = new Site(generateSite({ projectIds: [] }));
+        setup(defaultUser);
+        interceptSiteRequest([site]);
+        interceptProjectRequest([]);
+        spec.detectChanges();
+
+        const link = getCells()[0].querySelector("a");
+        expect(link).toBeFalsy();
+      });
     });
 
     it("should display last modified time", async () => {
@@ -145,7 +154,7 @@ describe("TheirSitesComponent", () => {
       [AccessLevel.reader, AccessLevel.writer, AccessLevel.owner].forEach(
         (accessLevel) => {
           it(`should display ${accessLevel} permissions`, async () => {
-            const site = new Site({ ...defaultSite, projectIds: [1] });
+            const site = new Site(generateSite({ projectIds: [1] }));
             const project = new Project({ ...generateProject(), accessLevel });
 
             setup(defaultUser);
@@ -161,7 +170,7 @@ describe("TheirSitesComponent", () => {
       );
 
       it("should display unknown permissions when no projects found", async () => {
-        const site = new Site({ ...defaultSite, projectIds: [] });
+        const site = new Site(generateSite({ projectIds: [] }));
 
         setup(defaultUser);
         interceptSiteRequest([site]);
@@ -174,14 +183,14 @@ describe("TheirSitesComponent", () => {
       });
 
       it("should prioritize owner level permission if multiple projects", async () => {
-        const site = new Site({ ...defaultSite, projectIds: [1] });
+        const site = new Site(generateSite({ projectIds: [1] }));
 
         setup(defaultUser);
         interceptSiteRequest([site]);
         const projectPromise = interceptProjectRequest([
-          new Project({ ...defaultProject, accessLevel: AccessLevel.reader }),
-          new Project({ ...defaultProject, accessLevel: AccessLevel.owner }),
-          new Project({ ...defaultProject, accessLevel: AccessLevel.writer }),
+          new Project(generateProject({ accessLevel: AccessLevel.reader })),
+          new Project(generateProject({ accessLevel: AccessLevel.owner })),
+          new Project(generateProject({ accessLevel: AccessLevel.writer })),
         ]);
         spec.detectChanges();
         await projectPromise;
@@ -191,14 +200,14 @@ describe("TheirSitesComponent", () => {
       });
 
       it("should prioritize writer level permission if multiple projects and no owner", async () => {
-        const site = new Site({ ...defaultSite, projectIds: [1] });
+        const site = new Site(generateSite({ projectIds: [1] }));
 
         setup(defaultUser);
         interceptSiteRequest([site]);
         const projectPromise = interceptProjectRequest([
-          new Project({ ...defaultProject, accessLevel: AccessLevel.reader }),
-          new Project({ ...defaultProject, accessLevel: AccessLevel.writer }),
-          new Project({ ...defaultProject, accessLevel: AccessLevel.reader }),
+          new Project(generateProject({ accessLevel: AccessLevel.reader })),
+          new Project(generateProject({ accessLevel: AccessLevel.writer })),
+          new Project(generateProject({ accessLevel: AccessLevel.reader })),
         ]);
         spec.detectChanges();
         await projectPromise;

--- a/src/app/components/profile/pages/their-edit/their-edit.component.spec.ts
+++ b/src/app/components/profile/pages/their-edit/their-edit.component.spec.ts
@@ -27,7 +27,7 @@ describe("TheirProfileEditComponent", () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute(
+          useValue: mockActivatedRoute(
             { account: accountResolvers.show },
             { account: { model, error } }
           ),

--- a/src/app/components/projects/pages/assign/assign.component.spec.ts
+++ b/src/app/components/projects/pages/assign/assign.component.spec.ts
@@ -33,7 +33,7 @@ describe("AssignComponent", () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute(
+          useValue: mockActivatedRoute(
             { project: projectResolvers.show },
             { project: { model, error } }
           ),

--- a/src/app/components/projects/pages/details/details.component.spec.ts
+++ b/src/app/components/projects/pages/details/details.component.spec.ts
@@ -75,14 +75,14 @@ describe("ProjectDetailsComponent", () => {
 
   function createSitesWithMeta(numSites: number) {
     return createModelWithMeta<Site>(
-      (id) => new Site(generateSite(id)),
+      (id) => new Site(generateSite({ id })),
       numSites
     );
   }
 
   function createRegionsWithMeta(numRegions: number) {
     return createModelWithMeta<Region>(
-      (id) => new Region(generateRegion(id)),
+      (id) => new Region(generateRegion({ id })),
       numRegions
     );
   }

--- a/src/app/components/projects/pages/edit/edit.component.spec.ts
+++ b/src/app/components/projects/pages/edit/edit.component.spec.ts
@@ -34,7 +34,7 @@ describe("ProjectsEditComponent", () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute(
+          useValue: mockActivatedRoute(
             { project: projectResolvers.show },
             { project: { model, error } }
           ),

--- a/src/app/components/projects/pages/new/new.component.spec.ts
+++ b/src/app/components/projects/pages/new/new.component.spec.ts
@@ -57,7 +57,7 @@ describe("ProjectsNewComponent", () => {
         providers: [
           {
             provide: ActivatedRoute,
-            useClass: mockActivatedRoute(),
+            useValue: mockActivatedRoute(),
           },
         ],
       }).compileComponents();

--- a/src/app/components/projects/pages/permissions/permissions.component.spec.ts
+++ b/src/app/components/projects/pages/permissions/permissions.component.spec.ts
@@ -28,7 +28,7 @@ describe("PermissionsComponent", () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute(
+          useValue: mockActivatedRoute(
             { project: projectResolvers.show },
             { project: { model, error } }
           ),

--- a/src/app/components/projects/pages/request/request.component.spec.ts
+++ b/src/app/components/projects/pages/request/request.component.spec.ts
@@ -34,7 +34,7 @@ describe("ProjectsRequestComponent", () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute(
+          useValue: mockActivatedRoute(
             { project: projectResolvers.show },
             { project: { model, error } }
           ),

--- a/src/app/components/projects/site-card/site-card.component.spec.ts
+++ b/src/app/components/projects/site-card/site-card.component.spec.ts
@@ -97,7 +97,7 @@ describe("SiteCardComponent", () => {
     }
 
     it("should display site image", () => {
-      const site = new Site({ ...generateSite(), imageUrl: undefined });
+      const site = new Site(generateSite({ imageUrl: undefined }));
       setup(true, site);
       spec.detectChanges();
 

--- a/src/app/components/projects/site-map/site-map.component.spec.ts
+++ b/src/app/components/projects/site-map/site-map.component.spec.ts
@@ -58,7 +58,7 @@ describe("SiteMapComponent", () => {
     }
 
     for (let id = 1; id <= numSites; id++) {
-      const site = new Site({ ...generateSite(id), ...overrides });
+      const site = new Site(generateSite({ id, ...overrides }));
       const page = calculatePage(id);
       site.addMetadata({ paging: { total: numSites, page, maxPage } });
       sites[page - 1].push(site);

--- a/src/app/components/regions/pages/edit/edit.component.spec.ts
+++ b/src/app/components/regions/pages/edit/edit.component.spec.ts
@@ -60,7 +60,8 @@ describe("RegionsEditComponent", () => {
     ]);
   });
 
-  describe("component", () => {
+  // TODO Disabled because of #1338
+  xdescribe("component", () => {
     let api: SpyObject<RegionsService>;
     let defaultProject: Project;
     let defaultRegion: Region;

--- a/src/app/components/regions/pages/edit/edit.component.spec.ts
+++ b/src/app/components/regions/pages/edit/edit.component.spec.ts
@@ -60,7 +60,7 @@ describe("RegionsEditComponent", () => {
     ]);
   });
 
-  xdescribe("component", () => {
+  describe("component", () => {
     let api: SpyObject<RegionsService>;
     let defaultProject: Project;
     let defaultRegion: Region;

--- a/src/app/components/regions/pages/new/new.component.spec.ts
+++ b/src/app/components/regions/pages/new/new.component.spec.ts
@@ -57,7 +57,8 @@ describe("RegionsNewComponent", () => {
     ]);
   });
 
-  describe("component", () => {
+  // TODO Disabled because of #1338
+  xdescribe("component", () => {
     let api: SpyObject<RegionsService>;
     let defaultProject: Project;
 

--- a/src/app/components/regions/pages/new/new.component.spec.ts
+++ b/src/app/components/regions/pages/new/new.component.spec.ts
@@ -57,7 +57,7 @@ describe("RegionsNewComponent", () => {
     ]);
   });
 
-  xdescribe("component", () => {
+  describe("component", () => {
     let api: SpyObject<RegionsService>;
     let defaultProject: Project;
 

--- a/src/app/components/shared/annotation-download/annotation-download.component.spec.ts
+++ b/src/app/components/shared/annotation-download/annotation-download.component.spec.ts
@@ -135,11 +135,9 @@ describe("AnnotationDownloadComponent", () => {
 
     beforeEach(
       () =>
-        (siteWithoutTimezone = new Site({
-          ...generateSite(),
-          timezoneInformation: undefined,
-          tzinfoTz: undefined,
-        }))
+        (siteWithoutTimezone = new Site(
+          generateSite({ timezoneInformation: undefined, tzinfoTz: undefined })
+        ))
     );
 
     it("should have timezone input", () => {

--- a/src/app/components/shared/header/header.component.spec.ts
+++ b/src/app/components/shared/header/header.component.spec.ts
@@ -96,10 +96,8 @@ describe("HeaderComponent", () => {
           } else {
             isLoggedIn = true;
             defaultUser = new SessionUser({
-              ...generateUser(),
+              ...generateUser({}, userType.type === "admin"),
               ...generateSessionUser(),
-              rolesMask: userType.type === "admin" ? 1 : 2,
-              rolesMaskNames: userType.type === "user" ? ["user"] : ["admin"],
             });
           }
         });

--- a/src/app/components/shared/header/header.component.spec.ts
+++ b/src/app/components/shared/header/header.component.spec.ts
@@ -200,10 +200,9 @@ describe("HeaderComponent", () => {
 
         if (userType.links.profile) {
           it("should display default profile icon", () => {
-            const user = new SessionUser({
-              ...defaultUser.toJSON(),
-              imageUrls: undefined,
-            });
+            const user = new SessionUser(
+              generateUser({ imageUrls: undefined })
+            );
             setUser(isLoggedIn, user);
             spec.detectChanges();
 
@@ -220,7 +219,7 @@ describe("HeaderComponent", () => {
             const url = modelData.image.imageUrl(60, 60);
             const imageUrls = modelData.imageUrls();
             imageUrls[3].url = url;
-            const customUser = new SessionUser({ ...defaultUser, imageUrls });
+            const customUser = new SessionUser(generateUser({ imageUrls }));
             setUser(isLoggedIn, customUser);
             spec.detectChanges();
 

--- a/src/app/components/shared/menu/user-badge/user-badge.component.spec.ts
+++ b/src/app/components/shared/menu/user-badge/user-badge.component.spec.ts
@@ -129,11 +129,9 @@ describe("UserBadgeComponent", () => {
     });
 
     it("should display default image", () => {
-      const user = new User({
-        ...generateUser(),
-        userName: "custom username",
-        imageUrls: undefined,
-      });
+      const user = new User(
+        generateUser({ userName: "custom username", imageUrls: undefined })
+      );
       setup({ users: [user] });
       spec.detectChanges();
       assertImage(
@@ -145,7 +143,7 @@ describe("UserBadgeComponent", () => {
 
     it("should display custom image", () => {
       const imageIndex = 1;
-      const user = new User({ ...generateUser(), userName: "custom username" });
+      const user = new User(generateUser({ userName: "custom username" }));
       user.image[imageIndex].size = ImageSizes.small;
       setup({ users: [user] });
       spec.detectChanges();

--- a/src/app/components/sites/pages/delete/point.component.spec.ts
+++ b/src/app/components/sites/pages/delete/point.component.spec.ts
@@ -65,7 +65,7 @@ describe("PointDeleteComponent", () => {
   beforeEach(() => {
     defaultProject = new Project(generateProject());
     defaultRegion = new Region(generateRegion());
-    defaultSite = new Site(generateSite(undefined, true));
+    defaultSite = new Site(generateSite({}, true));
   });
 
   describe("form", () => {

--- a/src/app/components/sites/pages/details/site.component.spec.ts
+++ b/src/app/components/sites/pages/details/site.component.spec.ts
@@ -1,7 +1,10 @@
-import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
-import { projectResolvers } from "@baw-api/project/projects.service";
-import { siteResolvers } from "@baw-api/site/sites.service";
+import {
+  ApiErrorDetails,
+  isApiErrorDetails,
+} from "@baw-api/api.interceptor.service";
+import { ResolvedModel } from "@baw-api/resolver-common";
 import { SiteComponent } from "@components/sites/site/site.component";
+import { Errorable } from "@helpers/advancedTypes";
 import { Project } from "@models/Project";
 import { Site } from "@models/Site";
 import { createRoutingFactory, SpectatorRouting } from "@ngneat/spectator";
@@ -15,26 +18,26 @@ import { SiteDetailsComponent } from "./site.component";
 const mockSiteComponent = MockComponent(SiteComponent);
 
 describe("SiteDetailsComponent", () => {
+  let defaultError: ApiErrorDetails;
   let defaultProject: Project;
   let defaultSite: Site;
-  let spectator: SpectatorRouting<SiteDetailsComponent>;
+  let spec: SpectatorRouting<SiteDetailsComponent>;
   const createComponent = createRoutingFactory({
     declarations: [mockSiteComponent],
     component: SiteDetailsComponent,
   });
 
-  function setup(
-    project: Project,
-    site: Site,
-    projectError?: ApiErrorDetails,
-    siteError?: ApiErrorDetails
-  ) {
-    spectator = createComponent({
+  function setup(project: Errorable<Project>, site: Errorable<Site>) {
+    function getResolvedModel<T>(model: Errorable<T>): ResolvedModel<T> {
+      return isApiErrorDetails(model) ? { error: model } : { model };
+    }
+
+    spec = createComponent({
       detectChanges: false,
       data: {
-        resolvers: { project: projectResolvers.show, site: siteResolvers.show },
-        project: { model: project, error: projectError },
-        site: { model: site, error: siteError },
+        resolvers: { project: "resolver", site: "resolver" },
+        project: getResolvedModel(project),
+        site: getResolvedModel(site),
       },
     });
   }
@@ -42,33 +45,33 @@ describe("SiteDetailsComponent", () => {
   beforeEach(() => {
     defaultProject = new Project(generateProject());
     defaultSite = new Site(generateSite());
+    defaultError = generateApiErrorDetails();
   });
 
   it("should create", () => {
     setup(defaultProject, defaultSite);
-    spectator.detectChanges();
-    expect(spectator.component).toBeTruthy();
+    spec.detectChanges();
+    expect(spec.component).toBeTruthy();
   });
 
   it("should handle failure to retrieve project", () => {
-    setup(undefined, defaultSite, generateApiErrorDetails());
-    spectator.detectChanges();
-    assertErrorHandler(spectator.fixture);
+    setup(defaultError, defaultSite);
+    spec.detectChanges();
+    assertErrorHandler(spec.fixture);
   });
 
   it("should handle failure to retrieve site", () => {
-    setup(defaultProject, undefined, undefined, generateApiErrorDetails());
-    spectator.detectChanges();
-    assertErrorHandler(spectator.fixture);
+    setup(defaultProject, defaultError);
+    spec.detectChanges();
+    assertErrorHandler(spec.fixture);
   });
 
   it("should create site details component", () => {
     setup(defaultProject, defaultSite);
-    spectator.detectChanges();
-    const siteDetails = spectator.query(mockSiteComponent);
-    expect(siteDetails).toBeTruthy();
-    expect(siteDetails.project).toEqual(defaultProject);
-    expect(siteDetails.region).toBeFalsy();
-    expect(siteDetails.site).toEqual(defaultSite);
+    spec.detectChanges();
+    const { project, region, site } = spec.query(mockSiteComponent);
+    expect(project).toEqual(defaultProject);
+    expect(region).toBeFalsy();
+    expect(site).toEqual(defaultSite);
   });
 });

--- a/src/app/components/sites/pages/edit/point.component.spec.ts
+++ b/src/app/components/sites/pages/edit/point.component.spec.ts
@@ -29,7 +29,7 @@ import schema from "../../point.base.json";
 import { PointEditComponent } from "./point.component";
 
 describe("PointEditComponent", () => {
-  let spectator: SpectatorRouting<PointEditComponent>;
+  let spec: SpectatorRouting<PointEditComponent>;
   const { fields } = schema;
   const createComponent = createRoutingFactory({
     component: PointEditComponent,
@@ -73,7 +73,7 @@ describe("PointEditComponent", () => {
     ]);
   });
 
-  xdescribe("component", () => {
+  describe("component", () => {
     let api: SpyObject<SitesService>;
     let defaultProject: Project;
     let defaultRegion: Region;
@@ -84,7 +84,7 @@ describe("PointEditComponent", () => {
       regionError?: ApiErrorDetails,
       siteError?: ApiErrorDetails
     ) {
-      spectator = createComponent({
+      spec = createComponent({
         detectChanges: false,
         params: {
           projectId: defaultProject?.id,
@@ -103,8 +103,8 @@ describe("PointEditComponent", () => {
         },
       });
 
-      api = spectator.inject(SitesService);
-      spectator.detectChanges();
+      api = spec.inject(SitesService);
+      spec.detectChanges();
     }
 
     beforeAll(async () => await embedGoogleMaps());
@@ -112,34 +112,34 @@ describe("PointEditComponent", () => {
     beforeEach(() => {
       defaultProject = new Project(generateProject());
       defaultRegion = new Region(generateRegion());
-      defaultSite = new Site(generateSite(undefined, true));
+      defaultSite = new Site(generateSite({}, true));
     });
 
     it("should create", () => {
       setup();
-      expect(spectator.component).toBeTruthy();
+      expect(spec.component).toBeTruthy();
     });
 
     it("should handle project error", () => {
       setup(generateApiErrorDetails());
-      assertErrorHandler(spectator.fixture);
+      assertErrorHandler(spec.fixture);
     });
 
     it("should handle region error", () => {
       setup(undefined, generateApiErrorDetails());
-      assertErrorHandler(spectator.fixture);
+      assertErrorHandler(spec.fixture);
     });
 
     it("should handle site error", () => {
       setup(undefined, undefined, generateApiErrorDetails());
-      assertErrorHandler(spectator.fixture);
+      assertErrorHandler(spec.fixture);
     });
 
     it("should call api", () => {
       setup();
       api.update.and.callFake(() => new Subject());
 
-      spectator.component.submit({ ...defaultSite });
+      spec.component.submit({ ...defaultSite });
       expect(api.update).toHaveBeenCalledWith(
         new Site(defaultSite),
         defaultProject
@@ -150,8 +150,8 @@ describe("PointEditComponent", () => {
       setup();
       api.update.and.callFake(() => new BehaviorSubject<Site>(defaultSite));
 
-      spectator.component.submit({});
-      expect(spectator.router.navigateByUrl).toHaveBeenCalledWith(
+      spec.component.submit({});
+      expect(spec.router.navigateByUrl).toHaveBeenCalledWith(
         defaultSite.getViewUrl(defaultProject)
       );
     });

--- a/src/app/components/sites/pages/edit/point.component.spec.ts
+++ b/src/app/components/sites/pages/edit/point.component.spec.ts
@@ -73,7 +73,8 @@ describe("PointEditComponent", () => {
     ]);
   });
 
-  describe("component", () => {
+  // TODO Disabled because of #1338
+  xdescribe("component", () => {
     let api: SpyObject<SitesService>;
     let defaultProject: Project;
     let defaultRegion: Region;

--- a/src/app/components/sites/pages/edit/site.component.spec.ts
+++ b/src/app/components/sites/pages/edit/site.component.spec.ts
@@ -26,7 +26,7 @@ import schema from "../../site.base.json";
 import { SiteEditComponent } from "./site.component";
 
 describe("SiteEditComponent", () => {
-  let spectator: SpectatorRouting<SiteEditComponent>;
+  let spec: SpectatorRouting<SiteEditComponent>;
   const { fields } = schema;
   const createComponent = createRoutingFactory({
     component: SiteEditComponent,
@@ -70,7 +70,7 @@ describe("SiteEditComponent", () => {
     ]);
   });
 
-  xdescribe("component", () => {
+  describe("component", () => {
     let api: SpyObject<SitesService>;
     let defaultProject: Project;
     let defaultSite: Site;
@@ -79,7 +79,7 @@ describe("SiteEditComponent", () => {
       projectError?: ApiErrorDetails,
       siteError?: ApiErrorDetails
     ) {
-      spectator = createComponent({
+      spec = createComponent({
         detectChanges: false,
         params: { projectId: defaultProject?.id, siteId: defaultSite?.id },
         data: {
@@ -92,8 +92,8 @@ describe("SiteEditComponent", () => {
         },
       });
 
-      api = spectator.inject(SitesService);
-      spectator.detectChanges();
+      api = spec.inject(SitesService);
+      spec.detectChanges();
     }
 
     beforeAll(async () => await embedGoogleMaps());
@@ -105,24 +105,24 @@ describe("SiteEditComponent", () => {
 
     it("should create", () => {
       setup();
-      expect(spectator.component).toBeTruthy();
+      expect(spec.component).toBeTruthy();
     });
 
     it("should handle site error", () => {
       setup(undefined, generateApiErrorDetails());
-      assertErrorHandler(spectator.fixture);
+      assertErrorHandler(spec.fixture);
     });
 
     it("should handle project error", () => {
       setup(generateApiErrorDetails());
-      assertErrorHandler(spectator.fixture);
+      assertErrorHandler(spec.fixture);
     });
 
     it("should call api", () => {
       setup();
       api.update.and.callFake(() => new Subject());
 
-      spectator.component.submit({ ...defaultSite });
+      spec.component.submit({ ...defaultSite });
       expect(api.update).toHaveBeenCalledWith(
         new Site({ ...defaultSite }),
         defaultProject
@@ -134,8 +134,8 @@ describe("SiteEditComponent", () => {
       const site = new Site(generateSite());
       api.update.and.callFake(() => new BehaviorSubject<Site>(site));
 
-      spectator.component.submit({});
-      expect(spectator.router.navigateByUrl).toHaveBeenCalledWith(
+      spec.component.submit({});
+      expect(spec.router.navigateByUrl).toHaveBeenCalledWith(
         site.getViewUrl(defaultProject)
       );
     });

--- a/src/app/components/sites/pages/edit/site.component.spec.ts
+++ b/src/app/components/sites/pages/edit/site.component.spec.ts
@@ -70,7 +70,8 @@ describe("SiteEditComponent", () => {
     ]);
   });
 
-  describe("component", () => {
+  // TODO Disabled because of #1338
+  xdescribe("component", () => {
     let api: SpyObject<SitesService>;
     let defaultProject: Project;
     let defaultSite: Site;

--- a/src/app/components/sites/pages/new/point.component.spec.ts
+++ b/src/app/components/sites/pages/new/point.component.spec.ts
@@ -73,7 +73,8 @@ describe("PointNewComponent", () => {
     ]);
   });
 
-  describe("component", () => {
+  // TODO Disabled because of #1338
+  xdescribe("component", () => {
     let api: SpyObject<SitesService>;
     let defaultProject: Project;
     let defaultRegion: Region;

--- a/src/app/components/sites/pages/new/point.component.spec.ts
+++ b/src/app/components/sites/pages/new/point.component.spec.ts
@@ -29,7 +29,7 @@ import schema from "../../point.base.json";
 import { PointNewComponent } from "./point.component";
 
 describe("PointNewComponent", () => {
-  let spectator: SpectatorRouting<PointNewComponent>;
+  let spec: SpectatorRouting<PointNewComponent>;
   const { fields } = schema;
   const createComponent = createRoutingFactory({
     component: PointNewComponent,
@@ -73,7 +73,7 @@ describe("PointNewComponent", () => {
     ]);
   });
 
-  xdescribe("component", () => {
+  describe("component", () => {
     let api: SpyObject<SitesService>;
     let defaultProject: Project;
     let defaultRegion: Region;
@@ -82,7 +82,7 @@ describe("PointNewComponent", () => {
       projectError?: ApiErrorDetails,
       regionError?: ApiErrorDetails
     ) {
-      spectator = createComponent({
+      spec = createComponent({
         detectChanges: false,
         params: { projectId: defaultProject?.id, regionId: defaultRegion?.id },
         data: {
@@ -95,8 +95,8 @@ describe("PointNewComponent", () => {
         },
       });
 
-      api = spectator.inject(SitesService);
-      spectator.detectChanges();
+      api = spec.inject(SitesService);
+      spec.detectChanges();
     }
 
     beforeAll(async () => await embedGoogleMaps());
@@ -108,17 +108,17 @@ describe("PointNewComponent", () => {
 
     it("should create", () => {
       setup();
-      expect(spectator.component).toBeTruthy();
+      expect(spec.component).toBeTruthy();
     });
 
     it("should handle project error", () => {
       setup(generateApiErrorDetails());
-      assertErrorHandler(spectator.fixture);
+      assertErrorHandler(spec.fixture);
     });
 
     it("should handle region error", () => {
       setup(undefined, generateApiErrorDetails());
-      assertErrorHandler(spectator.fixture);
+      assertErrorHandler(spec.fixture);
     });
 
     it("should call api", () => {
@@ -126,7 +126,7 @@ describe("PointNewComponent", () => {
       const site = new Site(generateSite());
       api.create.and.callFake(() => new Subject());
 
-      spectator.component.submit({ ...site });
+      spec.component.submit({ ...site });
       expect(api.create).toHaveBeenCalledWith(
         new Site({ ...site, regionId: defaultRegion.id }),
         defaultProject
@@ -138,8 +138,8 @@ describe("PointNewComponent", () => {
       const site = new Site(generateSite());
       api.create.and.callFake(() => new BehaviorSubject<Site>(site));
 
-      spectator.component.submit({});
-      expect(spectator.router.navigateByUrl).toHaveBeenCalledWith(
+      spec.component.submit({});
+      expect(spec.router.navigateByUrl).toHaveBeenCalledWith(
         site.getViewUrl(defaultProject)
       );
     });

--- a/src/app/components/sites/pages/new/site.component.spec.ts
+++ b/src/app/components/sites/pages/new/site.component.spec.ts
@@ -26,7 +26,7 @@ import schema from "../../site.base.json";
 import { SiteNewComponent } from "./site.component";
 
 describe("SiteNewComponent", () => {
-  let spectator: SpectatorRouting<SiteNewComponent>;
+  let spec: SpectatorRouting<SiteNewComponent>;
   const { fields } = schema;
   const createComponent = createRoutingFactory({
     component: SiteNewComponent,
@@ -75,7 +75,7 @@ describe("SiteNewComponent", () => {
     let defaultProject: Project;
 
     function setup(error?: ApiErrorDetails) {
-      spectator = createComponent({
+      spec = createComponent({
         detectChanges: false,
         params: { projectId: defaultProject?.id },
         data: {
@@ -84,8 +84,8 @@ describe("SiteNewComponent", () => {
         },
       });
 
-      api = spectator.inject(SitesService);
-      spectator.detectChanges();
+      api = spec.inject(SitesService);
+      spec.detectChanges();
     }
 
     beforeAll(async () => await embedGoogleMaps());
@@ -96,12 +96,12 @@ describe("SiteNewComponent", () => {
 
     it("should create", () => {
       setup();
-      expect(spectator.component).toBeTruthy();
+      expect(spec.component).toBeTruthy();
     });
 
     it("should handle project error", () => {
       setup(generateApiErrorDetails());
-      assertErrorHandler(spectator.fixture);
+      assertErrorHandler(spec.fixture);
     });
 
     it("should call api", () => {
@@ -109,7 +109,7 @@ describe("SiteNewComponent", () => {
       const site = new Site(generateSite());
       api.create.and.callFake(() => new Subject());
 
-      spectator.component.submit({ ...site });
+      spec.component.submit({ ...site });
       expect(api.create).toHaveBeenCalledWith(
         new Site({ ...site }),
         defaultProject
@@ -121,8 +121,8 @@ describe("SiteNewComponent", () => {
       const site = new Site(generateSite());
       api.create.and.callFake(() => new BehaviorSubject<Site>(site));
 
-      spectator.component.submit({});
-      expect(spectator.router.navigateByUrl).toHaveBeenCalledWith(
+      spec.component.submit({});
+      expect(spec.router.navigateByUrl).toHaveBeenCalledWith(
         site.getViewUrl(defaultProject)
       );
     });

--- a/src/app/components/sites/pages/new/site.component.spec.ts
+++ b/src/app/components/sites/pages/new/site.component.spec.ts
@@ -70,7 +70,8 @@ describe("SiteNewComponent", () => {
     ]);
   });
 
-  describe("component", () => {
+  // TODO Disabled because of #1338
+  xdescribe("component", () => {
     let api: SpyObject<SitesService>;
     let defaultProject: Project;
 

--- a/src/app/components/sites/site/site.component.spec.ts
+++ b/src/app/components/sites/site/site.component.spec.ts
@@ -162,7 +162,7 @@ describe("SiteComponent", () => {
     });
 
     it("should display default site image", () => {
-      const site = new Site({ ...generateSite(), imageUrl: undefined });
+      const site = new Site(generateSite({ imageUrl: undefined }));
       setup(defaultProject, site);
       interceptEventsRequest();
       interceptRecordingsRequest();
@@ -187,7 +187,7 @@ describe("SiteComponent", () => {
     });
 
     it("should display default description if model has none", () => {
-      const site = new Site({ ...generateSite(), descriptionHtml: undefined });
+      const site = new Site(generateSite({ descriptionHtml: undefined }));
       setup(defaultProject, site);
       interceptEventsRequest();
       interceptRecordingsRequest();

--- a/src/app/helpers/advancedTypes.ts
+++ b/src/app/helpers/advancedTypes.ts
@@ -1,3 +1,5 @@
+import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+
 /**
  * Like Partial<T> but require certain properties.
  */
@@ -46,3 +48,5 @@ export interface Tuple<T extends any, L extends number> extends Array<T> {
   0: T;
   length: L;
 }
+
+export type Errorable<T> = T | ApiErrorDetails;

--- a/src/app/helpers/tableTemplate/pagedTableTemplate.spec.ts
+++ b/src/app/helpers/tableTemplate/pagedTableTemplate.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from "@angular/core";
-import { fakeAsync, tick } from "@angular/core/testing";
+import { fakeAsync } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import {
@@ -316,7 +316,7 @@ describe("PagedTableTemplate", () => {
       const mockInput = createInput();
       createFilterEvent("testing", "", mockInput);
 
-      tick(defaultDebounceTime);
+      spec.tick(defaultDebounceTime);
       expect(api.filter).toHaveBeenCalledWith({ filter: undefined });
     }));
 
@@ -324,7 +324,7 @@ describe("PagedTableTemplate", () => {
       const mockInput = createInput();
       createFilterEvent("custom", "a", mockInput);
 
-      tick(defaultDebounceTime);
+      spec.tick(defaultDebounceTime);
       expect(api.filter).toHaveBeenCalledWith({
         filter: { ["custom" as any]: { contains: "a" } },
       });
@@ -334,7 +334,7 @@ describe("PagedTableTemplate", () => {
       const mockInput = createInput();
       createFilterEvent("testing", "a", mockInput);
 
-      tick(defaultDebounceTime);
+      spec.tick(defaultDebounceTime);
       expect(api.filter).toHaveBeenCalledWith({
         filter: { ["testing" as any]: { contains: "a" } },
       });
@@ -344,7 +344,7 @@ describe("PagedTableTemplate", () => {
       const mockInput = createInput();
       createFilterEvent("testing", "testing", mockInput);
 
-      tick(defaultDebounceTime);
+      spec.tick(defaultDebounceTime);
       expect(api.filter).toHaveBeenCalledWith({
         filter: { ["testing" as any]: { contains: "testing" } },
       });
@@ -359,7 +359,7 @@ describe("PagedTableTemplate", () => {
         createFilterEvent("testing", subSet, mockInput);
       }
 
-      tick(defaultDebounceTime);
+      spec.tick(defaultDebounceTime);
       expect(api.filter).toHaveBeenCalledTimes(2); // Initial filter request on ngOnInit
     }));
 
@@ -372,7 +372,7 @@ describe("PagedTableTemplate", () => {
         createFilterEvent("testing", subSet, mockInput);
       }
 
-      tick(defaultDebounceTime);
+      spec.tick(defaultDebounceTime);
       expect(api.filter).toHaveBeenCalledWith({
         filter: { ["testing" as any]: { contains: "testing" } },
       });
@@ -406,7 +406,7 @@ describe("PagedTableTemplate", () => {
       createSortEvent({ testing: "customKey" }, undefined, "testing");
       spec.detectChanges();
 
-      tick(defaultDebounceTime);
+      spec.tick(defaultDebounceTime);
       expect(api.filter).toHaveBeenCalledWith({ sorting: undefined });
     }));
 
@@ -414,7 +414,7 @@ describe("PagedTableTemplate", () => {
       createSortEvent({ testing: "customKey" }, "asc", "testing");
       spec.detectChanges();
 
-      tick(defaultDebounceTime);
+      spec.tick(defaultDebounceTime);
       expect(api.filter).toHaveBeenCalledWith({
         sorting: { orderBy: "customKey", direction: "asc" },
       });
@@ -424,7 +424,7 @@ describe("PagedTableTemplate", () => {
       createSortEvent({ testing: "customKey" }, "desc", "testing");
       spec.detectChanges();
 
-      tick(defaultDebounceTime);
+      spec.tick(defaultDebounceTime);
       expect(api.filter).toHaveBeenCalledWith({
         sorting: { orderBy: "customKey", direction: "desc" },
       });
@@ -434,7 +434,7 @@ describe("PagedTableTemplate", () => {
       createSortEvent({ testing: "customKey" }, "asc", "testing");
       spec.detectChanges();
 
-      tick(defaultDebounceTime);
+      spec.tick(defaultDebounceTime);
       expect(api.filter).toHaveBeenCalledWith({
         sorting: { orderBy: "customKey", direction: "asc" },
       });
@@ -448,7 +448,7 @@ describe("PagedTableTemplate", () => {
       );
       spec.detectChanges();
 
-      tick(defaultDebounceTime);
+      spec.tick(defaultDebounceTime);
       expect(api.filter).toHaveBeenCalledWith({
         sorting: { orderBy: "customKey", direction: "asc" },
       });

--- a/src/app/helpers/tableTemplate/pagedTableTemplate.spec.ts
+++ b/src/app/helpers/tableTemplate/pagedTableTemplate.spec.ts
@@ -61,7 +61,7 @@ describe("PagedTableTemplate", () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useClass: mockActivatedRoute(resolvers, data),
+          useValue: mockActivatedRoute(resolvers, data),
         },
       ],
     }).compileComponents();
@@ -258,9 +258,7 @@ describe("PagedTableTemplate", () => {
     it("should handle first page", () => {
       const project = new Project(generateProject());
       project.addMetadata(generateMetaData(1, 25));
-      api.filter.and.callFake(
-        () => new BehaviorSubject<Project[]>([project])
-      );
+      api.filter.and.callFake(() => new BehaviorSubject<Project[]>([project]));
       component.setPage({
         offset: 0,
         count: 1,
@@ -275,9 +273,7 @@ describe("PagedTableTemplate", () => {
     it("should handle random page", () => {
       const project = new Project(generateProject());
       project.addMetadata(generateMetaData(3, 25));
-      api.filter.and.callFake(
-        () => new BehaviorSubject<Project[]>([project])
-      );
+      api.filter.and.callFake(() => new BehaviorSubject<Project[]>([project]));
       component.setPage({
         offset: 2,
         count: 51,
@@ -484,9 +480,7 @@ describe("PagedTableTemplate", () => {
       const project = new Project(generateProject());
       project.addMetadata(generateMetaData(1, 1));
 
-      api.filter.and.callFake(
-        () => new BehaviorSubject<Project[]>([project])
-      );
+      api.filter.and.callFake(() => new BehaviorSubject<Project[]>([project]));
       fixture.detectChanges();
 
       expect(component.totalModels).toBe(1);
@@ -496,9 +490,7 @@ describe("PagedTableTemplate", () => {
       const project = new Project(generateProject());
       project.addMetadata(generateMetaData(1, 100));
 
-      api.filter.and.callFake(
-        () => new BehaviorSubject<Project[]>([project])
-      );
+      api.filter.and.callFake(() => new BehaviorSubject<Project[]>([project]));
       fixture.detectChanges();
 
       expect(component.totalModels).toBe(100);

--- a/src/app/services/baw-api/account/accounts.service.spec.ts
+++ b/src/app/services/baw-api/account/accounts.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { AccountsService } from "@baw-api/account/accounts.service";
 import { User } from "@models/User";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateUser } from "@test/fakes/User";
 import {
@@ -18,16 +18,15 @@ type Params = [];
 type Service = AccountsService;
 
 describe("AccountsService", () => {
-  const createModel = () => new User(generateUser(5));
+  const createModel = () => new User(generateUser({ id: 5 }));
   const baseUrl = "/user_accounts/";
+  const createService = createServiceFactory({
+    service: AccountsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [AccountsService],
-    });
-
-    this.service = TestBed.inject(AccountsService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl);

--- a/src/app/services/baw-api/analysis/analysis-job-items.service.spec.ts
+++ b/src/app/services/baw-api/analysis/analysis-job-items.service.spec.ts
@@ -1,8 +1,8 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { IdOr } from "@baw-api/api-common";
 import { AnalysisJob } from "@models/AnalysisJob";
 import { AnalysisJobItem } from "@models/AnalysisJobItem";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateAnalysisJobItem } from "@test/fakes/AnalysisJobItem";
 import {
@@ -17,16 +17,16 @@ type Params = [IdOr<AnalysisJob>];
 type Service = AnalysisJobItemsService;
 
 describe("AnalysisJobItemsService", function () {
-  const createModel = () => new AnalysisJobItem(generateAnalysisJobItem(10));
+  const createModel = () =>
+    new AnalysisJobItem(generateAnalysisJobItem({ id: 10 }));
   const baseUrl = "/analysis_jobs/5/audio_recordings/";
+  const createService = createServiceFactory({
+    service: AnalysisJobItemsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [AnalysisJobItemsService],
-    });
-
-    this.service = TestBed.inject(AnalysisJobItemsService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl, 5);

--- a/src/app/services/baw-api/analysis/analysis-jobs.service.spec.ts
+++ b/src/app/services/baw-api/analysis/analysis-jobs.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { AnalysisJob } from "@models/AnalysisJob";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateAnalysisJob } from "@test/fakes/AnalysisJob";
 import {
@@ -16,16 +16,15 @@ type Params = [];
 type Service = AnalysisJobsService;
 
 describe("AnalysisJobsService", function () {
-  const createModel = () => new AnalysisJob(generateAnalysisJob(5));
+  const createModel = () => new AnalysisJob(generateAnalysisJob({ id: 5 }));
   const baseUrl = "/analysis_jobs/";
+  const createService = createServiceFactory({
+    service: AnalysisJobsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [AnalysisJobsService],
-    });
-
-    this.service = TestBed.inject(AnalysisJobsService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl);

--- a/src/app/services/baw-api/api.interceptor.service.spec.ts
+++ b/src/app/services/baw-api/api.interceptor.service.spec.ts
@@ -39,7 +39,7 @@ describe("BawApiInterceptor", () => {
     spyOn(spec.service, "isLoggedIn").and.callFake(() => true);
     spyOn(spec.service, "getLocalUser").and.callFake(() =>
       authToken
-        ? new SessionUser({ ...generateSessionUser(), authToken })
+        ? new SessionUser(generateSessionUser({ authToken }))
         : new SessionUser(generateSessionUser())
     );
   }

--- a/src/app/services/baw-api/api.interceptor.service.ts
+++ b/src/app/services/baw-api/api.interceptor.service.ts
@@ -120,7 +120,7 @@ export class BawApiInterceptor implements HttpInterceptor {
     response = toCamelCase(response);
     let error: ApiErrorDetails;
 
-    if (isErrorDetails(response)) {
+    if (isApiErrorDetails(response)) {
       error = response;
     } else if (isErrorResponse(response)) {
       error = {
@@ -166,8 +166,8 @@ interface ApiErrorResponse extends HttpErrorResponse {
  *
  * @param errorResponse Error response
  */
-function isErrorDetails(
-  errorResponse: ApiErrorResponse | ApiErrorDetails | HttpErrorResponse
+export function isApiErrorDetails(
+  errorResponse: any
 ): errorResponse is ApiErrorDetails {
   const keys = Object.keys(errorResponse);
   return (

--- a/src/app/services/baw-api/audio-event/audio-events.service.spec.ts
+++ b/src/app/services/baw-api/audio-event/audio-events.service.spec.ts
@@ -1,8 +1,8 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { IdOr } from "@baw-api/api-common";
 import { AudioEvent } from "@models/AudioEvent";
 import { AudioRecording } from "@models/AudioRecording";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateAudioEvent } from "@test/fakes/AudioEvent";
 import {
@@ -20,16 +20,15 @@ type Params = [IdOr<AudioRecording>];
 type Service = AudioEventsService;
 
 describe("AudioEventsService", function () {
-  const createModel = () => new AudioEvent(generateAudioEvent(10));
+  const createModel = () => new AudioEvent(generateAudioEvent({ id: 10 }));
   const baseUrl = "/audio_recordings/5/audio_events/";
+  const createService = createServiceFactory({
+    service: AudioEventsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [AudioEventsService],
-    });
-
-    this.service = TestBed.inject(AudioEventsService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl, 5);

--- a/src/app/services/baw-api/audio-recording/audio-recordings.service.spec.ts
+++ b/src/app/services/baw-api/audio-recording/audio-recordings.service.spec.ts
@@ -1,8 +1,8 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { IdOr } from "@baw-api/api-common";
 import { AudioRecording } from "@models/AudioRecording";
 import { Site } from "@models/Site";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateAudioRecording } from "@test/fakes/AudioRecording";
 import {
@@ -18,15 +18,16 @@ type Params = [];
 type Service = AudioRecordingsService;
 
 describe("AudioRecordingsService", function () {
-  const createModel = () => new AudioRecording(generateAudioRecording(5));
+  const createModel = () =>
+    new AudioRecording(generateAudioRecording({ id: 5 }));
   const baseUrl = "/audio_recordings/";
+  const createService = createServiceFactory({
+    service: AudioRecordingsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [AudioRecordingsService],
-    });
-    this.service = TestBed.inject(AudioRecordingsService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl);

--- a/src/app/services/baw-api/bookmark/bookmarks.service.spec.ts
+++ b/src/app/services/baw-api/bookmark/bookmarks.service.spec.ts
@@ -1,8 +1,8 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { IdOr } from "@baw-api/api-common";
 import { Bookmark } from "@models/Bookmark";
 import { User } from "@models/User";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateBookmark } from "@test/fakes/Bookmark";
 import {
@@ -21,16 +21,15 @@ type Params = [];
 type Service = BookmarksService;
 
 describe("BookmarksService", function () {
-  const createModel = () => new Bookmark(generateBookmark(5));
+  const createModel = () => new Bookmark(generateBookmark({ id: 5 }));
   const baseUrl = "/bookmarks/";
+  const createService = createServiceFactory({
+    service: BookmarksService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [BookmarksService],
-    });
-
-    this.service = TestBed.inject(BookmarksService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl);

--- a/src/app/services/baw-api/dataset/dataset-items.service.spec.ts
+++ b/src/app/services/baw-api/dataset/dataset-items.service.spec.ts
@@ -1,8 +1,8 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { IdOr } from "@baw-api/api-common";
 import { Dataset } from "@models/Dataset";
 import { DatasetItem } from "@models/DatasetItem";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateDatasetItem } from "@test/fakes/DatasetItem";
 import {
@@ -19,16 +19,15 @@ type Params = [IdOr<Dataset>];
 type Service = DatasetItemsService;
 
 describe("DatasetItemsService", function () {
-  const createModel = () => new DatasetItem(generateDatasetItem(10));
+  const createModel = () => new DatasetItem(generateDatasetItem({ id: 10 }));
   const baseUrl = "/datasets/5/items/";
+  const createService = createServiceFactory({
+    service: DatasetItemsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [DatasetItemsService],
-    });
-
-    this.service = TestBed.inject(DatasetItemsService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl, 5);

--- a/src/app/services/baw-api/dataset/datasets.service.spec.ts
+++ b/src/app/services/baw-api/dataset/datasets.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { Dataset } from "@models/Dataset";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateDataset } from "@test/fakes/Dataset";
 import {
@@ -18,16 +18,15 @@ type Params = [];
 type Service = DatasetsService;
 
 describe("DatasetsService", function () {
-  const createModel = () => new Dataset(generateDataset(5));
+  const createModel = () => new Dataset(generateDataset({ id: 5 }));
   const baseUrl = "/datasets/";
+  const createService = createServiceFactory({
+    service: DatasetsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [DatasetsService],
-    });
-
-    this.service = TestBed.inject(DatasetsService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl);

--- a/src/app/services/baw-api/progress-event/progress-events.service.spec.ts
+++ b/src/app/services/baw-api/progress-event/progress-events.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { ProgressEvent } from "@models/ProgressEvent";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateProgressEvent } from "@test/fakes/ProgressEvent";
 import {
@@ -16,16 +16,15 @@ type Params = [];
 type Service = ProgressEventsService;
 
 describe("ProgressEventsService", function () {
-  const createModel = () => new ProgressEvent(generateProgressEvent(5));
+  const createModel = () => new ProgressEvent(generateProgressEvent({ id: 5 }));
   const baseUrl = "/progress_events/";
+  const createService = createServiceFactory({
+    service: ProgressEventsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [ProgressEventsService],
-    });
-
-    this.service = TestBed.inject(ProgressEventsService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl);

--- a/src/app/services/baw-api/project/projects.service.spec.ts
+++ b/src/app/services/baw-api/project/projects.service.spec.ts
@@ -1,9 +1,9 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { IdOr } from "@baw-api/api-common";
 import { ProjectsService } from "@baw-api/project/projects.service";
 import { Project } from "@models/Project";
 import { User } from "@models/User";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateProject } from "@test/fakes/Project";
 import {
@@ -21,16 +21,15 @@ type Params = [];
 type Service = ProjectsService;
 
 describe("ProjectsService", function () {
-  const createModel = () => new Project(generateProject(5));
+  const createModel = () => new Project(generateProject({ id: 5 }));
   const baseUrl = "/projects/";
+  const createService = createServiceFactory({
+    service: ProjectsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [ProjectsService],
-    });
-
-    this.service = TestBed.inject(ProjectsService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl);

--- a/src/app/services/baw-api/region/regions-shallow.service.spec.ts
+++ b/src/app/services/baw-api/region/regions-shallow.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { Region } from "@models/Region";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateRegion } from "@test/fakes/Region";
 import {
@@ -18,16 +18,15 @@ type Params = [];
 type Service = ShallowRegionsService;
 
 describe("ShallowRegionsService", function () {
-  const createModel = () => new Region(generateRegion(5));
+  const createModel = () => new Region(generateRegion({ id: 5 }));
   const baseUrl = "/regions/";
+  const createService = createServiceFactory({
+    service: ShallowRegionsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [ShallowRegionsService],
-    });
-
-    this.service = TestBed.inject(ShallowRegionsService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl);

--- a/src/app/services/baw-api/region/regions.service.spec.ts
+++ b/src/app/services/baw-api/region/regions.service.spec.ts
@@ -1,8 +1,8 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { IdOr } from "@baw-api/api-common";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateRegion } from "@test/fakes/Region";
 import {
@@ -20,16 +20,15 @@ type Params = [IdOr<Project>];
 type Service = RegionsService;
 
 describe("RegionsService", function () {
-  const createModel = () => new Region(generateRegion(10));
+  const createModel = () => new Region(generateRegion({ id: 10 }));
   const baseUrl = "/projects/5/regions/";
+  const createService = createServiceFactory({
+    service: RegionsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [RegionsService],
-    });
-
-    this.service = TestBed.inject(RegionsService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl, 5);

--- a/src/app/services/baw-api/saved-search/saved-searches.service.spec.ts
+++ b/src/app/services/baw-api/saved-search/saved-searches.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { SavedSearch } from "@models/SavedSearch";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateSavedSearch } from "@test/fakes/SavedSearch";
 import {
@@ -17,16 +17,15 @@ type Params = [];
 type Service = SavedSearchesService;
 
 describe("SavedSearchesService", function () {
-  const createModel = () => new SavedSearch(generateSavedSearch(5));
+  const createModel = () => new SavedSearch(generateSavedSearch({ id: 5 }));
   const baseUrl = "/saved_searches/";
+  const createService = createServiceFactory({
+    service: SavedSearchesService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [SavedSearchesService],
-    });
-
-    this.service = TestBed.inject(SavedSearchesService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl);

--- a/src/app/services/baw-api/script/scripts.service.spec.ts
+++ b/src/app/services/baw-api/script/scripts.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { ScriptsService } from "@baw-api/script/scripts.service";
 import { Script } from "@models/Script";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateScript } from "@test/fakes/Script";
 import {
@@ -16,15 +16,15 @@ type Params = [];
 type Service = ScriptsService;
 
 describe("ScriptsService", function () {
-  const createModel = () => new Script(generateScript(5));
+  const createModel = () => new Script(generateScript({ id: 5 }));
   const baseUrl = "/scripts/";
+  const createService = createServiceFactory({
+    service: ScriptsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [ScriptsService],
-    });
-    this.service = TestBed.inject(ScriptsService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl);

--- a/src/app/services/baw-api/security/security.service.spec.ts
+++ b/src/app/services/baw-api/security/security.service.spec.ts
@@ -59,11 +59,12 @@ describe("SecurityService", () => {
     spec = createService();
     userApi = spec.inject(UserService);
 
+    const userData = generateUser();
     defaultAuthToken = modelData.random.alphaNumeric(20);
     defaultError = generateApiErrorDetails();
-    defaultUser = new User(generateUser());
+    defaultUser = new User(userData);
     defaultSessionUser = new SessionUser({
-      ...defaultUser,
+      ...userData,
       ...generateSessionUser(),
     });
     defaultRegisterDetails = new RegisterDetails(generateRegisterDetails());
@@ -246,10 +247,9 @@ describe("SecurityService", () => {
       });
 
       it("should throw error if no recaptcha token", () => {
-        const registerDetails = new RegisterDetails({
-          ...defaultRegisterDetails,
-          recaptchaToken: null,
-        });
+        const registerDetails = new RegisterDetails(
+          generateRegisterDetails({ recaptchaToken: null })
+        );
         const page = `<input name="authenticity_token" value="${defaultAuthToken}"></input>`;
 
         spec.service.signUp(registerDetails);

--- a/src/app/services/baw-api/site/sites-shallow.service.spec.ts
+++ b/src/app/services/baw-api/site/sites-shallow.service.spec.ts
@@ -1,9 +1,9 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { IdOr } from "@baw-api/api-common";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
 import { User } from "@models/User";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateSite } from "@test/fakes/Site";
 import {
@@ -23,16 +23,15 @@ type Params = [];
 type Service = ShallowSitesService;
 
 describe("ShallowSitesService", function () {
-  const createModel = () => new Site(generateSite(5));
+  const createModel = () => new Site(generateSite({ id: 5 }));
   const baseUrl = "/sites/";
+  const createService = createServiceFactory({
+    service: ShallowSitesService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [ShallowSitesService],
-    });
-
-    this.service = TestBed.inject(ShallowSitesService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl);

--- a/src/app/services/baw-api/study/questions-shallow.service.spec.ts
+++ b/src/app/services/baw-api/study/questions-shallow.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { Question } from "@models/Question";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateQuestion } from "@test/fakes/Question";
 import {
@@ -18,16 +18,15 @@ type Params = [];
 type Service = ShallowQuestionsService;
 
 describe("ShallowQuestionsService", function () {
-  const createModel = () => new Question(generateQuestion(5));
+  const createModel = () => new Question(generateQuestion({ id: 5 }));
   const baseUrl = "/questions/";
+  const createService = createServiceFactory({
+    service: ShallowQuestionsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [ShallowQuestionsService],
-    });
-
-    this.service = TestBed.inject(ShallowQuestionsService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl);

--- a/src/app/services/baw-api/study/questions.service.spec.ts
+++ b/src/app/services/baw-api/study/questions.service.spec.ts
@@ -1,8 +1,8 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { IdOr } from "@baw-api/api-common";
 import { Question } from "@models/Question";
 import { Study } from "@models/Study";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateQuestion } from "@test/fakes/Question";
 import {
@@ -20,16 +20,15 @@ type Params = [IdOr<Study>];
 type Service = QuestionsService;
 
 describe("QuestionsService", function () {
-  const createModel = () => new Question(generateQuestion(10));
+  const createModel = () => new Question(generateQuestion({ id: 10 }));
   const baseUrl = "/studies/5/questions/";
+  const createService = createServiceFactory({
+    service: QuestionsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [QuestionsService],
-    });
-
-    this.service = TestBed.inject(QuestionsService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl, 5);

--- a/src/app/services/baw-api/study/responses-shallow.service.spec.ts
+++ b/src/app/services/baw-api/study/responses-shallow.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { Response } from "@models/Response";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateResponse } from "@test/fakes/Response";
 import {
@@ -18,16 +18,15 @@ type Params = [];
 type Service = ShallowResponsesService;
 
 describe("ShallowResponsesService", function () {
-  const createModel = () => new Response(generateResponse(5));
+  const createModel = () => new Response(generateResponse({ id: 5 }));
   const baseUrl = "/responses/";
+  const createService = createServiceFactory({
+    service: ShallowResponsesService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [ShallowResponsesService],
-    });
-
-    this.service = TestBed.inject(ShallowResponsesService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl);

--- a/src/app/services/baw-api/study/responses.service.spec.ts
+++ b/src/app/services/baw-api/study/responses.service.spec.ts
@@ -1,8 +1,8 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { IdOr } from "@baw-api/api-common";
 import { Response } from "@models/Response";
 import { Study } from "@models/Study";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateResponse } from "@test/fakes/Response";
 import {
@@ -20,16 +20,15 @@ type Params = [IdOr<Study>];
 type Service = ResponsesService;
 
 describe("ResponsesService", function () {
-  const createModel = () => new Response(generateResponse(10));
+  const createModel = () => new Response(generateResponse({ id: 10 }));
   const baseUrl = "/studies/5/responses/";
+  const createService = createServiceFactory({
+    service: ResponsesService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [ResponsesService],
-    });
-
-    this.service = TestBed.inject(ResponsesService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl, 5);

--- a/src/app/services/baw-api/study/studies.service.spec.ts
+++ b/src/app/services/baw-api/study/studies.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { Study } from "@models/Study";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateStudy } from "@test/fakes/Study";
 import {
@@ -18,16 +18,15 @@ type Params = [];
 type Service = StudiesService;
 
 describe("StudiesService", function () {
-  const createModel = () => new Study(generateStudy(5));
+  const createModel = () => new Study(generateStudy({ id: 5 }));
   const baseUrl = "/studies/";
+  const createService = createServiceFactory({
+    service: StudiesService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [StudiesService],
-    });
-
-    this.service = TestBed.inject(StudiesService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl);

--- a/src/app/services/baw-api/tag/tag-group.service.spec.ts
+++ b/src/app/services/baw-api/tag/tag-group.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { TagGroupsService } from "@baw-api/tag/tag-group.service";
 import { TagGroup } from "@models/TagGroup";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateTagGroup } from "@test/fakes/TagGroup";
 import {
@@ -18,15 +18,15 @@ type Params = [];
 type Service = TagGroupsService;
 
 describe("TagGroupService", function () {
-  const createModel = () => new TagGroup(generateTagGroup(5));
+  const createModel = () => new TagGroup(generateTagGroup({ id: 5 }));
   const baseUrl = "/tag_groups/";
+  const createService = createServiceFactory({
+    service: TagGroupsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [TagGroupsService],
-    });
-    this.service = TestBed.inject(TagGroupsService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl);

--- a/src/app/services/baw-api/tag/taggings.service.spec.ts
+++ b/src/app/services/baw-api/tag/taggings.service.spec.ts
@@ -1,9 +1,9 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { IdOr } from "@baw-api/api-common";
 import { AnalysisJob } from "@models/AnalysisJob";
 import { AudioEvent } from "@models/AudioEvent";
 import { Tagging } from "@models/Tagging";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateTagging } from "@test/fakes/Tagging";
 import {
@@ -21,18 +21,16 @@ type Params = [IdOr<AnalysisJob>, IdOr<AudioEvent>];
 type Service = TaggingsService;
 
 describe("TaggingsService", function () {
-  const createModel = () => new Tagging(generateTagging(15));
+  const createModel = () => new Tagging(generateTagging({ id: 15 }));
   const baseUrl = "/audio_recordings/5/audio_events/10/taggings/";
-
-  beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [TaggingsService],
-    });
-
-    this.service = TestBed.inject(TaggingsService);
+  const createService = createServiceFactory({
+    service: TaggingsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
   });
 
+  beforeEach(function () {
+    this.service = createService().service;
+  });
   validateApiList<Model, Params, Service>(baseUrl, 5, 10);
   validateApiFilter<Model, Params, Service>(baseUrl + "filter", 5, 10);
   validateApiShow<Model, Params, Service>(

--- a/src/app/services/baw-api/tag/tags.service.spec.ts
+++ b/src/app/services/baw-api/tag/tags.service.spec.ts
@@ -1,8 +1,8 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { IdOr } from "@baw-api/api-common";
 import { Tag } from "@models/Tag";
 import { User } from "@models/User";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateTag } from "@test/fakes/Tag";
 import {
@@ -21,15 +21,15 @@ type Params = [];
 type Service = TagsService;
 
 describe("TagsService", function () {
-  const createModel = () => new Tag(generateTag(5));
+  const createModel = () => new Tag(generateTag({ id: 5 }));
   const baseUrl = "/tags/";
+  const createService = createServiceFactory({
+    service: TagsService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [TagsService],
-    });
-    this.service = TestBed.inject(TagsService);
+    this.service = createService().service;
   });
 
   validateApiList<Model, Params, Service>(baseUrl);

--- a/src/app/services/baw-api/user/user.service.spec.ts
+++ b/src/app/services/baw-api/user/user.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { TestBed } from "@angular/core/testing";
 import { User } from "@models/User";
+import { createServiceFactory } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateUser } from "@test/fakes/User";
 import { validateApiShow } from "@test/helpers/api-common";
@@ -11,16 +11,15 @@ type Params = [];
 type Service = UserService;
 
 describe("UserService", function () {
-  const createModel = () => new User(generateUser(5));
+  const createModel = () => new User(generateUser({ id: 5 }));
   const baseUrl = "/my_account/";
+  const createService = createServiceFactory({
+    service: UserService,
+    imports: [HttpClientTestingModule, MockAppConfigModule],
+  });
 
   beforeEach(function () {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, MockAppConfigModule],
-      providers: [UserService],
-    });
-
-    this.service = TestBed.inject(UserService);
+    this.service = createService().service;
   });
 
   validateApiShow<Model, Params, Service>(baseUrl, 5, createModel);

--- a/src/app/test/fakes/AnalysisJob.ts
+++ b/src/app/test/fakes/AnalysisJob.ts
@@ -1,8 +1,9 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { AnalysisJobStatus, IAnalysisJob } from "@models/AnalysisJob";
 import { modelData } from "@test/helpers/faker";
 
-export function generateAnalysisJob(id?: Id): Required<IAnalysisJob> {
+export function generateAnalysisJob(
+  data?: Partial<IAnalysisJob>
+): Required<IAnalysisJob> {
   const overallDurationSeconds = modelData.datatype.number(3.154e7); // 1 year
   const overallDataLengthBytes = overallDurationSeconds * 22050 * 2; // duration seconds * sample rate * two bytes per sample
   const statuses: AnalysisJobStatus[] = [
@@ -15,7 +16,7 @@ export function generateAnalysisJob(id?: Id): Required<IAnalysisJob> {
   ];
 
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     name: modelData.param(),
     annotationName: modelData.param(),
     scriptId: modelData.id(),
@@ -37,5 +38,6 @@ export function generateAnalysisJob(id?: Id): Required<IAnalysisJob> {
     customSettings: modelData.randomObject(0, 5),
     ...modelData.model.generateDescription(),
     ...modelData.model.generateAllUsers(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/AnalysisJobItem.ts
+++ b/src/app/test/fakes/AnalysisJobItem.ts
@@ -1,11 +1,12 @@
-import { Id } from "@interfaces/apiInterfaces";
 import {
   AnalysisJobItemStatus,
   IAnalysisJobItem,
 } from "@models/AnalysisJobItem";
 import { modelData } from "@test/helpers/faker";
 
-export function generateAnalysisJobItem(id?: Id): Required<IAnalysisJobItem> {
+export function generateAnalysisJobItem(
+  data?: Partial<IAnalysisJobItem>
+): Required<IAnalysisJobItem> {
   const statuses: AnalysisJobItemStatus[] = [
     "successful",
     "new",
@@ -18,7 +19,7 @@ export function generateAnalysisJobItem(id?: Id): Required<IAnalysisJobItem> {
   ];
 
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     analysisJobId: modelData.id(),
     audioRecordingId: modelData.id(),
     queueId: modelData.datatype.uuid(),
@@ -28,5 +29,6 @@ export function generateAnalysisJobItem(id?: Id): Required<IAnalysisJobItem> {
     workStartedAt: modelData.timestamp(),
     completedAt: modelData.timestamp(),
     cancelStartedAt: modelData.timestamp(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/AudioEvent.ts
+++ b/src/app/test/fakes/AudioEvent.ts
@@ -17,7 +17,7 @@ export function generateAudioEvent(
     endTimeSeconds,
     lowFrequencyHertz,
     highFrequencyHertz,
-    taggings: modelData.randomArray(0, 5, (i) => generateTagging(i)),
+    taggings: modelData.randomArray(0, 5, (id) => generateTagging({ id })),
     isReference: modelData.bool(),
     ...modelData.model.generateAllUsers(),
     ...data,

--- a/src/app/test/fakes/AudioEvent.ts
+++ b/src/app/test/fakes/AudioEvent.ts
@@ -1,16 +1,17 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { IAudioEvent } from "@models/AudioEvent";
 import { generateTagging } from "@test/fakes/Tagging";
 import { modelData } from "@test/helpers/faker";
 
-export function generateAudioEvent(id?: Id): Required<IAudioEvent> {
+export function generateAudioEvent(
+  data?: Partial<IAudioEvent>
+): Required<IAudioEvent> {
   const [startTimeSeconds, endTimeSeconds] = modelData.startEndSeconds();
   const [lowFrequencyHertz, highFrequencyHertz] = modelData.startEndArray(
     modelData.defaults.sampleRateHertz
   );
 
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     audioRecordingId: modelData.id(),
     startTimeSeconds,
     endTimeSeconds,
@@ -19,5 +20,6 @@ export function generateAudioEvent(id?: Id): Required<IAudioEvent> {
     taggings: modelData.randomArray(0, 5, (i) => generateTagging(i)),
     isReference: modelData.bool(),
     ...modelData.model.generateAllUsers(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/AudioRecording.ts
+++ b/src/app/test/fakes/AudioRecording.ts
@@ -1,18 +1,14 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { AudioRecordingStatus, IAudioRecording } from "@models/AudioRecording";
 import { modelData } from "@test/helpers/faker";
 
-export function generateAudioRecording(id?: Id): Required<IAudioRecording> {
+export function generateAudioRecording(
+  data?: Partial<IAudioRecording>
+): Required<IAudioRecording> {
   const bitRateBps = modelData.random.arrayElement(
     modelData.defaults.bitRateBps
   );
   const durationSeconds = modelData.random.arrayElement([
-    30,
-    60,
-    1800,
-    3600,
-    7200,
-    21600,
+    30, 60, 1800, 3600, 7200, 21600,
   ]);
   const mediaTypes = ["audio/mpeg", "audio/flac", "audio/wave"];
   const statuses: AudioRecordingStatus[] = [
@@ -25,7 +21,7 @@ export function generateAudioRecording(id?: Id): Required<IAudioRecording> {
   ];
 
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     uuid: modelData.uuid(),
     uploaderId: modelData.id(),
     recordedDate: modelData.timestamp(),
@@ -44,5 +40,6 @@ export function generateAudioRecording(id?: Id): Required<IAudioRecording> {
     originalFileName: modelData.system.commonFileName(".mpg"),
     recordedUtcOffset: modelData.offset(),
     ...modelData.model.generateAllUsers(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/Bookmark.ts
+++ b/src/app/test/fakes/Bookmark.ts
@@ -1,15 +1,17 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { IBookmark } from "@models/Bookmark";
 import { modelData } from "@test/helpers/faker";
 
-export function generateBookmark(id?: Id): Required<IBookmark> {
+export function generateBookmark(
+  data?: Partial<IBookmark>
+): Required<IBookmark> {
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     audioRecordingId: modelData.id(),
     offsetSeconds: modelData.seconds(),
     name: modelData.param(),
     category: "<< application >>", // TODO Replace with list of possibilities
     ...modelData.model.generateDescription(),
     ...modelData.model.generateCreatorAndUpdater(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/Dataset.ts
+++ b/src/app/test/fakes/Dataset.ts
@@ -1,12 +1,12 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { IDataset } from "@models/Dataset";
 import { modelData } from "@test/helpers/faker";
 
-export function generateDataset(id?: Id): Required<IDataset> {
+export function generateDataset(data?: Partial<IDataset>): Required<IDataset> {
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     name: modelData.param(),
     ...modelData.model.generateDescription(),
     ...modelData.model.generateCreatorAndUpdater(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/DatasetItem.ts
+++ b/src/app/test/fakes/DatasetItem.ts
@@ -1,17 +1,19 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { IDatasetItem } from "@models/DatasetItem";
 import { modelData } from "@test/helpers/faker";
 
-export function generateDatasetItem(id?: Id): Required<IDatasetItem> {
+export function generateDatasetItem(
+  data?: Partial<IDatasetItem>
+): Required<IDatasetItem> {
   const [startTimeSeconds, endTimeSeconds] = modelData.startEndSeconds();
 
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     datasetId: modelData.id(),
     audioRecordingId: modelData.id(),
     startTimeSeconds,
     endTimeSeconds,
     order: modelData.datatype.number(100),
     ...modelData.model.generateCreator(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/LoginDetails.ts
+++ b/src/app/test/fakes/LoginDetails.ts
@@ -1,9 +1,12 @@
 import { ILoginDetails } from "@models/data/LoginDetails";
 import { modelData } from "@test/helpers/faker";
 
-export function generateLoginDetails(): Required<ILoginDetails> {
+export function generateLoginDetails(
+  data?: Partial<ILoginDetails>
+): Required<ILoginDetails> {
   return {
     login: modelData.internet.userName(),
     password: modelData.internet.password(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/ProgressEvent.ts
+++ b/src/app/test/fakes/ProgressEvent.ts
@@ -1,12 +1,14 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { IProgressEvent } from "@models/ProgressEvent";
 import { modelData } from "@test/helpers/faker";
 
-export function generateProgressEvent(id?: Id): Required<IProgressEvent> {
+export function generateProgressEvent(
+  data?: Partial<IProgressEvent>
+): Required<IProgressEvent> {
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     datasetItemId: modelData.id(),
     activity: modelData.random.arrayElement(["viewed", "played", "annotated"]),
     ...modelData.model.generateCreator(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/Project.ts
+++ b/src/app/test/fakes/Project.ts
@@ -1,10 +1,9 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { IProject } from "@models/Project";
 import { modelData } from "@test/helpers/faker";
 
-export function generateProject(id?: Id): Required<IProject> {
+export function generateProject(data?: Partial<IProject>): Required<IProject> {
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     name: modelData.param(),
     imageUrl: modelData.imageUrl(),
     accessLevel: modelData.accessLevel(),
@@ -14,5 +13,6 @@ export function generateProject(id?: Id): Required<IProject> {
     notes: modelData.notes(),
     ...modelData.model.generateDescription(),
     ...modelData.model.generateAllUsers(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/Question.ts
+++ b/src/app/test/fakes/Question.ts
@@ -1,12 +1,14 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { IQuestion } from "@models/Question";
 import { modelData } from "@test/helpers/faker";
 
-export function generateQuestion(id?: Id): Required<IQuestion> {
+export function generateQuestion(
+  data?: Partial<IQuestion>
+): Required<IQuestion> {
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     text: modelData.html(),
     data: modelData.notes(),
     ...modelData.model.generateCreatorAndUpdater(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/Region.ts
+++ b/src/app/test/fakes/Region.ts
@@ -1,10 +1,9 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { IRegion } from "@models/Region";
 import { modelData } from "@test/helpers/faker";
 
-export function generateRegion(id?: Id): Required<IRegion> {
+export function generateRegion(data?: Partial<IRegion>): Required<IRegion> {
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     name: modelData.param(),
     imageUrl: modelData.imageUrl(),
     projectId: modelData.id(),
@@ -12,5 +11,6 @@ export function generateRegion(id?: Id): Required<IRegion> {
     notes: modelData.notes(),
     ...modelData.model.generateDescription(),
     ...modelData.model.generateAllUsers(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/RegisterDetails.ts
+++ b/src/app/test/fakes/RegisterDetails.ts
@@ -1,7 +1,9 @@
 import { IRegisterDetails } from "@models/data/RegisterDetails";
 import { modelData } from "@test/helpers/faker";
 
-export function generateRegisterDetails(): Required<IRegisterDetails> {
+export function generateRegisterDetails(
+  data?: Partial<IRegisterDetails>
+): Required<IRegisterDetails> {
   const password = modelData.internet.password();
   return {
     email: modelData.internet.email(),
@@ -9,5 +11,6 @@ export function generateRegisterDetails(): Required<IRegisterDetails> {
     password,
     passwordConfirmation: password,
     recaptchaToken: modelData.random.alphaNumeric(484),
+    ...data,
   };
 }

--- a/src/app/test/fakes/Response.ts
+++ b/src/app/test/fakes/Response.ts
@@ -1,14 +1,16 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { IResponse } from "@models/Response";
 import { modelData } from "@test/helpers/faker";
 
-export function generateResponse(id?: Id): Required<IResponse> {
+export function generateResponse(
+  data?: Partial<IResponse>
+): Required<IResponse> {
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     data: modelData.notes(),
     datasetItemId: modelData.id(),
     questionId: modelData.id(),
     studyId: modelData.id(),
     ...modelData.model.generateCreator(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/SavedSearch.ts
+++ b/src/app/test/fakes/SavedSearch.ts
@@ -1,13 +1,15 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { ISavedSearch } from "@models/SavedSearch";
 import { modelData } from "@test/helpers/faker";
 
-export function generateSavedSearch(id?: Id): Required<ISavedSearch> {
+export function generateSavedSearch(
+  data?: Partial<ISavedSearch>
+): Required<ISavedSearch> {
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     name: modelData.param(),
     storedQuery: { uuid: { eq: "blah blah" } }, // TODO Implement with random values
     ...modelData.model.generateDescription(),
     ...modelData.model.generateCreatorAndDeleter(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/Script.ts
+++ b/src/app/test/fakes/Script.ts
@@ -1,10 +1,9 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { IScript } from "@models/Script";
 import { modelData } from "@test/helpers/faker";
 
-export function generateScript(id?: Id): Required<IScript> {
+export function generateScript(data?: Partial<IScript>): Required<IScript> {
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     name: modelData.param(),
     analysisIdentifier: "script machine identifier", // TODO Implement with random values
     version: parseFloat(modelData.system.semver()),
@@ -21,5 +20,6 @@ export function generateScript(id?: Id): Required<IScript> {
     }, // TODO Implement with random values
     ...modelData.model.generateDescription(),
     ...modelData.model.generateCreator(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/Site.ts
+++ b/src/app/test/fakes/Site.ts
@@ -1,10 +1,12 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { ISite } from "@models/Site";
 import { modelData } from "@test/helpers/faker";
 
-export function generateSite(id?: Id, hasRegion?: boolean): Required<ISite> {
+export function generateSite(
+  data?: Partial<ISite>,
+  hasRegion?: boolean
+): Required<ISite> {
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     name: modelData.param(),
     imageUrl: modelData.imageUrl(),
     locationObfuscated: modelData.bool(),
@@ -20,5 +22,6 @@ export function generateSite(id?: Id, hasRegion?: boolean): Required<ISite> {
     notes: modelData.notes(),
     ...modelData.model.generateDescription(),
     ...modelData.model.generateAllUsers(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/Study.ts
+++ b/src/app/test/fakes/Study.ts
@@ -1,12 +1,12 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { IStudy } from "@models/Study";
 import { modelData } from "@test/helpers/faker";
 
-export function generateStudy(id?: Id): Required<IStudy> {
+export function generateStudy(data?: Partial<IStudy>): Required<IStudy> {
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     name: modelData.param(),
     datasetId: modelData.id(),
     ...modelData.model.generateCreatorAndUpdater(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/Tag.ts
+++ b/src/app/test/fakes/Tag.ts
@@ -1,8 +1,7 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { ITag } from "@models/Tag";
 import { modelData } from "@test/helpers/faker";
 
-export function generateTag(id?: Id): Required<ITag> {
+export function generateTag(data?: Partial<ITag>): Required<ITag> {
   const tagTypes = [
     "general",
     "common_name",
@@ -12,12 +11,13 @@ export function generateTag(id?: Id): Required<ITag> {
   ];
 
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     text: modelData.param(),
     isTaxonomic: modelData.bool(),
     typeOfTag: modelData.random.arrayElement(tagTypes),
     retired: modelData.bool(),
     notes: modelData.notes(),
     ...modelData.model.generateCreatorAndUpdater(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/TagGroup.ts
+++ b/src/app/test/fakes/TagGroup.ts
@@ -1,12 +1,14 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { ITagGroup } from "@models/TagGroup";
 import { modelData } from "@test/helpers/faker";
 
-export function generateTagGroup(id?: Id): Required<ITagGroup> {
+export function generateTagGroup(
+  data?: Partial<ITagGroup>
+): Required<ITagGroup> {
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     groupIdentifier: modelData.param(),
     tagId: modelData.id(),
     ...modelData.model.generateCreator(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/Tagging.ts
+++ b/src/app/test/fakes/Tagging.ts
@@ -1,12 +1,12 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { ITagging } from "@models/Tagging";
 import { modelData } from "@test/helpers/faker";
 
-export function generateTagging(id?: Id): Required<ITagging> {
+export function generateTagging(data?: Partial<ITagging>): Required<ITagging> {
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     audioEventId: modelData.id(),
     tagId: modelData.id(),
     ...modelData.model.generateCreatorAndUpdater(),
+    ...data,
   };
 }

--- a/src/app/test/fakes/User.ts
+++ b/src/app/test/fakes/User.ts
@@ -27,21 +27,19 @@ export function generateUser(
     createdAt: modelData.timestamp(),
     updatedAt: modelData.timestamp(),
     lastSeenAt: modelData.timestamp(),
-    ...modelData.random.arrayElement([
-      { rolesMask: 1, rolesMaskNames: ["Admin"] },
-      { rolesMask: 2, rolesMaskNames: ["User"] },
-    ]),
     tzinfoTz: modelData.tzInfoTz(),
     ...data,
   };
 }
 
 export function generateSessionUser(
-  data?: Partial<ISessionUser>
+  data?: Partial<ISessionUser>,
+  userData?: Partial<IUser>
 ): ISessionUser {
   return {
     authToken: modelData.authToken(),
     userName: modelData.internet.userName(),
+    ...userData,
     ...data,
   };
 }

--- a/src/app/test/fakes/User.ts
+++ b/src/app/test/fakes/User.ts
@@ -1,10 +1,12 @@
-import { Id } from "@interfaces/apiInterfaces";
 import { ISessionUser, IUser } from "@models/User";
 import { modelData } from "@test/helpers/faker";
 
-export function generateUser(id?: Id, isAdmin?: boolean): Required<IUser> {
+export function generateUser(
+  data?: Partial<IUser>,
+  isAdmin?: boolean
+): Required<IUser> {
   return {
-    id: modelData.id(id),
+    id: modelData.id(),
     email: modelData.internet.email(),
     userName: modelData.internet.userName(),
     signInCount: modelData.datatype.number(100),
@@ -30,12 +32,16 @@ export function generateUser(id?: Id, isAdmin?: boolean): Required<IUser> {
       { rolesMask: 2, rolesMaskNames: ["User"] },
     ]),
     tzinfoTz: modelData.tzInfoTz(),
+    ...data,
   };
 }
 
-export function generateSessionUser(): ISessionUser {
+export function generateSessionUser(
+  data?: Partial<ISessionUser>
+): ISessionUser {
   return {
     authToken: modelData.authToken(),
     userName: modelData.internet.userName(),
+    ...data,
   };
 }

--- a/src/app/test/helpers/testbed.ts
+++ b/src/app/test/helpers/testbed.ts
@@ -46,15 +46,15 @@ export function mockActivatedRoute(
   params: MockParams = {},
   queryParams: Params = {}
 ) {
-  return class MockActivatedRoute {
-    public snapshot: Partial<ActivatedRouteSnapshot> = {
+  return {
+    snapshot: {
       data: resolvers ? { resolvers, ...data } : data,
       params,
       queryParams,
-    };
-    public data = new BehaviorSubject<Data>({ resolvers, ...data });
-    public params = new BehaviorSubject<Params>(params);
-    public queryParams = new BehaviorSubject<Params>(queryParams);
+    },
+    data: new BehaviorSubject<Data>({ resolvers, ...data }),
+    params: new BehaviorSubject<Params>(params),
+    queryParams: new BehaviorSubject<Params>(queryParams),
   };
 }
 

--- a/src/app/test/helpers/testbed.ts
+++ b/src/app/test/helpers/testbed.ts
@@ -4,7 +4,7 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { ReactiveFormsModule } from "@angular/forms";
 import { BrowserModule } from "@angular/platform-browser";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { ActivatedRouteSnapshot, Data, Params } from "@angular/router";
+import { Data, Params } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ResolvedModel } from "@baw-api/resolver-common";
 import { NgbModule } from "@ng-bootstrap/ng-bootstrap";


### PR DESCRIPTION
# General Unit Test Cleanup

## Changes

- Updated test model generators to accept a partial version of the model. This is far more flexible than just editing the `id`, and reduces the amount of code which replicates this functionality
- Removed instances of the following code `new Project({...defaultProject, name: "custom name"})` and other variants. This was a potential bug in our unit tests which would trigger if the persistent values for the model changed. Ie. If a test used the above pattern, and the component depended on reading the `createdAt` date for a model, removing the `createdAt` property from the list of persistent properties for the model would cause the test to fail
- Updated some component and service tests to use spectator library
- Enabled some disabled tests
- Updated `mockActivatedRoute` to be compatible with spectator library
- Created `Errorable` type

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
