### PR TITLE
Action Menu Cleanup

### DIFF
--- a/src/app/components/admin/analysis-jobs/details/details.component.ts
+++ b/src/app/components/admin/analysis-jobs/details/details.component.ts
@@ -5,7 +5,6 @@ import {
   hasResolvedSuccessfully,
   retrieveResolvers,
 } from "@baw-api/resolver-common";
-import { adminAnalysisJobsMenuItem } from "@components/admin/admin.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { IPageInfo } from "@helpers/page/pageInfo";
 import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
@@ -62,7 +61,7 @@ AdminAnalysisJobComponent.linkToRoute({
   category: adminAnalysisJobsCategory,
   pageRoute: adminAnalysisJobMenuItem,
   menus: {
-    actions: List([adminAnalysisJobsMenuItem, adminAnalysisJobMenuItem]),
+    actions: List([adminAnalysisJobMenuItem]),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: { [analysisJobKey]: analysisJobResolvers.show },

--- a/src/app/components/admin/analysis-jobs/details/details.component.ts
+++ b/src/app/components/admin/analysis-jobs/details/details.component.ts
@@ -8,8 +8,7 @@ import {
 import { PageComponent } from "@helpers/page/pageComponent";
 import { IPageInfo } from "@helpers/page/pageInfo";
 import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { AnalysisJob } from "@models/AnalysisJob";
 import { List } from "immutable";
 import schema from "../analysis-job.schema.json";
@@ -62,7 +61,7 @@ AdminAnalysisJobComponent.linkToRoute({
   pageRoute: adminAnalysisJobMenuItem,
   menus: {
     actions: List([adminAnalysisJobMenuItem]),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: { [analysisJobKey]: analysisJobResolvers.show },
 });

--- a/src/app/components/admin/analysis-jobs/list/list.component.ts
+++ b/src/app/components/admin/analysis-jobs/list/list.component.ts
@@ -1,9 +1,6 @@
 import { Component, OnInit } from "@angular/core";
 import { AnalysisJobsService } from "@baw-api/analysis/analysis-jobs.service";
-import {
-  adminAnalysisJobsMenuItem,
-  adminDashboardMenuItem,
-} from "@components/admin/admin.menus";
+import { adminAnalysisJobsMenuItem } from "@components/admin/admin.menus";
 import { adminMenuItemActions } from "@components/admin/dashboard/dashboard.component";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
 import { Id, Param } from "@interfaces/apiInterfaces";
@@ -56,7 +53,7 @@ class AdminAnalysisJobsComponent
 AdminAnalysisJobsComponent.linkToRoute({
   category: adminAnalysisJobsCategory,
   pageRoute: adminAnalysisJobsMenuItem,
-  menus: { actions: List([adminDashboardMenuItem, ...adminMenuItemActions]) },
+  menus: { actions: List(adminMenuItemActions) },
 });
 
 export { AdminAnalysisJobsComponent };

--- a/src/app/components/admin/audio-recordings/details/details.component.ts
+++ b/src/app/components/admin/audio-recordings/details/details.component.ts
@@ -16,7 +16,6 @@ import { List } from "immutable";
 import {
   adminAudioRecordingMenuItem,
   adminAudioRecordingsCategory,
-  adminAudioRecordingsMenuItem,
 } from "../audio-recordings.menus";
 
 const audioRecordingKey = "audioRecording";
@@ -62,7 +61,7 @@ AdminAudioRecordingComponent.linkToRoute({
   category: adminAudioRecordingsCategory,
   pageRoute: adminAudioRecordingMenuItem,
   menus: {
-    actions: List([adminAudioRecordingsMenuItem, adminAudioRecordingMenuItem]),
+    actions: List([adminAudioRecordingMenuItem]),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: { [audioRecordingKey]: audioRecordingResolvers.show },

--- a/src/app/components/admin/audio-recordings/details/details.component.ts
+++ b/src/app/components/admin/audio-recordings/details/details.component.ts
@@ -9,8 +9,7 @@ import schema from "@components/audio-recordings/pages/details/audio-recording.s
 import { PageComponent } from "@helpers/page/pageComponent";
 import { IPageInfo } from "@helpers/page/pageInfo";
 import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { AudioRecording } from "@models/AudioRecording";
 import { List } from "immutable";
 import {
@@ -62,7 +61,7 @@ AdminAudioRecordingComponent.linkToRoute({
   pageRoute: adminAudioRecordingMenuItem,
   menus: {
     actions: List([adminAudioRecordingMenuItem]),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: { [audioRecordingKey]: audioRecordingResolvers.show },
 });

--- a/src/app/components/admin/audio-recordings/list/list.component.ts
+++ b/src/app/components/admin/audio-recordings/list/list.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from "@angular/core";
 import { AudioRecordingsService } from "@baw-api/audio-recording/audio-recordings.service";
-import { adminDashboardMenuItem } from "@components/admin/admin.menus";
 import { adminMenuItemActions } from "@components/admin/dashboard/dashboard.component";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
 import { Id, toRelative } from "@interfaces/apiInterfaces";
@@ -57,7 +56,7 @@ class AdminAudioRecordingsComponent
 AdminAudioRecordingsComponent.linkToRoute({
   category: adminAudioRecordingsCategory,
   pageRoute: adminAudioRecordingsMenuItem,
-  menus: { actions: List([adminDashboardMenuItem, ...adminMenuItemActions]) },
+  menus: { actions: List(adminMenuItemActions) },
 });
 
 export { AdminAudioRecordingsComponent };

--- a/src/app/components/admin/orphan/details/details.component.ts
+++ b/src/app/components/admin/orphan/details/details.component.ts
@@ -10,8 +10,7 @@ import extendedSchema from "@components/sites/site.extended.json";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { IPageInfo } from "@helpers/page/pageInfo";
 import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { Site } from "@models/Site";
 import { List } from "immutable";
 import { adminOrphanMenuItem, adminOrphansCategory } from "../orphans.menus";
@@ -56,7 +55,7 @@ AdminOrphanComponent.linkToRoute({
   pageRoute: adminOrphanMenuItem,
   menus: {
     actions: List([adminOrphanMenuItem]),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: { [siteKey]: shallowSiteResolvers.show },
 });

--- a/src/app/components/admin/orphan/details/details.component.ts
+++ b/src/app/components/admin/orphan/details/details.component.ts
@@ -14,11 +14,7 @@ import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
 import { WidgetMenuItem } from "@menu/widgetItem";
 import { Site } from "@models/Site";
 import { List } from "immutable";
-import {
-  adminOrphanMenuItem,
-  adminOrphansCategory,
-  adminOrphansMenuItem,
-} from "../orphans.menus";
+import { adminOrphanMenuItem, adminOrphansCategory } from "../orphans.menus";
 
 const siteKey = "site";
 
@@ -59,7 +55,7 @@ AdminOrphanComponent.linkToRoute({
   category: adminOrphansCategory,
   pageRoute: adminOrphanMenuItem,
   menus: {
-    actions: List([adminOrphansMenuItem, adminOrphanMenuItem]),
+    actions: List([adminOrphanMenuItem]),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: { [siteKey]: shallowSiteResolvers.show },

--- a/src/app/components/admin/orphan/list/list.component.ts
+++ b/src/app/components/admin/orphan/list/list.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from "@angular/core";
 import { Filters } from "@baw-api/baw-api.service";
 import { ShallowSitesService } from "@baw-api/site/sites.service";
-import { adminDashboardMenuItem } from "@components/admin/admin.menus";
 import { adminMenuItemActions } from "@components/admin/dashboard/dashboard.component";
 import { assignSiteMenuItem } from "@components/projects/projects.menus";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
@@ -46,9 +45,7 @@ class AdminOrphansComponent
 AdminOrphansComponent.linkToRoute({
   category: adminOrphansCategory,
   pageRoute: adminOrphansMenuItem,
-  menus: {
-    actions: List([adminDashboardMenuItem, ...adminMenuItemActions]),
-  },
+  menus: { actions: List(adminMenuItemActions) },
 });
 
 export { AdminOrphansComponent };

--- a/src/app/components/admin/scripts/details/details.component.ts
+++ b/src/app/components/admin/scripts/details/details.component.ts
@@ -18,7 +18,6 @@ import {
   adminEditScriptMenuItem,
   adminScriptMenuItem,
   adminScriptsCategory,
-  adminScriptsMenuItem,
 } from "../scripts.menus";
 
 export const adminScriptActions = [adminEditScriptMenuItem];
@@ -61,7 +60,7 @@ AdminScriptComponent.linkToRoute({
   category: adminScriptsCategory,
   pageRoute: adminScriptMenuItem,
   menus: {
-    actions: List([adminScriptsMenuItem, ...adminScriptActions]),
+    actions: List(adminScriptActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: { [scriptKey]: scriptResolvers.show },

--- a/src/app/components/admin/scripts/details/details.component.ts
+++ b/src/app/components/admin/scripts/details/details.component.ts
@@ -8,8 +8,7 @@ import { scriptResolvers } from "@baw-api/script/scripts.service";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { IPageInfo } from "@helpers/page/pageInfo";
 import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { Script } from "@models/Script";
 import { List } from "immutable";
 import baseSchema from "../script.base.schema.json";
@@ -61,7 +60,7 @@ AdminScriptComponent.linkToRoute({
   pageRoute: adminScriptMenuItem,
   menus: {
     actions: List(adminScriptActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: { [scriptKey]: scriptResolvers.show },
 });

--- a/src/app/components/admin/scripts/edit/edit.component.ts
+++ b/src/app/components/admin/scripts/edit/edit.component.ts
@@ -15,7 +15,6 @@ import { adminScriptActions } from "../details/details.component";
 import schema from "../script.base.schema.json";
 import {
   adminEditScriptMenuItem,
-  adminScriptMenuItem,
   adminScriptsCategory,
 } from "../scripts.menus";
 
@@ -68,7 +67,7 @@ class AdminScriptsEditComponent extends FormTemplate<Script> implements OnInit {
 AdminScriptsEditComponent.linkToRoute({
   category: adminScriptsCategory,
   pageRoute: adminEditScriptMenuItem,
-  menus: { actions: List([adminScriptMenuItem, ...adminScriptActions]) },
+  menus: { actions: List(adminScriptActions) },
   resolvers: { [scriptKey]: scriptResolvers.show },
 });
 

--- a/src/app/components/admin/scripts/list/list.component.ts
+++ b/src/app/components/admin/scripts/list/list.component.ts
@@ -1,6 +1,5 @@
 import { Component } from "@angular/core";
 import { ScriptsService } from "@baw-api/script/scripts.service";
-import { adminDashboardMenuItem } from "@components/admin/admin.menus";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
 import { Id } from "@interfaces/apiInterfaces";
 import { Script } from "@models/Script";
@@ -51,9 +50,7 @@ class AdminScriptsComponent extends PagedTableTemplate<TableRow, Script> {
 AdminScriptsComponent.linkToRoute({
   category: adminScriptsCategory,
   pageRoute: adminScriptsMenuItem,
-  menus: {
-    actions: List([adminDashboardMenuItem, ...adminScriptsMenuItemActions]),
-  },
+  menus: { actions: List(adminScriptsMenuItemActions) },
 });
 
 export { AdminScriptsComponent };

--- a/src/app/components/admin/scripts/new/new.component.ts
+++ b/src/app/components/admin/scripts/new/new.component.ts
@@ -13,7 +13,6 @@ import schema from "../script.base.schema.json";
 import {
   adminNewScriptsMenuItem,
   adminScriptsCategory,
-  adminScriptsMenuItem,
 } from "../scripts.menus";
 
 /**
@@ -57,9 +56,7 @@ class AdminScriptsNewComponent extends FormTemplate<Script> {
 AdminScriptsNewComponent.linkToRoute({
   category: adminScriptsCategory,
   pageRoute: adminNewScriptsMenuItem,
-  menus: {
-    actions: List([adminScriptsMenuItem, ...adminScriptsMenuItemActions]),
-  },
+  menus: { actions: List(adminScriptsMenuItemActions) },
 });
 
 export { AdminScriptsNewComponent };

--- a/src/app/components/admin/tag-group/delete/delete.component.ts
+++ b/src/app/components/admin/tag-group/delete/delete.component.ts
@@ -72,9 +72,7 @@ class AdminTagGroupsDeleteComponent
 AdminTagGroupsDeleteComponent.linkToRoute({
   category: adminTagGroupsCategory,
   pageRoute: adminDeleteTagGroupMenuItem,
-  menus: {
-    actions: List([adminTagGroupsMenuItem, ...adminTagGroupMenuItemActions]),
-  },
+  menus: { actions: List(adminTagGroupMenuItemActions) },
   resolvers: { [tagGroupKey]: tagGroupResolvers.show },
 });
 

--- a/src/app/components/admin/tag-group/edit/edit.component.ts
+++ b/src/app/components/admin/tag-group/edit/edit.component.ts
@@ -17,7 +17,6 @@ import { adminTagGroupMenuItemActions } from "../list/list.component";
 import {
   adminEditTagGroupMenuItem,
   adminTagGroupsCategory,
-  adminTagGroupsMenuItem,
 } from "../tag-group.menus";
 import schema from "../tag-group.schema.json";
 
@@ -75,7 +74,7 @@ AdminTagGroupsEditComponent.linkToRoute({
   category: adminTagGroupsCategory,
   pageRoute: adminEditTagGroupMenuItem,
   menus: {
-    actions: List([adminTagGroupsMenuItem, ...adminTagGroupMenuItemActions]),
+    actions: List(adminTagGroupMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: { [tagGroupKey]: tagGroupResolvers.show },

--- a/src/app/components/admin/tag-group/edit/edit.component.ts
+++ b/src/app/components/admin/tag-group/edit/edit.component.ts
@@ -8,8 +8,7 @@ import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { TagGroup } from "@models/TagGroup";
 import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
@@ -75,7 +74,7 @@ AdminTagGroupsEditComponent.linkToRoute({
   pageRoute: adminEditTagGroupMenuItem,
   menus: {
     actions: List(adminTagGroupMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: { [tagGroupKey]: tagGroupResolvers.show },
 });

--- a/src/app/components/admin/tag-group/list/list.component.ts
+++ b/src/app/components/admin/tag-group/list/list.component.ts
@@ -1,6 +1,5 @@
 import { Component } from "@angular/core";
 import { TagGroupsService } from "@baw-api/tag/tag-group.service";
-import { adminDashboardMenuItem } from "@components/admin/admin.menus";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
 import { Id } from "@interfaces/apiInterfaces";
 import { TagGroup } from "@models/TagGroup";
@@ -46,9 +45,7 @@ class AdminTagGroupsComponent extends PagedTableTemplate<TableRow, TagGroup> {
 AdminTagGroupsComponent.linkToRoute({
   category: adminTagGroupsCategory,
   pageRoute: adminTagGroupsMenuItem,
-  menus: {
-    actions: List([adminDashboardMenuItem, ...adminTagGroupsMenuItemActions]),
-  },
+  menus: { actions: List(adminTagGroupsMenuItemActions) },
 });
 
 export { AdminTagGroupsComponent };

--- a/src/app/components/admin/tag-group/new/new.component.ts
+++ b/src/app/components/admin/tag-group/new/new.component.ts
@@ -12,7 +12,6 @@ import { adminTagGroupsMenuItemActions } from "../list/list.component";
 import {
   adminNewTagGroupMenuItem,
   adminTagGroupsCategory,
-  adminTagGroupsMenuItem,
 } from "../tag-group.menus";
 import schema from "../tag-group.schema.json";
 
@@ -54,9 +53,7 @@ class AdminTagGroupsNewComponent extends FormTemplate<TagGroup> {
 AdminTagGroupsNewComponent.linkToRoute({
   category: adminTagGroupsCategory,
   pageRoute: adminNewTagGroupMenuItem,
-  menus: {
-    actions: List([adminTagGroupsMenuItem, ...adminTagGroupsMenuItemActions]),
-  },
+  menus: { actions: List(adminTagGroupsMenuItemActions) },
 });
 
 export { AdminTagGroupsNewComponent };

--- a/src/app/components/admin/tags/delete/delete.component.ts
+++ b/src/app/components/admin/tags/delete/delete.component.ts
@@ -68,7 +68,6 @@ AdminTagsDeleteComponent.linkToRoute({
   pageRoute: adminDeleteTagMenuItem,
   menus: {
     actions: List([
-      adminTagsMenuItem,
       ...adminTagsMenuItemActions,
       adminEditTagMenuItem,
       adminDeleteTagMenuItem,

--- a/src/app/components/admin/tags/edit/edit.component.ts
+++ b/src/app/components/admin/tags/edit/edit.component.ts
@@ -16,7 +16,6 @@ import {
   adminDeleteTagMenuItem,
   adminEditTagMenuItem,
   adminTagsCategory,
-  adminTagsMenuItem,
 } from "../tags.menus";
 
 const tagKey = "tag";
@@ -85,7 +84,6 @@ AdminTagsEditComponent.linkToRoute({
   pageRoute: adminEditTagMenuItem,
   menus: {
     actions: List([
-      adminTagsMenuItem,
       ...adminTagsMenuItemActions,
       adminEditTagMenuItem,
       adminDeleteTagMenuItem,

--- a/src/app/components/admin/tags/edit/edit.component.ts
+++ b/src/app/components/admin/tags/edit/edit.component.ts
@@ -5,8 +5,7 @@ import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { Tag, TagType } from "@models/Tag";
 import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
@@ -88,7 +87,7 @@ AdminTagsEditComponent.linkToRoute({
       adminEditTagMenuItem,
       adminDeleteTagMenuItem,
     ]),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: {
     [tagKey]: tagResolvers.show,

--- a/src/app/components/admin/tags/list/list.component.ts
+++ b/src/app/components/admin/tags/list/list.component.ts
@@ -1,6 +1,5 @@
 import { Component } from "@angular/core";
 import { TagsService } from "@baw-api/tag/tags.service";
-import { adminDashboardMenuItem } from "@components/admin/admin.menus";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
 import { Tag } from "@models/Tag";
 import { List } from "immutable";
@@ -53,9 +52,7 @@ class AdminTagsComponent extends PagedTableTemplate<TableRow, Tag> {
 AdminTagsComponent.linkToRoute({
   category: adminTagsCategory,
   pageRoute: adminTagsMenuItem,
-  menus: {
-    actions: List([adminDashboardMenuItem, ...adminTagsMenuItemActions]),
-  },
+  menus: { actions: List(adminTagsMenuItemActions) },
 });
 
 export { AdminTagsComponent };

--- a/src/app/components/admin/tags/new/new.component.ts
+++ b/src/app/components/admin/tags/new/new.component.ts
@@ -10,11 +10,7 @@ import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
 import { adminTagsMenuItemActions } from "../list/list.component";
 import schema from "../tag.schema.json";
-import {
-  adminNewTagMenuItem,
-  adminTagsCategory,
-  adminTagsMenuItem,
-} from "../tags.menus";
+import { adminNewTagMenuItem, adminTagsCategory } from "../tags.menus";
 
 const typeOfTagsKey = "typeOfTags";
 
@@ -75,9 +71,7 @@ class AdminTagsNewComponent extends FormTemplate<Tag> implements OnInit {
 AdminTagsNewComponent.linkToRoute({
   category: adminTagsCategory,
   pageRoute: adminNewTagMenuItem,
-  menus: {
-    actions: List([adminTagsMenuItem, ...adminTagsMenuItemActions]),
-  },
+  menus: { actions: List(adminTagsMenuItemActions) },
   resolvers: { [typeOfTagsKey]: tagResolvers.tagTypes },
 });
 

--- a/src/app/components/admin/users/user.component.ts
+++ b/src/app/components/admin/users/user.component.ts
@@ -2,7 +2,6 @@ import { Component } from "@angular/core";
 import { AccountsService } from "@baw-api/account/accounts.service";
 import {
   adminCategory,
-  adminDashboardMenuItem,
   adminUserListMenuItem,
 } from "@components/admin/admin.menus";
 import { adminMenuItemActions } from "@components/admin/dashboard/dashboard.component";
@@ -46,7 +45,7 @@ class AdminUserListComponent extends PagedTableTemplate<TableRow, User> {
 AdminUserListComponent.linkToRoute({
   category: adminCategory,
   pageRoute: adminUserListMenuItem,
-  menus: { actions: List([adminDashboardMenuItem, ...adminMenuItemActions]) },
+  menus: { actions: List(adminMenuItemActions) },
 });
 
 export { AdminUserListComponent };

--- a/src/app/components/audio-analysis/pages/details/details.component.ts
+++ b/src/app/components/audio-analysis/pages/details/details.component.ts
@@ -9,8 +9,7 @@ import {
   retryFailedItemsMenuItem,
 } from "@components/audio-analysis/audio-analysis.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { List } from "immutable";
 
 const audioAnalysisKey = "audioAnalysis";
@@ -32,7 +31,7 @@ AudioAnalysisComponent.linkToRoute({
       pauseProcessingMenuItem,
       deleteAudioAnalysisMenuItem,
     ]),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: { [audioAnalysisKey]: analysisJobResolvers.show },
 });

--- a/src/app/components/audio-analysis/pages/details/details.component.ts
+++ b/src/app/components/audio-analysis/pages/details/details.component.ts
@@ -1,7 +1,6 @@
 import { Component } from "@angular/core";
 import { analysisJobResolvers } from "@baw-api/analysis/analysis-jobs.service";
 import {
-  audioAnalysesMenuItem,
   audioAnalysisCategory,
   audioAnalysisMenuItem,
   audioAnalysisResultsMenuItem,
@@ -28,7 +27,6 @@ AudioAnalysisComponent.linkToRoute({
   pageRoute: audioAnalysisMenuItem,
   menus: {
     actions: List([
-      audioAnalysesMenuItem,
       audioAnalysisResultsMenuItem,
       retryFailedItemsMenuItem,
       pauseProcessingMenuItem,

--- a/src/app/components/audio-analysis/pages/results/results.component.ts
+++ b/src/app/components/audio-analysis/pages/results/results.component.ts
@@ -2,7 +2,6 @@ import { Component } from "@angular/core";
 import { analysisJobResolvers } from "@baw-api/analysis/analysis-jobs.service";
 import {
   audioAnalysisCategory,
-  audioAnalysisMenuItem,
   audioAnalysisResultsMenuItem,
   downloadAudioAnalysisResultsMenuItem,
 } from "@components/audio-analysis/audio-analysis.menus";
@@ -24,10 +23,7 @@ AudioAnalysisResultsComponent.linkToRoute({
   category: audioAnalysisCategory,
   pageRoute: audioAnalysisResultsMenuItem,
   menus: {
-    actions: List([
-      audioAnalysisMenuItem,
-      downloadAudioAnalysisResultsMenuItem,
-    ]),
+    actions: List([downloadAudioAnalysisResultsMenuItem]),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: { [audioAnalysisKey]: analysisJobResolvers.show },

--- a/src/app/components/audio-analysis/pages/results/results.component.ts
+++ b/src/app/components/audio-analysis/pages/results/results.component.ts
@@ -6,8 +6,7 @@ import {
   downloadAudioAnalysisResultsMenuItem,
 } from "@components/audio-analysis/audio-analysis.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { List } from "immutable";
 
 const audioAnalysisKey = "audioAnalysis";
@@ -24,7 +23,7 @@ AudioAnalysisResultsComponent.linkToRoute({
   pageRoute: audioAnalysisResultsMenuItem,
   menus: {
     actions: List([downloadAudioAnalysisResultsMenuItem]),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: { [audioAnalysisKey]: analysisJobResolvers.show },
 });

--- a/src/app/components/audio-recordings/pages/details/details.component.ts
+++ b/src/app/components/audio-recordings/pages/details/details.component.ts
@@ -14,7 +14,6 @@ import {
   audioRecordingsCategory,
   downloadAudioRecordingMenuItem,
 } from "@components/audio-recordings/audio-recording.menus";
-import { listenRecordingMenuItem } from "@components/listen/listen.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { IPageInfo } from "@helpers/page/pageInfo";
 import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
@@ -81,7 +80,7 @@ function getPageInfo(
     pageRoute: audioRecordingMenuItems.details[subRoute],
     category: audioRecordingsCategory,
     menus: {
-      actions: List([listenRecordingMenuItem, downloadAudioRecordingMenuItem]),
+      actions: List([downloadAudioRecordingMenuItem]),
       actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
     },
     resolvers: {

--- a/src/app/components/audio-recordings/pages/details/details.component.ts
+++ b/src/app/components/audio-recordings/pages/details/details.component.ts
@@ -16,8 +16,6 @@ import {
 } from "@components/audio-recordings/audio-recording.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { IPageInfo } from "@helpers/page/pageInfo";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
 import { AudioRecording } from "@models/AudioRecording";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
@@ -79,10 +77,7 @@ function getPageInfo(
   return {
     pageRoute: audioRecordingMenuItems.details[subRoute],
     category: audioRecordingsCategory,
-    menus: {
-      actions: List([downloadAudioRecordingMenuItem]),
-      actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
-    },
+    menus: { actions: List([downloadAudioRecordingMenuItem]) },
     resolvers: {
       [audioRecordingKey]: audioRecordingResolvers.show,
       [projectKey]: projectResolvers.showOptional,

--- a/src/app/components/profile/pages/annotations/my-annotations.component.ts
+++ b/src/app/components/profile/pages/annotations/my-annotations.component.ts
@@ -1,12 +1,11 @@
 import { Component } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { ShallowAudioEventsService } from "@baw-api/audio-event/audio-events.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Filters } from "@baw-api/baw-api.service";
+import { BawSessionService } from "@baw-api/baw-session.service";
 import { userResolvers } from "@baw-api/user/user.service";
 import {
   myAccountCategory,
-  myAccountMenuItem,
   myAnnotationsMenuItem,
 } from "@components/profile/profile.menus";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
@@ -56,7 +55,7 @@ class MyAnnotationsComponent extends PagedTableTemplate<TableRow, AudioEvent> {
 MyAnnotationsComponent.linkToRoute({
   category: myAccountCategory,
   pageRoute: myAnnotationsMenuItem,
-  menus: { actions: List([myAccountMenuItem, ...myAccountActions]) },
+  menus: { actions: List(myAccountActions) },
   resolvers: { [userKey]: userResolvers.show },
 });
 

--- a/src/app/components/profile/pages/annotations/their-annotations.component.ts
+++ b/src/app/components/profile/pages/annotations/their-annotations.component.ts
@@ -4,7 +4,6 @@ import { Filters } from "@baw-api/baw-api.service";
 import {
   theirAnnotationsMenuItem,
   theirProfileCategory,
-  theirProfileMenuItem,
 } from "@components/profile/profile.menus";
 import { IAudioEvent } from "@models/AudioEvent";
 import { User } from "@models/User";
@@ -31,7 +30,7 @@ class TheirAnnotationsComponent extends MyAnnotationsComponent {
 TheirAnnotationsComponent.linkToRoute({
   category: theirProfileCategory,
   pageRoute: theirAnnotationsMenuItem,
-  menus: { actions: List([theirProfileMenuItem, ...theirProfileActions]) },
+  menus: { actions: List(theirProfileActions) },
   resolvers: { [accountKey]: accountResolvers.show },
 });
 

--- a/src/app/components/profile/pages/bookmarks/my-bookmarks.component.ts
+++ b/src/app/components/profile/pages/bookmarks/my-bookmarks.component.ts
@@ -4,7 +4,6 @@ import { BookmarksService } from "@baw-api/bookmark/bookmarks.service";
 import { userResolvers } from "@baw-api/user/user.service";
 import {
   myAccountCategory,
-  myAccountMenuItem,
   myBookmarksMenuItem,
 } from "@components/profile/profile.menus";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
@@ -48,7 +47,7 @@ class MyBookmarksComponent extends PagedTableTemplate<TableRow, Bookmark> {
 MyBookmarksComponent.linkToRoute({
   category: myAccountCategory,
   pageRoute: myBookmarksMenuItem,
-  menus: { actions: List([myAccountMenuItem, ...myAccountActions]) },
+  menus: { actions: List(myAccountActions) },
   resolvers: { [userKey]: userResolvers.show },
 });
 

--- a/src/app/components/profile/pages/bookmarks/their-bookmarks.component.ts
+++ b/src/app/components/profile/pages/bookmarks/their-bookmarks.component.ts
@@ -6,7 +6,6 @@ import { BookmarksService } from "@baw-api/bookmark/bookmarks.service";
 import {
   theirBookmarksMenuItem,
   theirProfileCategory,
-  theirProfileMenuItem,
 } from "@components/profile/profile.menus";
 import { IBookmark } from "@models/Bookmark";
 import { User } from "@models/User";
@@ -40,7 +39,7 @@ class TheirBookmarksComponent extends MyBookmarksComponent {
 TheirBookmarksComponent.linkToRoute({
   category: theirProfileCategory,
   pageRoute: theirBookmarksMenuItem,
-  menus: { actions: List([theirProfileMenuItem, ...theirProfileActions]) },
+  menus: { actions: List(theirProfileActions) },
   resolvers: { [accountKey]: accountResolvers.show },
 });
 

--- a/src/app/components/profile/pages/my-delete/my-delete.component.ts
+++ b/src/app/components/profile/pages/my-delete/my-delete.component.ts
@@ -4,7 +4,6 @@ import { AccountsService } from "@baw-api/account/accounts.service";
 import { userResolvers } from "@baw-api/user/user.service";
 import {
   myAccountCategory,
-  myAccountMenuItem,
   myDeleteMenuItem,
 } from "@components/profile/profile.menus";
 import {
@@ -58,7 +57,7 @@ class MyDeleteComponent extends FormTemplate<User> {
 MyDeleteComponent.linkToRoute({
   category: myAccountCategory,
   pageRoute: myDeleteMenuItem,
-  menus: { actions: List([myAccountMenuItem, ...myAccountActions]) },
+  menus: { actions: List(myAccountActions) },
   resolvers: { [userKey]: userResolvers.show },
 });
 

--- a/src/app/components/profile/pages/my-edit/my-edit.component.ts
+++ b/src/app/components/profile/pages/my-edit/my-edit.component.ts
@@ -4,7 +4,6 @@ import { AccountsService } from "@baw-api/account/accounts.service";
 import { userResolvers } from "@baw-api/user/user.service";
 import {
   myAccountCategory,
-  myAccountMenuItem,
   myEditMenuItem,
 } from "@components/profile/profile.menus";
 import {
@@ -59,7 +58,7 @@ class MyEditComponent extends FormTemplate<User> {
 MyEditComponent.linkToRoute({
   category: myAccountCategory,
   pageRoute: myEditMenuItem,
-  menus: { actions: List([myAccountMenuItem, ...myAccountActions]) },
+  menus: { actions: List(myAccountActions) },
   resolvers: { [userKey]: userResolvers.show },
 });
 

--- a/src/app/components/profile/pages/my-password/my-password.component.ts
+++ b/src/app/components/profile/pages/my-password/my-password.component.ts
@@ -4,7 +4,6 @@ import { AccountsService } from "@baw-api/account/accounts.service";
 import { userResolvers } from "@baw-api/user/user.service";
 import {
   myAccountCategory,
-  myAccountMenuItem,
   myPasswordMenuItem,
 } from "@components/profile/profile.menus";
 import {
@@ -59,7 +58,7 @@ class MyPasswordComponent extends FormTemplate<User> {
 MyPasswordComponent.linkToRoute({
   category: myAccountCategory,
   pageRoute: myPasswordMenuItem,
-  menus: { actions: List([myAccountMenuItem, ...myAccountActions]) },
+  menus: { actions: List(myAccountActions) },
   resolvers: { [userKey]: userResolvers.show },
 });
 

--- a/src/app/components/profile/pages/projects/my-projects.component.ts
+++ b/src/app/components/profile/pages/projects/my-projects.component.ts
@@ -4,7 +4,6 @@ import { ProjectsService } from "@baw-api/project/projects.service";
 import { userResolvers } from "@baw-api/user/user.service";
 import {
   myAccountCategory,
-  myAccountMenuItem,
   myProjectsMenuItem,
 } from "@components/profile/profile.menus";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
@@ -49,7 +48,7 @@ class MyProjectsComponent extends PagedTableTemplate<TableRow, Project> {
 MyProjectsComponent.linkToRoute({
   category: myAccountCategory,
   pageRoute: myProjectsMenuItem,
-  menus: { actions: List([myAccountMenuItem, ...myAccountActions]) },
+  menus: { actions: List(myAccountActions) },
   resolvers: { [userKey]: userResolvers.show },
 });
 

--- a/src/app/components/profile/pages/projects/their-projects.component.ts
+++ b/src/app/components/profile/pages/projects/their-projects.component.ts
@@ -5,7 +5,6 @@ import { Filters } from "@baw-api/baw-api.service";
 import { ProjectsService } from "@baw-api/project/projects.service";
 import {
   theirProfileCategory,
-  theirProfileMenuItem,
   theirProjectsMenuItem,
 } from "@components/profile/profile.menus";
 import { User } from "@models/User";
@@ -40,7 +39,7 @@ class TheirProjectsComponent extends MyProjectsComponent {
 TheirProjectsComponent.linkToRoute({
   category: theirProfileCategory,
   pageRoute: theirProjectsMenuItem,
-  menus: { actions: List([theirProfileMenuItem, ...theirProfileActions]) },
+  menus: { actions: List(theirProfileActions) },
   resolvers: { [accountKey]: accountResolvers.show },
 });
 

--- a/src/app/components/profile/pages/sites/my-sites.component.ts
+++ b/src/app/components/profile/pages/sites/my-sites.component.ts
@@ -5,7 +5,6 @@ import { userResolvers } from "@baw-api/user/user.service";
 import { dataRequestMenuItem } from "@components/data-request/data-request.menus";
 import {
   myAccountCategory,
-  myAccountMenuItem,
   mySitesMenuItem,
 } from "@components/profile/profile.menus";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
@@ -77,7 +76,7 @@ class MySitesComponent extends PagedTableTemplate<TableRow, Site> {
 MySitesComponent.linkToRoute({
   category: myAccountCategory,
   pageRoute: mySitesMenuItem,
-  menus: { actions: List([myAccountMenuItem, ...myAccountActions]) },
+  menus: { actions: List(myAccountActions) },
   resolvers: { [userKey]: userResolvers.show },
 });
 

--- a/src/app/components/profile/pages/sites/their-sites.component.ts
+++ b/src/app/components/profile/pages/sites/their-sites.component.ts
@@ -3,7 +3,6 @@ import { accountResolvers } from "@baw-api/account/accounts.service";
 import { Filters } from "@baw-api/baw-api.service";
 import {
   theirProfileCategory,
-  theirProfileMenuItem,
   theirSitesMenuItem,
 } from "@components/profile/profile.menus";
 import { User } from "@models/User";
@@ -33,7 +32,7 @@ class TheirSitesComponent extends MySitesComponent {
 TheirSitesComponent.linkToRoute({
   category: theirProfileCategory,
   pageRoute: theirSitesMenuItem,
-  menus: { actions: List([theirProfileMenuItem, ...theirProfileActions]) },
+  menus: { actions: List(theirProfileActions) },
   resolvers: { [accountKey]: accountResolvers.show },
 });
 

--- a/src/app/components/profile/pages/their-edit/their-edit.component.ts
+++ b/src/app/components/profile/pages/their-edit/their-edit.component.ts
@@ -7,7 +7,6 @@ import {
 import {
   theirEditMenuItem,
   theirProfileCategory,
-  theirProfileMenuItem,
 } from "@components/profile/profile.menus";
 import {
   defaultSuccessMsg,
@@ -79,7 +78,7 @@ class TheirEditComponent extends FormTemplate<User> implements OnInit {
 TheirEditComponent.linkToRoute({
   category: theirProfileCategory,
   pageRoute: theirEditMenuItem,
-  menus: { actions: List([theirProfileMenuItem, ...theirProfileActions]) },
+  menus: { actions: List(theirProfileActions) },
   resolvers: { [accountKey]: accountResolvers.show },
 });
 

--- a/src/app/components/projects/pages/assign/assign.component.ts
+++ b/src/app/components/projects/pages/assign/assign.component.ts
@@ -5,7 +5,6 @@ import { ShallowSitesService } from "@baw-api/site/sites.service";
 import {
   assignSiteMenuItem,
   projectCategory,
-  projectMenuItem,
 } from "@components/projects/projects.menus";
 import { BawApiError } from "@helpers/custom-errors/baw-api-error";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
@@ -157,7 +156,7 @@ AssignComponent.linkToRoute({
   category: projectCategory,
   pageRoute: assignSiteMenuItem,
   menus: {
-    actions: List([projectMenuItem, ...projectMenuItemActions]),
+    actions: List(projectMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: { [projectKey]: projectResolvers.show },

--- a/src/app/components/projects/pages/assign/assign.component.ts
+++ b/src/app/components/projects/pages/assign/assign.component.ts
@@ -9,8 +9,7 @@ import {
 import { BawApiError } from "@helpers/custom-errors/baw-api-error";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
 import { Id } from "@interfaces/apiInterfaces";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { Project } from "@models/Project";
 import { Site } from "@models/Site";
 import { List } from "immutable";
@@ -157,7 +156,7 @@ AssignComponent.linkToRoute({
   pageRoute: assignSiteMenuItem,
   menus: {
     actions: List(projectMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: { [projectKey]: projectResolvers.show },
 });

--- a/src/app/components/projects/pages/delete/delete.component.ts
+++ b/src/app/components/projects/pages/delete/delete.component.ts
@@ -13,8 +13,7 @@ import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { Project } from "@models/Project";
 import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
@@ -75,7 +74,7 @@ DeleteComponent.linkToRoute({
   pageRoute: deleteProjectMenuItem,
   menus: {
     actions: List(projectMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: { [projectKey]: projectResolvers.show },
 });

--- a/src/app/components/projects/pages/delete/delete.component.ts
+++ b/src/app/components/projects/pages/delete/delete.component.ts
@@ -7,7 +7,6 @@ import {
 import {
   deleteProjectMenuItem,
   projectCategory,
-  projectMenuItem,
   projectsMenuItem,
 } from "@components/projects/projects.menus";
 import {
@@ -75,7 +74,7 @@ DeleteComponent.linkToRoute({
   category: projectCategory,
   pageRoute: deleteProjectMenuItem,
   menus: {
-    actions: List([projectMenuItem, ...projectMenuItemActions]),
+    actions: List(projectMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: { [projectKey]: projectResolvers.show },

--- a/src/app/components/projects/pages/details/details.component.ts
+++ b/src/app/components/projects/pages/details/details.component.ts
@@ -21,8 +21,7 @@ import { newSiteMenuItem } from "@components/sites/sites.menus";
 import { visualizeMenuItem } from "@components/visualize/visualize.menus";
 import { IPageInfo } from "@helpers/page/pageInfo";
 import { PaginationTemplate } from "@helpers/paginationTemplate/paginationTemplate";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
@@ -203,7 +202,7 @@ DetailsComponent.linkToRoute({
   pageRoute: projectMenuItem,
   menus: {
     actions: List(projectMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: { [projectKey]: projectResolvers.show },
 });

--- a/src/app/components/projects/pages/details/details.component.ts
+++ b/src/app/components/projects/pages/details/details.component.ts
@@ -16,7 +16,6 @@ import {
   editProjectPermissionsMenuItem,
   projectCategory,
   projectMenuItem,
-  projectsMenuItem,
 } from "@components/projects/projects.menus";
 import { newSiteMenuItem } from "@components/sites/sites.menus";
 import { visualizeMenuItem } from "@components/visualize/visualize.menus";
@@ -203,7 +202,7 @@ DetailsComponent.linkToRoute({
   category: projectCategory,
   pageRoute: projectMenuItem,
   menus: {
-    actions: List([projectsMenuItem, ...projectMenuItemActions]),
+    actions: List(projectMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: { [projectKey]: projectResolvers.show },

--- a/src/app/components/projects/pages/edit/edit.component.ts
+++ b/src/app/components/projects/pages/edit/edit.component.ts
@@ -12,8 +12,7 @@ import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { Project } from "@models/Project";
 import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
@@ -71,7 +70,7 @@ EditComponent.linkToRoute({
   pageRoute: editProjectMenuItem,
   menus: {
     actions: List(projectMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: { [projectKey]: projectResolvers.show },
 });

--- a/src/app/components/projects/pages/edit/edit.component.ts
+++ b/src/app/components/projects/pages/edit/edit.component.ts
@@ -7,7 +7,6 @@ import {
 import {
   editProjectMenuItem,
   projectCategory,
-  projectMenuItem,
 } from "@components/projects/projects.menus";
 import {
   defaultSuccessMsg,
@@ -71,7 +70,7 @@ EditComponent.linkToRoute({
   category: projectCategory,
   pageRoute: editProjectMenuItem,
   menus: {
-    actions: List([projectMenuItem, ...projectMenuItemActions]),
+    actions: List(projectMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: { [projectKey]: projectResolvers.show },

--- a/src/app/components/projects/pages/harvest/harvest.component.ts
+++ b/src/app/components/projects/pages/harvest/harvest.component.ts
@@ -10,11 +10,7 @@ import filesize from "filesize";
 import { List } from "immutable";
 import { Observable, Subscription, timer } from "rxjs";
 import { map, startWith, takeUntil, takeWhile } from "rxjs/operators";
-import {
-  harvestProjectMenuItem,
-  projectCategory,
-  projectMenuItem,
-} from "../../projects.menus";
+import { harvestProjectMenuItem, projectCategory } from "../../projects.menus";
 import { projectMenuItemActions } from "../details/details.component";
 
 const projectKey = "project";
@@ -150,7 +146,7 @@ HarvestComponent.linkToRoute({
   category: projectCategory,
   pageRoute: harvestProjectMenuItem,
   menus: {
-    actions: List([projectMenuItem, ...projectMenuItemActions]),
+    actions: List(projectMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: { [projectKey]: projectResolvers.show },

--- a/src/app/components/projects/pages/harvest/harvest.component.ts
+++ b/src/app/components/projects/pages/harvest/harvest.component.ts
@@ -2,8 +2,7 @@ import { Component, OnInit, ViewEncapsulation } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { PageComponent } from "@helpers/page/pageComponent";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { Project } from "@models/Project";
 import { ResolvedModel } from "@services/baw-api/resolver-common";
 import filesize from "filesize";
@@ -147,7 +146,7 @@ HarvestComponent.linkToRoute({
   pageRoute: harvestProjectMenuItem,
   menus: {
     actions: List(projectMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: { [projectKey]: projectResolvers.show },
 });

--- a/src/app/components/projects/pages/new/new.component.ts
+++ b/src/app/components/projects/pages/new/new.component.ts
@@ -4,7 +4,6 @@ import { ProjectsService } from "@baw-api/project/projects.service";
 import {
   newProjectMenuItem,
   projectsCategory,
-  projectsMenuItem,
 } from "@components/projects/projects.menus";
 import {
   defaultSuccessMsg,
@@ -53,7 +52,7 @@ class NewComponent extends FormTemplate<Project> {
 NewComponent.linkToRoute({
   category: projectsCategory,
   pageRoute: newProjectMenuItem,
-  menus: { actions: List([projectsMenuItem, ...projectsMenuItemActions]) },
+  menus: { actions: List(projectsMenuItemActions) },
 });
 
 export { NewComponent };

--- a/src/app/components/projects/pages/permissions/permissions.component.ts
+++ b/src/app/components/projects/pages/permissions/permissions.component.ts
@@ -9,8 +9,7 @@ import {
 } from "@components/projects/projects.menus";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { TableTemplate } from "@helpers/tableTemplate/tableTemplate";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { Project } from "@models/Project";
 import { User } from "@models/User";
 import { ISelectableItem } from "@shared/items/selectable-items/selectable-items.component";
@@ -112,7 +111,7 @@ PermissionsComponent.linkToRoute({
   pageRoute: editProjectPermissionsMenuItem,
   menus: {
     actions: List(projectMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: { [projectKey]: projectResolvers.show },
 });

--- a/src/app/components/projects/pages/permissions/permissions.component.ts
+++ b/src/app/components/projects/pages/permissions/permissions.component.ts
@@ -6,7 +6,6 @@ import { theirProfileMenuItem } from "@components/profile/profile.menus";
 import {
   editProjectPermissionsMenuItem,
   projectCategory,
-  projectMenuItem,
 } from "@components/projects/projects.menus";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { TableTemplate } from "@helpers/tableTemplate/tableTemplate";
@@ -112,7 +111,7 @@ PermissionsComponent.linkToRoute({
   category: projectCategory,
   pageRoute: editProjectPermissionsMenuItem,
   menus: {
-    actions: List([projectMenuItem, ...projectMenuItemActions]),
+    actions: List(projectMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: { [projectKey]: projectResolvers.show },

--- a/src/app/components/projects/pages/request/request.component.ts
+++ b/src/app/components/projects/pages/request/request.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from "@angular/core";
 import { ProjectsService } from "@baw-api/project/projects.service";
 import {
   projectsCategory,
-  projectsMenuItem,
   requestProjectMenuItem,
 } from "@components/projects/projects.menus";
 import { withFormCheck } from "@guards/form/form.guard";
@@ -79,7 +78,7 @@ class RequestComponent extends withFormCheck(PageComponent) implements OnInit {
 RequestComponent.linkToRoute({
   category: projectsCategory,
   pageRoute: requestProjectMenuItem,
-  menus: { actions: List([projectsMenuItem, ...projectsMenuItemActions]) },
+  menus: { actions: List(projectsMenuItemActions) },
 });
 
 export { RequestComponent };

--- a/src/app/components/regions/pages/delete/delete.component.ts
+++ b/src/app/components/regions/pages/delete/delete.component.ts
@@ -7,7 +7,6 @@ import {
 } from "@baw-api/region/regions.service";
 import {
   deleteRegionMenuItem,
-  regionMenuItem,
   regionsCategory,
 } from "@components/regions/regions.menus";
 import {
@@ -80,7 +79,7 @@ DeleteComponent.linkToRoute({
   category: regionsCategory,
   pageRoute: deleteRegionMenuItem,
   menus: {
-    actions: List([regionMenuItem, ...regionMenuItemActions]),
+    actions: List(regionMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: {

--- a/src/app/components/regions/pages/delete/delete.component.ts
+++ b/src/app/components/regions/pages/delete/delete.component.ts
@@ -13,8 +13,7 @@ import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { List } from "immutable";
@@ -80,7 +79,7 @@ DeleteComponent.linkToRoute({
   pageRoute: deleteRegionMenuItem,
   menus: {
     actions: List(regionMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: {
     [projectKey]: projectResolvers.show,

--- a/src/app/components/regions/pages/details/details.component.ts
+++ b/src/app/components/regions/pages/details/details.component.ts
@@ -18,8 +18,7 @@ import { newPointMenuItem } from "@components/sites/points.menus";
 import { visualizeMenuItem } from "@components/visualize/visualize.menus";
 import { IPageInfo } from "@helpers/page/pageInfo";
 import { PaginationTemplate } from "@helpers/paginationTemplate/paginationTemplate";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
@@ -142,7 +141,7 @@ DetailsComponent.linkToRoute({
   pageRoute: regionMenuItem,
   menus: {
     actions: List(regionMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: {
     [projectKey]: projectResolvers.show,

--- a/src/app/components/regions/pages/details/details.component.ts
+++ b/src/app/components/regions/pages/details/details.component.ts
@@ -8,7 +8,6 @@ import {
 } from "@baw-api/resolver-common";
 import { SitesService } from "@baw-api/site/sites.service";
 import { audioRecordingMenuItems } from "@components/audio-recordings/audio-recording.menus";
-import { projectMenuItem } from "@components/projects/projects.menus";
 import {
   deleteRegionMenuItem,
   editRegionMenuItem,
@@ -142,7 +141,7 @@ DetailsComponent.linkToRoute({
   category: regionsCategory,
   pageRoute: regionMenuItem,
   menus: {
-    actions: List([projectMenuItem, ...regionMenuItemActions]),
+    actions: List(regionMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: {

--- a/src/app/components/regions/pages/edit/edit.component.ts
+++ b/src/app/components/regions/pages/edit/edit.component.ts
@@ -7,7 +7,6 @@ import {
 } from "@baw-api/region/regions.service";
 import {
   editRegionMenuItem,
-  regionMenuItem,
   regionsCategory,
 } from "@components/regions/regions.menus";
 import {
@@ -81,7 +80,7 @@ EditComponent.linkToRoute({
   category: regionsCategory,
   pageRoute: editRegionMenuItem,
   menus: {
-    actions: List([regionMenuItem, ...regionMenuItemActions]),
+    actions: List(regionMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: {

--- a/src/app/components/regions/pages/edit/edit.component.ts
+++ b/src/app/components/regions/pages/edit/edit.component.ts
@@ -13,8 +13,7 @@ import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { List } from "immutable";
@@ -81,7 +80,7 @@ EditComponent.linkToRoute({
   pageRoute: editRegionMenuItem,
   menus: {
     actions: List(regionMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: {
     [projectKey]: projectResolvers.show,

--- a/src/app/components/regions/pages/new/new.component.ts
+++ b/src/app/components/regions/pages/new/new.component.ts
@@ -3,10 +3,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { RegionsService } from "@baw-api/region/regions.service";
 import { projectMenuItemActions } from "@components/projects/pages/details/details.component";
-import {
-  projectCategory,
-  projectMenuItem,
-} from "@components/projects/projects.menus";
+import { projectCategory } from "@components/projects/projects.menus";
 import { newRegionMenuItem } from "@components/regions/regions.menus";
 import {
   defaultSuccessMsg,
@@ -65,7 +62,7 @@ class NewComponent extends FormTemplate<Region> {
 NewComponent.linkToRoute({
   category: projectCategory,
   pageRoute: newRegionMenuItem,
-  menus: { actions: List([projectMenuItem, ...projectMenuItemActions]) },
+  menus: { actions: List(projectMenuItemActions) },
   resolvers: { [projectKey]: projectResolvers.show },
 });
 

--- a/src/app/components/security/pages/confirm-account/confirm-account.component.ts
+++ b/src/app/components/security/pages/confirm-account/confirm-account.component.ts
@@ -3,7 +3,6 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { UserService } from "@baw-api/user/user.service";
 import {
   confirmAccountMenuItem,
-  loginMenuItem,
   securityCategory,
 } from "@components/security/security.menus";
 import { FormTemplate } from "@helpers/formTemplate/formTemplate";
@@ -53,7 +52,7 @@ class ConfirmPasswordComponent extends FormTemplate<ConfirmPassword> {
 ConfirmPasswordComponent.linkToRoute({
   category: securityCategory,
   pageRoute: confirmAccountMenuItem,
-  menus: { actions: List([loginMenuItem, ...loginMenuItemActions]) },
+  menus: { actions: List(loginMenuItemActions) },
 });
 
 export { ConfirmPasswordComponent };

--- a/src/app/components/security/pages/reset-password/reset-password.component.ts
+++ b/src/app/components/security/pages/reset-password/reset-password.component.ts
@@ -2,7 +2,6 @@ import { Component } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { UserService } from "@baw-api/user/user.service";
 import {
-  loginMenuItem,
   resetPasswordMenuItem,
   securityCategory,
 } from "@components/security/security.menus";
@@ -50,7 +49,7 @@ class ResetPasswordComponent extends FormTemplate<ResetPassword> {
 ResetPasswordComponent.linkToRoute({
   category: securityCategory,
   pageRoute: resetPasswordMenuItem,
-  menus: { actions: List([loginMenuItem, ...loginMenuItemActions]) },
+  menus: { actions: List(loginMenuItemActions) },
 });
 
 export { ResetPasswordComponent };

--- a/src/app/components/security/pages/unlock-account/unlock-account.component.ts
+++ b/src/app/components/security/pages/unlock-account/unlock-account.component.ts
@@ -2,7 +2,6 @@ import { Component } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { UserService } from "@baw-api/user/user.service";
 import {
-  loginMenuItem,
   securityCategory,
   unlockAccountMenuItem,
 } from "@components/security/security.menus";
@@ -50,7 +49,7 @@ class UnlockAccountComponent extends FormTemplate<UnlockAccount> {
 UnlockAccountComponent.linkToRoute({
   category: securityCategory,
   pageRoute: unlockAccountMenuItem,
-  menus: { actions: List([loginMenuItem, ...loginMenuItemActions]) },
+  menus: { actions: List(loginMenuItemActions) },
 });
 
 export { UnlockAccountComponent };

--- a/src/app/components/shared/breadcrumb/breadcrumb.component.scss
+++ b/src/app/components/shared/breadcrumb/breadcrumb.component.scss
@@ -1,3 +1,7 @@
+nav {
+  padding-left: 0.75rem;
+}
+
 ol {
   & > :not(:last-child) {
     color: var(--baw-highlight);

--- a/src/app/components/shared/breadcrumb/breadcrumb.component.ts
+++ b/src/app/components/shared/breadcrumb/breadcrumb.component.ts
@@ -18,8 +18,12 @@ import { map, Observable } from "rxjs";
         routeParams: routeParams$ | async
       } as data"
     >
-      <nav *ngIf="shouldShowBreadcrumbs(data)" aria-label="breadcrumb">
-        <ol class="breadcrumb bg-light p-1">
+      <nav
+        *ngIf="shouldShowBreadcrumbs(data)"
+        aria-label="breadcrumb"
+        class="bg-light"
+      >
+        <ol class="breadcrumb p-1">
           <li
             *ngFor="let breadcrumb of data.breadcrumbs"
             class="breadcrumb-item"

--- a/src/app/components/shared/menu/permissions-shield/permissions-shield.component.ts
+++ b/src/app/components/shared/menu/permissions-shield/permissions-shield.component.ts
@@ -7,12 +7,14 @@ import {
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
 import { AccessLevel } from "@interfaces/apiInterfaces";
+import { WidgetMenuItem } from "@menu/widgetItem";
 import { AbstractModel } from "@models/AbstractModel";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
 import { SharedActivatedRouteService } from "@services/shared-activated-route/shared-activated-route.service";
 import { map, takeUntil } from "rxjs";
+import { isLoggedInPredicate } from "src/app/app.menus";
 import { WidgetComponent } from "../widget/widget.component";
 
 /**
@@ -163,3 +165,8 @@ export class PermissionsShieldComponent
     return this.model["accessLevel"] ?? null;
   }
 }
+
+export const permissionsWidgetMenuItem = new WidgetMenuItem(
+  PermissionsShieldComponent,
+  isLoggedInPredicate
+);

--- a/src/app/components/shared/menu/widget/widgetItem.ts
+++ b/src/app/components/shared/menu/widget/widgetItem.ts
@@ -1,6 +1,6 @@
 import { Type } from "@angular/core";
 import { IPageInfo, PageInfo } from "@helpers/page/pageInfo";
-import { MenuAction } from "@interfaces/menusInterfaces";
+import { MenuAction, UserCallback } from "@interfaces/menusInterfaces";
 import { NgbModalOptions, NgbModalRef } from "@ng-bootstrap/ng-bootstrap";
 import { ModalComponent, WidgetComponent } from "./widget.component";
 
@@ -10,8 +10,12 @@ import { ModalComponent, WidgetComponent } from "./widget.component";
  */
 export class WidgetMenuItem {
   public constructor(
+    /** Component to display */
     public component: Type<WidgetComponent>,
-    public pageData: any = {}
+    /** Whether or not to show this link */
+    public predicate?: UserCallback<boolean>,
+    /** Data to pass to component */
+    public pageData: IPageInfo = {}
   ) {}
 
   /**

--- a/src/app/components/sites/pages/delete/delete.component.ts
+++ b/src/app/components/sites/pages/delete/delete.component.ts
@@ -16,8 +16,7 @@ import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
@@ -79,7 +78,7 @@ SiteDeleteComponent.linkToRoute({
   pageRoute: deleteSiteMenuItem,
   menus: {
     actions: List(siteMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: {
     [projectKey]: projectResolvers.show,
@@ -90,7 +89,7 @@ SiteDeleteComponent.linkToRoute({
   pageRoute: deletePointMenuItem,
   menus: {
     actions: List(pointMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: {
     [projectKey]: projectResolvers.show,

--- a/src/app/components/sites/pages/delete/delete.component.ts
+++ b/src/app/components/sites/pages/delete/delete.component.ts
@@ -5,12 +5,10 @@ import { regionResolvers } from "@baw-api/region/regions.service";
 import { siteResolvers, SitesService } from "@baw-api/site/sites.service";
 import {
   deletePointMenuItem,
-  pointMenuItem,
   pointsCategory,
 } from "@components/sites/points.menus";
 import {
   deleteSiteMenuItem,
-  siteMenuItem,
   sitesCategory,
 } from "@components/sites/sites.menus";
 import { Option } from "@helpers/advancedTypes";
@@ -80,7 +78,7 @@ SiteDeleteComponent.linkToRoute({
   category: sitesCategory,
   pageRoute: deleteSiteMenuItem,
   menus: {
-    actions: List([siteMenuItem, ...siteMenuItemActions]),
+    actions: List(siteMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: {
@@ -91,7 +89,7 @@ SiteDeleteComponent.linkToRoute({
   category: pointsCategory,
   pageRoute: deletePointMenuItem,
   menus: {
-    actions: List([pointMenuItem, ...pointMenuItemActions]),
+    actions: List(pointMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: {

--- a/src/app/components/sites/pages/details/details.component.ts
+++ b/src/app/components/sites/pages/details/details.component.ts
@@ -20,8 +20,7 @@ import { siteAnnotationsModal } from "@components/sites/sites.modals";
 import { visualizeMenuItem } from "@components/visualize/visualize.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { IPageInfo } from "@helpers/page/pageInfo";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
@@ -101,7 +100,7 @@ SiteDetailsComponent.linkToRoute({
   pageRoute: siteMenuItem,
   menus: {
     actions: List(siteMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: {
     [projectKey]: projectResolvers.show,
@@ -112,7 +111,7 @@ SiteDetailsComponent.linkToRoute({
   pageRoute: pointMenuItem,
   menus: {
     actions: List(pointMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: {
     [projectKey]: projectResolvers.show,

--- a/src/app/components/sites/pages/details/details.component.ts
+++ b/src/app/components/sites/pages/details/details.component.ts
@@ -8,8 +8,6 @@ import {
 } from "@baw-api/resolver-common";
 import { siteResolvers } from "@baw-api/site/sites.service";
 import { audioRecordingMenuItems } from "@components/audio-recordings/audio-recording.menus";
-import { projectMenuItem } from "@components/projects/projects.menus";
-import { regionMenuItem } from "@components/regions/regions.menus";
 import {
   deletePointMenuItem,
   editPointMenuItem,
@@ -102,7 +100,7 @@ SiteDetailsComponent.linkToRoute({
   category: sitesCategory,
   pageRoute: siteMenuItem,
   menus: {
-    actions: List([projectMenuItem, ...siteMenuItemActions]),
+    actions: List(siteMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: {
@@ -113,7 +111,7 @@ SiteDetailsComponent.linkToRoute({
   category: pointsCategory,
   pageRoute: pointMenuItem,
   menus: {
-    actions: List([regionMenuItem, ...pointMenuItemActions]),
+    actions: List(pointMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: {

--- a/src/app/components/sites/pages/edit/edit.component.ts
+++ b/src/app/components/sites/pages/edit/edit.component.ts
@@ -5,7 +5,6 @@ import { regionResolvers } from "@baw-api/region/regions.service";
 import { siteResolvers, SitesService } from "@baw-api/site/sites.service";
 import {
   editPointMenuItem,
-  pointMenuItem,
   pointsCategory,
 } from "@components/sites/points.menus";
 import { Option } from "@helpers/advancedTypes";
@@ -22,11 +21,7 @@ import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
 import pointSchema from "../../point.base.json";
 import siteSchema from "../../site.base.json";
-import {
-  editSiteMenuItem,
-  siteMenuItem,
-  sitesCategory,
-} from "../../sites.menus";
+import { editSiteMenuItem, sitesCategory } from "../../sites.menus";
 import {
   pointMenuItemActions,
   siteMenuItemActions,
@@ -83,7 +78,7 @@ SiteEditComponent.linkToRoute({
   category: sitesCategory,
   pageRoute: editSiteMenuItem,
   menus: {
-    actions: List([siteMenuItem, ...siteMenuItemActions]),
+    actions: List(siteMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: {
@@ -94,7 +89,7 @@ SiteEditComponent.linkToRoute({
   category: pointsCategory,
   pageRoute: editPointMenuItem,
   menus: {
-    actions: List([pointMenuItem, ...pointMenuItemActions]),
+    actions: List(pointMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: {

--- a/src/app/components/sites/pages/edit/edit.component.ts
+++ b/src/app/components/sites/pages/edit/edit.component.ts
@@ -12,8 +12,7 @@ import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
@@ -79,7 +78,7 @@ SiteEditComponent.linkToRoute({
   pageRoute: editSiteMenuItem,
   menus: {
     actions: List(siteMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: {
     [projectKey]: projectResolvers.show,
@@ -90,7 +89,7 @@ SiteEditComponent.linkToRoute({
   pageRoute: editPointMenuItem,
   menus: {
     actions: List(pointMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: {
     [projectKey]: projectResolvers.show,

--- a/src/app/components/sites/pages/harvest/harvest.component.ts
+++ b/src/app/components/sites/pages/harvest/harvest.component.ts
@@ -10,7 +10,6 @@ import {
 import { siteResolvers, SitesService } from "@baw-api/site/sites.service";
 import {
   pointHarvestMenuItem,
-  pointMenuItem,
   pointsCategory,
 } from "@components/sites/points.menus";
 import { API_ROOT } from "@helpers/app-initializer/app-initializer";
@@ -23,11 +22,7 @@ import { Region } from "@models/Region";
 import { Site } from "@models/Site";
 import { User } from "@models/User";
 import { List } from "immutable";
-import {
-  siteHarvestMenuItem,
-  siteMenuItem,
-  sitesCategory,
-} from "../../sites.menus";
+import { siteHarvestMenuItem, sitesCategory } from "../../sites.menus";
 import {
   pointMenuItemActions,
   siteMenuItemActions,
@@ -78,7 +73,7 @@ SiteHarvestComponent.linkToRoute({
   category: sitesCategory,
   pageRoute: siteHarvestMenuItem,
   menus: {
-    actions: List([siteMenuItem, ...siteMenuItemActions]),
+    actions: List(siteMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: {
@@ -89,7 +84,7 @@ SiteHarvestComponent.linkToRoute({
   category: pointsCategory,
   pageRoute: pointHarvestMenuItem,
   menus: {
-    actions: List([pointMenuItem, ...pointMenuItemActions]),
+    actions: List(pointMenuItemActions),
     actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
   },
   resolvers: {

--- a/src/app/components/sites/pages/harvest/harvest.component.ts
+++ b/src/app/components/sites/pages/harvest/harvest.component.ts
@@ -15,8 +15,7 @@ import {
 import { API_ROOT } from "@helpers/app-initializer/app-initializer";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { IPageInfo } from "@helpers/page/pageInfo";
-import { PermissionsShieldComponent } from "@menu/permissions-shield.component";
-import { WidgetMenuItem } from "@menu/widgetItem";
+import { permissionsWidgetMenuItem } from "@menu/permissions-shield.component";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
@@ -74,7 +73,7 @@ SiteHarvestComponent.linkToRoute({
   pageRoute: siteHarvestMenuItem,
   menus: {
     actions: List(siteMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: {
     [projectKey]: projectResolvers.show,
@@ -85,7 +84,7 @@ SiteHarvestComponent.linkToRoute({
   pageRoute: pointHarvestMenuItem,
   menus: {
     actions: List(pointMenuItemActions),
-    actionWidgets: List([new WidgetMenuItem(PermissionsShieldComponent)]),
+    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   resolvers: {
     [projectKey]: projectResolvers.show,

--- a/src/app/components/sites/pages/new/new.component.ts
+++ b/src/app/components/sites/pages/new/new.component.ts
@@ -4,7 +4,6 @@ import { projectResolvers } from "@baw-api/project/projects.service";
 import { regionResolvers } from "@baw-api/region/regions.service";
 import { SitesService } from "@baw-api/site/sites.service";
 import { regionMenuItemActions } from "@components/regions/pages/details/details.component";
-import { regionMenuItem } from "@components/regions/regions.menus";
 import {
   newPointMenuItem,
   pointsCategory,
@@ -74,7 +73,7 @@ class SiteNewComponent extends FormTemplate<Site> implements OnInit {
 SiteNewComponent.linkToRoute({
   category: pointsCategory,
   pageRoute: newPointMenuItem,
-  menus: { actions: List([regionMenuItem, ...regionMenuItemActions]) },
+  menus: { actions: List(regionMenuItemActions) },
   resolvers: {
     [projectKey]: projectResolvers.show,
     [regionKey]: regionResolvers.show,

--- a/src/app/components/sites/pages/wizard/wizard.component.ts
+++ b/src/app/components/sites/pages/wizard/wizard.component.ts
@@ -6,10 +6,7 @@ import {
   retrieveResolvers,
 } from "@baw-api/resolver-common";
 import { projectMenuItemActions } from "@components/projects/pages/details/details.component";
-import {
-  projectCategory,
-  projectMenuItem,
-} from "@components/projects/projects.menus";
+import { projectCategory } from "@components/projects/projects.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { IPageInfo } from "@helpers/page/pageInfo";
 import { Project } from "@models/Project";
@@ -87,7 +84,7 @@ class WizardComponent extends PageComponent implements OnInit {
 WizardComponent.linkToRoute({
   category: projectCategory,
   pageRoute: newSiteMenuItem,
-  menus: { actions: List([projectMenuItem, ...projectMenuItemActions]) },
+  menus: { actions: List(projectMenuItemActions) },
   resolvers: { [projectKey]: projectResolvers.show },
 });
 


### PR DESCRIPTION
# Action Menu Cleanup

A collection of smaller changes to the action menu

## Changes

- Removed parent links from action menus
- Filter widget menu items by predicate
- Hide permission shield component from guest users
- Modified padding on breadcrumb component to better align with menus on mobile layouts

## Issues

Related to #1790 

## Visual Changes

![image](https://user-images.githubusercontent.com/3955116/156740532-4c998d27-01fc-473a-bb08-f37a658965c1.png)
![image](https://user-images.githubusercontent.com/3955116/156740580-3d4349a8-5a3a-4f26-b0b6-2b18f4228957.png)


## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
