### PR TITLE
Audio recordings column name

### DIFF
--- a/src/app/components/audio-recordings/audio-recording.menus.ts
+++ b/src/app/components/audio-recordings/audio-recording.menus.ts
@@ -8,14 +8,17 @@ import {
   Category,
   menuLink,
   MenuRoute,
-  menuRoute
+  menuRoute,
 } from "@interfaces/menusInterfaces";
 import { AudioRecording } from "@models/AudioRecording";
 import {
-  audioRecordingBatchRoutes, audioRecordingRoutes, audioRecordingsRoutes
+  audioRecordingBatchRoutes,
+  audioRecordingRoutes,
+  audioRecordingsRoutes,
+  RecordingRoute,
 } from "./audio-recording.routes";
 
-type RecordingRoutes = "base" | "site" | "siteAndRegion" | "region" | "project";
+export type RecordingMenuRoutes = Record<RecordingRoute, MenuRoute>;
 
 export const audioRecordingsCategory: Category = {
   icon: ["fas", "file-archive"],
@@ -24,7 +27,7 @@ export const audioRecordingsCategory: Category = {
 };
 
 function makeListMenuItem(
-  subRoute: RecordingRoutes,
+  subRoute: RecordingRoute,
   parent?: MenuRoute
 ): MenuRoute {
   return menuRoute({
@@ -36,7 +39,7 @@ function makeListMenuItem(
   });
 }
 
-function makeDetailsMenuItem(subRoute: RecordingRoutes): MenuRoute {
+function makeDetailsMenuItem(subRoute: RecordingRoute): MenuRoute {
   return menuRoute({
     icon: ["fas", "file-audio"],
     label: "Audio Recording",
@@ -49,7 +52,7 @@ function makeDetailsMenuItem(subRoute: RecordingRoutes): MenuRoute {
   });
 }
 
-function makeBatchMenuItem(subRoute: RecordingRoutes): MenuRoute {
+function makeBatchMenuItem(subRoute: RecordingRoute): MenuRoute {
   return menuRoute({
     icon: ["fas", "file-download"],
     label: "Download Recordings",
@@ -61,7 +64,7 @@ function makeBatchMenuItem(subRoute: RecordingRoutes): MenuRoute {
   });
 }
 
-const listMenuItems: Record<RecordingRoutes, MenuRoute> = {
+const listMenuItems: RecordingMenuRoutes = {
   /** /audio_recordings */
   base: makeListMenuItem("base"),
   /** /project/:projectId/site/:siteId/audio_recordings */
@@ -74,7 +77,7 @@ const listMenuItems: Record<RecordingRoutes, MenuRoute> = {
   project: makeListMenuItem("project", projectMenuItem),
 };
 
-const detailsMenuItems: Record<RecordingRoutes, MenuRoute> = {
+const detailsMenuItems: RecordingMenuRoutes = {
   /** /audio_recordings */
   base: makeDetailsMenuItem("base"),
   /** /project/:projectId/site/:siteId/audio_recordings/:audioRecordingId */
@@ -87,7 +90,7 @@ const detailsMenuItems: Record<RecordingRoutes, MenuRoute> = {
   project: makeDetailsMenuItem("project"),
 };
 
-const batchMenuItems: Record<RecordingRoutes, MenuRoute> = {
+const batchMenuItems: RecordingMenuRoutes = {
   /** /audio_recordings/download */
   base: makeBatchMenuItem("base"),
   /** /project/:projectId/site/:siteId/audio_recordings/download */

--- a/src/app/components/audio-recordings/audio-recording.routes.ts
+++ b/src/app/components/audio-recordings/audio-recording.routes.ts
@@ -8,10 +8,16 @@ const listRoutePath = "audio_recordings";
 const showRoutePath = ":audioRecordingId";
 const batchDownloadRoutePath = "download";
 
-type RecordingRoutes = "base" | "site" | "siteAndRegion" | "region" | "project";
+export type RecordingRoute =
+  | "base"
+  | "site"
+  | "siteAndRegion"
+  | "region"
+  | "project";
+export type RecordingStrongRoutes = Record<RecordingRoute, StrongRoute>;
 
 // Create audio recording base route, and sub routes
-export const audioRecordingsRoutes: Record<RecordingRoutes, StrongRoute> = {
+export const audioRecordingsRoutes: RecordingStrongRoutes = {
   /** /audio_recordings */
   base: StrongRoute.newRoot().add(listRoutePath),
   /** /project/:projectId/site/:siteId/audio_recordings */
@@ -24,7 +30,7 @@ export const audioRecordingsRoutes: Record<RecordingRoutes, StrongRoute> = {
   project: projectRoute.addFeatureModule(listRoutePath),
 };
 
-export const audioRecordingRoutes: Record<RecordingRoutes, StrongRoute> = {
+export const audioRecordingRoutes: RecordingStrongRoutes = {
   /** /audio_recordings/:audioRecordingId */
   base: audioRecordingsRoutes.base.add(showRoutePath),
   /** /project/:projectId/site/:siteId/audio_recordings/:audioRecordingId */
@@ -37,7 +43,7 @@ export const audioRecordingRoutes: Record<RecordingRoutes, StrongRoute> = {
   project: audioRecordingsRoutes.project.add(showRoutePath),
 };
 
-export const audioRecordingBatchRoutes: Record<RecordingRoutes, StrongRoute> = {
+export const audioRecordingBatchRoutes: RecordingStrongRoutes = {
   /** /audio_recordings/download */
   base: audioRecordingsRoutes.base.add(batchDownloadRoutePath),
   /** /project/:projectId/site/:siteId/audio_recordings/download */

--- a/src/app/components/audio-recordings/pages/list/list.component.html
+++ b/src/app/components/audio-recordings/pages/list/list.component.html
@@ -38,6 +38,9 @@
       </ng-template>
     </ngx-datatable-column>
     <ngx-datatable-column name="Site">
+      <ng-template let-column="column" ngx-datatable-header-template>
+        {{ siteColumnName }}
+      </ng-template>
       <ng-template let-value="value" ngx-datatable-cell-template>
         <!-- Show loading animation while site is unresolved -->
         <baw-loading

--- a/src/app/components/audio-recordings/pages/list/list.component.ts
+++ b/src/app/components/audio-recordings/pages/list/list.component.ts
@@ -112,7 +112,7 @@ class AudioRecordingsListComponent
     // If a region exists, this must be a site with a region
     // If the site is a point...
     // Otherwise its a site
-    if (hideProjects || this.region || this.site.isPoint) {
+    if (hideProjects || this.region || this.site?.isPoint) {
       return "Point";
     } else {
       return "Site";

--- a/src/app/components/audio-recordings/pages/list/list.component.ts
+++ b/src/app/components/audio-recordings/pages/list/list.component.ts
@@ -17,6 +17,7 @@ import { AudioRecording, IAudioRecording } from "@models/AudioRecording";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
+import { ConfigService } from "@services/config/config.service";
 import { List } from "immutable";
 
 const projectKey = "project";
@@ -53,7 +54,8 @@ class AudioRecordingsListComponent
   public constructor(
     @Inject(API_ROOT) public apiRoot: string,
     api: AudioRecordingsService,
-    route: ActivatedRoute
+    route: ActivatedRoute,
+    private config: ConfigService
   ) {
     super(
       api,
@@ -101,6 +103,16 @@ class AudioRecordingsListComponent
 
   public get site(): Site | undefined {
     return this.models[siteKey] as Site;
+  }
+
+  public get siteColumnName(): string {
+    if (this.site) {
+      return this.site.isPoint ? "Point" : "Site";
+    } else if (this.region) {
+      return "Point";
+    } else {
+      return this.config.settings.hideProjects ? "Point" : "Site";
+    }
   }
 
   protected apiAction(filters: Filters<IAudioRecording>) {

--- a/src/app/components/audio-recordings/pages/list/list.component.ts
+++ b/src/app/components/audio-recordings/pages/list/list.component.ts
@@ -106,12 +106,16 @@ class AudioRecordingsListComponent
   }
 
   public get siteColumnName(): string {
-    if (this.site) {
-      return this.site.isPoint ? "Point" : "Site";
-    } else if (this.region) {
+    const hideProjects = this.config.settings.hideProjects;
+
+    // If we are hiding projects, any sites must be points
+    // If a region exists, this must be a site with a region
+    // If the site is a point...
+    // Otherwise its a site
+    if (hideProjects || this.region || this.site.isPoint) {
       return "Point";
     } else {
-      return this.config.settings.hideProjects ? "Point" : "Site";
+      return "Site";
     }
   }
 

--- a/src/app/models/AudioRecording.ts
+++ b/src/app/models/AudioRecording.ts
@@ -1,8 +1,12 @@
-import { IdOr, id } from "@baw-api/api-common";
+import { id, IdOr } from "@baw-api/api-common";
 import { audioRecordingOriginalEndpoint } from "@baw-api/audio-recording/audio-recordings.service";
 import { ACCOUNT, SHALLOW_SITE } from "@baw-api/ServiceTokens";
 import { adminAudioRecordingMenuItem } from "@components/admin/audio-recordings/audio-recordings.menus";
-import { audioRecordingMenuItems } from "@components/audio-recordings/audio-recording.menus";
+import {
+  audioRecordingBatchRoutes,
+  audioRecordingRoutes,
+  RecordingStrongRoutes,
+} from "@components/audio-recordings/audio-recording.routes";
 import { listenRecordingMenuItem } from "@components/listen/listen.menus";
 import { Duration } from "luxon";
 import {
@@ -106,9 +110,13 @@ export class AudioRecording
   }
 
   /** Routes to the batch download page */
-  public get batchDownloadUrl(): string {
-    // TODO Add download url when batch download page built
-    throw new Error("not implemented");
+  public getBatchDownloadUrl(
+    project?: IdOr<Project>,
+    region?: IdOr<Region>,
+    site?: IdOr<Site>
+  ): string {
+    const routes = audioRecordingBatchRoutes;
+    return this.selectRoute(routes, project, region, site);
   }
 
   /** Routes to the base details page */
@@ -122,33 +130,42 @@ export class AudioRecording
     region?: IdOr<Region>,
     site?: IdOr<Site>
   ): string {
-    const routeParams = {
-      audioRecordingId: this.id,
-      projectId: id(project),
-      regionId: id(region),
-      siteId: id(site),
-    };
-    const routes = audioRecordingMenuItems.details;
-
-    if (site) {
-      if (region) {
-        return routes.siteAndRegion.route.format(routeParams);
-      } else {
-        return routes.site.route.format(routeParams);
-      }
-    } else if (region) {
-      return routes.region.route.format(routeParams);
-    } else if (project) {
-      return routes.project.route.format(routeParams);
-    } else {
-      return routes.base.route.format(routeParams);
-    }
+    const routes = audioRecordingRoutes;
+    return this.selectRoute(routes, project, region, site);
   }
 
   public get adminViewUrl(): string {
     return adminAudioRecordingMenuItem.route.format({
       audioRecordingId: this.id,
     });
+  }
+
+  private selectRoute(
+    routes: RecordingStrongRoutes,
+    project: IdOr<Project>,
+    region: IdOr<Region>,
+    site: IdOr<Site>
+  ) {
+    const routeParams = {
+      audioRecordingId: this.id,
+      projectId: id(project),
+      regionId: id(region),
+      siteId: id(site),
+    };
+
+    if (site) {
+      if (region) {
+        return routes.siteAndRegion.format(routeParams);
+      } else {
+        return routes.site.format(routeParams);
+      }
+    } else if (region) {
+      return routes.region.format(routeParams);
+    } else if (project) {
+      return routes.project.format(routeParams);
+    } else {
+      return routes.base.format(routeParams);
+    }
   }
 }
 


### PR DESCRIPTION
# Wrong column name on audio recordings list 

Fixes a UI bug in the column name for the audio recordings list page

## Changes

- Change name of sites column depending on the config, and what data is available

## Issues

Closes #1814

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
