### PR TITLE
Deployment cleanup

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,6 +31,8 @@ jobs:
                   "apiRoot": "https://staging.ecosounds.org",
                   "siteRoot": "http://development.ecosounds.org:4200",
                   "siteDir": "/assets/old-client/",
+                  "parentRoot": "http://development.ecosounds.org:4200",
+                  "parentDir": "/",
                   "ga": { "trackingId": "" }
                 }
               },

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,12 @@ LABEL maintainer="Charles Alleman <alleman@qut.edu.au>" \
   ref=${GIT_COMMIT} \
   schema-version="1.0"
 
+USER root
+
+# Add ability to make https wget requests
+RUN apk upgrade libssl1.0 --update-cache && \
+    apk add wget ca-certificates
+
 # drop privileges
 USER node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,6 @@ LABEL maintainer="Charles Alleman <alleman@qut.edu.au>" \
   ref=${GIT_COMMIT} \
   schema-version="1.0"
 
-USER root
-
 # Add ability to make https wget requests
 RUN apk upgrade libssl1.0 --update-cache && \
     apk add wget ca-certificates

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "@swimlane/ngx-datatable": "^20.0.0",
         "@vvo/tzdb": "^6.29.0",
         "bootstrap": "^5.1.3",
-        "compression": "^1.7.4",
         "d3-color": "^3.0.1",
         "express": "^4.17.1",
         "filesize": "^8.0.3",
@@ -6580,6 +6579,7 @@
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
       "dependencies": {
         "mime-db": ">= 1.43.0 < 2"
       },
