### PR TITLE
Region Images

### DIFF
--- a/src/app/components/projects/components/site-card/site-card.component.scss
+++ b/src/app/components/projects/components/site-card/site-card.component.scss
@@ -17,6 +17,11 @@ li.list-group-item {
   }
 }
 
+img {
+  width: 60px;
+  height: auto;
+}
+
 .nav > li > a:hover {
   text-decoration: none;
   background-color: #eee;
@@ -33,9 +38,4 @@ li.list-group-item {
   span {
     background-color: var(--baw-highlight);
   }
-}
-
-#image {
-  width: 60px;
-  height: auto;
 }

--- a/src/app/components/projects/components/site-card/site-card.component.scss
+++ b/src/app/components/projects/components/site-card/site-card.component.scss
@@ -17,16 +17,6 @@ li.list-group-item {
   }
 }
 
-.image-wrapper {
-  min-height: 60px;
-  min-width: 60px;
-
-  img {
-    max-width: 60px;
-    max-height: 60px;
-  }
-}
-
 .nav > li > a:hover {
   text-decoration: none;
   background-color: #eee;

--- a/src/app/components/projects/components/site-card/site-card.component.scss
+++ b/src/app/components/projects/components/site-card/site-card.component.scss
@@ -34,3 +34,8 @@ li.list-group-item {
     background-color: var(--baw-highlight);
   }
 }
+
+#image {
+  width: 60px;
+  height: auto;
+}

--- a/src/app/components/projects/components/site-card/site-card.component.scss
+++ b/src/app/components/projects/components/site-card/site-card.component.scss
@@ -17,9 +17,14 @@ li.list-group-item {
   }
 }
 
