### PR TITLE
Correct Annotation Attribution and Audio Recording Links

### DIFF
--- a/src/app/components/projects/components/site-card/site-card.component.spec.ts
+++ b/src/app/components/projects/components/site-card/site-card.component.spec.ts
@@ -211,21 +211,6 @@ describe("SiteCardComponent", () => {
           spec.detectChanges();
           assertUrl(getLinks().play, spec.component.recording.viewUrl);
         });
-
-        it("should display audio recordings link if recordings exist", async () => {
-          initializeComponent();
-          await recordingPromise;
-          spec.detectChanges();
-          assertLink(getLinks().audioRecordings, "Audio Recordings");
-        });
-
-        it("should not display audio recordings link if no recordings exist", async () => {
-          recordingPromise = inputType.setup(null);
-          spec.detectChanges();
-          await recordingPromise;
-          spec.detectChanges();
-          expect(getLinks().audioRecordings).toBeFalsy();
-        });
       } else {
         it("should not display play link", () => {
           initializeComponent();
@@ -241,6 +226,19 @@ describe("SiteCardComponent", () => {
       it("should navigate user to visualizer page when clicking visualize link", () => {
         initializeComponent();
         assertUrl(getLinks().visualize, spec.component.model.visualizeUrl);
+      });
+
+      it("should display audio recordings link", async () => {
+        initializeComponent();
+        assertLink(getLinks().audioRecordings, "Audio Recordings");
+      });
+
+      it("should navigate user to audio recordings page when clicking audio recordings link", async () => {
+        initializeComponent();
+        assertUrl(
+          getLinks().audioRecordings,
+          spec.component.model.getAudioRecordingsUrl(spec.component.project)
+        );
       });
     });
   });

--- a/src/app/components/projects/components/site-card/site-card.component.spec.ts
+++ b/src/app/components/projects/components/site-card/site-card.component.spec.ts
@@ -148,6 +148,7 @@ describe("SiteCardComponent", () => {
         play: spec.query<HTMLAnchorElement>("#play"),
         noAudio: spec.query<HTMLAnchorElement>("#no-audio"),
         visualize: spec.query<HTMLAnchorElement>("#visualize"),
+        audioRecordings: spec.query<HTMLAnchorElement>("#audio-recordings"),
       };
     }
 
@@ -210,6 +211,21 @@ describe("SiteCardComponent", () => {
           spec.detectChanges();
           assertUrl(getLinks().play, spec.component.recording.viewUrl);
         });
+
+        it("should display audio recordings link if recordings exist", async () => {
+          initializeComponent();
+          await recordingPromise;
+          spec.detectChanges();
+          assertLink(getLinks().audioRecordings, "Audio Recordings");
+        });
+
+        it("should not display audio recordings link if no recordings exist", async () => {
+          recordingPromise = inputType.setup(null);
+          spec.detectChanges();
+          await recordingPromise;
+          spec.detectChanges();
+          expect(getLinks().audioRecordings).toBeFalsy();
+        });
       } else {
         it("should not display play link", () => {
           initializeComponent();
@@ -222,7 +238,10 @@ describe("SiteCardComponent", () => {
         assertLink(getLinks().visualize, "Visualise");
       });
 
-      xit("should navigate user to visualizer page when clicking play link", () => {});
+      it("should navigate user to visualizer page when clicking visualize link", () => {
+        initializeComponent();
+        assertUrl(getLinks().visualize, spec.component.model.visualizeUrl);
+      });
     });
   });
 

--- a/src/app/components/projects/components/site-card/site-card.component.ts
+++ b/src/app/components/projects/components/site-card/site-card.component.ts
@@ -84,7 +84,7 @@ import { takeUntil } from "rxjs/operators";
           </li>
 
           <!-- Audio Recordings link (if recordings exist) -->
-          <li *ngIf="recording" class="nav-item">
+          <li class="nav-item">
             <a
               id="audio-recordings"
               class="nav-link rounded-link-default"

--- a/src/app/components/projects/components/site-card/site-card.component.ts
+++ b/src/app/components/projects/components/site-card/site-card.component.ts
@@ -30,6 +30,8 @@ import { takeUntil } from "rxjs/operators";
               {{ numPoints() }} Points
             </span>
           </li>
+
+          <!-- Model details link -->
           <li class="nav-item">
             <a
               id="details"
@@ -40,6 +42,8 @@ import { takeUntil } from "rxjs/operators";
               Details
             </a>
           </li>
+
+          <!-- Play audio link (if recording exists) -->
           <li *ngIf="site" class="nav-item">
             <!-- Play link if recording exists -->
             <a
