### PR TITLE
Re enable tests from #1809

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -118,31 +118,35 @@
 <!-- View some projects -->
 <section id="projects" class="pb-5 pt-5 bg-light">
   <div class="container">
-    <h2>View Some {{ viewMore.modelName | titlecase }}s</h2>
+    <h2>View Some {{ viewMoreLink.label | titlecase }}s</h2>
     <p class="mb-5">
-      You can browse some public {{ viewMore.modelName }}s and audio recordings
+      You can browse some public {{ viewMoreLink.label }}s and audio recordings
       without logging in. To participate in the analysis work you will need to
       log in with an existing account or register for a new account. Don't worry
       its free and easy!
     </p>
 
-    <baw-loading *ngIf="viewMore.loading" [size]="lg"></baw-loading>
+    <ng-container *ngIf="models$ | withLoading | async as models">
+      <baw-loading *ngIf="models.loading" [size]="lg"></baw-loading>
 
-    <baw-model-cards *ngIf="!viewMore.loading" [models]="viewMore.list">
-      <ng-container *ngIf="viewMore.list.size === 0; else hasModels">
-        <p id="placeholder" class="m-auto">
-          No {{ viewMore.modelName }}s to display
+      <p *ngIf="models.error" id="error">
+        Unable to load {{ viewMoreLink.label | titlecase }}
+      </p>
+
+      <baw-model-cards *ngIf="models.value" [models]="models.value">
+        <p *ngIf="models.value.size === 0" id="placeholder" class="m-auto">
+          No {{ viewMoreLink.label | titlecase }}s to display
         </p>
-      </ng-container>
-      <ng-template #hasModels>
+
         <a
+          *ngIf="models.value.size > 0"
           id="viewMore"
           class="m-auto btn btn-outline-highlight btn-lg"
-          [strongRoute]="viewMore.link"
+          [strongRoute]="viewMoreLink.link"
         >
-          More {{ viewMore.modelName | titlecase }}s
+          More {{ viewMoreLink.label | titlecase }}s
         </a>
-      </ng-template>
-    </baw-model-cards>
+      </baw-model-cards>
+    </ng-container>
   </div>
 </section>

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -126,7 +126,6 @@ describe("HomeComponent", () => {
     return spec;
   }, CMS.home); */
 
