### PR TITLE
Bug in unused forms

### DIFF
--- a/src/app/components/shared/annotation-download/annotation-download.component.ts
+++ b/src/app/components/shared/annotation-download/annotation-download.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from "@angular/core";
 import { FormGroup } from "@angular/forms";
 import {
   hasResolvedSuccessfully,
-  retrieveResolvers
+  retrieveResolvers,
 } from "@baw-api/resolver-common";
 import { SitesService } from "@baw-api/site/sites.service";
 import { IPageInfo } from "@helpers/page/pageInfo";
@@ -68,6 +68,14 @@ const siteKey = "site";
       </a>
     </div>
   `,
+  styles: [
+    `
+      /* Otherwise timezone selector cannot be seen on firefox */
+      .modal-body {
+        overflow-y: unset;
+      }
+    `,
+  ],
 })
 export class AnnotationDownloadComponent implements OnInit, ModalComponent {
   public closeModal!: (result: any) => void;

--- a/src/app/models/data/ContactUs.ts
+++ b/src/app/models/data/ContactUs.ts
@@ -12,9 +12,9 @@ export interface IContactUs {
 export class ContactUs extends AbstractForm<IContactUs> implements IContactUs {
   public readonly kind = "Contact Us";
   @bawPersistAttr()
-  public readonly name: Param = "";
+  public readonly name: Param;
   @bawPersistAttr()
-  public readonly email: Param = "";
+  public readonly email: Param;
   @bawPersistAttr()
   public readonly content: Description;
   @bawPersistAttr()
@@ -23,8 +23,8 @@ export class ContactUs extends AbstractForm<IContactUs> implements IContactUs {
   public getBody(token: string): URLSearchParams {
     this.validateRecaptchaToken();
     const body = new URLSearchParams();
-    body.set("data_class_contact_us[name]", this.name);
-    body.set("data_class_contact_us[email]", this.email);
+    body.set("data_class_contact_us[name]", this.name ?? "");
+    body.set("data_class_contact_us[email]", this.email ?? "");
     body.set("data_class_contact_us[content]", this.content);
     body.set("g-recaptcha-response-data[contact_us]", this.recaptchaToken);
     body.set("g-recaptcha-response", "");

--- a/src/app/models/data/DataRequest.ts
+++ b/src/app/models/data/DataRequest.ts
@@ -28,7 +28,7 @@ export class DataRequest
 {
   public readonly kind = "Data Request";
   @bawPersistAttr()
-  public readonly name: string = "";
+  public readonly name: string;
   @bawPersistAttr()
   public readonly email: string;
   @bawPersistAttr()
@@ -42,7 +42,7 @@ export class DataRequest
 
   public getBody(token: string): URLSearchParams {
     const body = new URLSearchParams();
-    body.set("data_class_data_request[name]", this.name);
+    body.set("data_class_data_request[name]", this.name ?? "");
     body.set("data_class_data_request[email]", this.email);
     body.set("data_class_data_request[group]", this.group);
     body.set("data_class_data_request[group_type]", this.groupType);

--- a/src/app/services/baw-api/site/sites.service.spec.ts
+++ b/src/app/services/baw-api/site/sites.service.spec.ts
@@ -6,14 +6,20 @@ import { API_ROOT } from "@helpers/app-initializer/app-initializer";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
-import { SpectatorService, createServiceFactory, mockProvider } from "@ngneat/spectator";
+import {
+  SpectatorService,
+  createServiceFactory,
+  mockProvider,
+} from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
-import { validateStandardApi, validateCustomApiFilter } from "@test/helpers/api-common";
+import {
+  validateStandardApi,
+  validateCustomApiFilter,
+} from "@test/helpers/api-common";
 import { ToastrService } from "ngx-toastr";
 import { SitesService } from "./sites.service";
-
 
 type Model = Site;
 type Params = [IdOr<Project>];
@@ -25,7 +31,6 @@ describe("SitesService", (): void => {
   const showUrl = "/projects/5/sites/10";
   let service: SitesService;
   let apiRoot: string;
-  let session: BawSessionService;
   let spec: SpectatorService<SitesService>;
   const createService = createServiceFactory({
     service: SitesService,
@@ -37,7 +42,6 @@ describe("SitesService", (): void => {
     spec = createService();
     service = spec.inject(SitesService);
     apiRoot = spec.inject(API_ROOT);
-    session = spec.inject(BawSessionService);
   });
 
   validateStandardApi<Model, Params, Service>(

--- a/src/app/services/baw-api/site/sites.service.spec.ts
+++ b/src/app/services/baw-api/site/sites.service.spec.ts
@@ -1,26 +1,19 @@
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { IdOr, setAuthorizationQSP, setTimezoneQSP } from "@baw-api/api-common";
+import { IdOr, setTimezoneQSP } from "@baw-api/api-common";
 import { BawApiService } from "@baw-api/baw-api.service";
 import { BawSessionService } from "@baw-api/baw-session.service";
 import { API_ROOT } from "@helpers/app-initializer/app-initializer";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
+import { SpectatorService, createServiceFactory, mockProvider } from "@ngneat/spectator";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
-import {
-  validateCustomApiFilter,
-  validateStandardApi,
-} from "@test/helpers/api-common";
-import { modelData } from "@test/helpers/faker";
+import { validateStandardApi, validateCustomApiFilter } from "@test/helpers/api-common";
 import { ToastrService } from "ngx-toastr";
 import { SitesService } from "./sites.service";
+
 
 type Model = Site;
 type Params = [IdOr<Project>];
@@ -72,26 +65,19 @@ describe("SitesService", (): void => {
   describe("downloadAnnotations", () => {
     const defaultTimezone = "UTC";
 
-    function setLoggedIn(authToken: string) {
-      spyOnProperty(session, "authToken").and.returnValue(authToken);
-    }
-
-    function getUrl(timezone: string = defaultTimezone, token?: string) {
+    function getUrl(timezone: string = defaultTimezone) {
       const url = new URL(`${apiRoot}${showUrl}/audio_events/download`);
       setTimezoneQSP(url, timezone);
-      setAuthorizationQSP(url, token);
       return url.toString();
     }
 
     it("should return url using model ids", () => {
-      setLoggedIn(null);
       expect(service.downloadAnnotations(10, 5, defaultTimezone)).toBe(
         getUrl()
       );
     });
 
     it("should return url using model objects", () => {
-      setLoggedIn(null);
       expect(
         service.downloadAnnotations(
           new Site(generateSite({ id: 10 })),
@@ -101,16 +87,7 @@ describe("SitesService", (): void => {
       ).toBe(getUrl());
     });
 
-    it("should return url with auth token appended", () => {
-      const authToken = modelData.authToken();
-      setLoggedIn(authToken);
-      expect(service.downloadAnnotations(10, 5, defaultTimezone)).toBe(
-        getUrl(defaultTimezone, authToken)
-      );
-    });
-
     it("should return url with timezone", () => {
-      setLoggedIn(null);
       expect(service.downloadAnnotations(10, 5, "Brisbane")).toBe(
         getUrl("Brisbane")
       );

--- a/src/app/services/baw-api/site/sites.service.ts
+++ b/src/app/services/baw-api/site/sites.service.ts
@@ -15,7 +15,6 @@ import {
   IdParamOptional,
   option,
   param,
-  setAuthorizationQSP,
   setTimezoneQSP,
   StandardApi,
 } from "../api-common";
@@ -106,7 +105,6 @@ export class SitesService implements StandardApi<Site, [IdOr<Project>]> {
       this.api.getPath(annotationsEndpoint(project, model, emptyParam))
     );
     setTimezoneQSP(url, selectedTimezone);
-    setAuthorizationQSP(url, this.session.authToken);
     return url.toString();
   }
 


### PR DESCRIPTION
# Bug in unused forms

Bug fixes to some of the minor forms

## Changes

- Download Annotations route no longer accepting user_token. Removed in favour of using site cookie
- Data Request/Contact Us forms not submitting some data (default values for inputs were overriding user inputs)
- Fixed visual bug with timezone selector in annotation download modal

## Issues

Closes #1808

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