@@ -66,6 +70,8 @@ import { takeUntil } from "rxjs/operators";
               size="sm"
             ></baw-loading>
           </li>
+
+          <!-- Visualize link -->
           <li class="nav-item">
             <a
               id="visualize"
@@ -76,8 +82,11 @@ import { takeUntil } from "rxjs/operators";
               Visualise
             </a>
           </li>
-          <li class="nav-item">
+
+          <!-- Audio Recordings link (if recordings exist) -->
+          <li *ngIf="recording" class="nav-item">
             <a
+              id="audio-recordings"
               class="nav-link rounded-link-default"
               [bawUrl]="model.getAudioRecordingsUrl(project)"
             >

--- a/src/app/components/projects/components/site-card/site-card.component.ts
+++ b/src/app/components/projects/components/site-card/site-card.component.ts
@@ -76,6 +76,15 @@ import { takeUntil } from "rxjs/operators";
               Visualise
             </a>
           </li>
+          <li class="nav-item">
+            <a
+              class="nav-link rounded-link-default"
+              [bawUrl]="model.getAudioRecordingsUrl(project)"
+            >
+              <fa-icon [icon]="['fas', 'file-audio']"></fa-icon>
+              Audio Recordings
+            </a>
+          </li>
         </ul>
       </div>
     </li>

--- a/src/app/components/sites/components/recent-annotations/recent-annotations.component.html
+++ b/src/app/components/sites/components/recent-annotations/recent-annotations.component.html
@@ -47,12 +47,11 @@
 <ng-template #tagged let-event="event" let-tagging="tagging">
   <!-- Annotation link -->
   <a class="nav-link rounded-link-default" [bawUrl]="event.listenViewUrl">
-    <!-- Loading when unresolved -->
+    <!--
+      Loading when unresolved
+    -->
     <ng-container
-      *ngIf="
-        (tagging.tag | isUnresolved) || (event.creator | isUnresolved);
-        else loaded
-      "
+      *ngIf="modelsUnresolved(event.creator, tagging.tag); else loaded"
     >
       <baw-loading id="tag-loader" size="sm"></baw-loading>
     </ng-container>

--- a/src/app/components/sites/components/recent-annotations/recent-annotations.component.html
+++ b/src/app/components/sites/components/recent-annotations/recent-annotations.component.html
@@ -5,7 +5,9 @@
   <baw-loading *ngIf="!recentAudioEvents" id="annotation-loader"></baw-loading>
 
   <!-- Handle no annotations -->
-  <p *ngIf="recentAudioEvents?.length === 0">No recent annotations found</p>
+  <p *ngIf="recentAudioEvents?.length === 0" id="no-annotations">
+    No recent annotations found
+  </p>
 
   <!-- For each annotation and tagging -->
   <ng-container *ngFor="let event of recentAudioEvents">

--- a/src/app/components/sites/components/recent-annotations/recent-annotations.component.html
+++ b/src/app/components/sites/components/recent-annotations/recent-annotations.component.html
@@ -1,0 +1,64 @@
+<h3>Recent Annotations</h3>
+
+<ul class="nav">
+  <!-- Loading animation -->
+  <baw-loading *ngIf="!recentAudioEvents" id="annotation-loader"></baw-loading>
+
+  <!-- Handle no annotations -->
+  <p *ngIf="recentAudioEvents?.length === 0">No recent annotations found</p>
+
+  <!-- For each annotation and tagging -->
+  <ng-container *ngFor="let event of recentAudioEvents">
+    <li *ngIf="event.taggings.length === 0" class="nav-item">
+      <ng-container
+        [ngTemplateOutlet]="notTagged"
+        [ngTemplateOutletContext]="{ event }"
+      ></ng-container>
+    </li>
+
+    <li *ngFor="let tagging of event.taggings" class="nav-item">
+      <ng-container
+        [ngTemplateOutlet]="tagged"
+        [ngTemplateOutletContext]="{ tagging, event }"
+      ></ng-container>
+    </li>
+  </ng-container>
+</ul>
+
+<!-- Show event creator for untagged event -->
+<ng-template #notTagged let-event="event">
+  <!-- Annotation link -->
+  <a class="nav-link rounded-link-default" [bawUrl]="event.listenViewUrl">
+    <baw-loading
+      *ngIf="event.creator | isUnresolved; else loaded"
+      id="tag-loader"
+      size="sm"
+    ></baw-loading>
+
+    <ng-template #loaded>
+      (not tagged) by {{ event.creator.userName }}
+    </ng-template>
+  </a>
+</ng-template>
+
+<!-- Show event creator and tag name for event-->
+<ng-template #tagged let-event="event" let-tagging="tagging">
+  <!-- Annotation link -->
+  <a class="nav-link rounded-link-default" [bawUrl]="event.listenViewUrl">
+    <!-- Loading when unresolved -->
+    <ng-container
+      *ngIf="
+        (tagging.tag | isUnresolved) || (event.creator | isUnresolved);
+        else loaded
+      "
+    >
+      <baw-loading id="tag-loader" size="sm"></baw-loading>
+    </ng-container>
+
+    <!-- Annotation details -->
+    <ng-template #loaded>
+      "{{ tagging.tag.text }}" by
+      {{ event.creator.userName }}
+    </ng-template>
+  </a>
+</ng-template>