-img {
-  max-width: 60px;
-  height: auto;
+.image-wrapper {
+  min-height: 60px;
+  min-width: 60px;
+
+  img {
+    max-width: 60px;
+    max-height: 60px;
+  }
 }
 
 .nav > li > a:hover {

--- a/src/app/components/projects/components/site-card/site-card.component.ts
+++ b/src/app/components/projects/components/site-card/site-card.component.ts
@@ -12,9 +12,14 @@ import { takeUntil } from "rxjs/operators";
   selector: "baw-site-card",
   template: `
     <li class="list-group-item p-2">
-      <div class="image-wrapper me-2">
+      <div class="me-2">
         <a id="imageLink" [bawUrl]="model.getViewUrl(project)">
-          <img id="image" [src]="model.image" [alt]="model.name + ' alt'" />
+          <img
+            id="image"
+            [width]="'60px'"
+            [src]="model.image"
+            [alt]="model.name + ' alt'"
+          />
         </a>
       </div>
       <div class="body">

--- a/src/app/components/projects/components/site-card/site-card.component.ts
+++ b/src/app/components/projects/components/site-card/site-card.component.ts
@@ -11,8 +11,8 @@ import { takeUntil } from "rxjs/operators";
 @Component({
   selector: "baw-site-card",
   template: `
-    <li class="list-group-item">
-      <div class="image">
+    <li class="list-group-item p-2">
+      <div class="image-wrapper me-2">
         <a id="imageLink" [bawUrl]="model.getViewUrl(project)">
           <img id="image" [src]="model.image" [alt]="model.name + ' alt'" />
         </a>

--- a/src/app/components/projects/components/site-card/site-card.component.ts
+++ b/src/app/components/projects/components/site-card/site-card.component.ts
@@ -14,12 +14,7 @@ import { takeUntil } from "rxjs/operators";
     <li class="list-group-item p-2">
       <div class="me-2">
         <a id="imageLink" [bawUrl]="model.getViewUrl(project)">
-          <img
-            id="image"
-            [width]="'60px'"
-            [src]="model.image"
-            [alt]="model.name + ' alt'"
-          />
+          <img id="image" [src]="model.image" [alt]="model.name + ' alt'" />
         </a>
       </div>
       <div class="body">

--- a/src/app/components/regions/pages/details/details.component.scss
+++ b/src/app/components/regions/pages/details/details.component.scss
@@ -1,3 +1,6 @@
+// TODO Remove after thumbnail is global style
+@import "thumbnail";
+
 #model-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));

--- a/src/app/components/regions/pages/details/details.component.ts
+++ b/src/app/components/regions/pages/details/details.component.ts
@@ -46,10 +46,19 @@ const regionKey = "region";
         {{ region.name }}
       </h1>
 
-      <p
-        id="region_description"
-        [innerHtml]="region.descriptionHtml || defaultDescription"
-      ></p>
+      <div class="row">
+        <div class="col-sm-4">
+          <div class="thumbnail">
+            <img [src]="region.image" [alt]="region.name + ' image'" />
+          </div>
+        </div>
+        <div class="col-sm-8">
+          <p
+            id="region_description"
+            [innerHtml]="region.descriptionHtml || defaultDescription"
+          ></p>
+        </div>
+      </div>
 
       <baw-debounce-input
         label="Filter"

--- a/src/app/components/shared/cards/card-image/card-image.component.scss
+++ b/src/app/components/shared/cards/card-image/card-image.component.scss
@@ -15,8 +15,9 @@
     border-bottom: var(--card-border);
 
     img {
-      width: 100%;
-      height: 100%;
+      min-width: 100%;
+      max-width: 100%;
+      height: auto;
       object-fit: cover;
     }
   }

--- a/src/app/components/shared/header/header.component.html
+++ b/src/app/components/shared/header/header.component.html
@@ -86,7 +86,15 @@
       [bawUrl]="user.viewUrl"
     >
       <span [innerText]="user.userName"></span>
-      <img alt="Profile Icon" [src]="user.image" [thumbnail]="thumbnail" />
+      <div class="image-wrapper d-inline-block bg-light ms-2">
+        <img
+          alt="Profile Icon"
+          [width]="'30px'"
+          [height]="'30px'"
+          [src]="user.image"
+          [thumbnail]="thumbnail"
+        />
+      </div>
     </a>
   </li>
   <!-- Logout button -->

--- a/src/app/components/shared/header/header.component.html
+++ b/src/app/components/shared/header/header.component.html
@@ -87,13 +87,7 @@
     >
       <span [innerText]="user.userName"></span>
       <div class="image-wrapper d-inline-block bg-light ms-2">
-        <img
-          alt="Profile Icon"
-          [width]="'30px'"
-          [height]="'30px'"
-          [src]="user.image"
-          [thumbnail]="thumbnail"
-        />
+        <img alt="Profile Icon" [src]="user.image" [thumbnail]="thumbnail" />
       </div>
     </a>
   </li>

--- a/src/app/components/shared/header/header.component.html
+++ b/src/app/components/shared/header/header.component.html
@@ -87,7 +87,7 @@
     >
       <span [innerText]="user.userName"></span>
       <div class="image-wrapper d-inline-block bg-light ms-2">
-        <img alt="Profile Icon" [src]="user.image" [thumbnail]="thumbnail" />
+        <img alt="Profile Icon" [src]="user.image" />
       </div>
     </a>
   </li>

--- a/src/app/components/shared/header/header.component.scss
+++ b/src/app/components/shared/header/header.component.scss
@@ -24,10 +24,7 @@ fa-icon {
 
 #login-widget {
   img {
-    background-color: white;
-    margin: -10px 5px;
-    width: 30px;
-    height: 30px;
+    padding: -10px 5px;
   }
 }
 

--- a/src/app/components/shared/header/header.component.scss
+++ b/src/app/components/shared/header/header.component.scss
@@ -25,6 +25,8 @@ fa-icon {
 #login-widget {
   img {
     padding: -10px 5px;
+    width: 30px;
+    height: 30px;
   }
 }
 

--- a/src/app/components/shared/header/header.component.spec.ts
+++ b/src/app/components/shared/header/header.component.spec.ts
@@ -238,17 +238,15 @@ describe("HeaderComponent", () => {
             );
           });
 
