### PR TITLE
Fixed resolver-common circular dependency

### DIFF
--- a/src/app/components/projects/pages/list/list.component.spec.ts
+++ b/src/app/components/projects/pages/list/list.component.spec.ts
@@ -1,5 +1,5 @@
 import { RouterTestingModule } from "@angular/router/testing";
-import { isApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { isApiErrorDetails } from "@helpers/baw-api/baw-api";
 import { defaultApiPageSize, Filters } from "@baw-api/baw-api.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ProjectsService } from "@baw-api/project/projects.service";

--- a/src/app/components/regions/pages/list/list.component.spec.ts
+++ b/src/app/components/regions/pages/list/list.component.spec.ts
@@ -1,5 +1,5 @@
 import { RouterTestingModule } from "@angular/router/testing";
-import { isApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { isApiErrorDetails } from "@helpers/baw-api/baw-api";
 import { defaultApiPageSize, Filters } from "@baw-api/baw-api.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ShallowRegionsService } from "@baw-api/region/regions.service";

--- a/src/app/components/sites/pages/details/point.component.spec.ts
+++ b/src/app/components/sites/pages/details/point.component.spec.ts
@@ -1,7 +1,5 @@
-import {
-  ApiErrorDetails,
-  isApiErrorDetails,
-} from "@baw-api/api.interceptor.service";
+import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { isApiErrorDetails } from "@helpers/baw-api/baw-api";
 import { ResolvedModel } from "@baw-api/resolver-common";
 import { SiteComponent } from "@components/sites/components/site/site.component";
 import { Errorable } from "@helpers/advancedTypes";

--- a/src/app/components/sites/pages/details/site.component.spec.ts
+++ b/src/app/components/sites/pages/details/site.component.spec.ts
@@ -1,7 +1,5 @@
-import {
-  ApiErrorDetails,
-  isApiErrorDetails,
-} from "@baw-api/api.interceptor.service";
+import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { isApiErrorDetails } from "@helpers/baw-api/baw-api";
 import { ResolvedModel } from "@baw-api/resolver-common";
 import { SiteComponent } from "@components/sites/components/site/site.component";
 import { Errorable } from "@helpers/advancedTypes";

--- a/src/app/components/statistics/components/recent-annotations/recent-annotations.component.spec.ts
+++ b/src/app/components/statistics/components/recent-annotations/recent-annotations.component.spec.ts
@@ -1,7 +1,7 @@
 import { Injector } from "@angular/core";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AccountsService } from "@baw-api/account/accounts.service";
-import { isApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { isApiErrorDetails } from "@helpers/baw-api/baw-api";
 import { AudioRecordingsService } from "@baw-api/audio-recording/audio-recordings.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { SecurityService } from "@baw-api/security/security.service";

--- a/src/app/components/statistics/components/recent-audio-recordings/recent-audio-recordings.component.spec.ts
+++ b/src/app/components/statistics/components/recent-audio-recordings/recent-audio-recordings.component.spec.ts
@@ -1,6 +1,6 @@
 import { Injector } from "@angular/core";
 import { RouterTestingModule } from "@angular/router/testing";
-import { isApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { isApiErrorDetails } from "@helpers/baw-api/baw-api";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { SecurityService } from "@baw-api/security/security.service";
 import { SHALLOW_SITE } from "@baw-api/ServiceTokens";

--- a/src/app/helpers/baw-api/baw-api.ts
+++ b/src/app/helpers/baw-api/baw-api.ts
@@ -1,0 +1,19 @@
+import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+
+/**
+ * Determine if error response has already been processed
+ *
+ * @param errorResponse Error response
+ */
+export function isApiErrorDetails(
+  errorResponse: any
+): errorResponse is ApiErrorDetails {
+  if (!errorResponse) {
+    return false;
+  }
+
+  const keys = Object.keys(errorResponse);
+  return (
+    keys.length <= 3 && keys.includes("status") && keys.includes("message")
+  );
+}

--- a/src/app/helpers/tableTemplate/pagedTableTemplate.spec.ts
+++ b/src/app/helpers/tableTemplate/pagedTableTemplate.spec.ts
@@ -2,10 +2,8 @@ import { Component } from "@angular/core";
 import { fakeAsync } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
-import {
-  ApiErrorDetails,
-  isApiErrorDetails,
-} from "@baw-api/api.interceptor.service";
+import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { isApiErrorDetails } from "@helpers/baw-api/baw-api";
 import { defaultApiPageSize } from "@baw-api/baw-api.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { MockModel } from "@baw-api/mock/baseApiMock.service";

--- a/src/app/services/baw-api/api.interceptor.service.ts
+++ b/src/app/services/baw-api/api.interceptor.service.ts
@@ -16,6 +16,7 @@ import {
 import httpStatus from "http-status";
 import { Observable, throwError } from "rxjs";
 import { catchError, map } from "rxjs/operators";
+import { isApiErrorDetails } from "@helpers/baw-api/baw-api";
 import { ApiResponse } from "./baw-api.service";
 import { SecurityService } from "./security/security.service";
 
@@ -143,24 +144,6 @@ export interface ApiErrorDetails {
  */
 interface ApiErrorResponse extends HttpErrorResponse {
   error: ApiResponse<null>;
-}
-
-/**
- * Determine if error response has already been processed
- *
- * @param errorResponse Error response
- */
-export function isApiErrorDetails(
-  errorResponse: any
-): errorResponse is ApiErrorDetails {
-  if (!errorResponse) {
-    return false;
-  }
-
-  const keys = Object.keys(errorResponse);
-  return (
-    keys.length <= 3 && keys.includes("status") && keys.includes("message")
-  );
 }
 
 /**

--- a/src/app/services/baw-api/resolver-common.ts
+++ b/src/app/services/baw-api/resolver-common.ts
@@ -1,14 +1,17 @@
-import { Type } from "@angular/core";
-import { ActivatedRouteSnapshot, Resolve } from "@angular/router";
-import { Tuple, Option } from "@helpers/advancedTypes";
+// !Be careful with imports, resolvers are string-ly typed and can easily create
+// circular dependencies which are not detected by typescript
+import type { Type } from "@angular/core";
+import type { ActivatedRouteSnapshot, Resolve } from "@angular/router";
+import type { Tuple, Option } from "@helpers/advancedTypes";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { PageInfo } from "@helpers/page/pageInfo";
 import { Id } from "@interfaces/apiInterfaces";
-import { AbstractData } from "@models/AbstractData";
-import { AbstractModel } from "@models/AbstractModel";
+import type { AbstractData } from "@models/AbstractData";
+import type { AbstractModel } from "@models/AbstractModel";
 import httpStatus from "http-status";
 import { Observable, of } from "rxjs";
 import { catchError, first, map } from "rxjs/operators";
+import { isApiErrorDetails } from "@helpers/baw-api/baw-api";
 import {
   ApiCreate,
   ApiDestroy,
@@ -18,7 +21,7 @@ import {
   ApiUpdate,
   IdOr,
 } from "./api-common";
-import { ApiErrorDetails, isApiErrorDetails } from "./api.interceptor.service";
+import type { ApiErrorDetails } from "./api.interceptor.service";
 import { BawApiService, unknownErrorCode } from "./baw-api.service";
 
 /**

--- a/src/app/test/helpers/general.ts
+++ b/src/app/test/helpers/general.ts
@@ -1,9 +1,7 @@
 import { Injector } from "@angular/core";
 import { ApiFilter, ApiShow } from "@baw-api/api-common";
-import {
-  ApiErrorDetails,
-  isApiErrorDetails,
-} from "@baw-api/api.interceptor.service";
+import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { isApiErrorDetails } from "@helpers/baw-api/baw-api";
 import { Filters } from "@baw-api/baw-api.service";
 import { ResolvedModel } from "@baw-api/resolver-common";
 import { Errorable } from "@helpers/advancedTypes";


### PR DESCRIPTION
# Fixed resolver-common circular dependency

Resolver-common added an import to `isApiErrorDetails` in the following [commit](https://github.com/QutEcoacoustics/workbench-client/commit/50e9d84b934dd55838c2055a58bbd2845b5d62ac#diff-3265947d84f2dd223fff3eff7fc55ed38c35a0a6718d89d1cb3b4076a3b7c06eR21). This caused a circular dependency to silently happen because resolver-common creates resolver classes, which are imported as strings throughout the website, and bypasses typescripts typechecking. This PR fixes this issue by highlighting which imports are type only in the file, and extracting `isApiErrorDetails` to its own helper file.

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