--- a/src/app/components/sites/components/recent-annotations/recent-annotations.component.spec.ts
+++ b/src/app/components/sites/components/recent-annotations/recent-annotations.component.spec.ts
@@ -1,0 +1,301 @@
+import { Injector } from "@angular/core";
+import { RouterTestingModule } from "@angular/router/testing";
+import { ShallowAudioEventsService } from "@baw-api/audio-event/audio-events.service";
+import { Filters } from "@baw-api/baw-api.service";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { ACCOUNT, TAG } from "@baw-api/ServiceTokens";
+import { Errorable } from "@helpers/advancedTypes";
+import { isApiErrorDetails } from "@helpers/baw-api/baw-api";
+import { AudioEvent } from "@models/AudioEvent";
+import { Site } from "@models/Site";
+import { Tag } from "@models/Tag";
+import { Tagging } from "@models/Tagging";
+import { User } from "@models/User";
+import { createComponentFactory, Spectator } from "@ngneat/spectator";
+import { SharedModule } from "@shared/shared.module";
+import { generateApiErrorDetailsV2 } from "@test/fakes/ApiErrorDetails";
+import { generateAudioEvent } from "@test/fakes/AudioEvent";
+import { generateSite } from "@test/fakes/Site";
+import { generateTag } from "@test/fakes/Tag";
+import { generateTagging } from "@test/fakes/Tagging";
+import { generateUser } from "@test/fakes/User";
+import { nStepObservable } from "@test/helpers/general";
+import { MockProvider } from "ng-mocks";
+import { ToastrService } from "ngx-toastr";
+import { Subject } from "rxjs";
+import { RecentAnnotationsComponent } from "./recent-annotations.component";
+
+describe("RecentAnnotationsComponent", () => {
+  let defaultSite: Site;
+  let defaultTagging: Tagging;
+  let defaultUser: User;
+  let defaultTag: Tag;
+  let injector: Injector;
+  let spec: Spectator<RecentAnnotationsComponent>;
+  const createComponent = createComponentFactory({
+    component: RecentAnnotationsComponent,
+    imports: [MockBawApiModule, SharedModule, RouterTestingModule],
+    providers: [
+      MockProvider(ToastrService, {
+        error: jasmine.createSpy("error").and.stub(),
+      }),
+    ],
+  });
+
+  function getNavLinks() {
+    return spec.queryAll(".nav-link");
+  }
+
+  function assertNavLink(navLink: Element, text) {
+    expect(navLink).toHaveText(text);
+  }
+
+  function setAudioEvents(
+    audioEvents: Errorable<AudioEvent[]>,
+    creator: Errorable<User> = null,
+    tag: Errorable<Tag> = null
+  ) {
+    const subjects = {
+      audioEvents: new Subject<AudioEvent[]>(),
+      creator: new Subject<User>(),
+      tag: new Subject<Tag>(),
+    };
+
+    spec
+      .inject(ShallowAudioEventsService)
+      .filterBySite.and.callFake((filter: Filters<AudioEvent>, site: Site) => {
+        expect(filter).toEqual({
+          sorting: { orderBy: "updatedAt", direction: "desc" },
+        });
+        expect(site).toEqual(defaultSite);
+        return subjects.audioEvents;
+      });
+    spec.inject(ACCOUNT.token).show.and.callFake(() => subjects.creator);
+    spec.inject(TAG.token).show.and.callFake(() => subjects.tag);
+
+    const promises: {
+      events?: Promise<void>;
+      creator?: Promise<void>;
+      tag?: Promise<void>;
+    } = {};
+
+    if (audioEvents) {
+      const promise = nStepObservable(
+        subjects.audioEvents,
+        () => audioEvents,
+        isApiErrorDetails(audioEvents),
+        Object.keys(promises).length
+      );
+      promises.events = promise;
+    }
+    if (creator) {
+      const promise = nStepObservable(
+        subjects.creator,
+        () => creator,
+        isApiErrorDetails(creator),
+        Object.keys(promises).length
+      );
+      promises.creator = promise;
+    }
+    if (tag) {
+      const promise = nStepObservable(
+        subjects.tag,
+        () => tag,
+        isApiErrorDetails(tag),
+        Object.keys(promises).length
+      );
+      promises.tag = promise;
+    }
+
+    return promises;
+  }
+
+  beforeEach(() => {
+    defaultSite = new Site(generateSite());
+
+    spec = createComponent({
+      detectChanges: false,
+      props: { site: defaultSite },
+    });
+
+    injector = spec.inject(Injector);
+    defaultSite["injector"] = injector;
+    defaultTagging = new Tagging(generateTagging(), injector);
+    defaultUser = new User(generateUser(), injector);
+    defaultTag = new Tag(generateTag(), injector);
+  });
+
+  describe("audio events", () => {
+    it("should show baw-loader while retrieving audio events", () => {
+      setAudioEvents([]);
+      spec.detectChanges();
+      expect(spec.query("baw-loading#annotation-loader")).toBeTruthy();
+    });
+
+    it("should show default message if no audio events", async () => {
+      const promises = setAudioEvents([]);
+      spec.detectChanges();
+      await promises.events;
+      spec.detectChanges();
+      expect(spec.query("#no-annotations")).toHaveText("No recent annotations");
+    });
+
+    it("should send error notification if audio event failure", async () => {
+      const promises = setAudioEvents(generateApiErrorDetailsV2(), null, null);
+      spec.detectChanges();
+      await promises.events;
+      spec.detectChanges();
+      expect(spec.inject(ToastrService).error).toHaveBeenCalled();
+    });
+  });
+
+  describe("taggings", () => {
+    describe("not tagged", () => {
+      it("should show baw-loader while retrieving creator", async () => {
+        const audioEvent = new AudioEvent(
+          generateAudioEvent({ taggings: [] }),
+          injector
+        );
+        const promises = setAudioEvents([audioEvent]);
+        spec.detectChanges();
+        await promises.events;
+        spec.detectChanges();
+        expect(spec.query("baw-loading#tag-loader")).toBeTruthy();
+      });
+
+      it("should show (not tagged) with creator userName", async () => {
+        const audioEvent = new AudioEvent(
+          generateAudioEvent({ taggings: [] }),
+          injector
+        );
+        const promises = setAudioEvents([audioEvent], defaultUser);
+        spec.detectChanges();
+        await promises.events;
+        spec.detectChanges();
+        await promises.creator;
+        spec.detectChanges();
+        assertNavLink(
+          getNavLinks()[0],
+          `(not tagged) by ${defaultUser.userName}`
+        );
+      });
+    });
+
+    describe("tagged", () => {
+      function getTaggings(numTaggings: number) {
+        return Array.from(
+          { length: numTaggings },
+          () => new Tagging(generateTagging(), injector)
+        );
+      }
+
+      it("should show baw-loader while retrieving tag", async () => {
+        const audioEvent = new AudioEvent(
+          generateAudioEvent({ taggings: [defaultTagging] }),
+          injector
+        );
+        const promises = setAudioEvents([audioEvent], defaultUser);
+        spec.detectChanges();
+        await promises.events;
+        spec.detectChanges();
+        await promises.creator;
+        spec.detectChanges();
+        expect(spec.query("baw-loading#tag-loader")).toBeTruthy();
+      });
+
+      it("should show baw-loader while retrieving creator", async () => {
+        const audioEvent = new AudioEvent(
+          generateAudioEvent({ taggings: [defaultTagging] }),
+          injector
+        );
+        const promises = setAudioEvents([audioEvent], null, defaultTag);
+        spec.detectChanges();
+        await promises.events;
+        spec.detectChanges();
+        await promises.tag;
+        spec.detectChanges();
+        expect(spec.query("baw-loading#tag-loader")).toBeTruthy();
+      });
+
+      it("should show tag text and creator userName", async () => {
+        const audioEvent = new AudioEvent(
+          generateAudioEvent({ taggings: [defaultTagging] }),
+          injector
+        );
+        const promises = setAudioEvents([audioEvent], defaultUser, defaultTag);
+        spec.detectChanges();
+        await promises.events;
+        spec.detectChanges();
+        await promises.creator;
+        await promises.tag;
+        spec.detectChanges();
+        assertNavLink(
+          getNavLinks()[0],
+          `"${defaultTag.text}" by ${defaultUser.userName}`
+        );
+      });
+
+      it("should show multiple taggings", async () => {
+        const audioEvent1 = new AudioEvent(
+          generateAudioEvent({ taggings: getTaggings(3) }),
+          injector
+        );
+        const audioEvent2 = new AudioEvent(
+          generateAudioEvent({ taggings: getTaggings(2) }),
+          injector
+        );
+        const promises = setAudioEvents(
+          [audioEvent1, audioEvent2],
+          defaultUser,
+          defaultTag
+        );
+        spec.detectChanges();
+        await promises.events;
+        spec.detectChanges();
+        await promises.creator;
+        await promises.tag;
+        spec.detectChanges();
+
+        const navLinks = getNavLinks();
+        expect(navLinks).toHaveLength(5);
+      });
+
+      it("should limit number of shown tags to around 10", async () => {
+        // 6 Tags
+        const audioEvent1 = new AudioEvent(
+          generateAudioEvent({ taggings: getTaggings(6) }),
+          injector
+        );
+        // 1 Empty tag
+        const audioEvent2 = new AudioEvent(
+          generateAudioEvent({ taggings: getTaggings(0) }),
+          injector
+        );
+        // 5 Tags
+        const audioEvent3 = new AudioEvent(
+          generateAudioEvent({ taggings: getTaggings(5) }),
+          injector
+        );
+        // Past the 10 tag limit, should not appear
+        const audioEvent4 = new AudioEvent(
+          generateAudioEvent({ taggings: getTaggings(5) }),
+          injector
+        );
+        const promises = setAudioEvents(
+          [audioEvent1, audioEvent2, audioEvent3, audioEvent4],
+          defaultUser,
+          defaultTag
+        );
+        spec.detectChanges();
+        await promises.events;
+        spec.detectChanges();
+        await promises.creator;
+        await promises.tag;
+        spec.detectChanges();
+
+        const navLinks = getNavLinks();
+        expect(navLinks).toHaveLength(12);
+      });
+    });
+  });
+});

