### PR TITLE
toHaveComputedStyle custom matcher

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -83,11 +83,11 @@ describe("AppComponent", () => {
       expect(routerOutlets.length).toBe(4, "Wrong number of router-outlets");
 
       if (isFullscreen) {
-        expect(getComputedStyle(secondaryMenu).display).toBe("none");
-        expect(getComputedStyle(actionMenu).display).toBe("none");
+        expect(secondaryMenu).toHaveComputedStyle({ display: "none" });
+        expect(actionMenu).toHaveComputedStyle({ display: "none" });
       } else {
-        expect(getComputedStyle(secondaryMenu).display).not.toBe("none");
-        expect(getComputedStyle(actionMenu).display).not.toBe("none");
+        expect(secondaryMenu).not.toHaveComputedStyle({ display: "none" });
+        expect(actionMenu).not.toHaveComputedStyle({ display: "none" });
       }
     }
 

--- a/src/app/components/shared/baw-client/baw-client.component.spec.ts
+++ b/src/app/components/shared/baw-client/baw-client.component.spec.ts
@@ -57,7 +57,9 @@ describe("BawClientComponent", () => {
   function assertIframeHeight(height: number) {
     // BawClientComponent adds 50 pixels of padding
     const heightWithPadding = height + 50;
-    expect(getComputedStyle(getIframe()).height).toBe(heightWithPadding + "px");
+    expect(getIframe()).toHaveComputedStyle({
+      height: heightWithPadding + "px",
+    });
   }
 
   function postMessage(data: any, origin?: string) {

--- a/src/app/components/shared/cards/cards.component.spec.ts
+++ b/src/app/components/shared/cards/cards.component.spec.ts
@@ -133,7 +133,7 @@ describe("CardsComponent", () => {
       );
       const content = hostSpectator.query<HTMLDivElement>("#content");
       const header = hostSpectator.query<HTMLHeadingElement>("h1");
-      expect(content).toHaveComputedStyle({ display: "none" });
+      expect(content).not.toHaveComputedStyle({ display: "none" });
       expect(header.textContent).toBe("Internal Content");
     });
 

--- a/src/app/components/shared/cards/cards.component.spec.ts
+++ b/src/app/components/shared/cards/cards.component.spec.ts
@@ -133,14 +133,14 @@ describe("CardsComponent", () => {
       );
       const content = hostSpectator.query<HTMLDivElement>("#content");
       const header = hostSpectator.query<HTMLHeadingElement>("h1");
-      expect(getComputedStyle(content).display).not.toBe("none");
+      expect(content).toHaveComputedStyle({ display: "none" });
       expect(header.textContent).toBe("Internal Content");
     });
 
     it("should handle no content", () => {
       hostSpectator = createHost("<baw-cards></baw-cards>");
       const content = hostSpectator.query<HTMLDivElement>("#content");
-      expect(getComputedStyle(content).display).toBe("none");
+      expect(content).toHaveComputedStyle({ display: "none" });
     });
   });
 });

