### PR TITLE
Hide Baw-Client on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@ Then open a web browser to `http://localhost:4000`.
 
 This website can be customised through the environment file located at `./src/assets/environment.json` (note: look at the docker section for deploying environment files). Here is a list of settings and some example values:
 
-Parameter | Description | Example Value
-----------|-------------|--------------
-`endpoints.environment` | The environment for this instance. Currently used only for informational purposes. | `development`<br>`staging`<br>`production`
-`endpoints.apiRoot` | Any API requests made from the app will use this value for its base and append routes to it | `https://ecosounds.org`<br>`https://ecosounds.org:3000`<br>`https://ecosounds.org/api`
-`endpoints.clientOrigin` | This is the [origin](https://html.spec.whatwg.org/multipage/origin.html#concept-origin) of where the website will be hosted | `https://ecosounds.org`<br>`https://ecosounds.org:3000`
-`endpoints.clientDir` | This is the directory on the `clientOrigin` which the website is hosted | `/website`<br>`/web/angular`
-`keys.googleMaps` | Google maps API key | Check googles official setup guide
-`keys.googleAnalytics` | Google analytics domain and tracking ID | Check googles official setup guide
-`settings.brand.short` | This changes the logo branding of the website | `Ecosounds`
-`settings.brand.long` | This changes the full length name of the website | `Ecosounds - Acoustic Workbench`
-`settings.links` | This is a list of external links used throughout the website. Check the template for the list of modifiable links |
-`settings.customMenu` | This is a list of custom menu items which changes the contents of the header with instance specific links. Check the template for examples |
+| Parameter                | Description                                                                                                                                | Example Value                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| `endpoints.environment`  | The environment for this instance. Currently used only for informational purposes.                                                         | `development`<br>`staging`<br>`production`                                             |
+| `endpoints.apiRoot`      | Any API requests made from the app will use this value for its base and append routes to it                                                | `https://ecosounds.org`<br>`https://ecosounds.org:3000`<br>`https://ecosounds.org/api` |
+| `endpoints.clientOrigin` | This is the [origin](https://html.spec.whatwg.org/multipage/origin.html#concept-origin) of where the website will be hosted                | `https://ecosounds.org`<br>`https://ecosounds.org:3000`                                |
+| `endpoints.clientDir`    | This is the directory on the `clientOrigin` which the website is hosted                                                                    | `/website`<br>`/web/angular`                                                           |
+| `keys.googleMaps`        | Google maps API key                                                                                                                        | Check googles official setup guide                                                     |
+| `keys.googleAnalytics`   | Google analytics domain and tracking ID                                                                                                    | Check googles official setup guide                                                     |
+| `settings.brand.short`   | This changes the logo branding of the website                                                                                              | `Ecosounds`                                                                            |
+| `settings.brand.long`    | This changes the full length name of the website                                                                                           | `Ecosounds - Acoustic Workbench`                                                       |
+| `settings.links`         | This is a list of external links used throughout the website. Check the template for the list of modifiable links                          |
+| `settings.customMenu`    | This is a list of custom menu items which changes the contents of the header with instance specific links. Check the template for examples |
 
 ### Access the ng tool
 

--- a/src/app/components/error/resolver-handler.component.spec.ts
+++ b/src/app/components/error/resolver-handler.component.spec.ts
@@ -1,11 +1,11 @@
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { MockModel } from "@baw-api/mock/baseApiMock.service";
-import { ResolvedModel } from "@baw-api/resolver-common";
 import { IPageInfo } from "@helpers/page/pageInfo";
 import { createRoutingFactory, SpectatorRouting } from "@ngneat/spectator";
 import { ErrorHandlerComponent } from "@shared/error-handler/error-handler.component";
 import { generateApiErrorDetails } from "@test/fakes/ApiErrorDetails";
+import { generatePageInfo } from "@test/helpers/general";
 import { MockComponent } from "ng-mocks";
 import { ResolverHandlerComponent } from "./resolver-handler.component";
 
@@ -33,18 +33,6 @@ describe("ResolverHandlerComponent", () => {
     }
   }
 
-  function generateData(...models: ResolvedModel[]): Partial<IPageInfo> {
-    const data: Partial<IPageInfo> = { resolvers: {} };
-
-    models.forEach((model, index) => {
-      const key = "model" + index;
-      data.resolvers[key] = "resolver";
-      data[key] = model;
-    });
-
-    return data;
-  }
-
   describe("handleResolvers", () => {
     it("should handle undefined resolvers", () => {
       setup({ resolvers: undefined });
@@ -53,14 +41,14 @@ describe("ResolverHandlerComponent", () => {
     });
 
     it("should not display if single passing resolver", () => {
-      setup(generateData({ model: new MockModel({}) }));
+      setup(generatePageInfo({ model: new MockModel({}) }));
       spec.detectChanges();
       assertErrorHandler();
     });
 
     it("should not display if multiple passing resolvers", () => {
       setup(
-        generateData(
+        generatePageInfo(
           { model: new MockModel({}) },
           { model: new MockModel({}) },
           { model: new MockModel({}) }
@@ -72,14 +60,14 @@ describe("ResolverHandlerComponent", () => {
 
     it("should display error if single failing resolver", () => {
       const error = generateApiErrorDetails();
-      setup(generateData({ error }));
+      setup(generatePageInfo({ error }));
       spec.detectChanges();
       assertErrorHandler(error);
     });
 
     it("should display error if multiple failing resolvers", () => {
       const error = generateApiErrorDetails();
-      setup(generateData({ error }, { error }, { error }));
+      setup(generatePageInfo({ error }, { error }, { error }));
       spec.detectChanges();
       assertErrorHandler(error);
     });
@@ -88,7 +76,7 @@ describe("ResolverHandlerComponent", () => {
       const unauthorized = generateApiErrorDetails("Unauthorized");
       const notFound = generateApiErrorDetails("Not Found");
       setup(
-        generateData(
+        generatePageInfo(
           { error: notFound },
           { error: unauthorized },
           { error: notFound }
@@ -101,7 +89,7 @@ describe("ResolverHandlerComponent", () => {
     it("should display error if mixed passing and failing resolvers", () => {
       const error = generateApiErrorDetails();
       setup(
-        generateData(
+        generatePageInfo(
           { model: new MockModel({}) },
           { error },
           { model: new MockModel({}) }
@@ -114,10 +102,10 @@ describe("ResolverHandlerComponent", () => {
 
   describe("route data", () => {
     it("should clear error if new route data does not contain resolver failure", () => {
-      setup(generateData({ error: generateApiErrorDetails() }));
+      setup(generatePageInfo({ error: generateApiErrorDetails() }));
       spec.detectChanges();
       spec.triggerNavigation({
-        data: generateData({ model: new MockModel({}) }),
+        data: generatePageInfo({ model: new MockModel({}) }),
       });
       spec.detectChanges();
       assertErrorHandler();
@@ -125,9 +113,9 @@ describe("ResolverHandlerComponent", () => {
 
     it("should display error if new route data contains resolver failure", () => {
       const error = generateApiErrorDetails();
-      setup(generateData({ model: new MockModel({}) }));
+      setup(generatePageInfo({ model: new MockModel({}) }));
       spec.detectChanges();
-      spec.triggerNavigation({ data: generateData({ error }) });
+      spec.triggerNavigation({ data: generatePageInfo({ error }) });
       spec.detectChanges();
       assertErrorHandler(error);
     });

--- a/src/app/components/shared/baw-client/baw-client.component.spec.ts
+++ b/src/app/components/shared/baw-client/baw-client.component.spec.ts
@@ -93,14 +93,23 @@ describe("BawClientComponent", () => {
     }
   });
 
+  describe("ssr", () => {
+    it("should hide iframe if running on ssr", () => {
+      setup();
+      spec.component.isSsr = true;
+      spec.detectChanges();
+      expect(getIframe()).toBeFalsy();
+    });
+  });
+
   describe("resolver handling", () => {
-    it("should disable iframe if resolver errors occurred", () => {
+    it("should hide iframe if resolver errors occurred", () => {
       setup(generatePageInfo({ error: generateApiErrorDetailsV2() }));
       spec.detectChanges();
       expect(getIframe()).toBeFalsy();
     });
 
-    it("should not disabled iframe if resolver successfully resolves models", () => {
+    it("should not hide iframe if resolver successfully resolves models", () => {
       setup(generatePageInfo({ model: new MockModel({ id: 1 }) }));
       spec.detectChanges();
       expect(getIframe()).toBeTruthy();

--- a/src/app/components/shared/baw-client/baw-client.component.ts
+++ b/src/app/components/shared/baw-client/baw-client.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   ElementRef,
   HostListener,
+  Inject,
   Input,
   OnInit,
   ViewChild,
@@ -14,12 +15,13 @@ import { PageInfo } from "@helpers/page/pageInfo";
 import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
 import { ConfigService } from "@services/config/config.service";
 import { filter, takeUntil } from "rxjs/operators";
+import { IS_SERVER_PLATFORM } from "src/app/app.helper";
 
 //TODO: OLD-CLIENT REMOVE
 @Component({
   selector: "baw-client",
   template: `
-    <iframe *ngIf="url && !error" #content [src]="url">
+    <iframe #content *ngIf="url" [src]="url">
       <!-- This warning only shows on browsers which don't support iframes -->
       <p>
         Unfortunately your browser does not support iframes. Please ensure you
@@ -69,6 +71,7 @@ export class BawClientComponent extends withUnsubscribe() implements OnInit {
   }
 
   public constructor(
+    @Inject(IS_SERVER_PLATFORM) public isSsr: boolean,
     private config: ConfigService,
     private router: Router,
     private route: ActivatedRoute,
@@ -81,8 +84,9 @@ export class BawClientComponent extends withUnsubscribe() implements OnInit {
     const data = this.route.snapshot.data;
     const models = retrieveResolvers(data as PageInfo);
 
-    if (!models) {
-      this.error = true;
+    // Don't load client on SSR or if error occurs
+    if (!models || this.isSsr) {
+      this.url = undefined;
       return;
     }
 

--- a/src/app/components/shared/baw-client/baw-client.component.ts
+++ b/src/app/components/shared/baw-client/baw-client.component.ts
@@ -7,8 +7,10 @@ import {
   ViewChild,
 } from "@angular/core";
 import { DomSanitizer, SafeResourceUrl } from "@angular/platform-browser";
-import { NavigationEnd, Router } from "@angular/router";
+import { ActivatedRoute, NavigationEnd, Router } from "@angular/router";
+import { retrieveResolvers } from "@baw-api/resolver-common";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
+import { PageInfo } from "@helpers/page/pageInfo";
 import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
 import { ConfigService } from "@services/config/config.service";
 import { filter, takeUntil } from "rxjs/operators";
@@ -17,7 +19,7 @@ import { filter, takeUntil } from "rxjs/operators";
 @Component({
   selector: "baw-client",
   template: `
-    <iframe *ngIf="url" #content [src]="url">
+    <iframe *ngIf="url && !error" #content [src]="url">
       <!-- This warning only shows on browsers which don't support iframes -->
       <p>
         Unfortunately your browser does not support iframes. Please ensure you
@@ -44,8 +46,8 @@ export class BawClientComponent extends withUnsubscribe() implements OnInit {
    */
   @Input() public page: string;
 
+  public error: boolean;
   public url: SafeResourceUrl;
-  public loading = true;
 
   @HostListener("window:message", ["$event"])
   private onBawClientMessage(event: MessageEvent): void {
@@ -62,7 +64,6 @@ export class BawClientComponent extends withUnsubscribe() implements OnInit {
     }
 
     if (meta?.height > 0) {
-      this.loading = false;
       this.updateIframeSize(meta.height);
     }
   }
@@ -70,27 +71,37 @@ export class BawClientComponent extends withUnsubscribe() implements OnInit {
   public constructor(
     private config: ConfigService,
     private router: Router,
+    private route: ActivatedRoute,
     private sanitizer: DomSanitizer
   ) {
     super();
   }
 
   public ngOnInit(): void {
+    const data = this.route.snapshot.data;
+    const models = retrieveResolvers(data as PageInfo);
+
+    if (!models) {
+      this.error = true;
+      return;
+    }
+
     if (isInstantiated(this.page)) {
       // Use page provided
       this.updateUrl(this.page);
-    } else {
-      // Use router url
-      this.updateUrl(this.router.url);
-
-      // Monitor any changes to current url
-      this.router.events
-        .pipe(
-          filter((event) => event instanceof NavigationEnd),
-          takeUntil(this.unsubscribe)
-        )
-        .subscribe((event: NavigationEnd) => this.updateUrl(event.url));
+      return;
     }
+
+    // Use router url
+    this.updateUrl(this.router.url);
+
+    // Monitor any changes to current url
+    this.router.events
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        takeUntil(this.unsubscribe)
+      )
+      .subscribe((event: NavigationEnd) => this.updateUrl(event.url));
   }
 
   private updateIframeSize(height: number): void {

--- a/src/app/components/shared/error-handler/error-handler.component.ts
+++ b/src/app/components/shared/error-handler/error-handler.component.ts
@@ -1,7 +1,8 @@
-import { Component, Input } from "@angular/core";
+import { Component, Inject, Input, OnInit } from "@angular/core";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { reportProblemMenuItem } from "@components/report-problem/report-problem.menus";
 import httpCodes from "http-status";
+import { IS_SERVER_PLATFORM } from "src/app/app.helper";
 
 /**
  * Error Handler Wrapper
@@ -9,7 +10,7 @@ import httpCodes from "http-status";
 @Component({
   selector: "baw-error-handler",
   template: `
-    <ng-container *ngIf="error">
+    <ng-container *ngIf="error && !hideErrorDetails">
       <h1>{{ getTitle() }}</h1>
 
       <p>{{ error.message }}</p>
@@ -21,9 +22,10 @@ import httpCodes from "http-status";
     </ng-container>
   `,
 })
-export class ErrorHandlerComponent {
+export class ErrorHandlerComponent implements OnInit {
   @Input() public error: ApiErrorDetails;
   public reportProblem = reportProblemMenuItem.route;
+  public hideErrorDetails: boolean;
   public titles = {
     [httpCodes.UNAUTHORIZED]: "Unauthorized Access",
     [httpCodes.FORBIDDEN]: "Access Forbidden",
@@ -31,6 +33,22 @@ export class ErrorHandlerComponent {
     [httpCodes.REQUEST_TIMEOUT]: "Request Timed Out",
     [httpCodes.BAD_GATEWAY]: "Connection Failure",
   };
+
+  public constructor(@Inject(IS_SERVER_PLATFORM) private isSsr: boolean) {}
+
+  public ngOnInit(): void {
+    // If this is SSR, ignore auth or disconnect issues
+    if (
+      this.isSsr &&
+      [
+        httpCodes.UNAUTHORIZED,
+        httpCodes.REQUEST_TIMEOUT,
+        httpCodes.BAD_GATEWAY,
+      ].includes(this.error.status)
+    ) {
+      this.hideErrorDetails = true;
+    }
+  }
 
   public getTitle() {
     return this.titles[this.error.status] ?? "Unknown Error";

--- a/src/app/components/shared/form/form.component.html
+++ b/src/app/components/shared/form/form.component.html
@@ -23,7 +23,7 @@
         <button
           *ngIf="submitLabel"
           type="submit"
-          class="btn float-end"
+          class="btn float-end mt-3"
           [ngClass]="'btn-' + btnColor"
           [disabled]="!fields || submitLoading"
         >

--- a/src/app/directives/image/image.directive.ts
+++ b/src/app/directives/image/image.directive.ts
@@ -60,19 +60,9 @@ export class AuthenticatedImageDirective implements OnChanges {
 
     // On Component Initial Load
     if (changes.src.isFirstChange()) {
-      this.imageEl.onerror = () => {
-        // Prevent overriding of 'this'
-        this.errorHandler();
-      };
-
-      const classes = { loading: "loading-image", loaded: "loaded-image" };
-      this.imageEl.onload = () => {
-        // Prevent overriding of 'this'
-        this.imageEl.classList.remove(classes.loading);
-        this.imageEl.classList.add(classes.loaded);
-      };
-
-      this.imageEl.classList.add(classes.loading);
+      this.imageEl.classList.add("square-image");
+      // Prevent overriding of 'this'
+      this.imageEl.onerror = () => this.errorHandler();
     }
 
     // Update images if src changes

--- a/src/app/directives/image/image.directive.ts
+++ b/src/app/directives/image/image.directive.ts
@@ -11,7 +11,6 @@ import { API_ROOT } from "@helpers/app-initializer/app-initializer";
 import { ImageSizes, ImageUrl } from "@interfaces/apiInterfaces";
 import { assetRoot } from "@services/config/config.service";
 import { OrderedSet } from "immutable";
-import { IS_SERVER_PLATFORM } from "src/app/app.helper";
 
 export const notFoundImage: ImageUrl = {
   url: `${assetRoot}/images/404.png`,
@@ -48,7 +47,6 @@ export class AuthenticatedImageDirective implements OnChanges {
 
   public constructor(
     @Inject(API_ROOT) private apiRoot: string,
-    @Inject(IS_SERVER_PLATFORM) private isSsr: boolean,
     private securityApi: SecurityService,
     private imageRef: ElementRef<HTMLImageElement>
   ) {}
@@ -74,8 +72,7 @@ export class AuthenticatedImageDirective implements OnChanges {
         this.imageEl.classList.add(classes.loaded);
       };
 
-      // Treat image as loaded for ssr
-      this.imageEl.classList.add(this.isSsr ? classes.loaded : classes.loading);
+      this.imageEl.classList.add(classes.loading);
     }
 
     // Update images if src changes

--- a/src/app/styles/_images.scss
+++ b/src/app/styles/_images.scss
@@ -4,9 +4,11 @@
   color: rgb(237, 237, 237);
   font-size: 0px;
   text-decoration: none;
+  display: inline-block;
 }
 
 .loaded-image {
   aspect-ratio: 1/1;
   background-color: unset;
+  display: inline-block;
 }

--- a/src/app/styles/_images.scss
+++ b/src/app/styles/_images.scss
@@ -1,7 +1,7 @@
 .square-image {
   aspect-ratio: 1/1;
-  background-color: unset;
   display: inline-block;
+  // Hide alt text
   font-size: 0px;
   text-decoration: none;
 }

--- a/src/app/styles/_images.scss
+++ b/src/app/styles/_images.scss
@@ -1,14 +1,7 @@
-.loading-image {
-  aspect-ratio: 1/1;
-  background-color: rgb(237, 237, 237);
-  color: rgb(237, 237, 237);
-  font-size: 0px;
-  text-decoration: none;
-  display: inline-block;
-}
-
-.loaded-image {
+.square-image {
   aspect-ratio: 1/1;
   background-color: unset;
   display: inline-block;
+  font-size: 0px;
+  text-decoration: none;
 }

--- a/src/app/test/fakes/ApiErrorDetails.ts
+++ b/src/app/test/fakes/ApiErrorDetails.ts
@@ -12,7 +12,7 @@ import httpCodes, {
 
 // TODO Make this is the default method for error generation
 export function generateApiErrorDetailsV2(
-  status: number,
+  status: number = UNAUTHORIZED,
   custom?: Partial<ApiErrorDetails>
 ): ApiErrorDetails {
   let message: string;

--- a/src/app/test/helpers/general.ts
+++ b/src/app/test/helpers/general.ts
@@ -5,7 +5,9 @@ import {
   isApiErrorDetails,
 } from "@baw-api/api.interceptor.service";
 import { Filters } from "@baw-api/baw-api.service";
+import { ResolvedModel } from "@baw-api/resolver-common";
 import { Errorable } from "@helpers/advancedTypes";
+import { IPageInfo } from "@helpers/page/pageInfo";
 import { AbstractModel, AbstractModelConstructor } from "@models/AbstractModel";
 import { SpyObject } from "@ngneat/spectator";
 import { Subject } from "rxjs";
@@ -205,4 +207,18 @@ export function getCallArgs(spy: jasmine.Spy) {
 
 export function assertOk(): void {
   expect(true).toBeTrue();
+}
+
+export function generatePageInfo(
+  ...models: ResolvedModel[]
+): Partial<IPageInfo> {
+  const data: Partial<IPageInfo> = { resolvers: {} };
+
+  models.forEach((model, index) => {
+    const key = "model" + index;
+    data.resolvers[key] = "resolver";
+    data[key] = model;
+  });
+
+  return data;
 }


### PR DESCRIPTION
# Hide Baw Client on Failure

Baw client has no timeout on error messages 

## Changes

- Created generatePageInfo helper
- Changed image css class to use inline block fixing height issues
 
![image](https://user-images.githubusercontent.com/3955116/140273281-71673dfa-eadc-41fb-a6a7-b86fab916030.png)

- Removed custom SSR handling of image directive
- Added padding to form submit button

![image](https://user-images.githubusercontent.com/3955116/140272755-44c1ed32-4443-45d3-bc18-978ad56ea8b6.png)

- Added additional tests to `BawClientComponent`
- Hide `BawClientComponent` on SSR to prevent double render
- Hide some types of errors on SSR

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