--- a/src/app/components/sites/components/recent-annotations/recent-annotations.component.ts
+++ b/src/app/components/sites/components/recent-annotations/recent-annotations.component.ts
@@ -2,6 +2,11 @@ import { Component, Input, OnInit } from "@angular/core";
 import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
 import { ShallowAudioEventsService } from "@baw-api/audio-event/audio-events.service";
 import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
+import {
+  AbstractModel,
+  isUnresolvedModel,
+  UnresolvedModel,
+} from "@models/AbstractModel";
 import { AudioEvent } from "@models/AudioEvent";
 import { Site } from "@models/Site";
 import { ToastrService } from "ngx-toastr";
@@ -28,6 +33,12 @@ export class RecentAnnotationsComponent
 
   public ngOnInit(): void {
     this.getAnnotations();
+  }
+
+  public modelsUnresolved(
+    ...models: (AbstractModel | UnresolvedModel)[]
+  ): boolean {
+    return models.some((model): boolean => isUnresolvedModel(model));
   }
 
   private getAnnotations(): void {

--- a/src/app/components/sites/components/recent-annotations/recent-annotations.component.ts
+++ b/src/app/components/sites/components/recent-annotations/recent-annotations.component.ts
@@ -1,0 +1,60 @@
+import { Component, Input, OnInit } from "@angular/core";
+import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
+import { ShallowAudioEventsService } from "@baw-api/audio-event/audio-events.service";
+import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
+import { AudioEvent } from "@models/AudioEvent";
+import { Site } from "@models/Site";
+import { ToastrService } from "ngx-toastr";
+import { takeUntil } from "rxjs";
+
+@Component({
+  selector: "baw-site-recent-annotations",
+  templateUrl: "./recent-annotations.component.html",
+})
+export class RecentAnnotationsComponent
+  extends withUnsubscribe()
+  implements OnInit
+{
+  @Input() public site: Site;
+
+  public recentAudioEvents: AudioEvent[];
+
+  public constructor(
+    private audioEventsApi: ShallowAudioEventsService,
+    private notifications: ToastrService
+  ) {
+    super();
+  }
+
+  public ngOnInit(): void {
+    this.getAnnotations();
+  }
+
+  private getAnnotations(): void {
+    this.audioEventsApi
+      .filterBySite(
+        { sorting: { orderBy: "updatedAt", direction: "desc" } },
+        this.site
+      )
+      .pipe(takeUntil(this.unsubscribe))
+      .subscribe({
+        next: (events) => {
+          // Limit the selection of audio events by tagging count
+          const maxTags = 10;
+          let numTags = 0;
+          this.recentAudioEvents = [];
+
+          for (const event of events) {
+            this.recentAudioEvents.push(event);
+            // An event with no taggings will still show a (not tagged) tag
+            numTags += Math.max(event.taggings.length, 1);
+
+            if (numTags > maxTags) {
+              return;
+            }
+          }
+        },
+        error: (err: ApiErrorDetails) => this.notifications.error(err.message),
+      });
+  }
+}

--- a/src/app/components/sites/components/recent-annotations/recent-annotations.component.ts
+++ b/src/app/components/sites/components/recent-annotations/recent-annotations.component.ts
@@ -54,6 +54,7 @@ export class RecentAnnotationsComponent
             }
           }
         },