@@ -6591,6 +6591,7 @@
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
       "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "dev": true,
       "dependencies": {
         "accepts": "~1.3.5",
         "bytes": "3.0.0",
@@ -6608,6 +6609,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -6616,6 +6618,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -6623,7 +6626,8 @@
     "node_modules/compression/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -14287,6 +14291,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -27652,6 +27657,7 @@
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
       "requires": {
         "mime-db": ">= 1.43.0 < 2"
       }
@@ -27660,6 +27666,7 @@
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
       "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "dev": true,
       "requires": {
         "accepts": "~1.3.5",
         "bytes": "3.0.0",
@@ -27673,12 +27680,14 @@
         "bytes": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+          "dev": true
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -27686,7 +27695,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -33588,7 +33598,8 @@
     "on-headers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@swimlane/ngx-datatable": "^20.0.0",
         "@vvo/tzdb": "^6.29.0",
         "bootstrap": "^5.1.3",
+        "compression": "^1.7.4",
         "d3-color": "^3.0.1",
         "express": "^4.17.1",
         "filesize": "^8.0.3",
@@ -6579,7 +6580,6 @@
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
-      "dev": true,
       "dependencies": {
         "mime-db": ">= 1.43.0 < 2"
       },
@@ -6591,7 +6591,6 @@
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
       "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
-      "dev": true,
       "dependencies": {
         "accepts": "~1.3.5",
         "bytes": "3.0.0",
@@ -6609,7 +6608,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -6618,7 +6616,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -6626,8 +6623,7 @@
     "node_modules/compression/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -14291,7 +14287,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -27657,7 +27652,6 @@
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
-      "dev": true,
       "requires": {
         "mime-db": ">= 1.43.0 < 2"
       }
@@ -27666,7 +27660,6 @@
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
       "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
-      "dev": true,
       "requires": {
         "accepts": "~1.3.5",
         "bytes": "3.0.0",
@@ -27680,14 +27673,12 @@
         "bytes": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-          "dev": true
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -27695,8 +27686,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -33598,8 +33588,7 @@
     "on-headers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
-      "dev": true
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@swimlane/ngx-datatable": "^20.0.0",
     "@vvo/tzdb": "^6.29.0",
     "bootstrap": "^5.1.3",
+    "compression": "^1.7.4",
     "d3-color": "^3.0.1",
     "express": "^4.17.1",
     "filesize": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@swimlane/ngx-datatable": "^20.0.0",
     "@vvo/tzdb": "^6.29.0",
     "bootstrap": "^5.1.3",
-    "compression": "^1.7.4",
     "d3-color": "^3.0.1",
     "express": "^4.17.1",
     "filesize": "^8.0.3",

--- a/server.ts
+++ b/server.ts
@@ -18,6 +18,7 @@ import { ngExpressEngine } from "@nguniversal/express-engine";
 import { assetRoot } from "@services/config/config.service";
 import express from "express";
 import { environment } from "src/environments/environment";
+import * as compressionModule from "compression";
 import { AppServerModule } from "./src/main.server";
 
 // The Express app is exported so that it can be used by serverless Functions.
@@ -50,8 +51,20 @@ export function app(path: string): express.Express {
     })
   );
 
+  // Gzip static assets
+  server.use(compressionModule());
+
   server.set("view engine", "html");
   server.set("views", distFolder);
+
+  /*
+   * This allows us to reduce the chances of click-jacking by ensuring that the
+   * site cannot be embedded into another site
+   */
+  server.get("*", (_, res, next) => {
+    res.setHeader("X-Frame-Options", "SAMEORIGIN");
+    next();
+  });
 
   // special case rendering our settings file - we already have it loaded
   server.get(`${assetRoot}/environment.json`, (request, response) => {

--- a/server.ts
+++ b/server.ts
@@ -4,8 +4,8 @@
  * the application bundle downloads.
  */
 
-import "zone.js/node";
 import "reflect-metadata";
+import "zone.js/node";
 
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
@@ -18,7 +18,6 @@ import { ngExpressEngine } from "@nguniversal/express-engine";
 import { assetRoot } from "@services/config/config.service";
 import express from "express";
 import { environment } from "src/environments/environment";
-import * as compressionModule from "compression";
 import { AppServerModule } from "./src/main.server";
 
 // The Express app is exported so that it can be used by serverless Functions.
@@ -50,9 +49,6 @@ export function app(path: string): express.Express {
       providers: [apiConfig],
     })
   );
-
-  // Gzip static assets
-  server.use(compressionModule());
 
   server.set("view engine", "html");
   server.set("views", distFolder);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -79,7 +79,6 @@ export const appImports = [
 @NgModule({
   declarations: [AppComponent],
   imports: [
-    // Rehydrate client with data from SSR
     BrowserModule.withServerTransition({ appId: "workbench-client" }),
     // Timeout API requests after set period
     BawTimeoutModule.forRoot({ timeout: environment.browserTimeout }),

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -87,7 +87,8 @@ export const appImports = [
     HttpClientModule,
     AppConfigModule,
     BawApiModule,
-    // Rehydrate data from SSR. This must be set after BawApiModule
+    // Rehydrate data from SSR. This must be set after BawApiModule so that the
+    // interceptor runs after the API interceptor
     RehydrationModule,
     GuardModule,
     ...appLibraryImports,
@@ -95,7 +96,7 @@ export const appImports = [
   ],
   providers: [
     // Show loading animation after 3 seconds
-    { provide: LOADING_BAR_CONFIG, useValue: { latencyThreshold: 500 } },
+    { provide: LOADING_BAR_CONFIG, useValue: { latencyThreshold: 200 } },
   ],
   entryComponents: [AppComponent, PermissionsShieldComponent],
   exports: [],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -81,21 +81,21 @@ export const appImports = [
   imports: [
     // Rehydrate client with data from SSR
     BrowserModule.withServerTransition({ appId: "workbench-client" }),
-    // Rehydrate data from SSR
-    RehydrationModule,
     // Timeout API requests after set period
     BawTimeoutModule.forRoot({ timeout: environment.browserTimeout }),
     AppRoutingModule,
     HttpClientModule,
     AppConfigModule,
     BawApiModule,
+    // Rehydrate data from SSR. This must be set after BawApiModule
+    RehydrationModule,
     GuardModule,
     ...appLibraryImports,
     ...appImports,
   ],
   providers: [
     // Show loading animation after 3 seconds
-    { provide: LOADING_BAR_CONFIG, useValue: { latencyThreshold: 3_000 } },
+    { provide: LOADING_BAR_CONFIG, useValue: { latencyThreshold: 500 } },
   ],
   entryComponents: [AppComponent, PermissionsShieldComponent],
   exports: [],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -15,6 +15,7 @@ import { FormlyBootstrapModule } from "@ngx-formly/bootstrap";
 import { FormlyModule } from "@ngx-formly/core";
 import { LOADING_BAR_CONFIG } from "@ngx-loading-bar/core";
 import { AppConfigModule } from "@services/config/config.module";
+import { RehydrationModule } from "@services/rehydration/rehydration.module";
 import { BawTimeoutModule } from "@services/timeout/timeout.module";
 import { formlyConfig } from "@shared/formly/custom-inputs.module";
 import { ToastrModule } from "ngx-toastr";
@@ -80,6 +81,8 @@ export const appImports = [
   imports: [
     // Rehydrate client with data from SSR
     BrowserModule.withServerTransition({ appId: "workbench-client" }),
+    // Rehydrate data from SSR
+    RehydrationModule,
     // Timeout API requests after set period
     BawTimeoutModule.forRoot({ timeout: environment.browserTimeout }),
     AppRoutingModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { AppConfigModule } from "@services/config/config.module";
 import { BawTimeoutModule } from "@services/timeout/timeout.module";
 import { formlyConfig } from "@shared/formly/custom-inputs.module";
 import { ToastrModule } from "ngx-toastr";
+import { environment } from "src/environments/environment";
 import { AppRoutingModule } from "./app-routing.module";
 import { AppComponent } from "./app.component";
 import { toastrRoot } from "./app.helper";
@@ -77,9 +78,10 @@ export const appImports = [
 @NgModule({
   declarations: [AppComponent],
   imports: [
+    // Rehydrate client with data from SSR
     BrowserModule.withServerTransition({ appId: "workbench-client" }),
-    // Http request maximum timeout with 10 second limit
-    BawTimeoutModule.forRoot({ timeout: 10_000 }),
+    // Timeout API requests after set period
+    BawTimeoutModule.forRoot({ timeout: environment.browserTimeout }),
     AppRoutingModule,
     HttpClientModule,
     AppConfigModule,

--- a/src/app/app.server.module.ts
+++ b/src/app/app.server.module.ts
@@ -1,5 +1,8 @@
 import { NgModule } from "@angular/core";
-import { ServerModule } from "@angular/platform-server";
+import {
+  ServerModule,
+  ServerTransferStateModule,
+} from "@angular/platform-server";
 import { BawTimeoutModule } from "@services/timeout/timeout.module";
 import { environment } from "src/environments/environment";
 import { AppComponent } from "./app.component";
@@ -9,6 +12,7 @@ import { AppModule } from "./app.module";
   imports: [
     AppModule,
     ServerModule,
+    ServerTransferStateModule,
     // Timeout API requests after set period
     BawTimeoutModule.forRoot({ timeout: environment.ssrTimeout }),
   ],

--- a/src/app/app.server.module.ts
+++ b/src/app/app.server.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from "@angular/core";
 import { ServerModule } from "@angular/platform-server";
 import { BawTimeoutModule } from "@services/timeout/timeout.module";
+import { environment } from "src/environments/environment";
 import { AppComponent } from "./app.component";
 import { AppModule } from "./app.module";
 
@@ -8,8 +9,8 @@ import { AppModule } from "./app.module";
   imports: [
     AppModule,
     ServerModule,
-    // Http request maximum timeout with 100ms limit
-    BawTimeoutModule.forRoot({ timeout: 100 }),
+    // Timeout API requests after set period
+    BawTimeoutModule.forRoot({ timeout: environment.ssrTimeout }),
   ],
   bootstrap: [AppComponent],
 })

--- a/src/app/components/projects/pages/details/details.component.ts
+++ b/src/app/components/projects/pages/details/details.component.ts
@@ -74,8 +74,6 @@ const projectKey = "project";
         (filter)="onFilter($event)"
       ></baw-debounce-input>
 
-      <baw-loading *ngIf="loading"></baw-loading>
-
       <p *ngIf="!hasSites && !hasRegions && !loading" class="lead">
         No additional data to display here, try adding sites to the project
       </p>

--- a/src/app/components/projects/pages/edit/edit.component.ts
+++ b/src/app/components/projects/pages/edit/edit.component.ts
@@ -27,17 +27,16 @@ const projectKey = "project";
 @Component({
   selector: "baw-project-edit",
   template: `
-    <!-- Move ngIf to baw-form when baw-wip removed -->
-    <baw-wip *ngIf="!failure">
-      <baw-form
-        [title]="title"
-        [model]="model"
-        [fields]="fields"
-        [submitLoading]="loading"
-        submitLabel="Submit"
-        (onSubmit)="submit($event)"
-      ></baw-form>
-    </baw-wip>
+    <!-- TODO Image input #608 -->
+    <baw-form
+      *ngIf="!failure"
+      [title]="title"
+      [model]="model"
+      [fields]="fields"
+      [submitLoading]="loading"
+      submitLabel="Submit"
+      (onSubmit)="submit($event)"
+    ></baw-form>
   `,
 })
 class EditComponent extends FormTemplate<Project> implements OnInit {

--- a/src/app/components/projects/pages/list/list.component.spec.ts
+++ b/src/app/components/projects/pages/list/list.component.spec.ts
@@ -17,7 +17,7 @@ import { SharedModule } from "@shared/shared.module";
 import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateProject } from "@test/fakes/Project";
 import { nStepObservable } from "@test/helpers/general";
-import { assertErrorHandler, assertSpinner } from "@test/helpers/html";
+import { assertErrorHandler } from "@test/helpers/html";
 import { Subject } from "rxjs";
 import { ListComponent } from "./list.component";
 
@@ -86,16 +86,6 @@ describe("ProjectsListComponent", () => {
   it("should handle failed projects model", async () => {
     await handleApiRequest(generateApiErrorDetails());
     assertErrorHandler(spec.fixture, true);
-  });
-
-  it("should display loading animation during request", async () => {
-    handleApiRequest([]);
-    assertSpinner(spec.fixture, true);
-  });
-
-  it("should clear loading animation on response", async () => {
-    await handleApiRequest([]);
-    assertSpinner(spec.fixture, false);
   });
 
   describe("projects", () => {

--- a/src/app/components/projects/pages/list/list.component.ts
+++ b/src/app/components/projects/pages/list/list.component.ts
@@ -29,8 +29,6 @@ export const projectsMenuItemActions = [
         (filter)="onFilter($event)"
       ></baw-debounce-input>
 
-      <baw-loading *ngIf="loading"></baw-loading>
-
       <ng-container *ngIf="!loading">
         <!-- Projects Exist -->
         <ng-container *ngIf="cardList.size > 0; else empty">

--- a/src/app/components/projects/pages/new/new.component.ts
+++ b/src/app/components/projects/pages/new/new.component.ts
@@ -21,6 +21,7 @@ import { projectsMenuItemActions } from "../list/list.component";
 @Component({
   selector: "baw-projects-new",
   template: `
+    <!-- TODO Image input #608 -->
     <baw-form
       *ngIf="!failure"
       title="New Project"

--- a/src/app/components/regions/pages/details/details.component.ts
+++ b/src/app/components/regions/pages/details/details.component.ts
@@ -69,8 +69,6 @@ const regionKey = "region";
         (filter)="onFilter($event)"
       ></baw-debounce-input>
 
-      <baw-loading *ngIf="loading"></baw-loading>
-
       <p *ngIf="!hasSites() && !loading" class="lead">
         No additional data to display here, try adding points to the site
       </p>

--- a/src/app/components/regions/pages/edit/edit.component.ts
+++ b/src/app/components/regions/pages/edit/edit.component.ts
@@ -32,6 +32,7 @@ const regionKey = "region";
 @Component({
   selector: "baw-regions-edit",
   template: `
+    <!-- TODO Image input #608 -->
     <baw-form
       *ngIf="!failure"
       [title]="title"

--- a/src/app/components/regions/pages/list/list.component.spec.ts
+++ b/src/app/components/regions/pages/list/list.component.spec.ts
@@ -17,7 +17,7 @@ import { SharedModule } from "@shared/shared.module";
 import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
 import { generateRegion } from "@test/fakes/Region";
 import { nStepObservable } from "@test/helpers/general";
-import { assertErrorHandler, assertSpinner } from "@test/helpers/html";
+import { assertErrorHandler } from "@test/helpers/html";
 import { Subject } from "rxjs";
 import { ListComponent } from "./list.component";
 
@@ -86,16 +86,6 @@ describe("RegionsListComponent", () => {
   it("should handle failed regions model", async () => {
     await handleApiRequest(generateApiErrorDetails());
     assertErrorHandler(spec.fixture, true);
-  });
-
-  it("should display loading animation during request", async () => {
-    handleApiRequest([]);
-    assertSpinner(spec.fixture, true);
-  });
-
-  it("should clear loading animation on response", async () => {
-    await handleApiRequest([]);
-    assertSpinner(spec.fixture, false);
   });
 
   describe("regions", () => {

--- a/src/app/components/regions/pages/list/list.component.ts
+++ b/src/app/components/regions/pages/list/list.component.ts
@@ -25,8 +25,6 @@ export const regionsMenuItemActions = [newRegionMenuItem];
         (filter)="onFilter($event)"
       ></baw-debounce-input>
 
-      <baw-loading *ngIf="loading"></baw-loading>
-
       <ng-container *ngIf="!loading">
         <!-- Regions Exist -->
         <ng-container *ngIf="cardList.size > 0; else empty">

--- a/src/app/components/regions/pages/new/new.component.ts
+++ b/src/app/components/regions/pages/new/new.component.ts
@@ -26,6 +26,7 @@ const projectKey = "project";
 @Component({
   selector: "baw-regions-new",
   template: `
+    <!-- TODO Image input #608 -->
     <baw-form
       *ngIf="!failure"
       [title]="hideTitle ? '' : 'New Region'"

--- a/src/app/components/shared/baw-client/baw-client.component.spec.ts
+++ b/src/app/components/shared/baw-client/baw-client.component.spec.ts
@@ -160,19 +160,6 @@ describe("BawClientComponent", () => {
           "is running the most up to date version."
       );
     });
-
-    it("should initially display loading animation", () => {
-      spec.detectChanges();
-      assertSpinner(spec.fixture, true);
-    });
-
-    it("should clear loading animation when content loads", async () => {
-      preventLoadingBawClient();
-      spec.detectChanges();
-      postMessage(JSON.stringify({ height: modelData.datatype.number() }));
-      spec.detectChanges();
-      assertSpinner(spec.fixture, false);
-    });
   });
 
   describe("old-client", () => {

--- a/src/app/components/shared/baw-client/baw-client.component.ts
+++ b/src/app/components/shared/baw-client/baw-client.component.ts
@@ -17,8 +17,6 @@ import { filter, takeUntil } from "rxjs/operators";
 @Component({
   selector: "baw-client",
   template: `
-    <baw-loading *ngIf="loading"></baw-loading>
-
     <iframe *ngIf="url" #content [src]="url">
       <!-- This warning only shows on browsers which don't support iframes -->
       <p>

--- a/src/app/components/shared/error-handler/error-handler.component.ts
+++ b/src/app/components/shared/error-handler/error-handler.component.ts
@@ -1,8 +1,7 @@
-import { Component, Inject, Input, OnInit } from "@angular/core";
+import { Component, Input } from "@angular/core";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { reportProblemMenuItem } from "@components/report-problem/report-problem.menus";
 import httpCodes from "http-status";
-import { IS_SERVER_PLATFORM } from "src/app/app.helper";
 
 /**
  * Error Handler Wrapper
@@ -10,7 +9,7 @@ import { IS_SERVER_PLATFORM } from "src/app/app.helper";
 @Component({
   selector: "baw-error-handler",
   template: `
-    <ng-container *ngIf="error && !hideError">
+    <ng-container *ngIf="error">
       <h1>{{ getTitle() }}</h1>
 
       <p>{{ error.message }}</p>
@@ -22,7 +21,7 @@ import { IS_SERVER_PLATFORM } from "src/app/app.helper";
     </ng-container>
   `,
 })
-export class ErrorHandlerComponent implements OnInit {
+export class ErrorHandlerComponent {
   @Input() public error: ApiErrorDetails;
   public reportProblem = reportProblemMenuItem.route;
   public titles = {
@@ -32,18 +31,8 @@ export class ErrorHandlerComponent implements OnInit {
     [httpCodes.REQUEST_TIMEOUT]: "Request Timed Out",
     [httpCodes.BAD_GATEWAY]: "Connection Failure",
   };
-  public hideError: boolean;
-
-  public constructor(@Inject(IS_SERVER_PLATFORM) private isServer: boolean) {}
-
-  public ngOnInit(): void {
-    // TODO Remove this once SSR API requests work #1514
-    this.hideError =
-      this.isServer && this.error.status === httpCodes.BAD_GATEWAY;
-  }
 
   public getTitle() {
-    const message = this.titles[this.error.status];
-    return !message ? "Unknown Error" : message;
+    return this.titles[this.error.status] ?? "Unknown Error";
   }
 }

--- a/src/app/components/shared/error-handler/error-handler.component.ts
+++ b/src/app/components/shared/error-handler/error-handler.component.ts
@@ -1,7 +1,8 @@
-import { Component, Input } from "@angular/core";
+import { Component, Inject, Input, OnInit } from "@angular/core";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { reportProblemMenuItem } from "@components/report-problem/report-problem.menus";
 import httpCodes from "http-status";
+import { IS_SERVER_PLATFORM } from "src/app/app.helper";
 
 /**
  * Error Handler Wrapper
@@ -9,7 +10,7 @@ import httpCodes from "http-status";
 @Component({
   selector: "baw-error-handler",
   template: `
-    <ng-container *ngIf="error">
+    <ng-container *ngIf="error && !hideError">
       <h1>{{ getTitle() }}</h1>
 
       <p>{{ error.message }}</p>
@@ -21,7 +22,7 @@ import httpCodes from "http-status";
     </ng-container>
   `,
 })
-export class ErrorHandlerComponent {
+export class ErrorHandlerComponent implements OnInit {
   @Input() public error: ApiErrorDetails;
   public reportProblem = reportProblemMenuItem.route;
   public titles = {
@@ -31,6 +32,15 @@ export class ErrorHandlerComponent {
     [httpCodes.REQUEST_TIMEOUT]: "Request Timed Out",
     [httpCodes.BAD_GATEWAY]: "Connection Failure",
   };
+  public hideError: boolean;
+
+  public constructor(@Inject(IS_SERVER_PLATFORM) private isServer: boolean) {}
+
+  public ngOnInit(): void {
+    // TODO Remove this once SSR API requests work #1514
+    this.hideError =
+      this.isServer && this.error.status === httpCodes.BAD_GATEWAY;
+  }
 
   public getTitle() {
     const message = this.titles[this.error.status];

--- a/src/app/components/shared/form/form.component.html
+++ b/src/app/components/shared/form/form.component.html
@@ -11,12 +11,6 @@
 
   <div class="clearfix">
     <form [formGroup]="form" (ngSubmit)="onSubmit(model)">
-      <!-- Spinner -->
-      <ng-container *ngIf="!fields">
-        <h4 class="text-center">Loading</h4>
-        <baw-loading></baw-loading>
-      </ng-container>
-
       <!-- Form -->
       <formly-form
         [form]="form"

--- a/src/app/components/shared/header/header-item/header-item.component.spec.ts
+++ b/src/app/components/shared/header/header-item/header-item.component.spec.ts
@@ -18,6 +18,7 @@ import {
 } from "@test/helpers/html";
 import { HeaderItemComponent } from "./header-item.component";
 
+// TODO Add tests to validate ng-content is respected
 describe("HeaderItemComponent", () => {
   let defaultUri: string;
   let defaultLink: MenuLink;
@@ -52,33 +53,37 @@ describe("HeaderItemComponent", () => {
     });
   });
 
-  it("should handle internal link", () => {
-    setup(defaultRoute);
-    spec.detectChanges();
-    expect(getLink()).toContainText(defaultRoute.label);
+  describe("internal routes", () => {
+    beforeEach(() => {
+      setup(defaultRoute);
+      spec.detectChanges();
+    });
+
+    it("should render with label", () => {
+      expect(getLink()).toContainText(defaultRoute.label);
+    });
+
+    it("should have router link", () => {
+      assertStrongRouteLink(getLink(), defaultRoute.route.toRouterLink());
+    });
+
+    it("should have router link active attribute", () => {
+      assertStrongRouteActive(getLink());
+    });
   });
 
-  it("internal link should have router link", () => {
-    setup(defaultRoute);
-    spec.detectChanges();
-    assertStrongRouteLink(getLink(), defaultRoute.route.toRouterLink());
-  });
+  describe("external links", () => {
+    beforeEach(() => {
+      setup(defaultLink);
+      spec.detectChanges();
+    });
 
-  it("internal link should have router link active attribute", () => {
-    setup(defaultRoute);
-    spec.detectChanges();
-    assertStrongRouteActive(getLink());
-  });
+    it("should render external link with label", () => {
+      expect(getLink()).toContainText(defaultLink.label);
+    });
 
-  it("should handle external link", () => {
-    setup(defaultLink);
-    spec.detectChanges();
-    expect(getLink()).toContainText(defaultLink.label);
-  });
-
-  it("external link should have href", () => {
-    setup(defaultLink);
-    spec.detectChanges();
-    assertHref(getLink(), defaultLink.uri());
+    it("external link should have href", () => {
+      assertHref(getLink(), defaultLink.uri());
+    });
   });
 });

--- a/src/app/components/shared/header/header-item/header-item.component.ts
+++ b/src/app/components/shared/header/header-item/header-item.component.ts
@@ -1,15 +1,12 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  ElementRef,
   Input,
   OnInit,
-  ViewChild,
 } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import {
   getRoute,
-  isExternalLink,
   isInternalRoute,
   MenuRoute,
   NavigableMenuItem,
@@ -25,13 +22,11 @@ import camelCase from "just-camel-case";
   selector: "baw-header-item",
   template: `
     <ng-template #linkContents>
-      <ng-content></ng-content>
-      <ng-container *ngIf="!hasContent">{{ link.label }}</ng-container>
+      <ng-container>{{ link.label }}</ng-container>
     </ng-template>
 
     <ng-template #internalRoute>
       <a
-        #navLink
         class="nav-link"
         strongRouteActive="active"
         [id]="label + '-header-link'"
@@ -42,14 +37,14 @@ import camelCase from "just-camel-case";
     </ng-template>
 
     <ng-template #externalLink>
-      <a #navLink class="nav-link" [id]="label + '-header-link'" [href]="href">
+      <a class="nav-link" [id]="label + '-header-link'" [href]="href">
         <ng-container *ngTemplateOutlet="linkContents"></ng-container>
       </a>
     </ng-template>
 
     <li class="nav-item">
       <ng-container
-        *ngIf="isInternalRoute(link); else externalLink"
+        *ngIf="hasStrongRoute; else externalLink"
         [ngTemplateOutlet]="internalRoute"
       ></ng-container>
     </li>
@@ -57,29 +52,23 @@ import camelCase from "just-camel-case";
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class HeaderItemComponent implements OnInit {
-  @ViewChild("navLink", { read: ElementRef, static: true })
-  private navLink: ElementRef<HTMLElement>;
   @Input() public link: NavigableMenuItem;
 
-  public isInternalRoute = isInternalRoute;
-  public hasContent: boolean;
+  public hasStrongRoute: boolean;
   public label: string;
 
   public constructor(private route: ActivatedRoute) {}
 
   public ngOnInit(): void {
-    // Only nav links which contain content will initially have a child element
-    this.hasContent = this.navLink?.nativeElement?.childElementCount === 1;
     this.label = camelCase(this.link.label);
+    this.hasStrongRoute = isInternalRoute(this.link);
   }
 
   public get strongRoute(): StrongRoute {
-    return (this.link as MenuRoute)?.route;
+    return (this.link as MenuRoute).route;
   }
 
   public get href(): string {
-    return isExternalLink(this.link)
-      ? getRoute(this.link, this.route.snapshot.params)
-      : undefined;
+    return getRoute(this.link, this.route.snapshot.params);
   }
 }

--- a/src/app/components/shared/header/header.component.html
+++ b/src/app/components/shared/header/header.component.html
@@ -51,9 +51,16 @@
 </ng-template>
 
 <ng-template #userTemplate>
-  <baw-header-item *ngIf="user.isAdmin" [link]="routes.admin">
+  <!-- Admin toolbox -->
+  <a
+    *ngIf="user.isAdmin"
+    id="admin-header-link"
+    class="nav-link"
+    strongRouteActive="active"
+    [strongRoute]="routes.admin.route"
+  >
     <fa-icon [icon]="routes.admin.icon"></fa-icon>
-  </baw-header-item>
+  </a>
 
   <!-- Profile photo -->
   <li class="nav-item">

--- a/src/app/components/shared/header/header.component.html
+++ b/src/app/components/shared/header/header.component.html
@@ -19,13 +19,14 @@
       <!-- Left aligned navigation links -->
       <ul class="navbar-nav me-auto">
         <ng-container *ngFor="let header of headers">
-          <ng-container *ngIf="!isNavigableMenuItem(header)">
-            <baw-header-dropdown [links]="header"></baw-header-dropdown>
-          </ng-container>
-
-          <ng-container *ngIf="isNavigableMenuItem(header)">
-            <baw-header-item [link]="header"></baw-header-item>
-          </ng-container>
+          <baw-header-dropdown
+            *ngIf="!isNavigableMenuItem(header)"
+            [links]="header"
+          ></baw-header-dropdown>
+          <baw-header-item
+            *ngIf="isNavigableMenuItem(header)"
+            [link]="header"
+          ></baw-header-item>
         </ng-container>
       </ul>
 
@@ -43,40 +44,17 @@
 <div style="height: 3.5rem"></div>
 
 <ng-template #guestTemplate>
-  <!-- Register Link -->
-  <li class="nav-item">
-    <a
-      id="register-header-link"
-      class="nav-link"
-      strongRouteActive="active"
-      [strongRoute]="routes.register.route"
-      [innerText]="routes.register.label"
-    ></a>
-  </li>
-  <!-- Login link-->
-  <li class="nav-item">
-    <a
-      id="login-header-link"
-      class="nav-link"
-      strongRouteActive="active"
-      [strongRoute]="routes.login.route"
-      [innerText]="routes.login.label"
-    ></a>
-  </li>
+  <baw-header-item
+    *ngFor="let menuItem of [routes.register, routes.login]"
+    [link]="menuItem"
+  ></baw-header-item>
 </ng-template>
 
 <ng-template #userTemplate>
-  <!-- Admin dashboard link -->
-  <li *ngIf="user.isAdmin" class="nav-item">
-    <a
-      id="admin-settings"
-      class="nav-link"
-      strongRouteActive="active"
-      [strongRoute]="routes.admin.route"
-    >
-      <fa-icon [icon]="routes.admin.icon"></fa-icon>
-    </a>
-  </li>
+  <baw-header-item *ngIf="user.isAdmin" [link]="routes.admin">
+    <fa-icon [icon]="routes.admin.icon"></fa-icon>
+  </baw-header-item>
+
   <!-- Profile photo -->
   <li class="nav-item">
     <a
@@ -86,7 +64,7 @@
       [bawUrl]="user.viewUrl"
     >
       <span [innerText]="user.userName"></span>
-      <div class="image-wrapper d-inline-block bg-light ms-2">
+      <div class="d-inline-block bg-light ms-1">
         <img alt="Profile Icon" [src]="user.image" />
       </div>
     </a>
@@ -95,7 +73,7 @@
   <li class="nav-item">
     <button
       id="logout-header-link"
-      class="nav-link btn btn-link"
+      class="nav-link btn btn-link border-0"
       (click)="logout()"
     >
       Logout

--- a/src/app/components/shared/header/header.component.scss
+++ b/src/app/components/shared/header/header.component.scss
@@ -2,34 +2,10 @@ nav {
   background-color: var(--baw-header);
 }
 
-.nav-item {
-  cursor: pointer;
-  -webkit-touch-callout: none; /* iOS Safari */
-  -webkit-user-select: none; /* Safari */
-  -khtml-user-select: none; /* Konqueror HTML */
-  -moz-user-select: none; /* Firefox */
-  -ms-user-select: none; /* Internet Explorer/Edge */
-  user-select: none; /* Non-prefixed version, currently supported by Chrome and Opera */
-}
-
-fa-icon {
-  margin-right: 0.5rem;
-}
-
-.icon-wrapper {
-  display: inline-flex;
-  width: 1.25rem;
-  justify-content: center;
-}
-
 #login-widget {
   img {
     padding: -10px 5px;
     width: 26px;
     height: 26px;
   }
-}
-
-.btn-link {
-  border: 0px;
 }

--- a/src/app/components/shared/header/header.component.spec.ts
+++ b/src/app/components/shared/header/header.component.spec.ts
@@ -269,7 +269,7 @@ describe("HeaderComponent", () => {
           setUser(isLoggedIn, defaultUser);
           spec.detectChanges();
 
-          const settings = spec.query<HTMLElement>("#adminHome-header-link");
+          const settings = spec.query<HTMLElement>("#admin-header-link");
 
           if (links.admin) {
             expect(settings).toBeTruthy();

--- a/src/app/components/shared/header/header.component.spec.ts
+++ b/src/app/components/shared/header/header.component.spec.ts
@@ -194,7 +194,7 @@ describe("HeaderComponent", () => {
           setUser(isLoggedIn, defaultUser);
           spec.detectChanges();
 
-          const link = spec.query<HTMLElement>("#login-header-link");
+          const link = spec.query<HTMLElement>("#logIn-header-link");
 
           if (links.login) {
             assertStrongRouteLink(link, loginMenuItem.route.toRouterLink());
@@ -269,7 +269,7 @@ describe("HeaderComponent", () => {
           setUser(isLoggedIn, defaultUser);
           spec.detectChanges();
 
-          const settings = spec.query<HTMLElement>("#admin-settings");
+          const settings = spec.query<HTMLElement>("#adminHome-header-link");
 
           if (links.admin) {
             expect(settings).toBeTruthy();

--- a/src/app/components/shared/wip/wip.component.scss
+++ b/src/app/components/shared/wip/wip.component.scss
@@ -1,3 +1,0 @@
-.wrapper {
-  background-color: rgba(0, 0, 0, 0.2);
-}

--- a/src/app/components/shared/wip/wip.component.ts
+++ b/src/app/components/shared/wip/wip.component.ts
@@ -12,24 +12,30 @@ import { ConfigService } from "@services/config/config.service";
 @Component({
   selector: "baw-wip",
   template: `
-    <p class="h1 text-warning text-center">Work In Progress</p>
-    <div class="wrapper" [ngbTooltip]="tooltip">
-      <ng-content></ng-content>
-    </div>
+    <ng-container *ngIf="!production">
+      <p class="h1 text-warning text-center">Work In Progress</p>
+      <div class="wip-wrapper">
+        <ng-content></ng-content>
+      </div>
+    </ng-container>
   `,
-  styleUrls: ["./wip.component.scss"],
+  styles: [
+    `
+      .wip-wrapper {
+        background-color: rgba(0, 0, 0, 0.2);
+      }
+    `,
+  ],
   // eslint-disable-next-line @angular-eslint/use-component-view-encapsulation
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WIPComponent implements OnInit {
-  public tooltip: string;
+  public production: boolean;
 
   public constructor(private config: ConfigService) {}
 
   public ngOnInit() {
-    this.tooltip = this.config.config.production
-      ? "This feature is currently not functional."
-      : null;
+    this.production = this.config.config.production;
   }
 }

--- a/src/app/components/sites/pages/edit/edit.component.html
+++ b/src/app/components/sites/pages/edit/edit.component.html
@@ -1,3 +1,4 @@
+<!-- TODO Image input #608 -->
 <baw-form
   *ngIf="!failure"
   [title]="title"

--- a/src/app/components/sites/pages/new/new.component.html
+++ b/src/app/components/sites/pages/new/new.component.html
@@ -1,3 +1,4 @@
+<!-- TODO Image input #608 -->
 <baw-form
   *ngIf="!failure"
   [title]="title"

--- a/src/app/components/statistics/components/recent-annotations/recent-annotations.component.ts
+++ b/src/app/components/statistics/components/recent-annotations/recent-annotations.component.ts
@@ -78,9 +78,9 @@ import { ColumnMode, TableColumn } from "@swimlane/ngx-datatable";
           ></baw-loading>
 
           <ng-template #noTags>
-            <span *ngIf="value.tags.length === 0" class="badge bg-highlight">
+            <ng-container *ngIf="value.tags.length === 0">
               (none)
-            </span>
+            </ng-container>
           </ng-template>
         </ng-template>
       </ngx-datatable-column>

--- a/src/app/directives/image/image.directive.ts
+++ b/src/app/directives/image/image.directive.ts
@@ -68,12 +68,14 @@ export class AuthenticatedImageDirective implements OnChanges {
       };
 
       const classes = { loading: "loading-image", loaded: "loaded-image" };
-      this.imageEl.classList.add(classes.loading);
       this.imageEl.onload = () => {
         // Prevent overriding of 'this'
         this.imageEl.classList.remove(classes.loading);
         this.imageEl.classList.add(classes.loaded);
       };
+
+      // Treat image as loaded for ssr
+      this.imageEl.classList.add(this.isSsr ? classes.loaded : classes.loading);
     }
 
     // Update images if src changes

--- a/src/app/directives/image/image.directive.ts
+++ b/src/app/directives/image/image.directive.ts
@@ -11,6 +11,7 @@ import { API_ROOT } from "@helpers/app-initializer/app-initializer";
 import { ImageSizes, ImageUrl } from "@interfaces/apiInterfaces";
 import { assetRoot } from "@services/config/config.service";
 import { OrderedSet } from "immutable";
+import { IS_SERVER_PLATFORM } from "src/app/app.helper";
 
 export const notFoundImage: ImageUrl = {
   url: `${assetRoot}/images/404.png`,
@@ -47,6 +48,7 @@ export class AuthenticatedImageDirective implements OnChanges {
 
   public constructor(
     @Inject(API_ROOT) private apiRoot: string,
+    @Inject(IS_SERVER_PLATFORM) private isSsr: boolean,
     private securityApi: SecurityService,
     private imageRef: ElementRef<HTMLImageElement>
   ) {}
@@ -60,17 +62,21 @@ export class AuthenticatedImageDirective implements OnChanges {
 
     // On Component Initial Load
     if (changes.src.isFirstChange()) {
-      this.imageEl.classList.add("loading-image");
-
       this.imageEl.onerror = () => {
         // Prevent overriding of 'this'
         this.errorHandler();
       };
 
+      if (this.isSsr) {
+        return;
+      }
+
+      const classes = { loading: "loading-image", loaded: "loaded-image" };
+      this.imageEl.classList.add(classes.loading);
       this.imageEl.onload = () => {
         // Prevent overriding of 'this'
-        this.imageEl.classList.remove("loading-image");
-        this.imageEl.classList.add("loaded-image");
+        this.imageEl.classList.remove(classes.loading);
+        this.imageEl.classList.add(classes.loaded);
       };
     }
 

--- a/src/app/directives/image/image.directive.ts
+++ b/src/app/directives/image/image.directive.ts
@@ -67,10 +67,6 @@ export class AuthenticatedImageDirective implements OnChanges {
         this.errorHandler();
       };
 
-      if (this.isSsr) {
-        return;
-      }
-
       const classes = { loading: "loading-image", loaded: "loaded-image" };
       this.imageEl.classList.add(classes.loading);
       this.imageEl.onload = () => {

--- a/src/app/helpers/app-initializer/app-initializer.ts
+++ b/src/app/helpers/app-initializer/app-initializer.ts
@@ -80,7 +80,16 @@ export interface Keys {
  */
 export interface Configuration {
   kind: "Configuration";
+  /** Is the current environment running in production mode */
   production: boolean;
+  /** Timeout for web requests in server side renderer */
+  ssrTimeout: number;
+  /** Timeout for web requests in browser */
+  browserTimeout: number;
+  /**
+   * Current build version of this code. This is set by the docker container
+   * and should not be modified without care
+   */
   version: string;
   endpoints: Endpoints;
   keys: Keys;

--- a/src/app/services/rehydration/rehydration.interceptor.service.spec.ts
+++ b/src/app/services/rehydration/rehydration.interceptor.service.spec.ts
@@ -1,0 +1,2 @@
+// TODO
+describe("RehydrationInterceptorService", () => {});

--- a/src/app/services/rehydration/rehydration.interceptor.service.ts
+++ b/src/app/services/rehydration/rehydration.interceptor.service.ts
@@ -1,0 +1,105 @@
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+  HttpResponse,
+} from "@angular/common/http";
+import { Inject, Injectable } from "@angular/core";
+import {
+  makeStateKey,
+  StateKey,
+  TransferState,
+} from "@angular/platform-browser";
+import httpStatus from "http-status";
+import { Observable, of } from "rxjs";
+import { tap } from "rxjs/operators";
+import { IS_SERVER_PLATFORM } from "src/app/app.helper";
+
+const STATE_KEY_PREFIX = "http_requests:";
+
+/**
+ * This service handles caching and rehydrating the data sent from the API when
+ * transitioning between the SSR and the browser. This interceptor is built off
+ * the example code here:
+ * https://medium.com/@alireza.mirian/reusing-server-side-http-responses-in-front-end-when-using-ssr-in-angular-970d3efaea59
+ */
+@Injectable()
+export class RehydrationInterceptorService implements HttpInterceptor {
+  public constructor(
+    @Inject(IS_SERVER_PLATFORM) private isSsr: boolean,
+    private transferState: TransferState
+  ) {}
+
+  public intercept(
+    req: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    // Ignore any requests which are not GET or filter
+    const isGetRequest = req.method === "GET";
+    const isFilterRequest = req.url.endsWith("/filter");
+    if (!isGetRequest && !isFilterRequest) {
+      return next.handle(req);
+    }
+
+    // Predict key for request in state transfer, and intercept request
+    const key = makeStateKey<HttpResponse<any>>(STATE_KEY_PREFIX + req.url);
+    return this.isSsr
+      ? this.interceptServerRequests(req, next, key)
+      : this.interceptBrowserRequests(req, next, key);
+  }
+
+  /**
+   * Intercept browser request. If this is the first request after SSR, and the
+   * request exists in the transferred state, return the cached value. This will
+   * clear the cache for that request immediately after to reduce caching
+   * issues
+   */
+  private interceptBrowserRequests(
+    req: HttpRequest<any>,
+    next: HttpHandler,
+    key: StateKey<HttpResponse<any>>
+  ): Observable<HttpEvent<any>> {
+    // Try reusing transferred response from server
+    const cachedResponse = this.transferState.get(key, null);
+
+    if (!cachedResponse) {
+      return next.handle(req);
+    }
+
+    this.transferState.remove(key); // cached response should be used for the very first time
+    return of(
+      new HttpResponse({
+        body: cachedResponse.body,
+        status: httpStatus.OK,
+        statusText: "OK (from server)",
+        headers: cachedResponse.headers,
+      })
+    );
+  }
+
+  /**
+   * Intercept server side renderer request. Save the results of the request to
+   * the state, and sent it to the browser when it rehydrates. Only parts of the
+   * initial request are cached because http responses contain cyclical
+   * relationships
+   */
+  private interceptServerRequests(
+    req: HttpRequest<any>,
+    next: HttpHandler,
+    key: StateKey<HttpResponse<any>>
+  ): Observable<HttpEvent<any>> {
+    return next.handle(req).pipe(
+      tap((event) => {
+        if (event instanceof HttpResponse && event.status === httpStatus.OK) {
+          /*
+           * Only transferring body because http responses are not POJO and
+           * would require a custom serialization/deserialization solution
+           */
+          const response = { body: event.body, headers: event.headers };
+          this.transferState.set(key, response);
+        }
+      })
+    );
+  }
+}

--- a/src/app/services/rehydration/rehydration.interceptor.service.ts
+++ b/src/app/services/rehydration/rehydration.interceptor.service.ts
@@ -63,7 +63,8 @@ export class RehydrationInterceptorService implements HttpInterceptor {
     // Try reusing transferred response from server
     const cachedResponse = this.transferState.get(key, null);
 
-    if (!cachedResponse) {
+    // If no cached value, or the user is authed, let the original request go through
+    if (!cachedResponse || req.headers.has("Authorization")) {
       return next.handle(req);
     }
 

--- a/src/app/services/rehydration/rehydration.module.ts
+++ b/src/app/services/rehydration/rehydration.module.ts
@@ -1,0 +1,16 @@
+import { HTTP_INTERCEPTORS } from "@angular/common/http";
+import { NgModule } from "@angular/core";
+import { BrowserTransferStateModule } from "@angular/platform-browser";
+import { RehydrationInterceptorService } from "./rehydration.interceptor.service";
+
+@NgModule({
+  imports: [BrowserTransferStateModule],
+  providers: [
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: RehydrationInterceptorService,
+      multi: true,
+    },
+  ],
+})
+export class RehydrationModule {}

--- a/src/app/test/helpers/paginationTemplate.ts
+++ b/src/app/test/helpers/paginationTemplate.ts
@@ -3,7 +3,6 @@ import { AbstractModel } from "@models/AbstractModel";
 import { NgbPagination } from "@ng-bootstrap/ng-bootstrap";
 import { Spectator } from "@ngneat/spectator";
 import { DebounceInputComponent } from "@shared/debounce-input/debounce-input.component";
-import { LoadingComponent } from "@shared/loading/loading.component";
 
 export function assertPaginationTemplate<
   M extends AbstractModel,
@@ -37,24 +36,6 @@ export function assertPaginationTemplate<
         filter.filter.next("Custom Filter");
         spectator.detectChanges();
         expect(spy).toHaveBeenCalled();
-      });
-    });
-
-    describe("loading spinner", () => {
-      function getSpinner() {
-        return spectator.query(LoadingComponent);
-      }
-
-      it("should display when page is loading", () => {
-        spectator.component.loading = true;
-        spectator.detectChanges();
-        expect(getSpinner()).toBeTruthy();
-      });
-
-      it("should not display when page has loaded", () => {
-        spectator.component.loading = false;
-        spectator.detectChanges();
-        expect(getSpinner()).toBeFalsy();
       });
     });
 

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,6 +2,8 @@ import { Configuration } from "@helpers/app-initializer/app-initializer";
 
 export const environment = {
   production: true,
+  ssrTimeout: 100,
+  browserTimeout: 10_000,
   // Version is set by the docker container, edit with care
   version: "<<VERSION_REPLACED_WHEN_BUILT>>",
 } as Partial<Configuration> as Configuration;

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -2,6 +2,8 @@ import { Configuration } from "@helpers/app-initializer/app-initializer";
 
 export const environment = {
   production: false,
+  ssrTimeout: 1_000,
+  browserTimeout: 10_000,
   // Version is set by the docker container, edit with care
   version: "<<VERSION_REPLACED_WHEN_BUILT>>",
 } as Partial<Configuration> as Configuration;


### PR DESCRIPTION
# Deployment Cleanup

This is a collection of fixes for bugs which were exposed during the staging testing of workbench-client

## Changes

- Cleanup header component unit tests
- Removed pill colouring from (none) values when showing tags associated with an annotation in statistics page
- Hide WIP wrapped components in production build
- Fixed transition issue between SSR and browser where images would still have the loading css class applied after loading
- Fixed issue where SSR was unable to make API requests
- Extracted timeout values for API requests to environment file which can be more easily changed
  - Will need to check if current production timeout values for SSR are long enough to be viable
- Implemented `RehydrationInterceptorService` which will cache the requests made in SSR, and send them to the browser
- Minor changes to express server
  - Using compression middleware to compress data and reduce loading times (TODO validate this improves things)
  - Set X-Frame-Options header to SAMEORIGIN to reduce chances of click-jacking

## Problems

- Need to implement tests for `RehydrationInterceptorService`
- There is a (hopefully) dev only problem where baw-client throws an error attempting to access any of its assets because the local path does not exist

## Issues

Fixes #1514 
#1163 Should now be possible to implement properly

## Visual Changes

### Statistics Page Before

![image](https://user-images.githubusercontent.com/3955116/139633957-2ab4830d-c5b3-408c-a75c-1507fa7bff10.png)

### Statistics Page After

![image](https://user-images.githubusercontent.com/3955116/139633988-9e1a46ff-b764-4807-895a-4a0dbe0d6e79.png)

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
