### PR TITLE
Regions Visualize Link

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,21 +8,21 @@
       "type": "chrome",
       "request": "launch",
       "name": "Chrome Debugging",
-      "url": "http://localhost:4200",
+      "url": "http://development.ecosounds.org:4200",
       "webRoot": "${workspaceFolder}"
     },
     {
       "type": "firefox",
       "request": "launch",
       "name": "Firefox Debugging",
-      "url": "http://localhost:4200",
+      "url": "http://development.ecosounds.org:4200",
       "webRoot": "${workspaceFolder}"
     },
     {
       "type": "edge",
       "request": "launch",
       "name": "Edge Debugging",
-      "url": "http://localhost:4200",
+      "url": "http://development.ecosounds.org:4200",
       "webRoot": "${workspaceFolder}"
     },
     {

--- a/src/app/components/admin/analysis-jobs/details/details.component.ts
+++ b/src/app/components/admin/analysis-jobs/details/details.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { analysisJobResolvers } from "@baw-api/analysis/analysis-jobs.service";
-import { retrieveResolvers } from "@baw-api/resolver-common";
+import {
+  hasResolvedSuccessfully,
+  retrieveResolvers,
+} from "@baw-api/resolver-common";
 import { adminAnalysisJobsMenuItem } from "@components/admin/admin.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { PageInfo } from "@helpers/page/pageInfo";
@@ -46,7 +49,7 @@ class AdminAnalysisJobComponent
     const data = this.route.snapshot.data;
     const models = retrieveResolvers(data as PageInfo);
 
-    if (!models) {
+    if (!hasResolvedSuccessfully(models)) {
       this.failure = true;
       return;
     }

--- a/src/app/components/admin/audio-recordings/details/details.component.ts
+++ b/src/app/components/admin/audio-recordings/details/details.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { audioRecordingResolvers } from "@baw-api/audio-recording/audio-recordings.service";
-import { retrieveResolvers } from "@baw-api/resolver-common";
+import {
+  hasResolvedSuccessfully,
+  retrieveResolvers,
+} from "@baw-api/resolver-common";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { PageInfo } from "@helpers/page/pageInfo";
 import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
@@ -45,7 +48,7 @@ class AdminAudioRecordingComponent
   public ngOnInit(): void {
     const models = retrieveResolvers(this.route.snapshot.data as PageInfo);
 
-    if (!models) {
+    if (!hasResolvedSuccessfully(models)) {
       this.failure = true;
       return;
     }

--- a/src/app/components/admin/orphan/details/details.component.ts
+++ b/src/app/components/admin/orphan/details/details.component.ts
@@ -1,6 +1,9 @@
 import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
-import { retrieveResolvers } from "@baw-api/resolver-common";
+import {
+  hasResolvedSuccessfully,
+  retrieveResolvers,
+} from "@baw-api/resolver-common";
 import { shallowSiteResolvers } from "@baw-api/site/sites.service";
 import baseSchema from "@components/sites/site.base.json";
 import extendedSchema from "@components/sites/site.extended.json";
@@ -43,7 +46,7 @@ class AdminOrphanComponent
   public ngOnInit(): void {
     const models = retrieveResolvers(this.route.snapshot.data as PageInfo);
 
-    if (!models) {
+    if (!hasResolvedSuccessfully(models)) {
       this.failure = true;
       return;
     }

--- a/src/app/components/admin/scripts/details/details.component.ts
+++ b/src/app/components/admin/scripts/details/details.component.ts
@@ -1,6 +1,9 @@
 import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
-import { retrieveResolvers } from "@baw-api/resolver-common";
+import {
+  hasResolvedSuccessfully,
+  retrieveResolvers,
+} from "@baw-api/resolver-common";
 import { scriptResolvers } from "@baw-api/script/scripts.service";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { PageInfo } from "@helpers/page/pageInfo";
@@ -45,7 +48,7 @@ class AdminScriptComponent
   public ngOnInit(): void {
     const models = retrieveResolvers(this.route.snapshot.data as PageInfo);
 
-    if (!models) {
+    if (!hasResolvedSuccessfully(models)) {
       this.failure = true;
       return;
     }

--- a/src/app/components/projects/pages/details/details.component.ts
+++ b/src/app/components/projects/pages/details/details.component.ts
@@ -3,7 +3,10 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { Filters } from "@baw-api/baw-api.service";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { RegionsService } from "@baw-api/region/regions.service";
-import { retrieveResolvers } from "@baw-api/resolver-common";
+import {
+  hasResolvedSuccessfully,
+  retrieveResolvers,
+} from "@baw-api/resolver-common";
 import { SitesService } from "@baw-api/site/sites.service";
 import {
   assignSiteMenuItem,
@@ -167,7 +170,7 @@ class DetailsComponent
 
   public ngOnInit() {
     const models = retrieveResolvers(this.route.snapshot.data as PageInfo);
-    if (!models) {
+    if (!hasResolvedSuccessfully(models)) {
       return;
     }
     this.project = models[projectKey] as Project;

--- a/src/app/components/regions/pages/details/details.component.ts
+++ b/src/app/components/regions/pages/details/details.component.ts
@@ -12,6 +12,7 @@ import {
   regionsCategory,
 } from "@components/regions/regions.menus";
 import { newPointMenuItem } from "@components/sites/points.menus";
+import { visualizeMenuItem } from "@components/visualize/visualize.menus";
 import { PageInfo } from "@helpers/page/pageInfo";
 import { PaginationTemplate } from "@helpers/paginationTemplate/paginationTemplate";
 import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
@@ -24,6 +25,7 @@ import { List } from "immutable";
 
 export const regionMenuItemActions = [
   newPointMenuItem,
+  visualizeMenuItem,
   editRegionMenuItem,
   deleteRegionMenuItem,
 ];

--- a/src/app/components/regions/pages/details/details.component.ts
+++ b/src/app/components/regions/pages/details/details.component.ts
@@ -2,7 +2,10 @@ import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { regionResolvers } from "@baw-api/region/regions.service";
-import { retrieveResolvers } from "@baw-api/resolver-common";
+import {
+  hasResolvedSuccessfully,
+  retrieveResolvers,
+} from "@baw-api/resolver-common";
 import { SitesService } from "@baw-api/site/sites.service";
 import { projectMenuItem } from "@components/projects/projects.menus";
 import {
@@ -123,7 +126,7 @@ class DetailsComponent extends PaginationTemplate<Site> implements OnInit {
 
   public ngOnInit(): void {
     const models = retrieveResolvers(this.route.snapshot.data as PageInfo);
-    if (!models) {
+    if (!hasResolvedSuccessfully(models)) {
       return;
     }
     this.project = models[projectKey] as Project;

--- a/src/app/components/shared/annotation-download/annotation-download.component.ts
+++ b/src/app/components/shared/annotation-download/annotation-download.component.ts
@@ -1,6 +1,9 @@
 import { Component, OnInit } from "@angular/core";
 import { FormGroup } from "@angular/forms";
-import { retrieveResolvers } from "@baw-api/resolver-common";
+import {
+  hasResolvedSuccessfully,
+  retrieveResolvers,
+} from "@baw-api/resolver-common";
 import { SitesService } from "@baw-api/site/sites.service";
 import { PageInfo } from "@helpers/page/pageInfo";
 import { ModalComponent } from "@menu/widget.component";
@@ -84,7 +87,7 @@ export class AnnotationDownloadComponent implements OnInit, ModalComponent {
     const models = retrieveResolvers(this.routeData);
 
     // Close modal if an error has occurred
-    if (!models) {
+    if (!hasResolvedSuccessfully(models)) {
       this.dismissModal("Failure to resolve models");
       return;
     }

--- a/src/app/components/shared/baw-client/baw-client.component.ts
+++ b/src/app/components/shared/baw-client/baw-client.component.ts
@@ -9,7 +9,10 @@ import {
 } from "@angular/core";
 import { DomSanitizer, SafeResourceUrl } from "@angular/platform-browser";
 import { ActivatedRoute, NavigationEnd, Router } from "@angular/router";
-import { retrieveResolvers } from "@baw-api/resolver-common";
+import {
+  hasResolvedSuccessfully,
+  retrieveResolvers,
+} from "@baw-api/resolver-common";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { PageInfo } from "@helpers/page/pageInfo";
 import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
@@ -85,7 +88,7 @@ export class BawClientComponent extends withUnsubscribe() implements OnInit {
     const models = retrieveResolvers(data as PageInfo);
 
     // Don't load client on SSR or if error occurs
-    if (!models || this.isSsr) {
+    if (!hasResolvedSuccessfully(models) || this.isSsr) {
       this.url = undefined;
       return;
     }

--- a/src/app/components/shared/menu/link/link.component.ts
+++ b/src/app/components/shared/menu/link/link.component.ts
@@ -5,7 +5,7 @@ import {
   Input,
   OnChanges,
 } from "@angular/core";
-import { ActivatedRoute, Params } from "@angular/router";
+import { ActivatedRoute } from "@angular/router";
 import { API_ROOT } from "@helpers/app-initializer/app-initializer";
 import {
   isInternalRoute,
@@ -79,19 +79,17 @@ export class MenuLinkComponent implements OnChanges {
     private activatedRoute: ActivatedRoute
   ) {}
 
-  public ngOnChanges() {
-    const params = this.activatedRoute.snapshot.params;
-
+  public ngOnChanges(): void {
     if (typeof this.link.disabled === "string") {
       this.disabledReason = this.link.disabled;
     }
 
     if (!this.isInternalLink) {
-      this.handleExternalLink(params);
+      this.handleExternalLink();
     }
   }
 
-  public get isInternalLink() {
+  public get isInternalLink(): boolean {
     return isInternalRoute(this.link);
   }
 
@@ -103,8 +101,8 @@ export class MenuLinkComponent implements OnChanges {
     return this.link as MenuLink;
   }
 
-  private handleExternalLink(params: Params) {
-    const uri = this.externalLink.uri(params);
+  private handleExternalLink(): void {
+    const uri = this.externalLink.uri(this.activatedRoute.snapshot.params);
 
     /*
      * TODO This is a potential future point of failure if the website and the api

--- a/src/app/components/shared/menu/menu.component.ts
+++ b/src/app/components/shared/menu/menu.component.ts
@@ -7,7 +7,7 @@ import {
   ViewChild,
   ViewContainerRef,
 } from "@angular/core";
-import { ActivatedRoute, Params } from "@angular/router";
+import { ActivatedRoute } from "@angular/router";
 import { SecurityService } from "@baw-api/security/security.service";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { PageInfo } from "@helpers/page/pageInfo";
@@ -58,9 +58,7 @@ export class MenuComponent
   public filteredLinks: Set<MenuRoute | MenuLink | MenuAction | MenuModal> =
     Set();
   public placement: Placement;
-  public params: Params;
   public user: SessionUser;
-  public loadedModal: MenuModal;
 
   public isInternalLink = isInternalRoute;
   public isExternalLink = isExternalLink;
@@ -111,9 +109,6 @@ export class MenuComponent
         return link;
       })
       .sort(this.compare);
-
-    // Retrieve router parameters to override link attributes
-    this.params = snapshot.params;
   }
 
   public ngAfterViewInit(): void {

--- a/src/app/components/shared/menu/permissions-shield/permissions-shield.component.ts
+++ b/src/app/components/shared/menu/permissions-shield/permissions-shield.component.ts
@@ -1,6 +1,10 @@
 import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
-import { ResolvedModelList, retrieveResolvers } from "@baw-api/resolver-common";
+import {
+  hasResolvedSuccessfully,
+  ResolvedModelList,
+  retrieveResolvers,
+} from "@baw-api/resolver-common";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { PageInfo } from "@helpers/page/pageInfo";
 import { AccessLevel } from "@interfaces/apiInterfaces";
@@ -46,22 +50,18 @@ export class PermissionsShieldComponent implements OnInit, WidgetComponent {
 
   public ngOnInit() {
     const models = retrieveResolvers(this.route.snapshot.data as PageInfo);
-    this.model = this.retrieveModel(models);
 
-    if (!this.model) {
+    if (!hasResolvedSuccessfully(models) || Object.keys(models).length === 0) {
       return;
     }
 
+    this.model = this.retrieveModel(models);
     this.badges = this.createBadges(this.model);
     this.accessLevel = this.getAccessLevel(models as ResolvedModelList);
   }
 
-  private retrieveModel(models: false | ResolvedModelList): AbstractModel {
-    const modelKeys = models ? Object.keys(models) : [];
-
-    if (!models || modelKeys.length === 0) {
-      return undefined;
-    }
+  private retrieveModel(models: ResolvedModelList): AbstractModel {
+    const modelKeys = Object.keys(models);
 
     // Grab model in order of priority, site, then region, then project
     const priority = [Site, Region, Project];
@@ -79,8 +79,6 @@ export class PermissionsShieldComponent implements OnInit, WidgetComponent {
         return models[model] as AbstractModel;
       }
     }
-
-    return undefined;
   }
 
   private createBadges(model: AbstractModel) {

--- a/src/app/components/shared/menu/permissions-shield/permissions-shield.component.ts
+++ b/src/app/components/shared/menu/permissions-shield/permissions-shield.component.ts
@@ -50,18 +50,22 @@ export class PermissionsShieldComponent implements OnInit, WidgetComponent {
 
   public ngOnInit() {
     const models = retrieveResolvers(this.route.snapshot.data as PageInfo);
+    this.model = this.retrieveModel(models);
 
-    if (!hasResolvedSuccessfully(models) || Object.keys(models).length === 0) {
+    if (!this.model) {
       return;
     }
 
-    this.model = this.retrieveModel(models);
     this.badges = this.createBadges(this.model);
     this.accessLevel = this.getAccessLevel(models as ResolvedModelList);
   }
 
   private retrieveModel(models: ResolvedModelList): AbstractModel {
     const modelKeys = Object.keys(models);
+
+    if (!hasResolvedSuccessfully(models) || modelKeys.length === 0) {
+      return undefined;
+    }
 
     // Grab model in order of priority, site, then region, then project
     const priority = [Site, Region, Project];
@@ -79,6 +83,8 @@ export class PermissionsShieldComponent implements OnInit, WidgetComponent {
         return models[model] as AbstractModel;
       }
     }
+
+    return undefined;
   }
 
   private createBadges(model: AbstractModel) {

--- a/src/app/components/sites/pages/details/point.component.ts
+++ b/src/app/components/sites/pages/details/point.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from "@angular/core";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { regionResolvers } from "@baw-api/region/regions.service";
-import { retrieveResolvers } from "@baw-api/resolver-common";
+import {
+  hasResolvedSuccessfully,
+  retrieveResolvers,
+} from "@baw-api/resolver-common";
 import { siteResolvers } from "@baw-api/site/sites.service";
 import { regionMenuItem } from "@components/regions/regions.menus";
 import { pointAnnotationsModal } from "@components/sites/points.modals";
@@ -51,7 +54,7 @@ class PointDetailsComponent extends SiteDetailsComponent implements OnInit {
   public ngOnInit() {
     const models = retrieveResolvers(this.route.snapshot.data as PageInfo);
 
-    if (!models) {
+    if (!hasResolvedSuccessfully(models)) {
       return;
     }
 

--- a/src/app/components/sites/pages/details/site.component.ts
+++ b/src/app/components/sites/pages/details/site.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { projectResolvers } from "@baw-api/project/projects.service";
-import { retrieveResolvers } from "@baw-api/resolver-common";
+import {
+  hasResolvedSuccessfully,
+  retrieveResolvers,
+} from "@baw-api/resolver-common";
 import { siteResolvers } from "@baw-api/site/sites.service";
 import { projectMenuItem } from "@components/projects/projects.menus";
 import { siteAnnotationsModal } from "@components/sites/sites.modals";
@@ -56,7 +59,7 @@ class SiteDetailsComponent extends PageComponent implements OnInit {
   public ngOnInit() {
     const models = retrieveResolvers(this.route.snapshot.data as PageInfo);
 
-    if (!models) {
+    if (!hasResolvedSuccessfully(models)) {
       return;
     }
 

--- a/src/app/components/sites/pages/harvest/point.component.ts
+++ b/src/app/components/sites/pages/harvest/point.component.ts
@@ -2,7 +2,10 @@ import { Component, Inject, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { regionResolvers } from "@baw-api/region/regions.service";
-import { retrieveResolvers } from "@baw-api/resolver-common";
+import {
+  hasResolvedSuccessfully,
+  retrieveResolvers,
+} from "@baw-api/resolver-common";
 import { siteResolvers, SitesService } from "@baw-api/site/sites.service";
 import {
   pointHarvestMenuItem,
@@ -48,7 +51,7 @@ class PointHarvestComponent extends SiteHarvestComponent implements OnInit {
 
   public ngOnInit() {
     const models = retrieveResolvers(this.route.snapshot.data as PageInfo);
-    if (models) {
+    if (hasResolvedSuccessfully(models)) {
       this.project = models[projectKey] as Project;
       this.region = models[regionKey] as Region;
       this.site = models[siteKey] as Site;

--- a/src/app/components/sites/pages/harvest/site.component.ts
+++ b/src/app/components/sites/pages/harvest/site.component.ts
@@ -1,7 +1,10 @@
 import { Component, Inject, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { projectResolvers } from "@baw-api/project/projects.service";
-import { retrieveResolvers } from "@baw-api/resolver-common";
+import {
+  hasResolvedSuccessfully,
+  retrieveResolvers,
+} from "@baw-api/resolver-common";
 import { siteResolvers, SitesService } from "@baw-api/site/sites.service";
 import { API_ROOT } from "@helpers/app-initializer/app-initializer";
 import { PageComponent } from "@helpers/page/pageComponent";
@@ -46,7 +49,7 @@ class SiteHarvestComponent extends PageComponent implements OnInit {
 
   public ngOnInit() {
     const models = retrieveResolvers(this.route.snapshot.data as PageInfo);
-    if (models) {
+    if (hasResolvedSuccessfully(models)) {
       this.project = models[projectKey] as Project;
       this.site = models[siteKey] as Site;
       this.user = this.api.getLocalUser();

--- a/src/app/components/sites/pages/wizard/wizard.component.ts
+++ b/src/app/components/sites/pages/wizard/wizard.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { projectResolvers } from "@baw-api/project/projects.service";
-import { retrieveResolvers } from "@baw-api/resolver-common";
+import {
+  hasResolvedSuccessfully,
+  retrieveResolvers,
+} from "@baw-api/resolver-common";
 import { projectMenuItemActions } from "@components/projects/pages/details/details.component";
 import {
   projectCategory,
@@ -68,7 +71,7 @@ class WizardComponent extends PageComponent implements OnInit {
 
   public ngOnInit(): void {
     const models = retrieveResolvers(this.route.snapshot.data as PageInfo);
-    if (!models) {
+    if (!hasResolvedSuccessfully(models)) {
       this.error = true;
       return;
     }

--- a/src/app/components/visualize/visualize.menus.ts
+++ b/src/app/components/visualize/visualize.menus.ts
@@ -1,19 +1,16 @@
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { Category, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
+import { Region } from "@models/Region";
 
 export const visualizeRoute = StrongRoute.newRoot().add(
   "visualize",
-  ({ siteIds, siteId, projectId, extent0, extent1, lane }) => {
-    const qsp = {
-      extent0,
-      extent1,
-      lane,
-    };
-
+  ({ siteIds, siteId, projectId, extent0, extent1, lane }, { region }) => {
+    const qsp = { extent0, extent1, lane };
     const priority = [
       { key: "siteId", value: siteId },
       { key: "siteIds", value: siteIds },
+      { key: "siteIds", value: (region as Region)?.siteIds },
       { key: "projectId", value: projectId },
     ];
     const keyValuePair = priority.find((kvp) => isInstantiated(kvp.value));

--- a/src/app/directives/strongRoute/strong-route.directive.spec.ts
+++ b/src/app/directives/strongRoute/strong-route.directive.spec.ts
@@ -5,6 +5,7 @@ import {
   RouterLinkWithHref,
 } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { MockModel } from "@baw-api/mock/baseApiMock.service";
 import { RouteParams, StrongRoute } from "@interfaces/strongRoute";
 import { createDirectiveFactory, SpectatorDirective } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
@@ -188,6 +189,14 @@ describe("StrongRouteDirective", () => {
       spec.directive["angularRouteParams"] = { example: 5 };
       assertUrlTree("/home", { testing: "value", testing2: 5 });
     });
+  });
+
+  // TODO
+  describe("resolvedModels", () => {
+    it("should pass empty list of resolved models to queryParams", () => {});
+    it("should pass single resolved model to queryParams", () => {});
+    it("should pass multiple resolved models to queryParams", () => {});
+    it("should pass failed model to queryParams", () => {});
   });
 
   describe("urlTree", () => {

--- a/src/app/directives/strongRoute/strong-route.directive.spec.ts
+++ b/src/app/directives/strongRoute/strong-route.directive.spec.ts
@@ -5,15 +5,16 @@ import {
   RouterLinkWithHref,
 } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { MockModel } from "@baw-api/mock/baseApiMock.service";
+import { IPageInfo } from "@helpers/page/pageInfo";
 import { RouteParams, StrongRoute } from "@interfaces/strongRoute";
 import { createDirectiveFactory, SpectatorDirective } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
+import { generateApiErrorDetailsV2 } from "@test/fakes/ApiErrorDetails";
+import { generatePageInfo, nStepObservable } from "@test/helpers/general";
+import { Subject } from "rxjs";
 import { StrongRouteDirective } from "./strong-route.directive";
-
-// TODO Some tests work by bypassing the angular router. This can be solved by navigating
-// to a page with parameters set in the url. This will allow simulating the route changes
-// within the constraints of the testing framework
 
 describe("StrongRouteDirective", () => {
   let router: Router;
@@ -29,6 +30,31 @@ describe("StrongRouteDirective", () => {
     declarations: [StrongRouteDirective],
     imports: [RouterTestingModule],
   });
+
+  function interceptRouteParams(params: Params) {
+    const subject = new Subject();
+    spec.directive["_route"].params = subject;
+    return nStepObservable(subject, () => params);
+  }
+  async function setRouteParams(params: Params) {
+    const promise = interceptRouteParams(params);
+    spec.detectChanges();
+    await promise;
+    spec.detectChanges();
+  }
+
+  function interceptRouteData(data: IPageInfo) {
+    const subject = new Subject();
+    spec.directive["_route"].data = subject;
+    return nStepObservable(subject, () => data);
+  }
+
+  async function setRouteData(data: IPageInfo) {
+    const promise = interceptRouteData(data);
+    spec.detectChanges();
+    await promise;
+    spec.detectChanges();
+  }
 
   function assertUrlTree(url: string, queryParams: Params) {
     expect(spec.directive.urlTree).toEqual(
@@ -61,20 +87,23 @@ describe("StrongRouteDirective", () => {
           [queryParams]="queryParams"
         ></a>
       `,
-      { hostProps: { strongRoute, routeParams, queryParams } }
+      {
+        hostProps: { strongRoute, routeParams, queryParams },
+        detectChanges: false,
+      }
     );
     router = spec.inject(Router);
     route = spec.inject(ActivatedRoute);
   }
 
   it("should not interfere with routerLink if no [strongRoute]", () => {
-    const spectator = createRouterLink(
+    const routerLinkSpec = createRouterLink(
       '<a [routerLink]="link" [queryParams]="params"></a>',
       { hostProps: { link: "/home", params: { test: "value" } } }
     );
-    spectator.detectChanges();
+    routerLinkSpec.detectChanges();
 
-    const routerLink = spectator.query(RouterLinkWithHref);
+    const routerLink = routerLinkSpec.query(RouterLinkWithHref);
     expect(routerLink).toBeInstanceOf(RouterLinkWithHref);
     expect(routerLink.href).toContain("/home?test=value");
   });
@@ -149,19 +178,16 @@ describe("StrongRouteDirective", () => {
       assertRoute("/home?test=value&example=5");
     });
 
-    // TODO Update this to work through the router instead of bypassing it
-    it("should handle strongRoute with router query parameter", () => {
+    it("should handle strongRoute with router query parameter", async () => {
       const childRoute = StrongRoute.newRoot().add("home", ({ test }) => ({
         testing: test,
       }));
       setup(childRoute);
-      spec.detectChanges();
-      spec.directive["angularRouteParams"] = { test: "value" };
+      await setRouteParams({ test: "value" });
       assertUrlTree("/home", { testing: "value" });
     });
 
-    // TODO Update this to work through the router instead of bypassing it
-    it("should handle strongRoute with multiple router query parameter", () => {
+    it("should handle strongRoute with multiple router query parameter", async () => {
       const childRoute = StrongRoute.newRoot().add(
         "home",
         ({ test, example }) => ({
@@ -170,13 +196,11 @@ describe("StrongRouteDirective", () => {
         })
       );
       setup(childRoute);
-      spec.detectChanges();
-      spec.directive["angularRouteParams"] = { example: 5, test: "value" };
+      await setRouteParams({ example: 5, test: "value" });
       assertUrlTree("/home", { testing: "value", testing2: 5 });
     });
 
-    // TODO Update this to work through the router instead of bypassing it
-    it("should combine route query parameters and queryParams", () => {
+    it("should combine route query parameters and queryParams", async () => {
       const childRoute = StrongRoute.newRoot().add(
         "home",
         ({ test, example }) => ({
@@ -185,18 +209,74 @@ describe("StrongRouteDirective", () => {
         })
       );
       setup(childRoute, undefined, { test: "value" });
-      spec.detectChanges();
-      spec.directive["angularRouteParams"] = { example: 5 };
+      await setRouteParams({ example: 5 });
       assertUrlTree("/home", { testing: "value", testing2: 5 });
     });
   });
 
-  // TODO
   describe("resolvedModels", () => {
-    it("should pass empty list of resolved models to queryParams", () => {});
-    it("should pass single resolved model to queryParams", () => {});
-    it("should pass multiple resolved models to queryParams", () => {});
-    it("should pass failed model to queryParams", () => {});
+    it("should initially pass empty object to queryParams", async () => {
+      const childRoute = StrongRoute.newRoot().add("home", (_, models) => ({
+        testing: models,
+      }));
+      setup(childRoute);
+      // Do not return resolver, this is testing the default value before subject returns
+      interceptRouteData(generatePageInfo());
+      spec.detectChanges();
+      assertUrlTree("/home", { testing: {} });
+    });
+
+    it("should pass empty list of resolved models to queryParams", async () => {
+      const childRoute = StrongRoute.newRoot().add("home", (_, models) => ({
+        testing: models,
+      }));
+      setup(childRoute);
+      await setRouteData(generatePageInfo());
+      assertUrlTree("/home", { testing: {} });
+    });
+
+    it("should pass single resolved model to queryParams", async () => {
+      const childRoute = StrongRoute.newRoot().add("home", (_, { model0 }) => ({
+        testing: (model0 as MockModel)?.id,
+      }));
+      setup(childRoute);
+      await setRouteData(generatePageInfo({ model: new MockModel({ id: 1 }) }));
+      assertUrlTree("/home", { testing: 1 });
+    });
+
+    it("should pass multiple resolved models to queryParams", async () => {
+      const childRoute = StrongRoute.newRoot().add(
+        "home",
+        (_, { model0, model1 }) => ({
+          testing: (model0 as MockModel)?.id,
+          example: (model1 as MockModel)?.id,
+        })
+      );
+      setup(childRoute);
+      await setRouteData(
+        generatePageInfo(
+          { model: new MockModel({ id: 1 }) },
+          { model: new MockModel({ id: 5 }) }
+        )
+      );
+      assertUrlTree("/home", { testing: 1, example: 5 });
+    });
+
+    it("should pass failed model to queryParams", async () => {
+      const error = generateApiErrorDetailsV2();
+      const childRoute = StrongRoute.newRoot().add(
+        "home",
+        (_, { model0, model1 }) => ({
+          testing: (model0 as MockModel)?.id,
+          example: (model1 as ApiErrorDetails)?.status,
+        })
+      );
+      setup(childRoute);
+      await setRouteData(
+        generatePageInfo({ model: new MockModel({ id: 1 }) }, { error })
+      );
+      assertUrlTree("/home", { testing: 1, example: error.status });
+    });
   });
 
   describe("urlTree", () => {
@@ -214,14 +294,12 @@ describe("StrongRouteDirective", () => {
       assertUrlTree("/home", {});
     });
 
-    // TODO Update this to work through the router instead of bypassing it
-    it("should create url tree with query parameters from router", () => {
+    it("should create url tree with query parameters from router", async () => {
       const childRoute = StrongRoute.newRoot().add("home", ({ example }) => ({
         testing: example,
       }));
       setup(childRoute);
-      spec.detectChanges();
-      spec.directive["angularRouteParams"] = { example: 5 };
+      await setRouteParams({ example: 5 });
       assertUrlTree("/home", { testing: 5 });
     });
 
@@ -234,8 +312,7 @@ describe("StrongRouteDirective", () => {
       assertUrlTree("/home", { testing: "value" });
     });
 
-    // TODO Update this to work through the router instead of bypassing it
-    it("should create url tree with with custom and router query parameters", () => {
+    it("should create url tree with with custom and router query parameters", async () => {
       const childRoute = StrongRoute.newRoot().add(
         "home",
         ({ test, example }) => ({
@@ -244,8 +321,7 @@ describe("StrongRouteDirective", () => {
         })
       );
       setup(childRoute, undefined, { test: "value" });
-      spec.detectChanges();
-      spec.directive["angularRouteParams"] = { example: 5 };
+      await setRouteParams({ example: 5 });
       assertUrlTree("/home", { testing: "value", testing2: 5 });
     });
   });

--- a/src/app/directives/strongRoute/strong-route.directive.ts
+++ b/src/app/directives/strongRoute/strong-route.directive.ts
@@ -32,10 +32,10 @@ export class StrongRouteDirective
    * of the angular route parameters are already given to the StrongRoute.
    */
   @Input() public queryParams: Params;
-  private data: {
-    resolvedModels?: ResolvedModelList;
-    routeParams?: Params;
-  } = {};
+  private data = {
+    resolvedModels: {} as ResolvedModelList,
+    routeParams: {} as Params,
+  };
 
   public constructor(
     private _router: Router,
@@ -71,10 +71,11 @@ export class StrongRouteDirective
   }
 
   public get urlTree(): UrlTree {
-    const queryParams = this.strongRoute?.queryParams(
-      { ...this.queryParams, ...this.data.routeParams },
-      this.data.resolvedModels
-    );
+    const queryParams =
+      this.strongRoute?.queryParams(
+        { ...this.queryParams, ...this.data.routeParams },
+        this.data.resolvedModels
+      ) ?? {};
 
     // Normalize query parameters into string values which can be handled by
     // the browser

--- a/src/app/directives/strongRoute/strong-route.directive.ts
+++ b/src/app/directives/strongRoute/strong-route.directive.ts
@@ -55,7 +55,7 @@ export class StrongRouteDirective
       this._route.data.pipe(takeUntil(this.unsubscribe)).subscribe((data) => {
         // We are passing through resolved models even when some fail, this is
         // so that some links unrelated to the broken model do not break
-        const resolvedModels = retrieveResolvers(new PageInfo(data), true);
+        const resolvedModels = retrieveResolvers(new PageInfo(data));
         if (resolvedModels) {
           this.data.resolvedModels = resolvedModels;
         }

--- a/src/app/directives/strongRoute/strong-route.directive.ts
+++ b/src/app/directives/strongRoute/strong-route.directive.ts
@@ -76,7 +76,8 @@ export class StrongRouteDirective
       this.data.resolvedModels
     );
 
-    // Sanitize query parameters
+    // Normalize query parameters into string values which can be handled by
+    // the browser
     for (const key of Object.keys(queryParams)) {
       if (queryParams[key] instanceof Set) {
         queryParams[key] = Array.from(queryParams[key]);

--- a/src/app/helpers/formTemplate/formTemplate.ts
+++ b/src/app/helpers/formTemplate/formTemplate.ts
@@ -1,7 +1,11 @@
 import { Directive, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
-import { ResolvedModelList, retrieveResolvers } from "@baw-api/resolver-common";
+import {
+  hasResolvedSuccessfully,
+  ResolvedModelList,
+  retrieveResolvers,
+} from "@baw-api/resolver-common";
 import { withFormCheck } from "@guards/form/form.guard";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { AbstractModel } from "@models/AbstractModel";
@@ -32,7 +36,8 @@ const defaultOptions: FormTemplateOptions<any> = {
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export abstract class FormTemplate<Model extends AbstractModel>
   extends withFormCheck(PageComponent)
-  implements OnInit {
+  implements OnInit
+{
   /** Form submission processing */
   public loading: boolean;
   /** Initial setup failed */
@@ -80,7 +85,7 @@ export abstract class FormTemplate<Model extends AbstractModel>
 
     // Retrieve models and handle potential failure
     const models = retrieveResolvers(data);
-    if (!models) {
+    if (!hasResolvedSuccessfully(models)) {
       this.failure = true;
       return;
     }

--- a/src/app/helpers/tableTemplate/pagedTableTemplate.ts
+++ b/src/app/helpers/tableTemplate/pagedTableTemplate.ts
@@ -3,7 +3,11 @@ import { ActivatedRoute } from "@angular/router";
 import { ApiFilter } from "@baw-api/api-common";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { Direction, Filters } from "@baw-api/baw-api.service";
-import { ResolvedModelList, retrieveResolvers } from "@baw-api/resolver-common";
+import {
+  hasResolvedSuccessfully,
+  ResolvedModelList,
+  retrieveResolvers,
+} from "@baw-api/resolver-common";
 import { PageInfo } from "@helpers/page/pageInfo";
 import { AbstractModel } from "@models/AbstractModel";
 import {
@@ -87,7 +91,7 @@ export abstract class PagedTableTemplate<TableRow, M extends AbstractModel>
   public ngOnInit() {
     if (this.route) {
       const models = retrieveResolvers(this.route.snapshot.data as PageInfo);
-      if (!models) {
+      if (!hasResolvedSuccessfully(models)) {
         this.failure = true;
         return;
       }

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -1,5 +1,6 @@
 import { Type } from "@angular/core";
 import { Params, Route, Routes } from "@angular/router";
+import { ResolvedModelList } from "@baw-api/resolver-common";
 import { Option } from "@helpers/advancedTypes";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { PageComponent } from "@helpers/page/pageComponent";
@@ -11,7 +12,7 @@ export type RouteConfigCallback = (
 
 export type RouteParams = Record<string, string | number>;
 
-type QSPCallback = (params: Params) => Params;
+type QSPCallback = (params?: Params, models?: ResolvedModelList) => Params;
 
 /**
  * Strong Route class. This provides a workaround for issues related to the
@@ -253,9 +254,10 @@ export class StrongRoute {
    */
   public format(
     routeParams: RouteParams = {},
-    queryParams: Params = {}
+    queryParams: Params = {},
+    resolvedModels: ResolvedModelList = {}
   ): string {
-    const qsp = this.queryParams(queryParams);
+    const qsp = this.queryParams(queryParams, resolvedModels);
     const keys = Object.keys(qsp);
     const basePath = this.toRouterLink(routeParams);
 

--- a/src/app/services/baw-api/resolver-common.spec.ts
+++ b/src/app/services/baw-api/resolver-common.spec.ts
@@ -1,4 +1,4 @@
-import { ApiErrorDetails } from "./api.interceptor.service";
+import { generateApiErrorDetailsV2 } from "@test/fakes/ApiErrorDetails";
 import { MockModel } from "./mock/baseApiMock.service";
 import { retrieveResolvers } from "./resolver-common";
 
@@ -13,12 +13,8 @@ xdescribe("API Resolvers", () => {
 describe("retrieveResolvers", () => {
   it("should handle single resolver", () => {
     const data: any = {
-      resolvers: {
-        resolvedModel: "customResolver",
-      },
-      resolvedModel: {
-        model: new MockModel({ id: 1 }),
-      },
+      resolvers: { resolvedModel: "customResolver" },
+      resolvedModel: { model: new MockModel({ id: 1 }) },
     };
 
     expect(retrieveResolvers(data)).toEqual({
@@ -28,12 +24,8 @@ describe("retrieveResolvers", () => {
 
   it("should handle array resolver", () => {
     const data: any = {
-      resolvers: {
-        resolvedModel: "customResolver",
-      },
-      resolvedModel: {
-        model: [new MockModel({ id: 1 })],
-      },
+      resolvers: { resolvedModel: "customResolver" },
+      resolvedModel: { model: [new MockModel({ id: 1 })] },
     };
 
     expect(retrieveResolvers(data)).toEqual({
@@ -47,12 +39,8 @@ describe("retrieveResolvers", () => {
         resolvedModel1: "customResolver1",
         resolvedModel2: "customResolver2",
       },
-      resolvedModel1: {
-        model: new MockModel({ id: 1 }),
-      },
-      resolvedModel2: {
-        model: [new MockModel({ id: 2 })],
-      },
+      resolvedModel1: { model: new MockModel({ id: 1 }) },
+      resolvedModel2: { model: [new MockModel({ id: 2 })] },
     };
 
     expect(retrieveResolvers(data)).toEqual({
@@ -62,44 +50,42 @@ describe("retrieveResolvers", () => {
   });
 
   it("should handle single errored resolver", () => {
+    const error = generateApiErrorDetailsV2();
     const data: any = {
       resolvers: {
         resolvedModel1: "customResolver1",
         resolvedModel2: "customResolver2",
         resolvedModel3: "customResolver3",
       },
-      resolvedModel1: {
-        model: [new MockModel({ id: 1 })],
-      },
-      resolvedModel2: {
-        error: { status: 401, message: "Unauthorized" } as ApiErrorDetails,
-      },
-      resolvedModel3: {
-        model: [new MockModel({ id: 2 })],
-      },
+      resolvedModel1: { model: [new MockModel({ id: 1 })] },
+      resolvedModel2: { error },
+      resolvedModel3: { model: [new MockModel({ id: 2 })] },
     };
 
-    expect(retrieveResolvers(data)).toBeFalse();
+    expect(retrieveResolvers(data)).toEqual({
+      resolvedModel1: new MockModel({ id: 1 }),
+      resolvedModel2: error,
+      resolvedModel3: [new MockModel({ id: 2 })],
+    });
   });
 
   it("should handle multiple errored resolver", () => {
+    const error = generateApiErrorDetailsV2();
     const data: any = {
       resolvers: {
         resolvedModel1: "customResolver1",
         resolvedModel2: "customResolver2",
         resolvedModel3: "customResolver2",
       },
-      resolvedModel1: {
-        error: { status: 401, message: "Unauthorized" } as ApiErrorDetails,
-      },
-      resolvedModel2: {
-        error: { status: 401, message: "Unauthorized" } as ApiErrorDetails,
-      },
-      resolvedModel3: {
-        error: { status: 401, message: "Unauthorized" } as ApiErrorDetails,
-      },
+      resolvedModel1: { error },
+      resolvedModel2: { error },
+      resolvedModel3: { error },
     };
 
-    expect(retrieveResolvers(data)).toBeFalse();
+    expect(retrieveResolvers(data)).toEqual({
+      resolvedModel1: error,
+      resolvedModel2: error,
+      resolvedModel3: error,
+    });
   });
 });

--- a/src/app/services/baw-api/resolver-common.ts
+++ b/src/app/services/baw-api/resolver-common.ts
@@ -361,13 +361,9 @@ function convertToId(id: string): Id {
 export function hasResolvedSuccessfully(
   resolvedModelList: ResolvedModelList
 ): boolean {
-  for (const key of Object.keys(resolvedModelList)) {
-    const model = resolvedModelList[key];
-    if (!isInstantiated(model) || isApiErrorDetails(model)) {
-      return false;
-    }
-  }
-  return true;
+  return Object.values(resolvedModelList).every(
+    (model) => isInstantiated(model) && !isApiErrorDetails(model)
+  );
 }
 
 /**

--- a/src/app/services/baw-api/resolver-common.ts
+++ b/src/app/services/baw-api/resolver-common.ts
@@ -358,9 +358,14 @@ function convertToId(id: string): Id {
  * resolved models using the resolver key as the object key.
  *
  * @param data Page Data
+ * @param saveErrorDetails Set model value to ApiErrorDetails instead of
+ * returning false early
  */
-export function retrieveResolvers(data: PageInfo): ResolvedModelList | false {
-  const models = {};
+export function retrieveResolvers(
+  data: PageInfo,
+  saveErrorDetails?: boolean
+): ResolvedModelList | false {
+  const models: ResolvedModelList = {};
   const keys = Object.keys(data?.resolvers || {});
 
   if (keys.length === 0) {
@@ -373,11 +378,16 @@ export function retrieveResolvers(data: PageInfo): ResolvedModelList | false {
     const resolvedModel: ResolvedModel = data[key];
 
     // If error detected, return
-    if (!resolvedModel || resolvedModel.error) {
+    if (!resolvedModel) {
       return false;
+    } else if (resolvedModel.error) {
+      if (!saveErrorDetails) {
+        return false;
+      }
+      models[key] = resolvedModel.error;
+    } else {
+      models[key] = resolvedModel.model;
     }
-
-    models[key] = resolvedModel.model;
   }
 
   return models;
@@ -388,5 +398,6 @@ export interface ResolvedModelList {
     | AbstractModel
     | AbstractModel[]
     | AbstractData
-    | AbstractData[];
+    | AbstractData[]
+    | ApiErrorDetails;
 }


### PR DESCRIPTION
# Regions Visualize Link

This enables the visualize link for the region details page

## Changes

- Updated `MenuComponent` and `StrongRouteDirective` to handle passing resolved models to the query parameters. This allows more complex interactions such as using a region to set the siteIds query parameter
- Added visualize link to region details and related pages

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