+        // TODO This should be a standardized handler for all BAW API errors
         error: (err: ApiErrorDetails) => this.notifications.error(err.message),
       });
   }

--- a/src/app/components/sites/components/site/site.component.html
+++ b/src/app/components/sites/components/site/site.component.html
@@ -88,7 +88,7 @@
         </li>
 
         <!-- Audio recordings link (if recordings exist) -->
-        <li *ngIf="oldestRecording" class="nav-item">
+        <li class="nav-item">
           <a
             class="nav-link rounded-link-default"
             [bawUrl]="site.getAudioRecordingsUrl(project)"

--- a/src/app/components/sites/components/site/site.component.html
+++ b/src/app/components/sites/components/site/site.component.html
@@ -60,8 +60,8 @@
         </p>
       </baw-wip>
 
-      <!-- Play and Visualize links -->
       <ul class="nav mb-0">
+        <!-- Play link (if recordings exist) -->
         <li class="nav-item">
           <a
             *ngIf="oldestRecording"
@@ -78,10 +78,23 @@
             size="sm"
           ></baw-loading>
         </li>
+
+        <!-- Visualize link -->
         <li class="nav-item">
           <a class="nav-link rounded-link-default" [bawUrl]="site.visualizeUrl">
             <fa-icon [icon]="['fas', 'eye']"></fa-icon>
             Visualise