--- a/src/app/components/shared/checkbox/checkbox.component.spec.ts
+++ b/src/app/components/shared/checkbox/checkbox.component.spec.ts
@@ -31,9 +31,9 @@ describe("CheckboxComponent", () => {
     fixture.detectChanges();
 
     const checkbox: HTMLDivElement = fixture.nativeElement.querySelector("div");
-    const computedStyles = window.getComputedStyle(checkbox);
-    const marginLeft = parseInt(computedStyles.marginLeft.substr(0, 3), 10);
-    const marginRight = parseInt(computedStyles.marginRight.substr(0, 3), 10);
+    const styles = getComputedStyle(checkbox);
+    const marginLeft = parseInt(styles.marginLeft.substring(0, 3), 10);
+    const marginRight = parseInt(styles.marginRight.substring(0, 3), 10);
 
     expect(marginLeft).toBeGreaterThan(500);
     expect(marginRight).toBeGreaterThan(500);
@@ -47,44 +47,41 @@ describe("CheckboxComponent", () => {
     fixture.detectChanges();
 
     const checkbox: HTMLDivElement = fixture.nativeElement.querySelector("div");
-    const computedStyles = window.getComputedStyle(checkbox);
-    expect(computedStyles.marginLeft).toBe("0px");
-    expect(computedStyles.marginRight).toBe("0px");
+    expect(checkbox).toHaveComputedStyle({
+      marginLeft: "0px",
+      marginRight: "0px",
+    });
   });
 
   it("should be checked", () => {
     component.checked = true;
     fixture.detectChanges();
-    const checkbox: HTMLInputElement = fixture.nativeElement.querySelector(
-      "input"
-    );
+    const checkbox: HTMLInputElement =
+      fixture.nativeElement.querySelector("input");
     expect(checkbox.checked).toBeTruthy();
   });
 
   it("should not be checked", () => {
     component.checked = false;
     fixture.detectChanges();
-    const checkbox: HTMLInputElement = fixture.nativeElement.querySelector(
-      "input"
-    );
+    const checkbox: HTMLInputElement =
+      fixture.nativeElement.querySelector("input");
     expect(checkbox.checked).toBeFalsy();
   });
 
   it("should be disabled", () => {
     component.disabled = true;
     fixture.detectChanges();
-    const checkbox: HTMLInputElement = fixture.nativeElement.querySelector(
-      "input"
-    );
+    const checkbox: HTMLInputElement =
+      fixture.nativeElement.querySelector("input");
     expect(checkbox.disabled).toBeTruthy();
   });
 
   it("should not be disabled", () => {
     component.disabled = false;
     fixture.detectChanges();
-    const checkbox: HTMLInputElement = fixture.nativeElement.querySelector(
-      "input"
-    );
+    const checkbox: HTMLInputElement =
+      fixture.nativeElement.querySelector("input");
     expect(checkbox.disabled).toBeFalsy();
   });
 });