-          it("should display small profile custom icon", () => {
-            const url = modelData.image.imageUrl(60, 60);
+          it("should display profile custom icon", () => {
             const imageUrls = modelData.imageUrls();
-            imageUrls[3].url = url;
             const customUser = new SessionUser(generateUser({ imageUrls }));
             setUser(isLoggedIn, customUser);
             spec.detectChanges();
 
             const profile = spec.query<HTMLElement>("#login-widget");
             const image = profile.querySelector("img");
-            assertImage(image, url, "Profile Icon");
+            assertImage(image, imageUrls[0].url, "Profile Icon");
           });
         }
 

--- a/src/app/components/shared/header/header.component.ts
+++ b/src/app/components/shared/header/header.component.ts
@@ -12,7 +12,6 @@ import {
 } from "@helpers/app-initializer/app-initializer";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
-import { ImageSizes } from "@interfaces/apiInterfaces";
 import {
   isNavigableMenuItem,
   MenuLink,
@@ -52,7 +51,6 @@ export class HeaderComponent extends withUnsubscribe() implements OnInit {
     profile: myAccountMenuItem,
     register: registerMenuItem,
   };
-  public thumbnail = ImageSizes.small;
   public isNavigableMenuItem = isNavigableMenuItem;
 
   public constructor(

--- a/src/app/components/shared/menu/user-badge/user-badge.component.scss
+++ b/src/app/components/shared/menu/user-badge/user-badge.component.scss
@@ -2,11 +2,6 @@
   margin-top: auto;
   margin-bottom: auto;
   margin-right: 10px;
-
-  img {
-    max-width: 30px;
-    height: auto;
-  }
 }
 
 .body {

--- a/src/app/components/shared/menu/user-badge/user-badge.component.scss
+++ b/src/app/components/shared/menu/user-badge/user-badge.component.scss
@@ -4,7 +4,7 @@
   margin-right: 10px;
 
   img {
-    width: 30px;
+    max-width: 30px;
     height: auto;
   }
 }

--- a/src/app/components/shared/menu/user-badge/user-badge.component.scss
+++ b/src/app/components/shared/menu/user-badge/user-badge.component.scss
@@ -1,10 +1,9 @@
 .image {
-  margin-top: auto;
-  margin-bottom: auto;
-  margin-right: 10px;
+  width: 30px;
+  height: 30px;
 
   img {
-    max-width: 30px;
+    width: 100%;
     height: auto;
   }
 }

--- a/src/app/components/shared/menu/user-badge/user-badge.component.scss
+++ b/src/app/components/shared/menu/user-badge/user-badge.component.scss
@@ -2,6 +2,11 @@
   margin-top: auto;
   margin-bottom: auto;
   margin-right: 10px;
+
+  img {
+    width: 30px;
+    height: auto;
+  }
 }
 
 .body {

--- a/src/app/components/shared/menu/user-badge/user-badge.component.spec.ts
+++ b/src/app/components/shared/menu/user-badge/user-badge.component.spec.ts
@@ -142,14 +142,12 @@ describe("UserBadgeComponent", () => {
     });
 
     it("should display custom image", () => {
-      const imageIndex = 1;
       const user = new User(generateUser({ userName: "custom username" }));
-      user.image[imageIndex].size = ImageSizes.small;
       setup({ users: [user] });
       spec.detectChanges();
       assertImage(
         getImage()[0],
-        user.image[imageIndex].url,
+        user.image[0].url,
         "custom username profile picture"
       );
     });

--- a/src/app/components/shared/menu/user-badge/user-badge.component.spec.ts
+++ b/src/app/components/shared/menu/user-badge/user-badge.component.spec.ts
@@ -2,7 +2,6 @@ import { RouterTestingModule } from "@angular/router/testing";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { DirectivesModule } from "@directives/directives.module";
 import { AuthenticatedImageModule } from "@directives/image/image.module";
-import { ImageSizes } from "@interfaces/apiInterfaces";
 import { UnresolvedModel } from "@models/AbstractModel";
 import { User } from "@models/User";
 import { createComponentFactory, Spectator } from "@ngneat/spectator";

--- a/src/app/components/shared/menu/user-badge/user-badge.component.ts
+++ b/src/app/components/shared/menu/user-badge/user-badge.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, OnChanges } from "@angular/core";
-import { ImageSizes } from "@interfaces/apiInterfaces";
 import { User } from "@models/User";
 import { DateTime } from "luxon";
 
@@ -17,7 +16,7 @@ import { DateTime } from "luxon";
       <!-- User Resolved -->
       <div *ngIf="!(user | isUnresolved)" id="users" class="d-flex mb-1">
         <!-- User image -->
-        <div class="image">
+        <div class="image me-2 mt-auto mb-auto">
           <!-- Add link to non-ghost users -->
           <ng-container *ngIf="!(user | isGhostUser); else userImage">
             <a id="imageLink" [bawUrl]="user.viewUrl">
@@ -31,7 +30,6 @@ import { DateTime } from "luxon";
               class="rounded"
               [src]="user.image"
               [alt]="user.userName + ' profile picture'"
-              [thumbnail]="thumbnail"
             />
           </ng-template>
         </div>
@@ -69,7 +67,6 @@ export class UserBadgeComponent implements OnChanges {
   @Input() public label: string;
   @Input() public users: User | User[];
   @Input() public timestamp?: DateTime;
-  public thumbnail = ImageSizes.small;
   public models: User[];
 
   public ngOnChanges(): void {

--- a/src/app/components/shared/menu/user-badge/user-badge.component.ts
+++ b/src/app/components/shared/menu/user-badge/user-badge.component.ts
@@ -29,6 +29,7 @@ import { DateTime } from "luxon";
           <ng-template #userImage>
             <img
               class="rounded"
+              [width]="'30px'"
               [src]="user.image"
               [alt]="user.userName + ' profile picture'"
               [thumbnail]="thumbnail"

--- a/src/app/components/shared/menu/user-badge/user-badge.component.ts
+++ b/src/app/components/shared/menu/user-badge/user-badge.component.ts
@@ -29,7 +29,6 @@ import { DateTime } from "luxon";
           <ng-template #userImage>
             <img
               class="rounded"
-              [width]="'30px'"
               [src]="user.image"
               [alt]="user.userName + ' profile picture'"
               [thumbnail]="thumbnail"

--- a/src/app/directives/image/image.directive.spec.ts
+++ b/src/app/directives/image/image.directive.spec.ts
@@ -47,12 +47,6 @@ describe("ImageDirective", () => {
     );
   }
 
-  function createThumbnailDirective(src: ImageUrl[], thumbnail: ImageSizes) {
-    return createDirective(
-      '<img alt="alt" [src]="src" [thumbnail]="thumbnail" />',
-      { hostProps: { src, thumbnail } }
-    );
-  }
   function createImgErrorEvent(image: HTMLImageElement) {
     image.onerror?.("unit test");
     spectator.detectChanges();
@@ -125,31 +119,6 @@ describe("ImageDirective", () => {
       [1, 2, 3, 4].forEach(() => createImgErrorEvent(image));
       // Image url should have only been set once
       expect(spy).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("thumbnail", () => {
-    it("given a valid thumbnail, it displays the thumbnail url", () => {
-      const imageUrls = modelData.imageUrls();
-      imageUrls[1].size = ImageSizes.medium;
-      spectator = createThumbnailDirective(imageUrls, ImageSizes.medium);
-      assertImage(getImage(), imageUrls[1].url, "alt");
-    });
-
-    it("given a missing thumbnail, it loads the next available url", () => {
-      const imageUrls = modelData.imageUrls();
-      // DEFAULT image size is not set by modelData.imageUrls
-      spectator = createThumbnailDirective(imageUrls, ImageSizes.default);
-      assertImage(getImage(), imageUrls[0].url, "alt");
-    });
-
-    it("given an invalid thumbnail, it loads the next available url", () => {
-      const imageUrls = modelData.imageUrls();
-      imageUrls[1].size = ImageSizes.medium;
-      spectator = createThumbnailDirective(imageUrls, ImageSizes.medium);
-      const image = getImage();
-      createImgErrorEvent(image);
-      assertImage(image, imageUrls[0].url, "alt");
     });
   });
 
@@ -273,33 +242,6 @@ describe("ImageDirective", () => {
       spectator.setInput("src", imageUrls);
       spectator.directive.ngOnChanges({ src: change });
     }
-
-    function assertImageUrls(image: HTMLImageElement, imageUrls: ImageUrl[]) {
-      imageUrls.forEach((imageUrl) => {
-        assertImage(image, imageUrl.url, "alt");
-        createImgErrorEvent(image);
-      });
-    }
-
-    it("should handle update appending new urls", () => {
-      const imageUrls = modelData.imageUrls();
-      spectator = createDefaultDirective(undefined);
-
-      imageUrls.forEach((imageUrl) => updateDirective([imageUrl]));
-      // Images in reverse order because each new image is prepended to ordered set
-      assertImageUrls(getImage(), imageUrls.reverse());
-    });
-
-    it("should handle update appending new urls with duplicates", () => {
-      const imageUrls = modelData.imageUrls();
-      spectator = createDefaultDirective(undefined);
-
-      imageUrls.forEach((_, index) =>
-        updateDirective(imageUrls.slice(0, index + 1))
-      );
-      // Images not in reverse order because ordering from the input is kept
-      assertImageUrls(getImage(), imageUrls);
-    });
 
     it("should display 404 image after all urls attempted", () => {
       const imageUrls = modelData.imageUrls();

--- a/src/app/directives/image/image.directive.ts
+++ b/src/app/directives/image/image.directive.ts
@@ -16,7 +16,6 @@ export const notFoundImage: ImageUrl = {
   url: `${assetRoot}/images/404.png`,
   size: ImageSizes.fallback,
 };
-export const image404RelativeSrc = `${assetRoot}/images/404.png`;
 
 @Directive({
   // Directive applies directly to all image tags instead of being
@@ -95,7 +94,7 @@ export class AuthenticatedImageDirective implements OnChanges {
         if (aPixels === bPixels) {
           return 0;
         }
-        return aPixels > bPixels ? 1 : -1;
+        return aPixels > bPixels ? -1 : 1;
       });
     }
 
@@ -115,6 +114,8 @@ export class AuthenticatedImageDirective implements OnChanges {
    * Get next image to use
    */
   private getNextImage(): ImageUrl {
+    console.log("Using Default Image: ", this.useDefaultImage());
+
     if (this.useDefaultImage()) {
       return this.defaultImage;
     }
@@ -124,14 +125,9 @@ export class AuthenticatedImageDirective implements OnChanges {
     }
 
     // Retrieve first url from set
-    const image = this.images.first();
-    if (image) {
-      this.images = this.images.remove(image);
-      return image;
-    }
-
-    // Final fallback
-    return notFoundImage;
+    const image = this.images.first(notFoundImage);
+    this.images = this.images.remove(image);
+    return image;
   }
 
   /**
@@ -179,7 +175,12 @@ export class AuthenticatedImageDirective implements OnChanges {
    * Returns true if the default image is the only option left available
    */
   private useDefaultImage(): boolean {
-    return this.images.count() === 0 && this.currentImage !== this.defaultImage;
+    console.log("Images Count: ", this.images.count());
+    return (
+      this.images.count() === 0 &&
+      this.currentImage !== this.defaultImage &&
+      !!this.defaultImage
+    );
   }
 
   /** Get image reference native element */

--- a/src/app/directives/image/image.directive.ts
+++ b/src/app/directives/image/image.directive.ts
@@ -83,6 +83,7 @@ export class AuthenticatedImageDirective implements OnChanges {
       // Clear background color when loaded
       this.imageEl.onload = () => {
         // Prevent overriding of 'this'
+        // Make background transparent, use a wrapper to set a different background
         this.imageEl.style.backgroundColor = "unset";
         // Change height to automatic sizing once it is loaded
         this.imageEl.style.height = this.height ?? "auto";
@@ -94,6 +95,7 @@ export class AuthenticatedImageDirective implements OnChanges {
       this.usedImages = this.usedImages.delete(this.usedImages.last());
     }
 
+    // Retrieve list of new images
     let newImages = OrderedSet<ImageUrl>();
     for (const image of this._src ?? []) {
       if (image.size === ImageSizes.default) {
@@ -128,7 +130,9 @@ export class AuthenticatedImageDirective implements OnChanges {
     this.imageEl.style.height = this.height ?? this.width ?? baseWidth;
   }
 
-  /** Get next image to use */
+  /**
+   * Get next image to use
+   */
   private getNextImage(): ImageUrl {
     if (this.useDefaultImage()) {
       return this.defaultImage;
@@ -196,7 +200,7 @@ export class AuthenticatedImageDirective implements OnChanges {
   }
 
   /**
-   * Returns true is there are no image options available
+   * Returns true if all other image options are exhausted
    */
   private use404Image(): boolean {
     const hasDefaultImageAvailable = this.defaultImage
@@ -208,9 +212,7 @@ export class AuthenticatedImageDirective implements OnChanges {
   }
 
   /**
-   * Returns true if the default image is the only option available
-   *
-   * @param url Url
+   * Returns true if the default image is the only option left available
    */
   private useDefaultImage(): boolean {
     return this.defaultImage && this.images.count() === this.usedImages.count();

--- a/src/app/directives/image/image.directive.ts
+++ b/src/app/directives/image/image.directive.ts
@@ -14,8 +14,6 @@ import { OrderedSet } from "immutable";
 
 export const notFoundImage: ImageUrl = {
   url: `${assetRoot}/images/404.png`,
-  height: 221,
-  width: 220,
   size: ImageSizes.fallback,
 };
 export const image404RelativeSrc = `${assetRoot}/images/404.png`;

--- a/src/app/directives/image/image.directive.ts
+++ b/src/app/directives/image/image.directive.ts
@@ -35,10 +35,6 @@ export class AuthenticatedImageDirective implements OnChanges {
   @Input() public ignoreAuthToken: boolean;
   /** Disable authenticated image directive on image */
   @Input() public disableAuth: boolean;
-  /** Image width */
-  @Input() public width?: string;
-  /** Image height */
-  @Input() public height?: string;
 
   private _src: ImageUrl[];
   /**
@@ -73,20 +69,17 @@ export class AuthenticatedImageDirective implements OnChanges {
 
     // On Component Initial Load
     if (changes.src.isFirstChange()) {
+      this.imageEl.classList.add("loading-image");
+
       this.imageEl.onerror = () => {
         // Prevent overriding of 'this'
         this.errorHandler();
       };
 
-      this.imageEl.style.backgroundColor = "lightgrey";
-
-      // Clear background color when loaded
       this.imageEl.onload = () => {
         // Prevent overriding of 'this'
-        // Make background transparent, use a wrapper to set a different background
-        this.imageEl.style.backgroundColor = "unset";
-        // Change height to automatic sizing once it is loaded
-        this.imageEl.style.height = this.height ?? "auto";
+        this.imageEl.classList.remove("loading-image");
+        this.imageEl.classList.add("loaded-image");
       };
     }
 
@@ -118,16 +111,6 @@ export class AuthenticatedImageDirective implements OnChanges {
     const image = this.getNextImage();
     this.usedImages = this.usedImages.add(image);
     this.imageEl.src = this.appendAuthToken(image);
-
-    // Assume size of image so we can show a loading background
-    this.imageEl.style.width = this.width ?? this.width + "px";
-
-    /*
-     * Assume height to be either height, width, or match image width (this
-     * will be changed later when image is loaded)
-     */
-    const baseWidth = getComputedStyle(this.imageEl).width;
-    this.imageEl.style.height = this.height ?? this.width ?? baseWidth;
   }
 
   /**

--- a/src/app/directives/image/image.directive.ts
+++ b/src/app/directives/image/image.directive.ts
@@ -115,12 +115,17 @@ export class AuthenticatedImageDirective implements OnChanges {
   private setImageSrc(): void {
     const image = this.getNextImage();
     this.usedImages = this.usedImages.add(image);
-    // Assume size of image so we can show a loading background
-    this.imageEl.style.width = this.width ?? image.width + "px";
-    // Assume height to be either inputted height, matching the width, or image height
-    this.imageEl.style.height =
-      this.height ?? this.width ?? image.height + "px";
     this.imageEl.src = this.appendAuthToken(image);
+
+    // Assume size of image so we can show a loading background
+    this.imageEl.style.width = this.width ?? this.width + "px";
+
+    /*
+     * Assume height to be either height, width, or match image width (this
+     * will be changed later when image is loaded)
+     */
+    const baseWidth = getComputedStyle(this.imageEl).width;
+    this.imageEl.style.height = this.height ?? this.width ?? baseWidth;
   }
 
   /** Get next image to use */

--- a/src/app/interfaces/apiInterfaces.ts
+++ b/src/app/interfaces/apiInterfaces.ts
@@ -90,6 +90,7 @@ export enum ImageSizes {
   small = "small",
   tiny = "tiny",
   default = "default",
+  fallback = "fallback",
   unknown = "unknown",
 }
 

--- a/src/app/models/AttributeDecorators.spec.ts
+++ b/src/app/models/AttributeDecorators.spec.ts
@@ -1,5 +1,9 @@
+import { Injector } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { API_ROOT } from "@helpers/app-initializer/app-initializer";
 import { Id, Ids, ImageSizes, ImageUrl } from "@interfaces/apiInterfaces";
 import { assetRoot } from "@services/config/config.service";
+import { MockAppConfigModule } from "@services/config/configMock.module";
 import { modelData } from "@test/helpers/faker";
 import { DateTime, Duration } from "luxon";
 import { AbstractModel } from "./AbstractModel";
@@ -115,15 +119,24 @@ describe("Attribute Decorators", () => {
 
     function createModel(
       data?: { image?: ImageUrl[] | string; imageUrls?: ImageUrl[] },
-      opts?: BawDecoratorOptions<any>
+      opts?: BawDecoratorOptions<any>,
+      injector?: Injector
     ) {
       class MockModel extends BaseModel {
         @bawImage(defaultImageUrl.url, opts)
         public readonly image: ImageUrl[];
         public readonly imageUrls: ImageUrl[];
+
+        public constructor(_data: any, _injector: Injector) {
+          super(_data, _injector);
+        }
+
+        public override toString() {
+          return "MockModel";
+        }
       }
 
-      return new MockModel(data);
+      return new MockModel(data, injector);
     }
 
     it("should handle persist option", () => {
@@ -204,6 +217,38 @@ describe("Attribute Decorators", () => {
       const imageUrls = modelData.shuffleArray(defaultImageUrls.slice());
       const model = createModel({ image: imageUrls });
       expect(model.image).toEqual([...defaultImageUrls, defaultImageUrl]);
+    });
+
+    describe("prepend api root", () => {
+      let injector: Injector;
+      let apiRoot: string;
+
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [MockAppConfigModule],
+        }).compileComponents();
+        injector = TestBed.inject(Injector);
+        apiRoot = TestBed.inject(API_ROOT);
+      });
+
+      it("should prepend api root to url if it starts with /", () => {
+        const url = "/relative_path/image.jpg";
+        const model = createModel({ image: url }, {}, injector);
+        expect(model.image).toEqual([
+          { url: apiRoot + url, size: ImageSizes.unknown },
+          defaultImageUrl,
+        ]);
+      });
+
+      it("should prepend api root to urls if they starts with /", () => {
+        const url = "/relative_path/image.jpg";
+        const imageUrl: ImageUrl = { url, size: ImageSizes.unknown };
+        const model = createModel({ image: [imageUrl] }, {}, injector);
+        expect(model.image).toEqual([
+          { url: apiRoot + url, size: ImageSizes.unknown },
+          defaultImageUrl,
+        ]);
+      });
     });
   });
 

--- a/src/app/models/AttributeDecorators.spec.ts
+++ b/src/app/models/AttributeDecorators.spec.ts
@@ -127,10 +127,6 @@ describe("Attribute Decorators", () => {
         public readonly image: ImageUrl[];
         public readonly imageUrls: ImageUrl[];
 
-        public constructor(_data: any, _injector: Injector) {
-          super(_data, _injector);
-        }
-
         public override toString() {
           return "MockModel";
         }

--- a/src/app/models/AttributeDecorators.ts
+++ b/src/app/models/AttributeDecorators.ts
@@ -67,7 +67,7 @@ export function bawImage<Model>(
     return !images.find((image) => image.size === ImageSizes.default);
   }
 
-  function sanitizeUrl(apiRoot: string, url: string): string {
+  function normalizeUrl(apiRoot: string, url: string): string {
     // Prepend api root to url if it begins with '/'
     if (url.startsWith("/")) {
       return apiRoot + url;
@@ -89,7 +89,7 @@ export function bawImage<Model>(
       // Convert string to ImageURL[] and append default image
       if (typeof imageUrls === "string") {
         model[key] = [
-          { size: ImageSizes.unknown, url: sanitizeUrl(apiRoot, imageUrls) },
+          { size: ImageSizes.unknown, url: normalizeUrl(apiRoot, imageUrls) },
           defaultImage,
         ];
       } else if (imageUrls instanceof Array && imageUrls.length > 0) {
@@ -97,7 +97,7 @@ export function bawImage<Model>(
         const output = imageUrls
           .map((imageUrl) => ({
             ...imageUrl,
-            url: sanitizeUrl(apiRoot, imageUrl.url),
+            url: normalizeUrl(apiRoot, imageUrl.url),
           }))
           .sort(sortImageUrls);
 

--- a/src/app/models/Region.ts
+++ b/src/app/models/Region.ts
@@ -38,7 +38,7 @@ import { User } from "./User";
 export interface IRegion extends HasAllUsers, HasDescription {
   id?: Id;
   name?: Param;
-  imageUrl?: string;
+  imageUrls?: ImageUrl[];
   projectId?: Id;
   siteIds?: Id[] | Ids;
   notes?: Hash;
@@ -53,9 +53,9 @@ export class Region extends AbstractModel<IRegion> implements IRegion {
   @bawPersistAttr()
   public readonly name?: Param;
   @bawPersistAttr()
-  public readonly imageUrl?: string;
+  public readonly imageUrls?: ImageUrl[];
   @bawImage<IRegion>(`${assetRoot}/images/site/site_span4.png`, {
-    key: "imageUrl",
+    key: "imageUrls",
   })
   public readonly image: ImageUrl[];
   @bawPersistAttr()

--- a/src/app/styles/_images.scss
+++ b/src/app/styles/_images.scss
@@ -1,10 +1,12 @@
 .loading-image {
-  background-color: rgb(237, 237, 237);
   aspect-ratio: 1/1;
+  background-color: rgb(237, 237, 237);
   color: rgb(237, 237, 237);
+  font-size: 0px;
+  text-decoration: none;
 }
 
 .loaded-image {
-  background-color: unset;
   aspect-ratio: 1/1;
+  background-color: unset;
 }

--- a/src/app/styles/_images.scss
+++ b/src/app/styles/_images.scss
@@ -1,0 +1,10 @@
+.loading-image {
+  background-color: rgb(237, 237, 237);
+  aspect-ratio: 1/1;
+  color: rgb(237, 237, 237);
+}
+
+.loaded-image {
+  background-color: unset;
+  aspect-ratio: 1/1;
+}

--- a/src/app/styles/_thumbnail.scss
+++ b/src/app/styles/_thumbnail.scss
@@ -9,7 +9,6 @@
   line-height: 1.428571429;
   margin-bottom: 20px;
   padding: 4px;
-  padding-right: 10px;
   transition: border 0.2s ease-in-out;
 
   img {

--- a/src/app/test/fakes/Region.ts
+++ b/src/app/test/fakes/Region.ts
@@ -5,7 +5,7 @@ export function generateRegion(data?: Partial<IRegion>): Required<IRegion> {
   return {
     id: modelData.id(),
     name: modelData.param(),
-    imageUrl: modelData.imageUrl(),
+    imageUrls: modelData.imageUrls(),
     projectId: modelData.id(),
     siteIds: modelData.ids(),
     notes: modelData.notes(),

--- a/src/assets/images/404.png
+++ b/src/assets/images/404.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de518c7ada305854fee02473e71de10f00728597ffc1c9f78261e652f538bdeb
-size 14978
+oid sha256:0d3d3c365c27d7c489464a4179078f6fb11c679c859fc94c0b09fa2de104600d
+size 17294

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,7 @@
-@import "./app/styles/bootstrap/index";
-@import "./app/styles/ngx-datatable";
-@import "./app/styles/functions";
+@import "bootstrap/index";
+@import "ngx-datatable";
+@import "images";
+@import "functions";
 @import "~@fortawesome/fontawesome-svg-core/styles.css";
 @import "~ngx-toastr/toastr";
 


### PR DESCRIPTION
# Enable Region Images

Previous implementation of region images was flawed, and this was exposed when images were finally added to the regions

## Changes

- Added image to region details page
- Updated region model to return image
- Updated `bawImage` decorator to handle relative links
- Updated `ImageDirective` to display a grey background placeholder while images are loading

## Problems

- Need to implement tests

## Visual Changes

Loading Animation:

![Image Loading 2](https://user-images.githubusercontent.com/3955116/133620029-771fb20a-bd62-4984-80b4-999fdc422ab9.gif)

Region Details Page

![image](https://user-images.githubusercontent.com/3955116/133377560-a58bbbf7-6712-4a08-a4e3-d5a7f3fd53b5.png)

Project Details Page

![image](https://user-images.githubusercontent.com/3955116/133377595-9206818f-020b-4a21-ba4f-5edd16154d2d.png)

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