+          </a>
+        </li>
+
+        <!-- Audio recordings link (if recordings exist) -->
+        <li *ngIf="oldestRecording" class="nav-item">
+          <a
+            class="nav-link rounded-link-default"
+            [bawUrl]="site.getAudioRecordingsUrl(project)"
+          >
+            <fa-icon [icon]="['fas', 'file-audio']"></fa-icon>
+            Audio Recordings
           </a>
         </li>
       </ul>

--- a/src/app/components/sites/components/site/site.component.html
+++ b/src/app/components/sites/components/site/site.component.html
@@ -87,57 +87,9 @@
       </ul>
 
       <!-- Recent Annotations Summary -->
-      <h3>Recent Annotations</h3>
-
-      <ul class="nav">
-        <!-- Loading animation -->
-        <baw-loading
-          *ngIf="!recentAudioEvents"
-          id="annotation-loader"
-        ></baw-loading>
-
-        <!-- Handle no annotations -->
-        <p *ngIf="recentAudioEvents?.length === 0">
-          No recent annotations found
-        </p>
-
-        <!-- For each annotation and tagging -->
-        <ng-container *ngFor="let event of recentAudioEvents">
-          <li *ngIf="event.taggings.length === 0" class="nav-item">
-            <!-- Annotation link -->
-            <a
-              class="nav-link rounded-link-default"
-              [bawUrl]="event.listenViewUrl"
-            >
-              "(not tagged)" by {{ event.creator?.userName }}
-            </a>
-          </li>
-          <li *ngFor="let tagging of event.taggings" class="nav-item">
-            <!-- Annotation link -->
-            <a
-              class="nav-link rounded-link-default"
-              [bawUrl]="event.listenViewUrl"
-            >
-              <!-- Loading when unresolved -->
-              <ng-container
-                *ngIf="
-                  (tagging.tag | isUnresolved) ||
-                    (tagging.tag?.creator | isUnresolved);
-                  else loaded
-                "
-              >
-                <baw-loading id="tag-loader" size="sm"></baw-loading>
-              </ng-container>
-
-              <!-- Annotation details -->
-              <ng-template #loaded>
-                "{{ tagging.tag?.text }}" by
-                {{ tagging.tag?.creator?.userName }}
-              </ng-template>
-            </a>
-          </li>
-        </ng-container>
-      </ul>
+      <baw-site-recent-annotations
+        [site]="site"
+      ></baw-site-recent-annotations>
     </ng-container>
   </div>
   <!-- Map using right column -->

