### PR TITLE
Breaking Changes to Access Levels

### DIFF
--- a/src/app/components/profile/pages/projects/my-projects.component.spec.ts
+++ b/src/app/components/profile/pages/projects/my-projects.component.spec.ts
@@ -115,7 +115,7 @@ describe("MyProjectsComponent", () => {
     });
 
     describe("access level", () => {
-      (["Reader", "Writer", "Owner"] as AccessLevel[]).forEach(
+      (["reader", "writer", "owner"] as AccessLevel[]).forEach(
         (accessLevel) => {
           it(`should display ${accessLevel} permissions`, async () => {
             const project = new Project({ ...generateProject(), accessLevel });
@@ -124,7 +124,9 @@ describe("MyProjectsComponent", () => {
             interceptRequest([project]);
             spec.detectChanges();
 
-            expect(getCells()[2]).toHaveText(accessLevel);
+            const titleCaseAccessLevel =
+              accessLevel.charAt(0).toUpperCase() + accessLevel.slice(1);
+            expect(getCells()[2]).toHaveText(titleCaseAccessLevel);
           });
         }
       );

--- a/src/app/components/profile/pages/projects/projects.component.html
+++ b/src/app/components/profile/pages/projects/projects.component.html
@@ -41,7 +41,11 @@
         [width]="100"
         [maxWidth]="100"
         [sortable]="false"
-      ></ngx-datatable-column>
+      >
+        <ng-template let-value="value" ngx-datatable-cell-template>
+          {{ value | titlecase }}
+        </ng-template>
+      </ngx-datatable-column>
     </ngx-datatable>
   </ng-container>
 

--- a/src/app/components/profile/pages/projects/their-projects.component.spec.ts
+++ b/src/app/components/profile/pages/projects/their-projects.component.spec.ts
@@ -115,7 +115,7 @@ describe("TheirProjectsComponent", () => {
     });
 
     describe("access level", () => {
-      (["Reader", "Writer", "Owner"] as AccessLevel[]).forEach(
+      (["reader", "writer", "owner"] as AccessLevel[]).forEach(
         (accessLevel) => {
           it(`should display ${accessLevel} permissions`, async () => {
             const project = new Project({ ...generateProject(), accessLevel });
@@ -124,7 +124,9 @@ describe("TheirProjectsComponent", () => {
             interceptRequest([project]);
             spec.detectChanges();
 
-            expect(getCells()[2]).toHaveText(accessLevel);
+            const titleCaseAccessLevel =
+              accessLevel.charAt(0).toUpperCase() + accessLevel.slice(1);
+            expect(getCells()[2]).toHaveText(titleCaseAccessLevel);
           });
         }
       );

--- a/src/app/components/profile/pages/sites/my-sites.component.spec.ts
+++ b/src/app/components/profile/pages/sites/my-sites.component.spec.ts
@@ -161,7 +161,9 @@ describe("MySitesComponent", () => {
             await projectPromise;
             spec.detectChanges();
 
-            expect(getCells()[2]).toHaveText(accessLevel);
+            const titleCaseAccessLevel =
+              accessLevel.charAt(0).toUpperCase() + accessLevel.slice(1);
+            expect(getCells()[2]).toHaveText(titleCaseAccessLevel);
           });
         }
       );

--- a/src/app/components/profile/pages/sites/my-sites.component.ts
+++ b/src/app/components/profile/pages/sites/my-sites.component.ts
@@ -8,7 +8,6 @@ import {
   mySitesMenuItem,
 } from "@components/profile/profile.menus";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
-import { Project } from "@models/Project";
 import { Site } from "@models/Site";
 import { User } from "@models/User";
 import { List } from "immutable";
@@ -52,24 +51,6 @@ class MySitesComponent extends PagedTableTemplate<TableRow, Site> {
 
   public hasViewUrl(site: Site): boolean {
     return site.projectIds.size > 0;
-  }
-
-  public resolveHighestAccessLevel(projects: Project[]): string {
-    if ((projects ?? []).length === 0) {
-      return "Unknown";
-    }
-
-    let isWriter = false;
-
-    for (const project of projects) {
-      if (project.accessLevel === "Owner") {
-        return project.accessLevel;
-      } else if (project.accessLevel === "Writer") {
-        isWriter = true;
-      }
-    }
-
-    return isWriter ? "Writer" : "Reader";
   }
 }
 

--- a/src/app/components/profile/pages/sites/sites.component.html
+++ b/src/app/components/profile/pages/sites/sites.component.html
@@ -48,7 +48,9 @@
             size="sm"
           ></baw-loading>
 
-          <ng-template #loaded>{{ value.accessLevel }} </ng-template>
+          <ng-template #loaded>
+            {{ value.accessLevel | titlecase }}
+          </ng-template>
         </ng-template>
       </ngx-datatable-column>
       <ngx-datatable-column

--- a/src/app/components/profile/pages/sites/their-sites.component.spec.ts
+++ b/src/app/components/profile/pages/sites/their-sites.component.spec.ts
@@ -161,7 +161,9 @@ describe("TheirSitesComponent", () => {
             await projectPromise;
             spec.detectChanges();
 
-            expect(getCells()[2]).toHaveText(accessLevel);
+            const titleCaseAccessLevel =
+              accessLevel.charAt(0).toUpperCase() + accessLevel.slice(1);
+            expect(getCells()[2]).toHaveText(titleCaseAccessLevel);
           });
         }
       );

--- a/src/app/components/projects/pages/permissions/permissions.component.ts
+++ b/src/app/components/projects/pages/permissions/permissions.component.ts
@@ -84,23 +84,23 @@ class PermissionsComponent extends TableTemplate<TableRow> implements OnInit {
       {
         user: "allcharles",
         individual: "testing",
-        visitors: "Reader",
-        users: "Reader",
-        overall: "Reader",
+        visitors: "reader",
+        users: "reader",
+        overall: "reader",
       },
       {
         user: "anthony",
         individual: "testing",
-        visitors: "Reader",
-        users: "Reader",
-        overall: "Reader",
+        visitors: "reader",
+        users: "reader",
+        overall: "reader",
       },
       {
         user: "phil",
         individual: "testing",
-        visitors: "Reader",
-        users: "Reader",
-        overall: "Reader",
+        visitors: "reader",
+        users: "reader",
+        overall: "reader",
       },
     ];
   }
@@ -121,7 +121,7 @@ export { PermissionsComponent };
 interface TableRow {
   user: string;
   individual: string;
-  visitors: "None" | "Reader";
-  users: "None" | "Reader" | "Writer" | "Owner";
-  overall: "None" | "Reader" | "Writer" | "Owner";
+  visitors: "none" | "reader";
+  users: "none" | "reader" | "writer" | "owner";
+  overall: "none" | "reader" | "writer" | "owner";
 }

--- a/src/app/interfaces/apiInterfaces.ts
+++ b/src/app/interfaces/apiInterfaces.ts
@@ -35,11 +35,11 @@ export type AuthToken = string;
  * BAW API Access Levels
  */
 export enum AccessLevel {
-  reader = "Reader",
-  writer = "Writer",
-  owner = "Owner",
-  unresolved = "Unresolved",
-  unknown = "Unknown",
+  reader = "reader",
+  writer = "writer",
+  owner = "owner",
+  unresolved = "unresolved",
+  unknown = "unknown",
 }
 
 /**


### PR DESCRIPTION
# Handle Breaking Changes to Access Levels

This change to the server https://github.com/QutEcoacoustics/baw-server/commit/f9ba4051f59b5e2c7c89597bf3b6d606e24939e8 caused breaking changes from the perspective of the workbench client. This PR cleans up any of the breakages which have occured

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
