### PR TITLE
Fix labels not being populated from args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ RUN npm run build:ssr
 
 FROM node:14-alpine
 
+ARG GIT_COMMIT
+ARG WORKBENCH_CLIENT_VERSION
+
 WORKDIR /home/node/workbench-client
 
 LABEL maintainer="Charles Alleman <alleman@qut.edu.au>" \


### PR DESCRIPTION
See https://stackoverflow.com/a/53683625/224512

Essentially ARG is only in scope for a single stage of a multistage build


## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