--- a/src/app/components/sites/components/site/site.component.html
+++ b/src/app/components/sites/components/site/site.component.html
@@ -87,9 +87,7 @@
       </ul>
 
       <!-- Recent Annotations Summary -->
-      <baw-site-recent-annotations
-        [site]="site"
-      ></baw-site-recent-annotations>
+      <baw-site-recent-annotations [site]="site"></baw-site-recent-annotations>
     </ng-container>
   </div>
   <!-- Map using right column -->

--- a/src/app/components/sites/components/site/site.component.spec.ts
+++ b/src/app/components/sites/components/site/site.component.spec.ts
@@ -374,6 +374,11 @@ describe("SiteComponent", () => {
       it("should route to correct location", () => {});
     });
 
+    xdescribe("audio recordings", () => {
+      it("should create audio recordings link", () => {});
+      it("should route to correct location", () => {});
+    });
+
     describe("filterByDates", () => {
       it("should request list of newest audio recordings", (done) => {
         setup(defaultProject, defaultSite);

--- a/src/app/components/sites/sites.module.ts
+++ b/src/app/components/sites/sites.module.ts
@@ -4,6 +4,7 @@ import { RegionsModule } from "@components/regions/regions.module";
 import { getRouteConfigForPage } from "@helpers/page/pageRouting";
 import { MapModule } from "@shared/map/map.module";
 import { SharedModule } from "@shared/shared.module";
+import { RecentAnnotationsComponent } from "./components/recent-annotations/recent-annotations.component";
 import { SiteComponent } from "./components/site/site.component";
 import { SiteDeleteComponent } from "./pages/delete/delete.component";
 import { SiteDetailsComponent } from "./pages/details/details.component";
@@ -22,6 +23,7 @@ const components = [
   SiteHarvestComponent,
   SiteNewComponent,
   WizardComponent,
+  RecentAnnotationsComponent,
 ];
 
 const siteRoutes = sitesRoute.compileRoutes(getRouteConfigForPage);

--- a/src/app/interfaces/strongRoute.ts
+++ b/src/app/interfaces/strongRoute.ts
@@ -203,7 +203,9 @@ export class StrongRoute {
     const [full, parameters] = this.rootToHere();
     const numArgs = Object.keys(params).length;
     if (numArgs < parameters.length) {
-      const msg = `Got ${numArgs} route arguments but expected ${parameters.length}`;
+      const msg = `${this.toString()}: Got ${numArgs} route arguments but expected ${
+        parameters.length
+      }`;
       console.error(msg);
       throw new Error(msg);
     }
@@ -215,7 +217,9 @@ export class StrongRoute {
         if (Object.prototype.hasOwnProperty.call(params, key)) {
           return params[key];
         } else {
-          const msg = `Parameter named ${x.pathFragment} was not supplied a value and a default value was not given`;
+          const msg = `${this.toString()}: Parameter named ${
+            x.pathFragment
+          } was not supplied a value and a default value was not given`;
           console.error(msg);
           throw new Error(msg);
         }

--- a/src/app/models/AbstractModel.ts
+++ b/src/app/models/AbstractModel.ts
@@ -243,6 +243,12 @@ export class UnresolvedModel extends AbstractModel {
   }
 }
 
+export function isUnresolvedModel<T extends AbstractModel>(
+  model: Readonly<T | T[] | UnresolvedModel>
+): model is UnresolvedModel {
+  return model === UnresolvedModel.one || model === UnresolvedModel.many;
+}
+
 export const unknownViewUrl = "/not_implemented";
 export function getUnknownViewUrl(errorMsg: string) {
   console.warn(errorMsg);

--- a/src/app/models/AudioEvent.ts
+++ b/src/app/models/AudioEvent.ts
@@ -93,9 +93,13 @@ export class AudioEvent
   }
 
   public get listenViewUrl(): string {
+    const paddingSeconds = 10;
     return listenRecordingMenuItem.route.format(
       { audioRecordingId: this.audioRecordingId },
-      { start: this.startTimeSeconds, end: this.endTimeSeconds }
+      {
+        start: Math.max(0, this.startTimeSeconds - paddingSeconds),
+        end: this.endTimeSeconds + paddingSeconds,
+      }
     );
   }
 

--- a/src/app/models/Region.ts
+++ b/src/app/models/Region.ts
@@ -1,4 +1,6 @@
+import { id, IdOr } from "@baw-api/api-common";
 import { PROJECT, SHALLOW_SITE } from "@baw-api/ServiceTokens";
+import { audioRecordingMenuItems } from "@components/audio-recordings/audio-recording.menus";
 import { regionMenuItem } from "@components/regions/regions.menus";
 import { visualizeMenuItem } from "@components/visualize/visualize.menus";
 import {
@@ -98,6 +100,13 @@ export class Region extends AbstractModel<IRegion> implements IRegion {
 
   public get visualizeUrl(): string {
     return visualizeMenuItem.route.format(undefined, { siteIds: this.siteIds });
+  }
+
+  public getAudioRecordingsUrl(): string {
+    return audioRecordingMenuItems.list.region.route.format({
+      projectId: this.projectId,
+      regionId: this.id,
+    });
   }
 
   /**

--- a/src/app/models/Region.ts
+++ b/src/app/models/Region.ts
@@ -1,4 +1,3 @@
-import { id, IdOr } from "@baw-api/api-common";
 import { PROJECT, SHALLOW_SITE } from "@baw-api/ServiceTokens";
 import { audioRecordingMenuItems } from "@components/audio-recordings/audio-recording.menus";
 import { regionMenuItem } from "@components/regions/regions.menus";

--- a/src/app/models/Site.ts
+++ b/src/app/models/Site.ts
@@ -2,6 +2,7 @@ import { Injector } from "@angular/core";
 import { id, IdOr } from "@baw-api/api-common";
 import { PROJECT } from "@baw-api/ServiceTokens";
 import { adminOrphanMenuItem } from "@components/admin/orphan/orphans.menus";
+import { audioRecordingMenuItems } from "@components/audio-recordings/audio-recording.menus";
 import { pointMenuItem } from "@components/sites/points.menus";
 import { visualizeMenuItem } from "@components/visualize/visualize.menus";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
@@ -130,6 +131,21 @@ export class Site extends AbstractModel<ISite> implements ISite {
 
   public get visualizeUrl(): string {
     return visualizeMenuItem.route.format(undefined, { siteId: this.id });
+  }
+
+  public getAudioRecordingsUrl(projectId: IdOr<Project>): string {
+    if (isInstantiated(this.regionId)) {
+      return audioRecordingMenuItems.list.siteAndRegion.route.format({
+        projectId: id(projectId),
+        regionId: this.regionId,
+        siteId: this.id,
+      });
+    } else {
+      return audioRecordingMenuItems.list.site.route.format({
+        projectId: id(projectId),
+        siteId: this.id,
+      });
+    }
   }
 
   public getViewUrl(project: IdOr<Project>): string {

--- a/src/app/pipes/isUnresolved/is-unresolved.pipe.ts
+++ b/src/app/pipes/isUnresolved/is-unresolved.pipe.ts
@@ -1,6 +1,6 @@
 import { Pipe, PipeTransform } from "@angular/core";
 import { AccessLevel } from "@interfaces/apiInterfaces";
-import { AbstractModel, UnresolvedModel } from "@models/AbstractModel";
+import { AbstractModel, isUnresolvedModel } from "@models/AbstractModel";
 
 /**
  * Evaluate if a model, or array or models, is resolved
@@ -13,8 +13,9 @@ export class IsUnresolvedPipe implements PipeTransform {
     value: Readonly<AbstractModel | AbstractModel[]> | AccessLevel
   ): boolean {
     const isUnresolvedAccessLevel = value === AccessLevel.unresolved;
-    const isSingle = value === UnresolvedModel.one;
-    const isMultiple = value === UnresolvedModel.many;
-    return isUnresolvedAccessLevel || isSingle || isMultiple;
+    return (
+      isUnresolvedAccessLevel ||
+      isUnresolvedModel(value as AbstractModel | AbstractModel[])
+    );
   }
 }


### PR DESCRIPTION
# Correct Annotation Attribution and Audio Recording Links

Fixed incorrect attribution of annotation creation, and added some links to the audio recording pages

## Issues

Closes #1688 
Relates to #984 

## Visual Changes

### Project/Region Details Page with Audio Recordings Link
![image](https://user-images.githubusercontent.com/3955116/153132526-81664e60-e717-4028-a214-bd6c0b4df96f.png)

### Site Details Page with Audio Recordings Link and fixed Annotation Attribution
![image](https://user-images.githubusercontent.com/3955116/153132590-069dbc3a-91e7-47ac-b535-b4416169da84.png)

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