--- a/src/app/components/shared/cms/cms.component.spec.ts
+++ b/src/app/components/shared/cms/cms.component.spec.ts
@@ -122,8 +122,8 @@ describe("CmsComponent", () => {
     spectator.detectChanges();
 
     const body = spectator.debugElement.nativeElement.querySelector("p");
-    expect(body.innerText.trim()).toBe("Example HTML response from API");
-    expect(getComputedStyle(body).color).toBe("rgb(68, 34, 0)");
+    expect(body).toHaveText("Example HTML response from API");
+    expect(body).toHaveComputedStyle({ color: "rgb(68, 34, 0)" });
   });
 
   it("should display cms response containing script tag", async () => {
@@ -137,8 +137,8 @@ describe("CmsComponent", () => {
     spectator.detectChanges();
 
     const body = spectator.debugElement.nativeElement.querySelector("p");
-    expect(body.innerText.trim()).toBe("Example HTML response from API");
-    expect(getComputedStyle(body).color).toBe("rgb(68, 34, 0)");
+    expect(body).toHaveText("Example HTML response from API");
+    expect(body).toHaveComputedStyle({ color: "rgb(68, 34, 0)" });
   });
 
   it("should display error message on failure", async () => {

--- a/src/app/components/shared/detail-view/detail-view.component.spec.ts
+++ b/src/app/components/shared/detail-view/detail-view.component.spec.ts
@@ -235,14 +235,12 @@ describe("DetailViewComponent", () => {
 
     it("should right align field on small screen", () => {
       viewport.set(viewports.small);
-      const fieldStyle = window.getComputedStyle(getFields()[0]);
-      expect(fieldStyle.textAlign).toBe("right");
+      expect(getFields()[0]).toHaveComputedStyle({ textAlign: "right" });
     });
 
     it("should left align field on smallest screen", () => {
       viewport.set(viewports.extraSmall);
-      const fieldStyle = window.getComputedStyle(getFields()[0]);
-      expect(fieldStyle.textAlign).toBe("left");
+      expect(getFields()[0]).toHaveComputedStyle({ textAlign: "left" });
     });
   });
 });

--- a/src/app/components/shared/header/header.component.spec.ts
+++ b/src/app/components/shared/header/header.component.spec.ts
@@ -419,14 +419,14 @@ describe("HeaderComponent", () => {
       viewport.set(viewports.large);
       setUser(false);
       spec.detectChanges();
-      expect(getComputedStyle(getToggleButton()).display).toBe("none");
+      expect(getToggleButton()).toHaveComputedStyle({ display: "none" });
     });
 
     it("should display toggle button at medium screen size", () => {
       viewport.set(viewports.medium);
       setUser(false);
       spec.detectChanges();
-      expect(getComputedStyle(getToggleButton()).display).not.toBe("none");
+      expect(getToggleButton()).not.toHaveComputedStyle({ display: "none" });
     });
 
     it("navbar should initially be collapsed", () => {

--- a/src/app/helpers/page/pageComponent.spec.ts
+++ b/src/app/helpers/page/pageComponent.spec.ts
@@ -111,11 +111,11 @@ describe("PageComponents", () => {
     const actionMenu = spec.query("#action");
 
     if (isVisible) {
-      expect(getComputedStyle(secondaryMenu).display).not.toBe("none");
-      expect(getComputedStyle(actionMenu).display).not.toBe("none");
+      expect(secondaryMenu).not.toHaveComputedStyle({ display: "none" });
+      expect(actionMenu).not.toHaveComputedStyle({ display: "none" });
     } else {
-      expect(getComputedStyle(secondaryMenu).display).toBe("none");
-      expect(getComputedStyle(actionMenu).display).toBe("none");
+      expect(secondaryMenu).toHaveComputedStyle({ display: "none" });
+      expect(actionMenu).toHaveComputedStyle({ display: "none" });
     }
   }
 

--- a/src/app/interfaces/strongRoute.spec.ts
+++ b/src/app/interfaces/strongRoute.spec.ts
@@ -510,7 +510,7 @@ describe("StrongRoute", () => {
 
           const path =
             parent.baseRef.length > 0
-              ? parent.baseRef.substr(0, parent.baseRef.length - 1)
+              ? parent.baseRef.substring(0, parent.baseRef.length - 1)
               : "";
           rootRoute = createRoute(path);
         });

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -210,7 +210,7 @@ export class StrongRoute {
 
     const prepareParam = (x: StrongRoute): string | number => {
       if (x.isParameter) {
-        const key = x.pathFragment.substr(1, x.pathFragment.length - 1);
+        const key = x.pathFragment.substring(1);
 
         if (Object.prototype.hasOwnProperty.call(params, key)) {
           return params[key];

--- a/src/app/test/helpers/faker.ts
+++ b/src/app/test/helpers/faker.ts
@@ -29,22 +29,11 @@ export const modelData = {
   defaults: {
     sampleRateHertz: [8000, 22050, 44100, 48000],
     bitRateBps: [
-      64000,
-      82000,
-      123000,
-      124000,
-      125000,
-      128000,
-      256000,
-      352800,
-      353000,
-      512000,
-      705600,
-      768000,
-      1411200,
+      64000, 82000, 123000, 124000, 125000, 128000, 256000, 352800, 353000,
+      512000, 705600, 768000, 1411200,
     ],
   },
-  hash: () => "SHA256::" + modelData.hexaDecimal(256 / 4).substr(2),
+  hash: () => "SHA256::" + modelData.hexaDecimal(256 / 4).substring(2),
   html: () => "hello <b>world</b>",
   id: (id?: Id) => (id ? id : faker.datatype.number(25)),
   ids: () => randomArray(1, 5, () => faker.datatype.number(100)),
@@ -256,9 +245,9 @@ function randomObject(min: number, max: number): Record<string, string> {
   const obj = {};
 
   for (let i = 0; i < len; ++i) {
-    obj[
-      faker.random.word().replace(specialCharRegex, "")
-    ] = faker.random.words().replace(specialCharRegex, "");
+    obj[faker.random.word().replace(specialCharRegex, "")] = faker.random
+      .words()
+      .replace(specialCharRegex, "");
   }
 
   return obj;

--- a/src/app/test/matchers/matcher-types.d.ts
+++ b/src/app/test/matchers/matcher-types.d.ts
@@ -1,0 +1,6 @@
+declare namespace jasmine {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface Matchers<T> {
+    toHaveComputedStyle(expected: Partial<CSSStyleDeclaration>): boolean;
+  }
+}

--- a/src/app/test/matchers/toHaveComputedStyle.ts
+++ b/src/app/test/matchers/toHaveComputedStyle.ts
@@ -1,0 +1,76 @@
+import CustomMatcherFactories = jasmine.CustomMatcherFactories;
+import CustomMatcher = jasmine.CustomMatcher;
+import CustomMatcherResult = jasmine.CustomMatcherResult;
+
+/**
+ * Custom matchers use a combination of the following resources:
+ * https://stackoverflow.com/questions/42956195/create-custom-jasmine-matcher-using-typescript
+ * https://jasmine.github.io/tutorials/custom_matcher
+ *
+ * Remember to update matcher-types.d.ts when making changes
+ */
+
+type StyleValue = string | number;
+
+function validateStyles(
+  actual: HTMLElement,
+  expected: Partial<CSSStyleDeclaration>,
+  callback: (
+    key: string,
+    actualStyle: StyleValue,
+    expectedStyle: StyleValue
+  ) => CustomMatcherResult
+): CustomMatcherResult {
+  const computedStyle = getComputedStyle(actual);
+
+  /*
+   * For each expected value, compare to computed value, and return if
+   * miss match detected
+   */
+  Object.entries(expected).forEach(([key, value]) => {
+    const computedValue = computedStyle[key];
+    const result = callback(key, computedValue, value as StyleValue);
+    if (!result.pass) {
+      return result;
+    }
+  });
+
+  return { pass: true };
+}
+
+export const computedStyleMatchers: CustomMatcherFactories = {
+  /**
+   * Determines if the computed style of an element matches the expected values
+   *
+   * @param util Jasmine matcher utilities
+   * @returns Jasmine comparison function
+   */
+  toHaveComputedStyle(): CustomMatcher {
+    return {
+      negativeCompare: (
+        actual: HTMLElement,
+        expected: Partial<CSSStyleDeclaration>
+      ): CustomMatcherResult =>
+        validateStyles(actual, expected, (key, actualStyle, expectedStyle) =>
+          actualStyle !== expectedStyle
+            ? { pass: true }
+            : {
+                pass: false,
+                message: `Expected ${key} to be not be equal to ${expectedStyle}`,
+              }
+        ),
+      compare: (
+        actual: HTMLElement,
+        expected: Partial<CSSStyleDeclaration>
+      ): CustomMatcherResult =>
+        validateStyles(actual, expected, (key, actualStyle, expectedStyle) =>
+          actualStyle === expectedStyle
+            ? { pass: true }
+            : {
+                pass: false,
+                message: `Expected ${key} to be equal to ${expectedStyle}, got ${actualStyle} instead`,
+              }
+        ),
+    };
+  },
+};

--- a/src/test.ts
+++ b/src/test.ts
@@ -8,16 +8,23 @@ import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting,
 } from "@angular/platform-browser-dynamic/testing";
+import { computedStyleMatchers } from "@test/matchers/toHaveComputedStyle";
 
 declare const require: any;
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+
+// Load matchers into jasmine
+// https://stackoverflow.com/questions/11942085/is-there-a-way-to-add-a-jasmine-matcher-to-the-whole-environment
+beforeEach(function () {
+  jasmine.addMatchers(computedStyleMatchers);
+});
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting()
 );
-
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 
 // Then we find all the tests.
 const context = require.context("./", true, /\.spec\.ts$/);


### PR DESCRIPTION
# toHaveComputedStyle custom matcher

This adds a custom jasmine matcher for computed styles in a html element

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
