### PR TITLE
Filter by time of day

### DIFF
--- a/src/app/components/audio-recordings/audio-recording.module.ts
+++ b/src/app/components/audio-recordings/audio-recording.module.ts
@@ -3,9 +3,16 @@ import { RouterModule } from "@angular/router";
 import { getRouteConfigForPage } from "@helpers/page/pageRouting";
 import { SharedModule } from "@shared/shared.module";
 import { audioRecordingsRoutes } from "./audio-recording.routes";
+import { DownloadTableComponent } from "./download-table/download-table.component";
 import { AudioRecordingsDetailsComponent } from "./pages/details/details.component";
 import { DownloadAudioRecordingsComponent } from "./pages/download/download.component";
 import { AudioRecordingsListComponent } from "./pages/list/list.component";
+import { SitesWithoutTimezonesComponent } from "./sites-without-timezones/sites-without-timezones.component";
+
+const internalComponents = [
+  SitesWithoutTimezonesComponent,
+  DownloadTableComponent,
+];
 
 const components = [
   AudioRecordingsListComponent,
@@ -18,7 +25,7 @@ const routes = Object.values(audioRecordingsRoutes)
   .flat();
 
 @NgModule({
-  declarations: components,
+  declarations: [...components, internalComponents],
   imports: [SharedModule, RouterModule.forChild(routes)],
   exports: [RouterModule, ...components],
 })

--- a/src/app/components/audio-recordings/download-table/download-table.component.spec.ts
+++ b/src/app/components/audio-recordings/download-table/download-table.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { DownloadTableComponent } from "./download-table.component";
+
+// TODO
+xdescribe("DownloadTableComponent", () => {
+  let component: DownloadTableComponent;
+  let fixture: ComponentFixture<DownloadTableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DownloadTableComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DownloadTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/audio-recordings/download-table/download-table.component.ts
+++ b/src/app/components/audio-recordings/download-table/download-table.component.ts
@@ -1,0 +1,58 @@
+import { Component, Input } from "@angular/core";
+import { AudioRecording } from "@models/AudioRecording";
+import { Observable } from "rxjs";
+
+@Component({
+  selector: "baw-download-table",
+  template: `
+    <ng-container *ngIf="recordings$ | withLoading | async as recordings">
+      <baw-loading *ngIf="recordings.loading"></baw-loading>
+
+      <pre *ngIf="recordings.error">{{ recordings.error | json }}</pre>
+
+      <p *ngIf="recordings.value">
+        Number of Recordings Selected:
+        {{ getNumberOfRecordings(recordings.value) }}
+      </p>
+      <!--
+        <p *ngIf="recordings.value">
+        Newest (in current page): {{ getNewestRecording(recordings.value) }}
+      </p>
+      <p *ngIf="recordings.value">
+        Oldest (in current page): {{ getOldestRecording(recordings.value) }}
+      </p>
+      <pre *ngIf="recordings.value">{{ recordings.value | json }}</pre>
+      -->
+    </ng-container>
+  `,
+})
+export class DownloadTableComponent {
+  @Input() public recordings$: Observable<AudioRecording[]>;
+
+  public getNumberOfRecordings(recordings: AudioRecording[]): number {
+    if (recordings.length === 0) {
+      return 0;
+    }
+    return recordings[0].getMetadata().paging.total;
+  }
+
+  public getNewestRecording(recordings: AudioRecording[]): string {
+    if (recordings.length === 0) {
+      return "No recordings";
+    }
+
+    return recordings
+      .reduce((a, b) => (a.recordedDate > b.recordedDate ? a : b))
+      .recordedDate.toFormat("yyyy-MM-dd hh:mm:ss");
+  }
+
+  public getOldestRecording(recordings: AudioRecording[]): string {
+    if (recordings.length === 0) {
+      return "No recordings";
+    }
+
+    return recordings
+      .reduce((a, b) => (a.recordedDate < b.recordedDate ? a : b))
+      .recordedDate.toFormat("yyyy-MM-dd hh:mm:ss");
+  }
+}

--- a/src/app/components/audio-recordings/pages/download/download.component.html
+++ b/src/app/components/audio-recordings/pages/download/download.component.html
@@ -1,35 +1,11 @@
 <h1>Batch Download Audio Recordings</h1>
 
 <!-- Warn users about limitations of time of day filter -->
-<ng-container
-  *ngIf="
-    sitesWithoutTimezones(
-      site,
-      region?.sites,
-      project?.sites
-    ) as sitesWithoutTimezone
-  "
->
-  <div *ngIf="sitesWithoutTimezone.length > 0" class="alert alert-danger">
-    Warning, this batch download includes site/s which do not have their
-    timezones set. Any time of day filtering will not work on these sites until
-    the site owner or editors update them. The list of sites can be seen below:
-
-    <ul *ngFor="let siteWithoutTimezone of sitesWithoutTimezone" class="mb-0">
-      <li>
-        <a
-          [bawUrl]="
-            project
-              ? siteWithoutTimezone.getViewUrl(project)
-              : siteWithoutTimezone.viewUrl
-          "
-        >
-          {{ siteWithoutTimezone.name }}
-        </a>
-      </li>
-    </ul>
-  </div>
-</ng-container>
+<baw-sites-without-timezones
+  [site]="site"
+  [region]="region"
+  [project]="project"
+></baw-sites-without-timezones>
 
 <form #form>
   <!-- Project -->
@@ -200,24 +176,7 @@
   </div>
 </form>
 
-<ng-container *ngIf="recordings$ | withLoading | async as recordings">
-  <baw-loading *ngIf="recordings.loading"></baw-loading>
-
-  <pre *ngIf="recordings.error">{{ recordings.error | json }}</pre>
-
-  <p *ngIf="recordings.value">
-    Number of Recordings Selected: {{ getNumberOfRecordings(recordings.value) }}
-  </p>
-  <!--
-    <p *ngIf="recordings.value">
-    Newest (in current page): {{ getNewestRecording(recordings.value) }}
-  </p>
-  <p *ngIf="recordings.value">
-    Oldest (in current page): {{ getOldestRecording(recordings.value) }}
-  </p>
-  <pre *ngIf="recordings.value">{{ recordings.value | json }}</pre>
-  -->
-</ng-container>
+<baw-download-table [recordings$]="recordings$"></baw-download-table>
 
 <div class="clearfix">
   <a

--- a/src/app/components/audio-recordings/pages/download/download.component.html
+++ b/src/app/components/audio-recordings/pages/download/download.component.html
@@ -46,19 +46,21 @@
     </label>
     <!-- TODO Replace with dates using yyyy-mm-dd format -->
     <input
-      id="started-after-date"
-      name="startedAfterDate"
+      id="started-after"
+      name="startedAfter"
       type="date"
       class="form-control"
-      [(ngModel)]="model.startedAfterDate"
+      [(ngModel)]="model.startedAfter"
       useValueAsDate
     />
 
-    <small class="form-text text-muted">
-      The UTC (+00:00) time zone is used for all date filtering. If you're
-      unsure if your data will be included in a filter, expand your date range
-      by one-day in either direction.
-    </small>
+    <div class="form-text">
+      <strong
+        >The UTC (+00:00) time zone is used for all date filtering.</strong
+      >
+      If you're unsure if your data will be included in a filter, expand your
+      date range by one-day in either direction.
+    </div>
   </div>
 
   <!-- End Date -->
@@ -68,52 +70,94 @@
     </label>
     <!-- TODO Replace with dates using yyyy-mm-dd format -->
     <input
-      id="finished-before-date"
-      name="finishedBeforeDate"
+      id="finished-before"
+      name="finishedBefore"
       type="date"
       class="form-control"
-      [(ngModel)]="model.finishedBeforeDate"
+      [(ngModel)]="model.finishedBefore"
       useValueAsDate
     />
 
-    <small class="form-text text-muted">
-      The UTC (+00:00) time zone is used for all date filtering. If you're
-      unsure if your data will be included in a filter, expand your date range
-      by one-day in either direction.
-    </small>
+    <div class="form-text">
+      <strong
+        >The UTC (+00:00) time zone is used for all date filtering.</strong
+      >
+      If you're unsure if your data will be included in a filter, expand your
+      date range by one-day in either direction.
+    </div>
 
     <!-- TODO Warning message if end date is before start date -->
   </div>
 
   <!-- Time of Day Selector -->
 
-  <div class="mb-3">
-    <label class="form-label">Filter results by time of day</label>
+  <label for="timeOfDay" class="form-label">Time of Day Filter</label>
 
-    <div class="input-group">
+  <div class="form-check mb-3">
+    <input
+      id="time-of-day-filtering"
+      name="todEnabled"
+      type="checkbox"
+      class="form-check-input"
+      [(ngModel)]="model.todEnabled"
+    />
+
+    <label class="form-check-label" for="time-of-day-filtering">
+      Enable filtering by time of day
+    </label>
+  </div>
+
+  <div #collapse="ngbCollapse" [ngbCollapse]="!model.todEnabled">
+    <div class="form-check mb-3">
+      <input
+        id="tod-ignore-dst"
+        name="todIgnoreDst"
+        type="checkbox"
+        class="form-check-input"
+        [disabled]="!model.todEnabled"
+        [(ngModel)]="model.todIgnoreDst"
+      />
+
+      <label class="form-check-label" for="tod-ignore-dst">
+        Ignore day light savings (DST)
+      </label>
+
+      <div class="form-text">
+        Real world events, like dawn chorus, or the vocalization of fauna are
+        not affected by daylight savings time. Ignoring DST is advised to ensure
+        audio is filtered consistently. If any recordings occur during a DST
+        period, the base offset, that is the time it would be if DST were not in
+        effect, will be used.
+      </div>
+    </div>
+
+    <div class="input-group mb-3">
       <span class="input-group-text">Start Time</span>
       <input
-        id="started-after-time"
-        name="startedAfterTime"
+        id="tod-started-after"
+        name="todStartedAfter"
         type="time"
         class="form-control"
-        [(ngModel)]="startedAfterTime"
+        [disabled]="!model.todEnabled"
+        [(ngModel)]="todStartedAfter"
+        useValueAsDate
       />
       <span class="input-group-text">End Time</span>
       <input
-        id="finished-before-time"
-        name="finishedBeforeTime"
+        id="tod-finished-before"
+        name="todFinishedBefore"
         type="time"
         class="form-control"
-        [(ngModel)]="finishedBeforeTime"
+        [disabled]="!model.todEnabled"
+        [(ngModel)]="todFinishedBefore"
+        useValueAsDate
       />
-    </div>
 
-    <small class="form-text text-muted">
-      Filter recordings by the time of day they were recorded. If the filter is
-      set to 09:00-11:00, it will match recordings which go from 08:00-10:00 and
-      10:00-12:00.
-    </small>
+      <div class="form-text">
+        Filter recordings by the time of day they were recorded. If any part of
+        a recording overlaps these limits, then it will be included.
+      </div>
+    </div>
   </div>
 </form>
 
@@ -122,6 +166,21 @@
 </div>
 
 <!-- TODO Preview audio recordings which will be downloaded by this request -->
+
+<ng-container *ngIf="recordings$ | withLoading | async as recordings">
+  <baw-loading *ngIf="recordings.loading"></baw-loading>
+
+  <pre *ngIf="recordings.error">{{ recordings.error | json }}</pre>
+
+  <p *ngIf="recordings.value">
+    Newest: {{ getNewestRecording(recordings.value) }}
+  </p>
+  <p *ngIf="recordings.value">
+    Oldest: {{ getOldestRecording(recordings.value) }}
+  </p>
+
+  <pre *ngIf="recordings.value">{{ recordings.value | json }}</pre>
+</ng-container>
 
 <hr />
 

--- a/src/app/components/audio-recordings/pages/download/download.component.html
+++ b/src/app/components/audio-recordings/pages/download/download.component.html
@@ -114,7 +114,11 @@
     </label>
   </div>
 
-  <div #collapse="ngbCollapse" [ngbCollapse]="!model.todEnabled">
+  <div
+    id="tod-filters-wrapper"
+    #collapse="ngbCollapse"
+    [ngbCollapse]="!model.todEnabled"
+  >
     <div class="form-check mb-3">
       <input
         id="tod-ignore-dst"
@@ -180,6 +184,7 @@
 
 <div class="clearfix">
   <a
+    id="download-script"
     class="btn btn-primary float-end mt-3"
     [class.disabled]="invalidForm(errors)"
     [href]="href"

--- a/src/app/components/audio-recordings/pages/download/download.component.html
+++ b/src/app/components/audio-recordings/pages/download/download.component.html
@@ -1,5 +1,36 @@
 <h1>Batch Download Audio Recordings</h1>
 
+<!-- Warn users about limitations of time of day filter -->
+<ng-container
+  *ngIf="
+    sitesWithoutTimezones(
+      site,
+      region?.sites,
+      project?.sites
+    ) as sitesWithoutTimezone
+  "
+>
+  <div *ngIf="sitesWithoutTimezone.length > 0" class="alert alert-danger">
+    Warning, this batch download includes site/s which do not have their
+    timezones set. Any time of day filtering will not work on these sites until
+    the site owner or editors update them. The list of sites can be seen below:
+
+    <ul *ngFor="let siteWithoutTimezone of sitesWithoutTimezone" class="mb-0">
+      <li>
+        <a
+          [bawUrl]="
+            project
+              ? siteWithoutTimezone.getViewUrl(project)
+              : siteWithoutTimezone.viewUrl
+          "
+        >
+          {{ siteWithoutTimezone.name }}
+        </a>
+      </li>
+    </ul>
+  </div>
+</ng-container>
+
 <form #form>
   <!-- Project -->
   <div *ngIf="project" class="mb-3">
@@ -140,7 +171,6 @@
         class="form-control"
         [disabled]="!model.todEnabled"
         [(ngModel)]="todStartedAfter"
-        useValueAsDate
       />
       <span class="input-group-text">End Time</span>
       <input
@@ -150,7 +180,6 @@
         class="form-control"
         [disabled]="!model.todEnabled"
         [(ngModel)]="todFinishedBefore"
-        useValueAsDate
       />
 
       <div class="form-text">
@@ -173,10 +202,13 @@
   <pre *ngIf="recordings.error">{{ recordings.error | json }}</pre>
 
   <p *ngIf="recordings.value">
-    Newest: {{ getNewestRecording(recordings.value) }}
+    Number of Recordings: {{ getNumberOfRecordings(recordings.value) }}
   </p>
   <p *ngIf="recordings.value">
-    Oldest: {{ getOldestRecording(recordings.value) }}
+    Newest (in current page): {{ getNewestRecording(recordings.value) }}
+  </p>
+  <p *ngIf="recordings.value">
+    Oldest (in current page): {{ getOldestRecording(recordings.value) }}
   </p>
 
   <pre *ngIf="recordings.value">{{ recordings.value | json }}</pre>

--- a/src/app/components/audio-recordings/pages/download/download.component.html
+++ b/src/app/components/audio-recordings/pages/download/download.component.html
@@ -102,14 +102,14 @@
 
   <div class="form-check mb-3">
     <input
-      id="time-of-day-filtering"
+      id="tod-filtering"
       name="todEnabled"
       type="checkbox"
       class="form-check-input"
       [(ngModel)]="model.todEnabled"
     />
 
-    <label class="form-check-label" for="time-of-day-filtering">
+    <label class="form-check-label" for="tod-filtering">
       Enable filtering by time of day
     </label>
   </div>

--- a/src/app/components/audio-recordings/pages/download/download.component.html
+++ b/src/app/components/audio-recordings/pages/download/download.component.html
@@ -162,34 +162,36 @@
       </div>
     </div>
 
-    <div class="input-group mb-3">
-      <span class="input-group-text">Start Time</span>
-      <input
-        id="tod-started-after"
-        name="todStartedAfter"
-        type="time"
-        class="form-control"
-        [class.is-invalid]="errors.todBoundaryError"
-        [disabled]="!model.todEnabled"
-        [(ngModel)]="todStartedAfter"
-      />
-      <span class="input-group-text">End Time</span>
-      <input
-        id="tod-finished-before"
-        name="todFinishedBefore"
-        type="time"
-        class="form-control"
-        [class.is-invalid]="errors.todBoundaryError"
-        [disabled]="!model.todEnabled"
-        [(ngModel)]="todFinishedBefore"
-      />
+    <div class="mb-3">
+      <div class="input-group">
+        <span class="input-group-text">Start Time</span>
+        <input
+          id="tod-started-after"
+          name="todStartedAfter"
+          type="time"
+          class="form-control"
+          [class.is-invalid]="errors.todBoundaryError"
+          [disabled]="!model.todEnabled"
+          [(ngModel)]="todStartedAfter"
+        />
+        <span class="input-group-text">End Time</span>
+        <input
+          id="tod-finished-before"
+          name="todFinishedBefore"
+          type="time"
+          class="form-control"
+          [class.is-invalid]="errors.todBoundaryError"
+          [disabled]="!model.todEnabled"
+          [(ngModel)]="todFinishedBefore"
+        />
+      </div>
 
       <div class="form-text">
         Filter recordings by the time of day they were recorded. If any part of
         a recording overlaps these limits, then it will be included.
       </div>
 
-      <div *ngIf="errors.todBoundaryError" class="invalid-feedback">
+      <div *ngIf="errors.todBoundaryError" class="form-error">
         Time of day filtering does not currently support filtering past a day
         boundary. Please adjust your request so that the start time is before
         the end time.
@@ -266,7 +268,24 @@
     move the script to your external hard drive.
   </p>
 
-  <h3>3. Open a terminal</h3>
+  <h3>3. Unblock the downloader script</h3>
+
+  <ul>
+    <li>
+      If you are on Windows
+      <a href="https://www.thewindowsclub.com/fix-windows-blocked-access-file"
+        >unblock the file</a
+      >
+    </li>
+    <li>
+      If you are on Linux or MacOS, update the permissions of the file using
+      <code>chmod +x "download_audio_files.ps1"</code>
+    </li>
+  </ul>
+
+  <p>Depending on your personal settings,</p>
+
+  <h3>4. Open a terminal</h3>
 
   <p>
     Next open PowerShell in the same folder as your script. In most operating
@@ -281,7 +300,7 @@
     shell (like <code>cmd</code>/<code>bash</code>/<code>zsh</code>).
   </p>
 
-  <h3>4. Get an authentication token</h3>
+  <h3>5. Get an authentication token</h3>
 
   <p>
     Each time you want to run this script, you will need to supply an
@@ -295,7 +314,7 @@
 
   <!-- TODO Show users how with asciicast -->
 
-  <h3>5. Run the script</h3>
+  <h3>6. Run the script</h3>
 
   <p>
     Copy and paste the following command into your PowerShell session. Ensure
@@ -304,7 +323,7 @@
 
   <p>
     <code>
-      ./download_audio_files.ps1 -auth_token="INSERT_AUTH_TOKEN_HERE
+      ./download_audio_files.ps1 -auth_token "INSERT_AUTH_TOKEN_HERE
     </code>
   </p>
 

--- a/src/app/components/audio-recordings/pages/download/download.component.html
+++ b/src/app/components/audio-recordings/pages/download/download.component.html
@@ -169,6 +169,7 @@
         name="todStartedAfter"
         type="time"
         class="form-control"
+        [class.is-invalid]="errors.todBoundaryError"
         [disabled]="!model.todEnabled"
         [(ngModel)]="todStartedAfter"
       />
@@ -178,6 +179,7 @@
         name="todFinishedBefore"
         type="time"
         class="form-control"
+        [class.is-invalid]="errors.todBoundaryError"
         [disabled]="!model.todEnabled"
         [(ngModel)]="todFinishedBefore"
       />
@@ -186,15 +188,15 @@
         Filter recordings by the time of day they were recorded. If any part of
         a recording overlaps these limits, then it will be included.
       </div>
+
+      <div *ngIf="errors.todBoundaryError" class="invalid-feedback">
+        Time of day filtering does not currently support filtering past a day
+        boundary. Please adjust your request so that the start time is before
+        the end time.
+      </div>
     </div>
   </div>
 </form>
-
-<div class="clearfix">
-  <a class="btn btn-primary float-end mt-3" [href]="href">Download Script</a>
-</div>
-
-<!-- TODO Preview audio recordings which will be downloaded by this request -->
 
 <ng-container *ngIf="recordings$ | withLoading | async as recordings">
   <baw-loading *ngIf="recordings.loading"></baw-loading>
@@ -202,17 +204,29 @@
   <pre *ngIf="recordings.error">{{ recordings.error | json }}</pre>
 
   <p *ngIf="recordings.value">
-    Number of Recordings: {{ getNumberOfRecordings(recordings.value) }}
+    Number of Recordings Selected: {{ getNumberOfRecordings(recordings.value) }}
   </p>
-  <p *ngIf="recordings.value">
+  <!--
+    <p *ngIf="recordings.value">
     Newest (in current page): {{ getNewestRecording(recordings.value) }}
   </p>
   <p *ngIf="recordings.value">
     Oldest (in current page): {{ getOldestRecording(recordings.value) }}
   </p>
-
   <pre *ngIf="recordings.value">{{ recordings.value | json }}</pre>
+  -->
 </ng-container>
+
+<div class="clearfix">
+  <a
+    class="btn btn-primary float-end mt-3"
+    [class.disabled]="invalidForm(errors)"
+    [href]="href"
+    >Download Script</a
+  >
+</div>
+
+<!-- TODO Preview audio recordings which will be downloaded by this request -->
 
 <hr />
 

--- a/src/app/components/audio-recordings/pages/download/download.component.html
+++ b/src/app/components/audio-recordings/pages/download/download.component.html
@@ -46,11 +46,11 @@
     </label>
     <!-- TODO Replace with dates using yyyy-mm-dd format -->
     <input
-      id="recording-started-after"
-      name="recordingStartedAfter"
+      id="started-after-date"
+      name="startedAfterDate"
       type="date"
       class="form-control"
-      [(ngModel)]="model.recordingStartedAfter"
+      [(ngModel)]="model.startedAfterDate"
       useValueAsDate
     />
 
@@ -68,11 +68,11 @@
     </label>
     <!-- TODO Replace with dates using yyyy-mm-dd format -->
     <input
-      id="recording-finished-before"
-      name="recordingFinishedBefore"
+      id="finished-before-date"
+      name="finishedBeforeDate"
       type="date"
       class="form-control"
-      [(ngModel)]="model.recordingFinishedBefore"
+      [(ngModel)]="model.finishedBeforeDate"
       useValueAsDate
     />
 
@@ -83,6 +83,37 @@
     </small>
 
     <!-- TODO Warning message if end date is before start date -->
+  </div>
+
+  <!-- Time of Day Selector -->
+
+  <div class="mb-3">
+    <label class="form-label">Filter results by time of day</label>
+
+    <div class="input-group">
+      <span class="input-group-text">Start Time</span>
+      <input
+        id="started-after-time"
+        name="startedAfterTime"
+        type="time"
+        class="form-control"
+        [(ngModel)]="startedAfterTime"
+      />
+      <span class="input-group-text">End Time</span>
+      <input
+        id="finished-before-time"
+        name="finishedBeforeTime"
+        type="time"
+        class="form-control"
+        [(ngModel)]="finishedBeforeTime"
+      />
+    </div>
+
+    <small class="form-text text-muted">
+      Filter recordings by the time of day they were recorded. If the filter is
+      set to 09:00-11:00, it will match recordings which go from 08:00-10:00 and
+      10:00-12:00.
+    </small>
   </div>
 </form>
 

--- a/src/app/components/audio-recordings/pages/download/download.component.scss
+++ b/src/app/components/audio-recordings/pages/download/download.component.scss
@@ -5,3 +5,10 @@ label {
     font-weight: normal;
   }
 }
+
+.form-error {
+  width: 100%;
+  margin-top: 0.25rem;
+  font-size: 0.875em;
+  color: #dc3545;
+}

--- a/src/app/components/audio-recordings/pages/download/download.component.scss
+++ b/src/app/components/audio-recordings/pages/download/download.component.scss
@@ -1,0 +1,7 @@
+label {
+  font-weight: bold;
+
+  .form-check label {
+    font-weight: normal;
+  }
+}

--- a/src/app/components/audio-recordings/pages/download/download.component.spec.ts
+++ b/src/app/components/audio-recordings/pages/download/download.component.spec.ts
@@ -2,6 +2,8 @@ import { fakeAsync } from "@angular/core/testing";
 import { AudioRecordingsService } from "@baw-api/audio-recording/audio-recordings.service";
 import { Filters } from "@baw-api/baw-api.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { DownloadTableComponent } from "@components/audio-recordings/download-table/download-table.component";
+import { SitesWithoutTimezonesComponent } from "@components/audio-recordings/sites-without-timezones/sites-without-timezones.component";
 import { AudioRecording } from "@models/AudioRecording";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
@@ -12,9 +14,10 @@ import { generateProject } from "@test/fakes/Project";
 import { generateRegion } from "@test/fakes/Region";
 import { generateSite } from "@test/fakes/Site";
 import { inputValue } from "@test/helpers/html";
+import { MockComponent } from "ng-mocks";
 import { DownloadAudioRecordingsComponent } from "./download.component";
 
-xdescribe("DownloadAudioRecordingsComponent", () => {
+describe("DownloadAudioRecordingsComponent", () => {
   let defaultProject: Project;
   let defaultRegion: Region;
   let defaultSite: Site;
@@ -22,6 +25,10 @@ xdescribe("DownloadAudioRecordingsComponent", () => {
   const createComponent = createRoutingFactory({
     component: DownloadAudioRecordingsComponent,
     imports: [SharedModule, MockBawApiModule],
+    declarations: [
+      MockComponent(SitesWithoutTimezonesComponent),
+      MockComponent(DownloadTableComponent),
+    ],
   });
 
   function getProjectInput() {
@@ -59,6 +66,8 @@ xdescribe("DownloadAudioRecordingsComponent", () => {
   }
 
   function filterByStartDate(filter: Filters<AudioRecording>, date: Date) {
+    console.log(filter);
+
     expect(filter.filter["recordedDate"]).toEqual({
       greaterThan: date.toISOString(),
     });

--- a/src/app/components/audio-recordings/pages/download/download.component.spec.ts
+++ b/src/app/components/audio-recordings/pages/download/download.component.spec.ts
@@ -30,17 +30,26 @@ describe("DownloadAudioRecordingsComponent", () => {
       MockComponent(DownloadTableComponent),
     ],
   });
+  const projectInputSelector = "#project";
+  const regionInputSelector = "#region";
+  const siteInputSelector = "#site";
+  const startedAfterInputSelector = "#started-after";
+  const finishedBeforeInputSelector = "#finished-before";
+  const todEnabledInputSelector = "#tod-filtering";
+  const todIgnoreDstInputSelector = "#tod-ignore-dst";
+  const todStartedAfter = "#tod-started-after";
+  const todFinishedBefore = "#tod-finished-before";
 
   function getProjectInput() {
-    return spec.query<HTMLInputElement>("#project");
+    return spec.query<HTMLInputElement>(projectInputSelector);
   }
 
   function getRegionInput() {
-    return spec.query<HTMLInputElement>("#region");
+    return spec.query<HTMLInputElement>(regionInputSelector);
   }
 
   function getSiteInput() {
-    return spec.query<HTMLInputElement>("#site");
+    return spec.query<HTMLInputElement>(siteInputSelector);
   }
 
   function getSiteLabel() {
@@ -66,16 +75,14 @@ describe("DownloadAudioRecordingsComponent", () => {
   }
 
   function filterByStartDate(filter: Filters<AudioRecording>, date: Date) {
-    console.log(filter);
-
     expect(filter.filter["recordedDate"]).toEqual({
-      greaterThan: date.toISOString(),
+      greaterThanOrEqual: date.toISOString(),
     });
   }
 
   function filterByEndDate(filter: Filters<AudioRecording>, date: Date) {
     expect(filter.filter["recordedEndDate"]).toEqual({
-      lessThan: date.toISOString(),
+      lessThanOrEqual: date.toISOString(),
     });
   }
 
@@ -255,7 +262,7 @@ describe("DownloadAudioRecordingsComponent", () => {
         "/bulk_download",
         () => {
           // Update input after the form has been set
-          inputValue(spec.element, "#recording-started-after", "2020-01-01");
+          inputValue(spec.element, startedAfterInputSelector, "2020-01-01");
           spec.detectChanges();
         },
         (filter) => {
@@ -284,7 +291,7 @@ describe("DownloadAudioRecordingsComponent", () => {
         "/bulk_download",
         () => {
           // Update input after the form has been set
-          inputValue(spec.element, "#recording-finished-before", "2020-01-01");
+          inputValue(spec.element, finishedBeforeInputSelector, "2020-01-01");
           spec.detectChanges();
         },
         (filter) => {
@@ -306,12 +313,12 @@ describe("DownloadAudioRecordingsComponent", () => {
         "/bulk_download",
         () => {
           // Update input after the form has been set
-          inputValue(spec.element, "#recording-started-after", "2019-01-01");
+          inputValue(spec.element, startedAfterInputSelector, "2019-01-01");
           spec.detectChanges();
         },
         () => {
           // Update input after the form has been set
-          inputValue(spec.element, "#recording-finished-before", "2020-01-01");
+          inputValue(spec.element, finishedBeforeInputSelector, "2020-01-01");
           spec.detectChanges();
         },
         (filter) => {

--- a/src/app/components/audio-recordings/pages/download/download.component.spec.ts
+++ b/src/app/components/audio-recordings/pages/download/download.component.spec.ts
@@ -1,111 +1,90 @@
 import { fakeAsync } from "@angular/core/testing";
 import { AudioRecordingsService } from "@baw-api/audio-recording/audio-recordings.service";
-import { Filters } from "@baw-api/baw-api.service";
-import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { BawApiService } from "@baw-api/baw-api.service";
+import { BawSessionService } from "@baw-api/baw-session.service";
 import { DownloadTableComponent } from "@components/audio-recordings/download-table/download-table.component";
 import { SitesWithoutTimezonesComponent } from "@components/audio-recordings/sites-without-timezones/sites-without-timezones.component";
 import { AudioRecording } from "@models/AudioRecording";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
-import { createRoutingFactory, SpectatorRouting } from "@ngneat/spectator";
+import { NgbCollapse, NgbCollapseModule } from "@ng-bootstrap/ng-bootstrap";
+import {
+  createRoutingFactory,
+  mockProvider,
+  SpectatorRouting,
+} from "@ngneat/spectator";
+import { MockAppConfigModule } from "@services/config/configMock.module";
 import { SharedModule } from "@shared/shared.module";
 import { generateProject } from "@test/fakes/Project";
 import { generateRegion } from "@test/fakes/Region";
 import { generateSite } from "@test/fakes/Site";
-import { inputValue } from "@test/helpers/html";
+import { assertHref } from "@test/helpers/html";
 import { MockComponent } from "ng-mocks";
+import { ToastrService } from "ngx-toastr";
+import { Subject } from "rxjs";
 import { DownloadAudioRecordingsComponent } from "./download.component";
 
 describe("DownloadAudioRecordingsComponent", () => {
   let defaultProject: Project;
   let defaultRegion: Region;
   let defaultSite: Site;
+  let api: AudioRecordingsService;
+  let apiFilter: Subject<AudioRecording[]>;
   let spec: SpectatorRouting<DownloadAudioRecordingsComponent>;
   const createComponent = createRoutingFactory({
     component: DownloadAudioRecordingsComponent,
-    imports: [SharedModule, MockBawApiModule],
+    imports: [SharedModule, NgbCollapseModule, MockAppConfigModule],
     declarations: [
       MockComponent(SitesWithoutTimezonesComponent),
       MockComponent(DownloadTableComponent),
     ],
+    // We are relying on AudioRecordingsService's batchDownloadUrl so we will
+    // mock out any API calls
+    providers: [
+      mockProvider(ToastrService),
+      BawSessionService,
+      BawApiService,
+      AudioRecordingsService,
+    ],
   });
-  const projectInputSelector = "#project";
-  const regionInputSelector = "#region";
-  const siteInputSelector = "#site";
-  const startedAfterInputSelector = "#started-after";
-  const finishedBeforeInputSelector = "#finished-before";
-  const todEnabledInputSelector = "#tod-filtering";
-  const todIgnoreDstInputSelector = "#tod-ignore-dst";
-  const todStartedAfter = "#tod-started-after";
-  const todFinishedBefore = "#tod-finished-before";
 
-  function getProjectInput() {
-    return spec.query<HTMLInputElement>(projectInputSelector);
+  const getProjectInput = () => spec.query<HTMLInputElement>("#project");
+  const getRegionInput = () => spec.query<HTMLInputElement>("#region");
+  const getSiteInput = () => spec.query<HTMLInputElement>("#site");
+  const getSiteLabel = () => spec.query<HTMLLabelElement>("#site-label");
+  const getDownloadLink = () =>
+    spec.query<HTMLAnchorElement>("#download-script");
+  const getStartedAfterInput = () =>
+    spec.query<HTMLInputElement>("#started-after");
+  const getFinishedBeforeInput = () =>
+    spec.query<HTMLInputElement>("#finished-before");
+  const getTodInputWrapper = () =>
+    spec.query("#tod-filters-wrapper", { read: NgbCollapse });
+  const getTodToggleInput = () =>
+    spec.query<HTMLInputElement>("#tod-filtering");
+  const getTodIgnoreDstInput = () =>
+    spec.query<HTMLInputElement>("#tod-ignore-dst");
+  const getTodStartedAfterInput = () =>
+    spec.query<HTMLInputElement>("#tod-started-after");
+  const getTodFinishedBeforeInput = () =>
+    spec.query<HTMLInputElement>("#tod-finished-before");
+
+  function toggleTod() {
+    const input = getTodToggleInput();
+    input.click();
+    input.dispatchEvent(new Event("input"));
+    spec.detectChanges();
+    // NgbCollapse takes a bit to open/close
+    spec.tick(1000);
+    spec.detectChanges();
   }
 
-  function getRegionInput() {
-    return spec.query<HTMLInputElement>(regionInputSelector);
-  }
-
-  function getSiteInput() {
-    return spec.query<HTMLInputElement>(siteInputSelector);
-  }
-
-  function getSiteLabel() {
-    return spec.query<HTMLLabelElement>("#site-label");
-  }
-
-  function filterByProject(filter: Filters<AudioRecording>, project: Project) {
-    expect(filter.filter["projects.id"]).toEqual({ eq: project.id });
-    expect(filter.filter["regions.id"]).toBeUndefined();
-    expect(filter.filter["sites.id"]).toBeUndefined();
-  }
-
-  function filterByRegion(filter: Filters<AudioRecording>, region: Region) {
-    expect(filter.filter["projects.id"]).toBeUndefined();
-    expect(filter.filter["regions.id"]).toEqual({ eq: region.id });
-    expect(filter.filter["sites.id"]).toBeUndefined();
-  }
-
-  function filterBySite(filter: Filters<AudioRecording>, site: Site) {
-    expect(filter.filter["projects.id"]).toBeUndefined();
-    expect(filter.filter["regions.id"]).toBeUndefined();
-    expect(filter.filter["sites.id"]).toEqual({ eq: site.id });
-  }
-
-  function filterByStartDate(filter: Filters<AudioRecording>, date: Date) {
-    expect(filter.filter["recordedDate"]).toEqual({
-      greaterThanOrEqual: date.toISOString(),
-    });
-  }
-
-  function filterByEndDate(filter: Filters<AudioRecording>, date: Date) {
-    expect(filter.filter["recordedEndDate"]).toEqual({
-      lessThanOrEqual: date.toISOString(),
-    });
-  }
-
-  function interceptDownloadUrl(
-    url: string = "/batch_download",
-    ...expectations: ((filter: Filters<AudioRecording>) => void)[]
-  ) {
-    let count = 0;
-    const initialExpectation = 3;
-
-    const recordingsApi = spec.inject(AudioRecordingsService);
-    recordingsApi.batchDownloadUrl.and.callFake(
-      (filter: Filters<AudioRecording>) => {
-        count++;
-
-        const index = count - initialExpectation;
-        if (index >= 0 && expectations.length > index) {
-          expectations[index](filter);
-        }
-
-        return url;
-      }
-    );
+  function toggleIgnoreDst() {
+    const input = getTodIgnoreDstInput();
+    input.click();
+    input.dispatchEvent(new Event("input"));
+    spec.detectChanges();
   }
 
   function setup(project: Project, region?: Region, site?: Site) {
@@ -129,6 +108,10 @@ describe("DownloadAudioRecordingsComponent", () => {
       data: { resolvers, ...models },
       detectChanges: false,
     });
+    apiFilter = new Subject();
+    api = spec.inject(AudioRecordingsService);
+    spyOn(api, "filter").and.callFake(() => apiFilter);
+    spyOn(api, "batchDownloadUrl").and.callThrough();
   }
 
   beforeEach(() => {
@@ -141,7 +124,6 @@ describe("DownloadAudioRecordingsComponent", () => {
     describe("project", () => {
       it("should show project if exists", fakeAsync(() => {
         setup(defaultProject);
-        interceptDownloadUrl();
         spec.detectChanges();
         // Have to do this tick because of
         // https://github.com/angular/angular/issues/22606#issuecomment-377390233
@@ -149,188 +131,351 @@ describe("DownloadAudioRecordingsComponent", () => {
         expect(getProjectInput()).toHaveValue(defaultProject.name);
       }));
 
-      it("should sort bulk download by projects", (done) => {
+      it("should sort bulk download by projects", () => {
+        const expectedFilter: any = {
+          filter: { "projects.id": { eq: defaultProject.id } },
+        };
         setup(defaultProject);
-        interceptDownloadUrl("/bulk_download", (filter) => {
-          filterByProject(filter, defaultProject);
-          done();
-        });
         spec.detectChanges();
+        expect(api.batchDownloadUrl).toHaveBeenCalledWith(expectedFilter);
+        assertHref(getDownloadLink(), api.batchDownloadUrl(expectedFilter));
       });
     });
 
     describe("region", () => {
       it("should not show region if not exists", () => {
         setup(defaultProject);
-        interceptDownloadUrl();
         spec.detectChanges();
         expect(getRegionInput()).toBeFalsy();
       });
 
       it("should show region if exists", fakeAsync(() => {
         setup(defaultProject, defaultRegion);
-        interceptDownloadUrl();
         spec.detectChanges();
         spec.tick();
         expect(getRegionInput()).toHaveValue(defaultRegion.name);
       }));
 
-      it("should sort bulk download by regions", (done) => {
+      it("should sort bulk download by regions", () => {
+        const expectedFilter: any = {
+          filter: { "regions.id": { eq: defaultRegion.id } },
+        };
         setup(defaultProject, defaultRegion);
-        interceptDownloadUrl("/bulk_download", (filter) => {
-          filterByRegion(filter, defaultRegion);
-          done();
-        });
         spec.detectChanges();
+        expect(api.batchDownloadUrl).toHaveBeenCalledWith(expectedFilter);
+        assertHref(getDownloadLink(), api.batchDownloadUrl(expectedFilter));
       });
     });
 
     describe("site", () => {
       it("should not show site if not exists", () => {
         setup(defaultProject, defaultRegion);
-        interceptDownloadUrl();
         spec.detectChanges();
         expect(getSiteInput()).toBeFalsy();
       });
 
       it("should show site label if exists", () => {
         setup(defaultProject, undefined, defaultSite);
-        interceptDownloadUrl();
         spec.detectChanges();
         expect(getSiteLabel()).toHaveText("Site");
       });
 
       it("should show site if exists", fakeAsync(() => {
         setup(defaultProject, undefined, defaultSite);
-        interceptDownloadUrl();
         spec.detectChanges();
         spec.tick();
         expect(getSiteInput()).toHaveValue(defaultSite.name);
       }));
 
-      it("should sort bulk download by sites", (done) => {
+      it("should sort bulk download by sites", () => {
+        const expectedFilter: any = {
+          filter: { "sites.id": { eq: defaultSite.id } },
+        };
         setup(defaultProject, undefined, defaultSite);
-        interceptDownloadUrl("/bulk_download", (filter) => {
-          filterBySite(filter, defaultSite);
-          done();
-        });
         spec.detectChanges();
+        expect(api.batchDownloadUrl).toHaveBeenCalledWith(expectedFilter);
+        assertHref(getDownloadLink(), api.batchDownloadUrl(expectedFilter));
       });
     });
 
     describe("point", () => {
       it("should show point label if region and site exists", () => {
         setup(defaultProject, defaultRegion, defaultSite);
-        interceptDownloadUrl();
         spec.detectChanges();
         expect(getSiteLabel()).toHaveText("Point");
       });
 
       it("should show point if region and site exists", fakeAsync(() => {
         setup(defaultProject, defaultRegion, defaultSite);
-        interceptDownloadUrl();
         spec.detectChanges();
         spec.tick();
         expect(getSiteInput()).toHaveValue(defaultSite.name);
       }));
 
-      it("should sort bulk download by points", (done) => {
-        setup(defaultProject, undefined, defaultSite);
-        interceptDownloadUrl("/bulk_download", (filter) => {
-          filterBySite(filter, defaultSite);
-          done();
-        });
+      it("should sort bulk download by points", () => {
+        const expectedFilter: any = {
+          filter: { "sites.id": { eq: defaultSite.id } },
+        };
+        setup(defaultProject, defaultRegion, defaultSite);
         spec.detectChanges();
+        expect(api.batchDownloadUrl).toHaveBeenCalledWith(expectedFilter);
+        assertHref(getDownloadLink(), api.batchDownloadUrl(expectedFilter));
+      });
+    });
+
+    describe("sites without timezones", () => {
+      function getSitesWithoutTimezones() {
+        return spec.query(SitesWithoutTimezonesComponent);
+      }
+
+      it("should pass project to sites without timezones component", () => {
+        setup(defaultProject);
+        spec.detectChanges();
+        expect(getSitesWithoutTimezones().project).toBe(defaultProject);
+      });
+
+      it("should pass region to sites without timezones component if exists", () => {
+        setup(defaultProject, defaultRegion);
+        spec.detectChanges();
+        expect(getSitesWithoutTimezones().region).toBe(defaultRegion);
+      });
+
+      it("should not pass region to sites without timezones component if exists", () => {
+        setup(defaultProject);
+        spec.detectChanges();
+        expect(getSitesWithoutTimezones().region).toBeFalsy();
+      });
+
+      it("should pass site to sites without timezones component if exists", () => {
+        setup(defaultProject, undefined, defaultSite);
+        spec.detectChanges();
+        expect(getSitesWithoutTimezones().site).toBe(defaultSite);
+      });
+
+      it("should not pass site to sites without timezones component if exists", () => {
+        setup(defaultProject);
+        spec.detectChanges();
+        expect(getSitesWithoutTimezones().site).toBeFalsy();
       });
     });
   });
 
-  describe("recording started after", () => {
-    it("should initially not include date in filter", (done) => {
+  describe("date inputs", () => {
+    beforeEach(fakeAsync(() => {
       setup(defaultProject);
-      interceptDownloadUrl("/bulk_download", (filter) => {
-        expect(filter.filter["recordedDate"]).toBeUndefined();
-        done();
-      });
+      // Load form elements
       spec.detectChanges();
-    });
+      spec.tick();
+    }));
 
-    it("should include date in filter when selected", (done) => {
+    it("should include start date in filter", fakeAsync(() => {
       const date = new Date("2020-01-01");
-      setup(defaultProject);
-      interceptDownloadUrl(
-        "/bulk_download",
-        () => {
-          // Update input after the form has been set
-          inputValue(spec.element, startedAfterInputSelector, "2020-01-01");
-          spec.detectChanges();
+      const expectedFilter: any = {
+        filter: {
+          "projects.id": { eq: defaultProject.id },
+          recordedDate: {
+            greaterThanOrEqual: date.toISOString(),
+          },
         },
-        (filter) => {
-          filterByStartDate(filter, date);
-          done();
-        }
-      );
+      };
+
+      spec.typeInElement("2020-01-01", getStartedAfterInput());
       spec.detectChanges();
-    });
+
+      expect(api.batchDownloadUrl).toHaveBeenCalledWith(expectedFilter);
+      assertHref(getDownloadLink(), api.batchDownloadUrl(expectedFilter));
+    }));
+
+    it("should include end date in filter", fakeAsync(() => {
+      const date = new Date("2020-01-01");
+      const expectedFilter: any = {
+        filter: {
+          "projects.id": { eq: defaultProject.id },
+          recordedEndDate: {
+            lessThanOrEqual: date.toISOString(),
+          },
+        },
+      };
+
+      spec.typeInElement("2020-01-01", getFinishedBeforeInput());
+      spec.detectChanges();
+
+      expect(api.batchDownloadUrl).toHaveBeenCalledWith(expectedFilter);
+      assertHref(getDownloadLink(), api.batchDownloadUrl(expectedFilter));
+    }));
   });
 
-  describe("recording finished after", () => {
-    it("should initially not include date in filter", (done) => {
-      setup(defaultProject);
-      interceptDownloadUrl("/bulk_download", (filter) => {
-        expect(filter.filter["recordedEndDate"]).toBeUndefined();
-        done();
-      });
-      spec.detectChanges();
+  describe("time of day filtering", () => {
+    describe("enable tod input", () => {
+      beforeEach(fakeAsync(() => {
+        setup(defaultProject);
+        spec.detectChanges();
+        spec.tick();
+      }));
+
+      it("should initially hide time of day filters", fakeAsync(() => {
+        expect(getTodToggleInput()).toBeTruthy();
+        expect(getTodInputWrapper().collapsed).toBeTrue();
+      }));
+
+      it("should show time of day filters when checkbox selected", fakeAsync(() => {
+        toggleTod();
+        expect(getTodToggleInput()).toBeTruthy();
+        expect(getTodInputWrapper().collapsed).toBeFalse();
+      }));
+
+      it("should hide time of day filters when checkbox unselected", fakeAsync(() => {
+        toggleTod();
+        toggleTod();
+        expect(getTodToggleInput()).toBeTruthy();
+        expect(getTodInputWrapper().collapsed).toBeTrue();
+      }));
+
+      it("should not affect filter until time inputs are set", fakeAsync(() => {
+        const expectedFilter: any = {
+          filter: { "projects.id": { eq: defaultProject.id } },
+        };
+        toggleTod();
+        expect(api.batchDownloadUrl).toHaveBeenCalledWith(expectedFilter);
+        assertHref(getDownloadLink(), api.batchDownloadUrl(expectedFilter));
+      }));
     });
 
-    it("should include date in filter when selected", (done) => {
-      const date = new Date("2020-01-01");
-      setup(defaultProject);
-      interceptDownloadUrl(
-        "/bulk_download",
-        () => {
-          // Update input after the form has been set
-          inputValue(spec.element, finishedBeforeInputSelector, "2020-01-01");
+    describe("ignore dst input", () => {
+      beforeEach(fakeAsync(() => {
+        setup(defaultProject);
+        spec.detectChanges();
+        spec.tick();
+        toggleTod();
+      }));
+
+      it("should initially be enabled", () => {
+        expect(getTodIgnoreDstInput().checked).toBeTrue();
+        expect(spec.component.model.todIgnoreDst).toBeTrue();
+      });
+
+      it("should disable on click", fakeAsync(() => {
+        toggleIgnoreDst();
+        expect(getTodIgnoreDstInput().checked).toBeFalse();
+        expect(spec.component.model.todIgnoreDst).toBeFalse();
+      }));
+    });
+
+    describe("time input", () => {
+      beforeEach(fakeAsync(() => {
+        setup(defaultProject);
+        spec.detectChanges();
+        spec.tick();
+        toggleTod();
+      }));
+
+      [true, false].forEach((ignoreDst) => {
+        it(`should include start time in filter with ignoreDst ${
+          ignoreDst ? "set" : "unset"
+        }`, fakeAsync(() => {
+          const time = "06:00";
+          const expectedFilter: any = {
+            filter: {
+              "projects.id": { eq: defaultProject.id },
+              recordedEndDate: {
+                greaterThanOrEqual: {
+                  expressions: ignoreDst
+                    ? ["local_offset", "time_of_day"]
+                    : ["local_tz", "time_of_day"],
+                  value: time,
+                },
+              },
+            },
+          };
+
+          // If ignoreDst is unset, toggle state
+          if (!ignoreDst) {
+            toggleIgnoreDst();
+          }
+
+          spec.typeInElement(time, getTodStartedAfterInput());
           spec.detectChanges();
-        },
-        (filter) => {
-          filterByEndDate(filter, date);
-          done();
-        }
-      );
-      spec.detectChanges();
+
+          expect(api.batchDownloadUrl).toHaveBeenCalledWith(expectedFilter);
+          assertHref(getDownloadLink(), api.batchDownloadUrl(expectedFilter));
+        }));
+
+        it(`should include end time in filter with ignoreDst ${
+          ignoreDst ? "set" : "unset"
+        }`, fakeAsync(() => {
+          const time = "06:00";
+          const expectedFilter: any = {
+            filter: {
+              "projects.id": { eq: defaultProject.id },
+              recordedDate: {
+                lessThanOrEqual: {
+                  expressions: ignoreDst
+                    ? ["local_offset", "time_of_day"]
+                    : ["local_tz", "time_of_day"],
+                  value: time,
+                },
+              },
+            },
+          };
+
+          // If ignoreDst is unset, toggle state
+          if (!ignoreDst) {
+            toggleIgnoreDst();
+          }
+
+          spec.typeInElement(time, getTodFinishedBeforeInput());
+          spec.detectChanges();
+
+          expect(api.batchDownloadUrl).toHaveBeenCalledWith(expectedFilter);
+          assertHref(getDownloadLink(), api.batchDownloadUrl(expectedFilter));
+        }));
+      });
     });
   });
 
   describe("multiple inputs", () => {
-    it("should include filters for both date fields", (done) => {
+    it("should handle all inputs being set", fakeAsync(() => {
       const startDate = new Date("2019-01-01");
       const endDate = new Date("2020-01-01");
+      const startTime = "06:00";
+      const endTime = "18:00";
+
+      const expectedFilter: any = {
+        filter: {
+          "projects.id": { eq: defaultProject.id },
+          recordedDate: {
+            greaterThanOrEqual: startDate.toISOString(),
+            lessThanOrEqual: {
+              expressions: ["local_offset", "time_of_day"],
+              value: endTime,
+            },
+          },
+          recordedEndDate: {
+            lessThanOrEqual: endDate.toISOString(),
+            greaterThanOrEqual: {
+              expressions: ["local_offset", "time_of_day"],
+              value: startTime,
+            },
+          },
+        },
+      };
+
       setup(defaultProject);
-
-      interceptDownloadUrl(
-        "/bulk_download",
-        () => {
-          // Update input after the form has been set
-          inputValue(spec.element, startedAfterInputSelector, "2019-01-01");
-          spec.detectChanges();
-        },
-        () => {
-          // Update input after the form has been set
-          inputValue(spec.element, finishedBeforeInputSelector, "2020-01-01");
-          spec.detectChanges();
-        },
-        (filter) => {
-          filterByProject(filter, defaultProject);
-          filterByStartDate(filter, startDate);
-          filterByEndDate(filter, endDate);
-          done();
-        }
-      );
-
       spec.detectChanges();
-    });
+      spec.tick();
+      toggleTod();
+
+      spec.typeInElement("2019-01-01", getStartedAfterInput());
+      spec.typeInElement("2020-01-01", getFinishedBeforeInput());
+      spec.typeInElement(startTime, getTodStartedAfterInput());
+      spec.typeInElement(endTime, getTodFinishedBeforeInput());
+      spec.detectChanges();
+
+      expect(api.batchDownloadUrl).toHaveBeenCalledWith(expectedFilter);
+      assertHref(getDownloadLink(), api.batchDownloadUrl(expectedFilter));
+    }));
+
+    // TODO Expand to test various edge cases
   });
 
   it("should have instructions", () => {

--- a/src/app/components/audio-recordings/pages/download/download.component.spec.ts
+++ b/src/app/components/audio-recordings/pages/download/download.component.spec.ts
@@ -14,7 +14,7 @@ import { generateSite } from "@test/fakes/Site";
 import { inputValue } from "@test/helpers/html";
 import { DownloadAudioRecordingsComponent } from "./download.component";
 
-describe("DownloadAudioRecordingsComponent", () => {
+xdescribe("DownloadAudioRecordingsComponent", () => {
   let defaultProject: Project;
   let defaultRegion: Region;
   let defaultSite: Site;

--- a/src/app/components/audio-recordings/pages/download/download.component.ts
+++ b/src/app/components/audio-recordings/pages/download/download.component.ts
@@ -29,8 +29,10 @@ interface Model {
   projects?: Project[];
   regions?: Region[];
   sites?: Site[];
-  recordingStartedAfter?: Date;
-  recordingFinishedBefore?: Date;
+  startedAfterDate?: Date;
+  finishedBeforeDate?: Date;
+  startedAfterTime?: string;
+  finishedBeforeTime?: string;
 }
 
 @Component({
@@ -96,14 +98,14 @@ class DownloadAudioRecordingsComponent
       filter["projects.id"] = { eq: this.project.id };
     }
 
-    if (model.recordingStartedAfter) {
+    if (model.startedAfterDate) {
       filter["recordedDate"] = {
-        greaterThan: model.recordingStartedAfter.toISOString(),
+        greaterThan: model.startedAfterDate.toISOString(),
       };
     }
-    if (model.recordingFinishedBefore) {
+    if (model.finishedBeforeDate) {
       filter["recordedEndDate"] = {
-        lessThan: model.recordingFinishedBefore.toISOString(),
+        lessThan: model.finishedBeforeDate.toISOString(),
       };
     }
 

--- a/src/app/components/audio-recordings/pages/download/download.component.ts
+++ b/src/app/components/audio-recordings/pages/download/download.component.ts
@@ -18,10 +18,8 @@ import {
   audioRecordingsCategory,
 } from "@components/audio-recordings/audio-recording.menus";
 import { myAccountMenuItem } from "@components/profile/profile.menus";
-import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { IPageInfo } from "@helpers/page/pageInfo";
-import { isUnresolvedModel } from "@models/AbstractModel";
 import { AudioRecording } from "@models/AudioRecording";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
@@ -117,63 +115,10 @@ class DownloadAudioRecordingsComponent
     return this.models[siteKey] as Site;
   }
 
-  public sitesWithoutTimezones(
-    site?: Site,
-    regionSites?: Site[],
-    projectSites?: Site[]
-  ): Site[] {
-    if (site) {
-      return site.timezoneInformation ? [] : [site];
-    }
-
-    if (regionSites) {
-      if (!isInstantiated(regionSites) || isUnresolvedModel(regionSites)) {
-        return [];
-      } else {
-        return regionSites.filter((s) => !s.timezoneInformation);
-      }
-    }
-
-    if (projectSites) {
-      if (!isInstantiated(projectSites) || isUnresolvedModel(projectSites)) {
-        return [];
-      } else {
-        return projectSites.filter((s) => !s.timezoneInformation);
-      }
-    }
-  }
-
   public updateHref(model: Model): void {
     const filters = this.generateFilter(model);
     this.filters$.next(filters);
     this.href = this.recordingsApi.batchDownloadUrl(filters);
-  }
-
-  public getNumberOfRecordings(recordings: AudioRecording[]): number {
-    if (recordings.length === 0) {
-      return 0;
-    }
-    return recordings[0].getMetadata().paging.total;
-  }
-
-  public getNewestRecording(recordings: AudioRecording[]): string {
-    if (recordings.length === 0) {
-      return "No recordings";
-    }
-
-    return recordings
-      .reduce((a, b) => (a.recordedDate > b.recordedDate ? a : b))
-      .recordedDate.toFormat("yyyy-MM-dd hh:mm:ss");
-  }
-
-  public getOldestRecording(recordings: AudioRecording[]): string {
-    if (recordings.length === 0) {
-      return "No recordings";
-    }
-
-    return recordings
-      .reduce((a, b) => (a.recordedDate < b.recordedDate ? a : b))
-      .recordedDate.toFormat("yyyy-MM-dd hh:mm:ss");
   }
 
   public invalidForm(errors: any): boolean {

--- a/src/app/components/audio-recordings/pages/download/download.component.ts
+++ b/src/app/components/audio-recordings/pages/download/download.component.ts
@@ -246,12 +246,8 @@ class DownloadAudioRecordingsComponent
     }
 
     // TODO Add support for timezones which overflow a boundary
-    if (model.todFinishedBefore < model.todStartedAfter) {
-      this.errors.todBoundaryError = true;
-      console.log("Finish time is before start time");
-    } else {
-      this.errors.todBoundaryError = false;
-    }
+    this.errors.todBoundaryError =
+      model.todFinishedBefore < model.todStartedAfter;
   }
 }
 

--- a/src/app/components/audio-recordings/pages/download/download.component.ts
+++ b/src/app/components/audio-recordings/pages/download/download.component.ts
@@ -247,6 +247,8 @@ class DownloadAudioRecordingsComponent
 
     // TODO Add support for timezones which overflow a boundary
     this.errors.todBoundaryError =
+      model.todFinishedBefore &&
+      model.todStartedAfter &&
       model.todFinishedBefore < model.todStartedAfter;
   }
 }

--- a/src/app/components/audio-recordings/sites-without-timezones/sites-without-timezones.component.spec.ts
+++ b/src/app/components/audio-recordings/sites-without-timezones/sites-without-timezones.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { SitesWithoutTimezonesComponent } from "./sites-without-timezones.component";
+
+// TODO
+xdescribe("SitesWithoutTimezonesComponent", () => {
+  let component: SitesWithoutTimezonesComponent;
+  let fixture: ComponentFixture<SitesWithoutTimezonesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SitesWithoutTimezonesComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SitesWithoutTimezonesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/audio-recordings/sites-without-timezones/sites-without-timezones.component.ts
+++ b/src/app/components/audio-recordings/sites-without-timezones/sites-without-timezones.component.ts
@@ -1,0 +1,77 @@
+import { Component, Input } from "@angular/core";
+import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
+import { isUnresolvedModel } from "@models/AbstractModel";
+import { Project } from "@models/Project";
+import { Region } from "@models/Region";
+import { Site } from "@models/Site";
+
+@Component({
+  selector: "baw-sites-without-timezones",
+  template: `
+    <!-- Warn users about limitations of time of day filter -->
+    <ng-container
+      *ngIf="
+        sitesWithoutTimezones(
+          site,
+          region?.sites,
+          project?.sites
+        ) as sitesWithoutTimezone
+      "
+    >
+      <div *ngIf="sitesWithoutTimezone.length > 0" class="alert alert-danger">
+        Warning, this batch download includes site/s which do not have their
+        timezones set. Any time of day filtering will not work on these sites
+        until the site owner or editors update them. The list of sites can be
+        seen below:
+
+        <ul
+          *ngFor="let siteWithoutTimezone of sitesWithoutTimezone"
+          class="mb-0"
+        >
+          <li>
+            <a
+              [bawUrl]="
+                project
+                  ? siteWithoutTimezone.getViewUrl(project)
+                  : siteWithoutTimezone.viewUrl
+              "
+            >
+              {{ siteWithoutTimezone.name }}
+            </a>
+          </li>
+        </ul>
+      </div>
+    </ng-container>
+  `,
+})
+export class SitesWithoutTimezonesComponent {
+  @Input() public site?: Site;
+  @Input() public region?: Region;
+  @Input() public project!: Project;
+
+  public sitesWithoutTimezones(
+    site?: Site,
+    regionSites?: Site[],
+    projectSites?: Site[]
+  ): Site[] {
+    if (site) {
+      return site.timezoneInformation ? [] : [site];
+    }
+
+    if (regionSites) {
+      if (!isInstantiated(regionSites) || isUnresolvedModel(regionSites)) {
+        return [];
+      } else {
+        return regionSites.filter((s) => !s.timezoneInformation);
+      }
+    }
+
+    if (projectSites) {
+      if (!isInstantiated(projectSites) || isUnresolvedModel(projectSites)) {
+        return [];
+      } else {
+        return projectSites.filter((s) => !s.timezoneInformation);
+      }
+    }
+  }
+}

--- a/src/app/components/shared/shared.components.ts
+++ b/src/app/components/shared/shared.components.ts
@@ -4,6 +4,7 @@ import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { RouterModule } from "@angular/router";
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
 import {
+  NgbCollapseModule,
   NgbPaginationModule,
   NgbProgressbarModule,
   NgbTooltipModule,
@@ -21,7 +22,6 @@ import { DirectivesModule } from "src/app/directives/directives.module";
 import { AnnotationDownloadComponent } from "./annotation-download/annotation-download.component";
 import { BawClientModule } from "./baw-client/baw-client.module";
 import { BreadcrumbModule } from "./breadcrumb/breadcrumb.module";
-import { ModelCardsModule } from "./model-cards/model-cards.module";
 import { CheckboxModule } from "./checkbox/checkbox.module";
 import { CmsComponent } from "./cms/cms.component";
 import { DebounceInputComponent } from "./debounce-input/debounce-input.component";
@@ -35,6 +35,7 @@ import { IndicatorModule } from "./indicator/indicator.module";
 import { ItemsModule } from "./items/items.module";
 import { LoadingModule } from "./loading/loading.module";
 import { MenuModule } from "./menu/menu.module";
+import { ModelCardsModule } from "./model-cards/model-cards.module";
 import { UserLinkModule } from "./user-link/user-link.module";
 import { WIPComponent } from "./wip/wip.component";
 
@@ -58,6 +59,7 @@ export const sharedModules = [
   NgbTooltipModule,
   NgbPaginationModule,
   NgbProgressbarModule,
+  NgbCollapseModule,
   FontAwesomeModule,
   FormsModule,
   ReactiveFormsModule,

--- a/src/app/services/baw-api/baw-api.service.ts
+++ b/src/app/services/baw-api/baw-api.service.ts
@@ -464,27 +464,49 @@ export interface Combinations<T> {
   not?: InnerFilter<T>;
 }
 
+/**
+ * Date filter expressions
+ * https://github.com/QutEcoacoustics/baw-server/wiki/API:-Filtering#supported-expressions
+ *
+ * @param time_of_day Extract the time fraction from a date
+ * @param local_tz Convert a date to local date. Requires a date that can infer
+ * its timezone. Must come before `time_of_day`
+ * @param local_offset Convert a date to local date with a fixed UTC offset.
+ * Requires a date that can infer its timezone. Must come before
+ * `time_of_day`
+ */
+export type DateExpressions = "local_offset" | "local_tz" | "time_of_day";
+
+/**
+ * Filter expressions
+ * https://github.com/QutEcoacoustics/baw-server/wiki/API:-Filtering#expressions-experimental
+ */
+export interface Expression {
+  expressions: (DateExpressions | string)[];
+  value: string;
+}
+
 export interface Comparisons {
   eq?: string | number;
   equal?: string | number;
   notEq?: string | number;
   notEqual?: string | number;
-  lt?: string | number;
-  lessThan?: string | number;
-  notLt?: string | number;
-  notLessThan?: string | number;
-  gt?: string | number;
-  greaterThan?: string | number;
-  notGt?: string | number;
-  notGreaterThan?: string | number;
-  lteq?: string | number;
-  lessThanOrEqual?: string | number;
-  notLteq?: string | number;
-  notLessThanOrEqual?: string | number;
-  gteq?: string | number;
-  greaterThanOrEqual?: string | number;
-  notGteq?: string | number;
-  notGreaterThanOrEqual?: string | number;
+  lt?: string | number | Expression;
+  lessThan?: string | number | Expression;
+  notLt?: string | number | Expression;
+  notLessThan?: string | number | Expression;
+  gt?: string | number | Expression;
+  greaterThan?: string | number | Expression;
+  notGt?: string | number | Expression;
+  notGreaterThan?: string | number | Expression;
+  lteq?: string | number | Expression;
+  lessThanOrEqual?: string | number | Expression;
+  notLteq?: string | number | Expression;
+  notLessThanOrEqual?: string | number | Expression;
+  gteq?: string | number | Expression;
+  greaterThanOrEqual?: string | number | Expression;
+  notGteq?: string | number | Expression;
+  notGreaterThanOrEqual?: string | number | Expression;
 }
 
 /**


### PR DESCRIPTION
# Filter by Time of Day (TOD)

Updated the batch download page to allow for time of day filtering

## Changes

- Updated the batch download page

## Problems

- Does not handle time of day requests for time frames which cross the day boundary
- Not tested
- Some unresolved issues with ecosounds data where any time of day filtering will not match some sites for unknown reasons
- Form has inconsistent style compared to other forms (bold labels)

## Issues

Relates to #1829 

## Visual Changes

### Batch download where some sites are missing

![image](https://user-images.githubusercontent.com/3955116/159959085-affa2ec7-76f0-406c-8346-633aad15045c.png)

### Selected time of day filter

![image](https://user-images.githubusercontent.com/3955116/159959283-982d89f5-d060-4d58-9b02-ad2792a489e1.png)

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