-  // TODO Re-enable tests #1809
   [
     {
       test: "projects",

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -15,6 +15,7 @@ import {
   Spectator,
   SpyObject,
 } from "@ngneat/spectator";
+import { PipesModule } from "@pipes/pipes.module";
 import { ConfigService } from "@services/config/config.service";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { testApiConfig } from "@services/config/configMock.service";
@@ -31,8 +32,6 @@ import { MockComponent } from "ng-mocks";
 import { BehaviorSubject } from "rxjs";
 import { HomeComponent } from "./home.component";
 
-const mockCardComponent = MockComponent(CardComponent);
-
 describe("HomeComponent", () => {
   let regionApi: SpyObject<ShallowRegionsService>;
   let projectApi: SpyObject<ProjectsService>;
@@ -41,7 +40,7 @@ describe("HomeComponent", () => {
   let spec: Spectator<HomeComponent>;
   const createComponent = createComponentFactory({
     component: HomeComponent,
-    declarations: [CardsComponent, mockCardComponent],
+    declarations: [CardsComponent, MockComponent(CardComponent)],
     imports: [
       MockBawApiModule,
       MockAppConfigModule,
@@ -49,6 +48,7 @@ describe("HomeComponent", () => {
       DirectivesModule,
       RouterTestingModule,
       LoadingModule,
+      PipesModule,
     ],
   });
 
@@ -88,19 +88,21 @@ describe("HomeComponent", () => {
   }
 
   function assertModelCardsCount(count: number) {
-    expect(getModelCards().models.count()).toBe(count);
+    expect(getModelCards()?.models?.count() ?? 0).toBe(count);
   }
 
   function getViewMoreButton(): HTMLButtonElement {
     return spec.query("#viewMore");
   }
 
+  function assertErrorPlaceholder(modelName?: string) {
+    expect(spec.query("#error")).toContainText(`Unable to load ${modelName}`);
+  }
+
   function assertViewMorePlaceholder(exists?: boolean, modelName?: string) {
     const placeholder = spec.query("#placeholder");
     if (exists) {
-      expect(placeholder).toContainText(
-        `No ${modelName.toLowerCase()}s to display`
-      );
+      expect(placeholder).toContainText(`No ${modelName}s to display`);
     } else {
       expect(placeholder).toBeFalsy();
     }
@@ -145,7 +147,7 @@ describe("HomeComponent", () => {
       link: shallowRegionsMenuItem.route.toRouterLink(),
     },
   ].forEach((test) => {
-    xdescribe(`${test.test} api`, () => {
+    describe(`${test.test} api`, () => {
       beforeEach(() => {
         handleCms();
         setConfigHideProjects(test.hideProjects);
@@ -162,11 +164,11 @@ describe("HomeComponent", () => {
       it("should handle filter error", async () => {
         await test.awaitModel(generateBawApiError());
         assertModelCardsCount(0);
-        assertViewMorePlaceholder(true, test.modelName);
+        assertErrorPlaceholder(test.modelName);
       });
     });
 
-    xdescribe(`${test.test} cards`, () => {
+    describe(`${test.test} cards`, () => {
       beforeEach(() => {
         handleCms();
         setConfigHideProjects(test.hideProjects);

--- a/src/app/components/projects/components/site-card/site-card.component.ts
+++ b/src/app/components/projects/components/site-card/site-card.component.ts
@@ -41,6 +41,7 @@ import { map } from "rxjs/operators";
         <li>
           <span
             *ngIf="hasNoAudio.value !== false"
+            id="no-audio"
             class="badge rounded-pill bg-secondary my-1"
           >
             <baw-loading

--- a/src/app/components/projects/pages/list/list.component.spec.ts
+++ b/src/app/components/projects/pages/list/list.component.spec.ts
@@ -13,20 +13,34 @@ import {
 } from "@ngneat/spectator";
 import { DebounceInputComponent } from "@shared/debounce-input/debounce-input.component";
 import { CardsComponent } from "@shared/model-cards/cards/cards.component";
+import { ModelCardsModule } from "@shared/model-cards/model-cards.module";
 import { SharedModule } from "@shared/shared.module";
 import { generateBawApiError } from "@test/fakes/BawApiError";
 import { generateProject } from "@test/fakes/Project";
 import { nStepObservable } from "@test/helpers/general";
 import { assertErrorHandler } from "@test/helpers/html";
+import { MockComponent } from "ng-mocks";
 import { Subject } from "rxjs";
 import { ListComponent } from "./list.component";
 
-// TODO Re-enable tests #1809
-xdescribe("ProjectsListComponent", () => {
+const mockCardsComponent = MockComponent(CardsComponent);
+
+describe("ProjectsListComponent", () => {
   let api: SpyObject<ProjectsService>;
   let spec: Spectator<ListComponent>;
   const createComponent = createComponentFactory({
     component: ListComponent,
+    overrideModules: [
+      [
+        ModelCardsModule,
+        {
+          set: {
+            declarations: [mockCardsComponent],
+            exports: [mockCardsComponent],
+          },
+        },
+      ],
+    ],
     imports: [SharedModule, RouterTestingModule, MockBawApiModule],
   });
 

--- a/src/app/components/regions/pages/list/list.component.spec.ts
+++ b/src/app/components/regions/pages/list/list.component.spec.ts
@@ -13,20 +13,34 @@ import {
 } from "@ngneat/spectator";
 import { DebounceInputComponent } from "@shared/debounce-input/debounce-input.component";
 import { CardsComponent } from "@shared/model-cards/cards/cards.component";
+import { ModelCardsModule } from "@shared/model-cards/model-cards.module";
 import { SharedModule } from "@shared/shared.module";
 import { generateBawApiError } from "@test/fakes/BawApiError";
 import { generateRegion } from "@test/fakes/Region";
 import { nStepObservable } from "@test/helpers/general";
 import { assertErrorHandler } from "@test/helpers/html";
+import { MockComponent } from "ng-mocks";
 import { Subject } from "rxjs";
 import { ListComponent } from "./list.component";
 
-// TODO Re-enable tests #1809
-xdescribe("RegionsListComponent", () => {
+const mockCardsComponent = MockComponent(CardsComponent);
+
+describe("RegionsListComponent", () => {
   let api: SpyObject<ShallowRegionsService>;
   let spec: Spectator<ListComponent>;
   const createComponent = createComponentFactory({
     component: ListComponent,
+    overrideModules: [
+      [
+        ModelCardsModule,
+        {
+          set: {
+            declarations: [mockCardsComponent],
+            exports: [mockCardsComponent],
+          },
+        },
+      ],
+    ],
     imports: [SharedModule, RouterTestingModule, MockBawApiModule],
   });
 

--- a/src/app/test/helpers/html.ts
+++ b/src/app/test/helpers/html.ts
@@ -231,12 +231,14 @@ export function assertErrorHandler(
  * @param visible Is spinner visible
  */
 export function assertSpinner(
-  fixture: ComponentFixture<any>,
+  fixture: ComponentFixture<any> | Element,
   visible: boolean
 ) {
-  const expectation = expect(
-    fixture.nativeElement.querySelector("baw-loading")
-  );
+  const spinner = (
+    fixture instanceof ComponentFixture ? fixture.nativeElement : fixture
+  ).querySelector("baw-loading");
+
+  const expectation = expect(spinner);
 
   if (visible) {
     expectation.toBeTruthy("Expected Spinner to Exist");


### PR DESCRIPTION
# Re enable tests from #1809

Some tests were disabled to achieve the fast release of #1809. This re-enables those tests.

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
