### PR TITLE
Api Request Caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@ng-bootstrap/ng-bootstrap": "12.1.2",
+        "@ngneat/cashew": "^3.0.0",
         "@nguniversal/express-engine": "13.1.1",
         "@ngx-formly/bootstrap": "^6.0.0-next.6",
         "@ngx-formly/core": "^6.0.0-next.6",
@@ -2908,6 +2909,17 @@
         "@angular/localize": "^13.0.0",
         "@popperjs/core": "^2.10.2",
         "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@ngneat/cashew": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ngneat/cashew/-/cashew-3.0.0.tgz",
+      "integrity": "sha512-1xK6p5S76dY45PyNSdnuJKIW758BJsU+KbRrHH5RE49hzo6RGqlSC/ynuKn2yWV1zL4Z3vTMYCtqm/l79Gavsg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=13.0.0"
       }
     },
     "node_modules/@ngneat/spectator": {
@@ -21185,6 +21197,14 @@
       "version": "12.1.2",
       "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-12.1.2.tgz",
       "integrity": "sha512-p27c+mYVdHiJMYrj5hwClVJxLdiZxafAqlbw1sdJh2xJ1rGOe+H/kCf5YDRbhlHqRN+34Gr0RQqIUeD1I2V8hg==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@ngneat/cashew": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ngneat/cashew/-/cashew-3.0.0.tgz",
+      "integrity": "sha512-1xK6p5S76dY45PyNSdnuJKIW758BJsU+KbRrHH5RE49hzo6RGqlSC/ynuKn2yWV1zL4Z3vTMYCtqm/l79Gavsg==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@ng-bootstrap/ng-bootstrap": "12.1.2",
+    "@ngneat/cashew": "^3.0.0",
     "@nguniversal/express-engine": "13.1.1",
     "@ngx-formly/bootstrap": "^6.0.0-next.6",
     "@ngx-formly/core": "^6.0.0-next.6",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,7 +13,6 @@ import { GuardModule } from "@guards/guards.module";
 import { FormlyBootstrapModule } from "@ngx-formly/bootstrap";
 import { FormlyModule } from "@ngx-formly/core";
 import { LOADING_BAR_CONFIG } from "@ngx-loading-bar/core";
-import { CacheModule } from "@services/cache/cache.module";
 import { AppConfigModule } from "@services/config/config.module";
 import { RehydrationModule } from "@services/rehydration/rehydration.module";
 import { BawTimeoutModule } from "@services/timeout/timeout.module";
@@ -83,7 +82,6 @@ export const appImports = [
     BawTimeoutModule.forRoot({ timeout: environment.browserTimeout }),
     AppRoutingModule,
     AppConfigModule,
-    CacheModule,
     BawApiModule,
     // Rehydrate data from SSR. This must be set after BawApiModule so that the
     // interceptor runs after the API interceptor

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { LibraryModule } from "@components/library/library.module";
 import { RegionsModule } from "@components/regions/regions.module";
 import { VisualizeModule } from "@components/visualize/visualize.module";
 import { GuardModule } from "@guards/guards.module";
+import { HttpCacheInterceptorModule } from "@ngneat/cashew";
 import { FormlyBootstrapModule } from "@ngx-formly/bootstrap";
 import { FormlyModule } from "@ngx-formly/core";
 import { LOADING_BAR_CONFIG } from "@ngx-loading-bar/core";
@@ -80,6 +81,8 @@ export const appImports = [
     BrowserModule.withServerTransition({ appId: "workbench-client" }),
     // Timeout API requests after set period
     BawTimeoutModule.forRoot({ timeout: environment.browserTimeout }),
+    // Cache API requests
+    HttpCacheInterceptorModule.forRoot({ strategy: "explicit" }),
     AppRoutingModule,
     AppConfigModule,
     BawApiModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,10 +10,10 @@ import { LibraryModule } from "@components/library/library.module";
 import { RegionsModule } from "@components/regions/regions.module";
 import { VisualizeModule } from "@components/visualize/visualize.module";
 import { GuardModule } from "@guards/guards.module";
-import { HttpCacheInterceptorModule } from "@ngneat/cashew";
 import { FormlyBootstrapModule } from "@ngx-formly/bootstrap";
 import { FormlyModule } from "@ngx-formly/core";
 import { LOADING_BAR_CONFIG } from "@ngx-loading-bar/core";
+import { CacheModule } from "@services/cache/cache.module";
 import { AppConfigModule } from "@services/config/config.module";
 import { RehydrationModule } from "@services/rehydration/rehydration.module";
 import { BawTimeoutModule } from "@services/timeout/timeout.module";
@@ -81,10 +81,9 @@ export const appImports = [
     BrowserModule.withServerTransition({ appId: "workbench-client" }),
     // Timeout API requests after set period
     BawTimeoutModule.forRoot({ timeout: environment.browserTimeout }),
-    // Cache API requests
-    HttpCacheInterceptorModule.forRoot({ strategy: "explicit" }),
     AppRoutingModule,
     AppConfigModule,
+    CacheModule,
     BawApiModule,
     // Rehydrate data from SSR. This must be set after BawApiModule so that the
     // interceptor runs after the API interceptor

--- a/src/app/app.server.module.ts
+++ b/src/app/app.server.module.ts
@@ -3,6 +3,7 @@ import {
   ServerModule,
   ServerTransferStateModule,
 } from "@angular/platform-server";
+import { HttpCacheInterceptorModule } from "@ngneat/cashew";
 import { BawTimeoutModule } from "@services/timeout/timeout.module";
 import { environment } from "src/environments/environment";
 import { AppComponent } from "./app.component";
@@ -15,6 +16,8 @@ import { AppModule } from "./app.module";
     ServerTransferStateModule,
     // Timeout API requests after set period
     BawTimeoutModule.forRoot({ timeout: environment.ssrTimeout }),
+    // Cache API requests
+    HttpCacheInterceptorModule.forRoot({ strategy: "explicit" }),
   ],
   bootstrap: [AppComponent],
 })

--- a/src/app/components/admin/admin.module.ts
+++ b/src/app/components/admin/admin.module.ts
@@ -7,6 +7,7 @@ import { AnalysisJobsModule } from "./analysis-jobs/analysis-jobs.module";
 import { AdminDashboardComponent } from "./dashboard/dashboard.component";
 import { OrphanSitesModule } from "./orphan/orphans.module";
 import { ScriptsModule } from "./scripts/scripts.module";
+import { SettingsModule } from "./settings/settings.module";
 import { TagGroupsModule } from "./tag-group/tag-groups.module";
 import { TagsModule } from "./tags/tags.module";
 import { AdminThemeTemplateComponent } from "./theme-template/theme-template.component";
@@ -16,6 +17,7 @@ const modules = [
   AnalysisJobsModule,
   OrphanSitesModule,
   ScriptsModule,
+  SettingsModule,
   TagGroupsModule,
   TagsModule,
 ];

--- a/src/app/components/admin/dashboard/dashboard.component.ts
+++ b/src/app/components/admin/dashboard/dashboard.component.ts
@@ -12,19 +12,21 @@ import {
 } from "../admin.menus";
 import { adminOrphansMenuItem } from "../orphan/orphans.menus";
 import { adminScriptsMenuItem } from "../scripts/scripts.menus";
+import { adminSettingsMenuItem } from "../settings/settings.menus";
 import { adminTagGroupsMenuItem } from "../tag-group/tag-group.menus";
 import { adminTagsMenuItem } from "../tags/tags.menus";
 
 export const adminMenuItemActions = [
-  adminUserListMenuItem,
+  adminAnalysisJobsMenuItem,
+  adminCmsMenuItem,
+  adminJobStatusMenuItem,
   adminOrphansMenuItem,
   adminScriptsMenuItem,
-  adminTagsMenuItem,
+  adminSettingsMenuItem,
   adminTagGroupsMenuItem,
-  adminAnalysisJobsMenuItem,
-  adminJobStatusMenuItem,
-  adminCmsMenuItem,
+  adminTagsMenuItem,
   adminThemeMenuItem,
+  adminUserListMenuItem,
 ];
 
 @Component({

--- a/src/app/components/admin/settings/settings.component.ts
+++ b/src/app/components/admin/settings/settings.component.ts
@@ -1,0 +1,59 @@
+import { Component } from "@angular/core";
+import { PageComponent } from "@helpers/page/pageComponent";
+import { cacheSettings } from "@services/cache/cache-settings";
+import { List } from "immutable";
+import { adminCategory } from "../admin.menus";
+import { adminMenuItemActions } from "../dashboard/dashboard.component";
+import { adminSettingsMenuItem } from "./settings.menus";
+
+@Component({
+  template: `
+    <h1>Client Settings</h1>
+
+    <p class="subTitle">
+      This page allows for you to modify settings of the website in real time.
+      However, they will only affect your browser, and will be reset on a page
+      refresh. These features should be considered as debugging tools only.
+    </p>
+
+    <h2>Caching</h2>
+
+    <div class="form-check">
+      <input
+        id="enable-cache"
+        class="form-check-input"
+        type="checkbox"
+        [checked]="cacheSettings.enabled"
+        (change)="cacheSettings.setCaching($any($event.target).value)"
+      />
+      <label class="form-check-label" for="enable-cache">
+        Enable/Disable caching of API requests
+      </label>
+    </div>
+
+    <div class="form-check">
+      <input
+        id="enable-cache-logging"
+        class="form-check-input"
+        type="checkbox"
+        [checked]="cacheSettings.showLogging"
+        [disabled]="!cacheSettings.enabled"
+        (change)="cacheSettings.setLogging($any($event.target).value)"
+      />
+      <label class="form-check-label" for="enable-cache-logging">
+        Enable/Disable cache logging in the console
+      </label>
+    </div>
+  `,
+})
+class AdminSettingsComponent extends PageComponent {
+  public cacheSettings = cacheSettings;
+}
+
+AdminSettingsComponent.linkToRoute({
+  category: adminCategory,
+  pageRoute: adminSettingsMenuItem,
+  menus: { actions: List(adminMenuItemActions) },
+});
+
+export { AdminSettingsComponent };

--- a/src/app/components/admin/settings/settings.component.ts
+++ b/src/app/components/admin/settings/settings.component.ts
@@ -24,7 +24,7 @@ import { adminSettingsMenuItem } from "./settings.menus";
         class="form-check-input"
         type="checkbox"
         [checked]="cacheSettings.enabled"
-        (change)="cacheSettings.setCaching($any($event.target).value)"
+        (change)="cacheSettings.setCaching($any($event.target).checked)"
       />
       <label class="form-check-label" for="enable-cache">
         Enable/Disable caching of API requests
@@ -38,7 +38,7 @@ import { adminSettingsMenuItem } from "./settings.menus";
         type="checkbox"
         [checked]="cacheSettings.showLogging"
         [disabled]="!cacheSettings.enabled"
-        (change)="cacheSettings.setLogging($any($event.target).value)"
+        (change)="cacheSettings.setLogging($any($event.target).checked)"
       />
       <label class="form-check-label" for="enable-cache-logging">
         Enable/Disable cache logging in the console

--- a/src/app/components/admin/settings/settings.menus.ts
+++ b/src/app/components/admin/settings/settings.menus.ts
@@ -1,0 +1,14 @@
+import { menuRoute } from "@interfaces/menusInterfaces";
+import { isAdminPredicate } from "src/app/app.menus";
+import { adminDashboardMenuItem, adminRoute } from "../admin.menus";
+
+export const adminSettingsRoute = adminRoute.addFeatureModule("settings");
+
+export const adminSettingsMenuItem = menuRoute({
+  icon: ["fas", "wrench"],
+  label: "Client Settings",
+  route: adminSettingsRoute,
+  tooltip: () => "Manage client settings",
+  parent: adminDashboardMenuItem,
+  predicate: isAdminPredicate,
+});

--- a/src/app/components/admin/settings/settings.module.ts
+++ b/src/app/components/admin/settings/settings.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from "@angular/core";
+import { RouterModule } from "@angular/router";
+import { getRouteConfigForPage } from "@helpers/page/pageRouting";
+import { SharedModule } from "@shared/shared.module";
+import { AdminSettingsComponent } from "./settings.component";
+import { adminSettingsRoute } from "./settings.menus";
+
+const components = [AdminSettingsComponent];
+const routes = adminSettingsRoute.compileRoutes(getRouteConfigForPage);
+
+@NgModule({
+  declarations: components,
+  imports: [SharedModule, RouterModule.forChild(routes)],
+  exports: [RouterModule, ...components],
+})
+export class SettingsModule {}

--- a/src/app/components/audio-recordings/pages/download/download.component.spec.ts
+++ b/src/app/components/audio-recordings/pages/download/download.component.spec.ts
@@ -28,6 +28,7 @@ import { modelData } from "@test/helpers/faker";
 import { MockComponent } from "ng-mocks";
 import { ToastrService } from "ngx-toastr";
 import { Subject } from "rxjs";
+import { CacheModule } from "@services/cache/cache.module";
 import { SitesWithoutTimezonesComponent } from "../../components/sites-without-timezones/sites-without-timezones.component";
 import { DownloadTableComponent } from "../../components/download-table/download-table.component";
 import { DownloadAudioRecordingsComponent } from "./download.component";
@@ -41,7 +42,12 @@ describe("DownloadAudioRecordingsComponent", () => {
   let spec: SpectatorRouting<DownloadAudioRecordingsComponent>;
   const createComponent = createRoutingFactory({
     component: DownloadAudioRecordingsComponent,
-    imports: [SharedModule, NgbCollapseModule, MockAppConfigModule],
+    imports: [
+      SharedModule,
+      NgbCollapseModule,
+      MockAppConfigModule,
+      CacheModule,
+    ],
     declarations: [
       MockComponent(SitesWithoutTimezonesComponent),
       MockComponent(DownloadTableComponent),

--- a/src/app/models/AssociationDecorators.ts
+++ b/src/app/models/AssociationDecorators.ts
@@ -202,9 +202,9 @@ function createModelDecorator<
 
     // Create service and request from API
     const service = injector.get(serviceToken.token);
-    apiRequest(service, parent, parameters).subscribe(
-      (model) => updateBackingField(parent, backingFieldKey, model),
-      (error) => {
+    apiRequest(service, parent, parameters).subscribe({
+      next: (model) => updateBackingField(parent, backingFieldKey, model),
+      error: (error) => {
         console.error(`${parent} failed to load ${identifierKey}.`, {
           target: parent,
           associationKey: identifierKey,
@@ -212,8 +212,8 @@ function createModelDecorator<
           error,
         });
         updateBackingField(parent, backingFieldKey, failureValue);
-      }
-    );
+      },
+    });
 
     // Save request to cache so other requests are ignored
     updateBackingField(parent, backingFieldKey, unresolvedValue);

--- a/src/app/models/AssociationDecorators.ts
+++ b/src/app/models/AssociationDecorators.ts
@@ -202,6 +202,11 @@ function createModelDecorator<
 
     // Create service and request from API
     const service = injector.get(serviceToken.token);
+
+    // Set initial value for field
+    updateBackingField(parent, backingFieldKey, unresolvedValue);
+
+    // Load value from API (note: because of caching, this can be instant)
     apiRequest(service, parent, parameters).subscribe({
       next: (model) => updateBackingField(parent, backingFieldKey, model),
       error: (error) => {
@@ -215,8 +220,6 @@ function createModelDecorator<
       },
     });
 
-    // Save request to cache so other requests are ignored
-    updateBackingField(parent, backingFieldKey, unresolvedValue);
     return unresolvedValue;
   }
 

--- a/src/app/services/baw-api/account/accounts.service.spec.ts
+++ b/src/app/services/baw-api/account/accounts.service.spec.ts
@@ -1,17 +1,12 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { AccountsService } from "@baw-api/account/accounts.service";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { User } from "@models/User";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateUser } from "@test/fakes/User";
-import { validateStandardApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateStandardApi,
+} from "@test/helpers/api-common";
 
 describe("AccountsService", (): void => {
   const createModel = () => new User(generateUser({ id: 5 }));
@@ -20,8 +15,8 @@ describe("AccountsService", (): void => {
   let spec: SpectatorService<AccountsService>;
   const createService = createServiceFactory({
     service: AccountsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/analysis/analysis-job-items.service.spec.ts
+++ b/src/app/services/baw-api/analysis/analysis-job-items.service.spec.ts
@@ -1,16 +1,11 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { AnalysisJobItem } from "@models/AnalysisJobItem";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateAnalysisJobItem } from "@test/fakes/AnalysisJobItem";
-import { validateReadonlyApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateReadonlyApi,
+} from "@test/helpers/api-common";
 import { AnalysisJobItemsService } from "./analysis-job-items.service";
 
 describe("AnalysisJobItemsService", (): void => {
@@ -20,8 +15,8 @@ describe("AnalysisJobItemsService", (): void => {
   let spec: SpectatorService<AnalysisJobItemsService>;
   const createService = createServiceFactory({
     service: AnalysisJobItemsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/analysis/analysis-jobs.service.spec.ts
+++ b/src/app/services/baw-api/analysis/analysis-jobs.service.spec.ts
@@ -1,16 +1,11 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { AnalysisJob } from "@models/AnalysisJob";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateAnalysisJob } from "@test/fakes/AnalysisJob";
-import { validateReadAndUpdateApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateReadAndUpdateApi,
+} from "@test/helpers/api-common";
 import { AnalysisJobsService } from "./analysis-jobs.service";
 
 describe("AnalysisJobsService", (): void => {
@@ -19,8 +14,8 @@ describe("AnalysisJobsService", (): void => {
   let spec: SpectatorService<AnalysisJobsService>;
   const createService = createServiceFactory({
     service: AnalysisJobsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/audio-event/audio-events-shallow.service.spec.ts
+++ b/src/app/services/baw-api/audio-event/audio-events-shallow.service.spec.ts
@@ -1,21 +1,14 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { IdOr } from "@baw-api/api-common";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { AudioEvent } from "@models/AudioEvent";
 import { Site } from "@models/Site";
 import { User } from "@models/User";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
-import {
+  mockServiceImports,
+  mockServiceProviders,
   validateApiFilter,
   validateCustomApiFilter,
 } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
 import { ShallowAudioEventsService } from "./audio-events.service";
 
 type Model = AudioEvent;
@@ -26,8 +19,8 @@ describe("Shallow AudioEventsService", (): void => {
   let spec: SpectatorService<ShallowAudioEventsService>;
   const createService = createServiceFactory({
     service: ShallowAudioEventsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/audio-event/audio-events.service.spec.ts
+++ b/src/app/services/baw-api/audio-event/audio-events.service.spec.ts
@@ -1,18 +1,13 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { IdOr } from "@baw-api/api-common";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { AudioEvent } from "@models/AudioEvent";
 import { AudioRecording } from "@models/AudioRecording";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateAudioEvent } from "@test/fakes/AudioEvent";
-import { validateStandardApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateStandardApi,
+} from "@test/helpers/api-common";
 import { AudioEventsService } from "./audio-events.service";
 
 type Model = AudioEvent;
@@ -26,8 +21,8 @@ describe("AudioEventsService", (): void => {
   let spec: SpectatorService<AudioEventsService>;
   const createService = createServiceFactory({
     service: AudioEventsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/audio-recording/audio-recordings.service.spec.ts
+++ b/src/app/services/baw-api/audio-recording/audio-recordings.service.spec.ts
@@ -1,4 +1,3 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { IdOr } from "@baw-api/api-common";
 import { BawApiService } from "@baw-api/baw-api.service";
 import { BawSessionService } from "@baw-api/baw-session.service";
@@ -8,18 +7,17 @@ import { AudioRecording } from "@models/AudioRecording";
 import { Site } from "@models/Site";
 import {
   createServiceFactory,
-  mockProvider,
   SpectatorService,
   SpyObject,
 } from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateAudioRecording } from "@test/fakes/AudioRecording";
 import {
+  mockServiceImports,
+  mockServiceProviders,
   validateCustomApiFilter,
   validateReadonlyApi,
 } from "@test/helpers/api-common";
 import { modelData } from "@test/helpers/faker";
-import { ToastrService } from "ngx-toastr";
 import { AudioRecordingsService } from "./audio-recordings.service";
 
 type Model = AudioRecording;
@@ -33,8 +31,8 @@ describe("AudioRecordingsService", function () {
   let spec: SpectatorService<AudioRecordingsService>;
   const createService = createServiceFactory({
     service: AudioRecordingsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach(function () {

--- a/src/app/services/baw-api/baw-api.module.ts
+++ b/src/app/services/baw-api/baw-api.module.ts
@@ -1,16 +1,17 @@
 import { HttpClientModule, HTTP_INTERCEPTORS } from "@angular/common/http";
 import { NgModule } from "@angular/core";
+import { CacheModule } from "@services/cache/cache.module";
 import { AppConfigModule } from "../config/config.module";
 import { BawApiInterceptor } from "./api.interceptor.service";
-import { BawSessionService } from "./baw-session.service";
 import { BawApiService } from "./baw-api.service";
 import { BawFormApiService } from "./baw-form-api.service";
+import { BawSessionService } from "./baw-session.service";
 import { CmsService } from "./cms/cms.service";
 import { SecurityService } from "./security/security.service";
 import { serviceResolvers, services, serviceTokens } from "./ServiceProviders";
 
 @NgModule({
-  imports: [HttpClientModule, AppConfigModule],
+  imports: [HttpClientModule, AppConfigModule, CacheModule],
   providers: [
     {
       provide: HTTP_INTERCEPTORS,

--- a/src/app/services/baw-api/baw-api.service.spec.ts
+++ b/src/app/services/baw-api/baw-api.service.spec.ts
@@ -32,7 +32,7 @@ import { modelData } from "@test/helpers/faker";
 import { assertOk } from "@test/helpers/general";
 import { UNAUTHORIZED, UNPROCESSABLE_ENTITY } from "http-status";
 import { ToastrService } from "ngx-toastr";
-import { BehaviorSubject, noop, Observable, single, Subject } from "rxjs";
+import { BehaviorSubject, noop, Observable, Subject } from "rxjs";
 import {
   BawSessionService,
   guestAuthToken,

--- a/src/app/services/baw-api/baw-api.service.ts
+++ b/src/app/services/baw-api/baw-api.service.ts
@@ -138,7 +138,9 @@ export class BawApiService<
    */
   public list(classBuilder: ClassBuilder, path: string): Observable<Model[]> {
     return this.session.authTrigger.pipe(
-      switchMap(() => this.httpGet(path)),
+      switchMap(() =>
+        this.httpGet(path, defaultApiHeaders, { cache: cacheSettings.enabled })
+      ),
       map(this.handleCollectionResponse(classBuilder))
     );
   }
@@ -167,15 +169,10 @@ export class BawApiService<
    * @param classBuilder Model to create
    * @param path API path
    */
-  public show(
-    classBuilder: ClassBuilder,
-    path: string,
-    cacheResponse = true
-  ): Observable<Model> {
-    cacheResponse = cacheResponse && cacheSettings.enabled;
+  public show(classBuilder: ClassBuilder, path: string): Observable<Model> {
     return this.session.authTrigger.pipe(
       switchMap(() =>
-        this.httpGet(path, defaultApiHeaders, { cache: cacheResponse })
+        this.httpGet(path, defaultApiHeaders, { cache: cacheSettings.enabled })
       ),
       map(this.handleSingleResponse(classBuilder))
     );
@@ -270,9 +267,9 @@ export class BawApiService<
       responseType: "json",
       headers: options,
       context: withCache({
-        ...cacheOptions,
-        ttl: 50,
+        ttl: cacheSettings.httpGetTtlMs,
         context: withCacheLogging(),
+        ...cacheOptions,
       }),
     });
   }

--- a/src/app/services/baw-api/baw-api.service.ts
+++ b/src/app/services/baw-api/baw-api.service.ts
@@ -80,6 +80,16 @@ export class BawApiService<
    */
   private handleEmptyResponse = () => null;
 
+  /**
+   * Clear an API call from the cache. Note: This does not currently work with
+   * API requests which include QSP and may be an issue in the future.
+   *
+   * @param path API path
+   */
+  private clearCache = (path: string) => {
+    this.manager.delete(path);
+  };
+
   public constructor(
     @Inject(API_ROOT) protected apiRoot: string,
     @Inject(IS_SERVER_PLATFORM) protected isServer: boolean,
@@ -236,7 +246,7 @@ export class BawApiService<
         map(this.handleSingleResponse(classBuilder))
       );
     }
-    return request.pipe(tap(() => this.manager.delete(path)));
+    return request.pipe(tap(() => this.clearCache(path)));
   }
 
   /**
@@ -247,7 +257,7 @@ export class BawApiService<
   public destroy(path: string): Observable<null> {
     return this.httpDelete(path).pipe(
       map(this.handleEmptyResponse),
-      tap(() => this.manager.delete(path))
+      tap(() => this.clearCache(path))
     );
   }
 

--- a/src/app/services/baw-api/baw-api.service.ts
+++ b/src/app/services/baw-api/baw-api.service.ts
@@ -11,6 +11,8 @@ import {
   AbstractModelConstructor,
   AbstractModelWithoutId,
 } from "@models/AbstractModel";
+import { withCache } from "@ngneat/cashew";
+import { ContextOptions } from "@ngneat/cashew/lib/cache-context";
 import { ToastrService } from "ngx-toastr";
 import { Observable, throwError } from "rxjs";
 import { map, mergeMap, switchMap } from "rxjs/operators";
@@ -162,9 +164,15 @@ export class BawApiService<
    * @param classBuilder Model to create
    * @param path API path
    */
-  public show(classBuilder: ClassBuilder, path: string): Observable<Model> {
+  public show(
+    classBuilder: ClassBuilder,
+    path: string,
+    cacheResponse = true
+  ): Observable<Model> {
     return this.session.authTrigger.pipe(
-      switchMap(() => this.httpGet(path)),
+      switchMap(() =>
+        this.httpGet(path, defaultHeaders, { cache: cacheResponse, ttl: 50 })
+      ),
       map(this.handleSingleResponse(classBuilder))
     );
   }
@@ -248,11 +256,13 @@ export class BawApiService<
    */
   public httpGet(
     path: string,
-    options: any = defaultHeaders
+    options: any = defaultHeaders,
+    cacheOptions?: ContextOptions
   ): Observable<ApiResponse<Model | Model[]>> {
     return this.http.get<ApiResponse<Model>>(this.getPath(path), {
       responseType: "json",
       headers: options,
+      context: withCache(cacheOptions ?? { cache: false }),
     });
   }
 

--- a/src/app/services/baw-api/baw-api.service.ts
+++ b/src/app/services/baw-api/baw-api.service.ts
@@ -23,14 +23,14 @@ export const defaultApiPageSize = 25;
 export const unknownErrorCode = -1;
 
 /** Default headers for API requests */
-const defaultHeaders = new HttpHeaders({
+export const defaultApiHeaders = new HttpHeaders({
   // eslint-disable-next-line @typescript-eslint/naming-convention
   Accept: "application/json",
   // eslint-disable-next-line @typescript-eslint/naming-convention
   "Content-Type": "application/json",
 });
 /** Headers for MultiPart API requests */
-const multiPartHeaders = new HttpHeaders({
+export const multiPartApiHeaders = new HttpHeaders({
   // Do not set Content-Type for this request, otherwise web browsers wont calculate boundaries automatically
   // https://muffinman.io/blog/uploading-files-using-fetch-multipart-form-data/
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -171,7 +171,7 @@ export class BawApiService<
   ): Observable<Model> {
     return this.session.authTrigger.pipe(
       switchMap(() =>
-        this.httpGet(path, defaultHeaders, { cache: cacheResponse, ttl: 50 })
+        this.httpGet(path, defaultApiHeaders, { cache: cacheResponse, ttl: 50 })
       ),
       map(this.handleSingleResponse(classBuilder))
     );
@@ -201,7 +201,7 @@ export class BawApiService<
       const formData = body.getFormDataOnlyAttributes({ create: true });
       return request.pipe(
         mergeMap((model) =>
-          this.httpPut(updatePath(model), formData, multiPartHeaders)
+          this.httpPut(updatePath(model), formData, multiPartApiHeaders)
         ),
         map(this.handleSingleResponse(classBuilder))
       );
@@ -231,7 +231,7 @@ export class BawApiService<
     if (body?.hasFormDataOnlyAttributes({ update: true })) {
       const formData = body.getFormDataOnlyAttributes({ update: true });
       return request.pipe(
-        mergeMap(() => this.httpPut(path, formData, multiPartHeaders)),
+        mergeMap(() => this.httpPut(path, formData, multiPartApiHeaders)),
         map(this.handleSingleResponse(classBuilder))
       );
     }
@@ -256,7 +256,7 @@ export class BawApiService<
    */
   public httpGet(
     path: string,
-    options: any = defaultHeaders,
+    options: any = defaultApiHeaders,
     cacheOptions?: ContextOptions
   ): Observable<ApiResponse<Model | Model[]>> {
     return this.http.get<ApiResponse<Model>>(this.getPath(path), {
@@ -275,7 +275,7 @@ export class BawApiService<
    */
   public httpDelete(
     path: string,
-    options: any = defaultHeaders
+    options: any = defaultApiHeaders
   ): Observable<ApiResponse<Model | void>> {
     return this.http.delete<ApiResponse<null>>(this.getPath(path), {
       responseType: "json",
@@ -294,7 +294,7 @@ export class BawApiService<
   public httpPost(
     path: string,
     body?: any,
-    options: any = defaultHeaders
+    options: any = defaultApiHeaders
   ): Observable<ApiResponse<Model | Model[]>> {
     return this.http.post<ApiResponse<Model | Model[]>>(
       this.getPath(path),
@@ -317,7 +317,7 @@ export class BawApiService<
   public httpPut(
     path: string,
     body?: any,
-    options: any = defaultHeaders
+    options: any = defaultApiHeaders
   ): Observable<ApiResponse<Model>> {
     return this.http.put<ApiResponse<Model>>(this.getPath(path), body, {
       responseType: "json",
@@ -336,7 +336,7 @@ export class BawApiService<
   public httpPatch(
     path: string,
     body?: any,
-    options: any = defaultHeaders
+    options: any = defaultApiHeaders
   ): Observable<ApiResponse<Model>> {
     return this.http.patch<ApiResponse<Model>>(this.getPath(path), body, {
       responseType: "json",

--- a/src/app/services/baw-api/baw-apiMock.module.ts
+++ b/src/app/services/baw-api/baw-apiMock.module.ts
@@ -2,6 +2,7 @@ import { HTTP_INTERCEPTORS } from "@angular/common/http";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { NgModule, Provider } from "@angular/core";
 import { mockProvider } from "@ngneat/spectator";
+import { CacheModule } from "@services/cache/cache.module";
 import { MockAppConfigModule } from "../config/configMock.module";
 import { AccountsService } from "./account/accounts.service";
 import { AnalysisJobItemsService } from "./analysis/analysis-job-items.service";
@@ -81,7 +82,7 @@ const mockProviders: Provider[] = [
 ];
 
 @NgModule({
-  imports: [HttpClientTestingModule, MockAppConfigModule],
+  imports: [HttpClientTestingModule, MockAppConfigModule, CacheModule],
   providers: [
     {
       provide: HTTP_INTERCEPTORS,

--- a/src/app/services/baw-api/baw-form-api.service.spec.ts
+++ b/src/app/services/baw-api/baw-form-api.service.spec.ts
@@ -11,6 +11,7 @@ import {
   mockProvider,
   SpectatorHttp,
 } from "@ngneat/spectator";
+import { CacheModule } from "@services/cache/cache.module";
 import { MockAppConfigModule } from "@services/config/configMock.module";
 import { generateBawApiError } from "@test/fakes/BawApiError";
 import { modelData } from "@test/helpers/faker";
@@ -30,7 +31,7 @@ describe("BawFormApiService", () => {
   let spec: SpectatorHttp<BawFormApiService<MockForm>>;
   const createService = createHttpFactory<BawFormApiService<MockForm>>({
     service: BawFormApiService,
-    imports: [MockAppConfigModule],
+    imports: [MockAppConfigModule, CacheModule],
     providers: [
       BawSessionService,
       BawApiService,

--- a/src/app/services/baw-api/bookmark/bookmarks.service.spec.ts
+++ b/src/app/services/baw-api/bookmark/bookmarks.service.spec.ts
@@ -1,21 +1,14 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { IdOr } from "@baw-api/api-common";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Bookmark } from "@models/Bookmark";
 import { User } from "@models/User";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateBookmark } from "@test/fakes/Bookmark";
 import {
+  mockServiceImports,
+  mockServiceProviders,
   validateCustomApiFilter,
   validateStandardApi,
 } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
 import { BookmarksService } from "./bookmarks.service";
 
 describe("BookmarksService", (): void => {
@@ -25,8 +18,8 @@ describe("BookmarksService", (): void => {
   let spec: SpectatorService<BookmarksService>;
   const createService = createServiceFactory({
     service: BookmarksService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/dataset/dataset-items.service.spec.ts
+++ b/src/app/services/baw-api/dataset/dataset-items.service.spec.ts
@@ -1,18 +1,13 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { IdOr } from "@baw-api/api-common";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Dataset } from "@models/Dataset";
 import { DatasetItem } from "@models/DatasetItem";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateDatasetItem } from "@test/fakes/DatasetItem";
-import { validateImmutableApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateImmutableApi,
+} from "@test/helpers/api-common";
 import { DatasetItemsService } from "./dataset-items.service";
 
 type Model = DatasetItem;
@@ -26,8 +21,8 @@ describe("DatasetItemsService", (): void => {
   let spec: SpectatorService<DatasetItemsService>;
   const createService = createServiceFactory({
     service: DatasetItemsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/dataset/datasets.service.spec.ts
+++ b/src/app/services/baw-api/dataset/datasets.service.spec.ts
@@ -1,16 +1,11 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Dataset } from "@models/Dataset";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateDataset } from "@test/fakes/Dataset";
-import { validateStandardApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateStandardApi,
+} from "@test/helpers/api-common";
 import { DatasetsService } from "./datasets.service";
 
 describe("DatasetsService", (): void => {
@@ -20,8 +15,8 @@ describe("DatasetsService", (): void => {
   let spec: SpectatorService<DatasetsService>;
   const createService = createServiceFactory({
     service: DatasetsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/harvest/harvest-items-shallow.service.spec.ts
+++ b/src/app/services/baw-api/harvest/harvest-items-shallow.service.spec.ts
@@ -1,16 +1,11 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { HarvestItem } from "@models/HarvestItem";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateHarvestItem } from "@test/fakes/HarvestItem";
-import { validateReadonlyApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateReadonlyApi,
+} from "@test/helpers/api-common";
 import { ShallowHarvestItemsService } from "./harvest-items.service";
 
 describe("ShallowHarvestItemsService", () => {
@@ -22,8 +17,8 @@ describe("ShallowHarvestItemsService", () => {
   let spec: SpectatorService<ShallowHarvestItemsService>;
   const createService = createServiceFactory({
     service: ShallowHarvestItemsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/harvest/harvest-items.service.spec.ts
+++ b/src/app/services/baw-api/harvest/harvest-items.service.spec.ts
@@ -1,16 +1,11 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { HarvestItem } from "@models/HarvestItem";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateHarvestItem } from "@test/fakes/HarvestItem";
-import { validateReadonlyApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateReadonlyApi,
+} from "@test/helpers/api-common";
 import { HarvestItemsService } from "./harvest-items.service";
 
 describe("HarvestItemsService", () => {
@@ -21,8 +16,8 @@ describe("HarvestItemsService", () => {
   let spec: SpectatorService<HarvestItemsService>;
   const createService = createServiceFactory({
     service: HarvestItemsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {
@@ -38,6 +33,6 @@ describe("HarvestItemsService", () => {
     createModel,
     harvestItemId, // harvest item
     5, // project
-    10, // harvest
+    10 // harvest
   );
 });

--- a/src/app/services/baw-api/harvest/harvest-shallow.service.spec.ts
+++ b/src/app/services/baw-api/harvest/harvest-shallow.service.spec.ts
@@ -1,16 +1,11 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Harvest } from "@models/Harvest";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateHarvest } from "@test/fakes/Harvest";
-import { validateStandardApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateStandardApi,
+} from "@test/helpers/api-common";
 import { ShallowHarvestsService } from "./harvest.service";
 
 describe("ShallowHarvestsService", () => {
@@ -21,8 +16,8 @@ describe("ShallowHarvestsService", () => {
   let spec: SpectatorService<ShallowHarvestsService>;
   const createService = createServiceFactory({
     service: ShallowHarvestsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/harvest/harvest.service.spec.ts
+++ b/src/app/services/baw-api/harvest/harvest.service.spec.ts
@@ -1,16 +1,11 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Harvest } from "@models/Harvest";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateHarvest } from "@test/fakes/Harvest";
-import { validateStandardApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateStandardApi,
+} from "@test/helpers/api-common";
 import { HarvestsService, ShallowHarvestsService } from "./harvest.service";
 
 describe("HarvestsService", () => {
@@ -20,13 +15,8 @@ describe("HarvestsService", () => {
   let spec: SpectatorService<HarvestsService>;
   const createService = createServiceFactory({
     service: HarvestsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [
-      BawApiService,
-      BawSessionService,
-      ShallowHarvestsService,
-      mockProvider(ToastrService),
-    ],
+    imports: mockServiceImports,
+    providers: [...mockServiceProviders, ShallowHarvestsService],
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/progress-event/progress-events.service.spec.ts
+++ b/src/app/services/baw-api/progress-event/progress-events.service.spec.ts
@@ -1,16 +1,11 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { ProgressEvent } from "@models/ProgressEvent";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateProgressEvent } from "@test/fakes/ProgressEvent";
-import { validateReadAndCreateApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateReadAndCreateApi,
+} from "@test/helpers/api-common";
 import { ProgressEventsService } from "./progress-events.service";
 
 describe("ProgressEventsService", (): void => {
@@ -20,8 +15,8 @@ describe("ProgressEventsService", (): void => {
   let spec: SpectatorService<ProgressEventsService>;
   const createService = createServiceFactory({
     service: ProgressEventsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/project/projects.service.spec.ts
+++ b/src/app/services/baw-api/project/projects.service.spec.ts
@@ -1,22 +1,15 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { IdOr } from "@baw-api/api-common";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { ProjectsService } from "@baw-api/project/projects.service";
 import { Project } from "@models/Project";
 import { User } from "@models/User";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateProject } from "@test/fakes/Project";
 import {
+  mockServiceImports,
+  mockServiceProviders,
   validateCustomApiFilter,
   validateStandardApi,
 } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
 
 describe("ProjectsService", (): void => {
   const createModel = () => new Project(generateProject({ id: 5 }));
@@ -25,8 +18,8 @@ describe("ProjectsService", (): void => {
   let spec: SpectatorService<ProjectsService>;
   const createService = createServiceFactory({
     service: ProjectsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/region/regions-shallow.service.spec.ts
+++ b/src/app/services/baw-api/region/regions-shallow.service.spec.ts
@@ -1,16 +1,11 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Region } from "@models/Region";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateRegion } from "@test/fakes/Region";
-import { validateStandardApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateStandardApi,
+} from "@test/helpers/api-common";
 import { ShallowRegionsService } from "./regions.service";
 
 describe("ShallowRegionsService", function () {
@@ -20,8 +15,8 @@ describe("ShallowRegionsService", function () {
   let spec: SpectatorService<ShallowRegionsService>;
   const createService = createServiceFactory({
     service: ShallowRegionsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/region/regions.service.spec.ts
+++ b/src/app/services/baw-api/region/regions.service.spec.ts
@@ -1,18 +1,13 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { IdOr } from "@baw-api/api-common";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateRegion } from "@test/fakes/Region";
-import { validateStandardApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateStandardApi,
+} from "@test/helpers/api-common";
 import { RegionsService } from "./regions.service";
 
 type Model = Region;
@@ -26,8 +21,8 @@ describe("RegionsService", (): void => {
   let spec: SpectatorService<RegionsService>;
   const createService = createServiceFactory({
     service: RegionsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/resolver-common.ts
+++ b/src/app/services/baw-api/resolver-common.ts
@@ -103,7 +103,7 @@ export abstract class BawResolver<
 
         const id =
           route.paramMap.get(uniqueId) ?? route.queryParamMap.get(uniqueId);
-        return convertToId(id);
+        return isInstantiated(id) ? convertToId(id) : undefined;
       }
 
       /**
@@ -326,7 +326,7 @@ export class ShowOptionalResolver<
   }
 
   public resolverFn(_: any, api: Service, id: Id, ids: Params) {
-    return api.show(id, ...ids);
+    return id ? api.show(id, ...ids) : of(undefined);
   }
 }
 

--- a/src/app/services/baw-api/resolver-common.ts
+++ b/src/app/services/baw-api/resolver-common.ts
@@ -383,7 +383,8 @@ export function retrieveResolvers(data: IPageInfo): ResolvedModelList {
   const keys = Object.keys(data?.resolvers || {});
 
   if (keys.length === 0) {
-    console.warn("resolver-common: Failed to detect any resolvers");
+    // eslint-disable-next-line no-console
+    console.debug("resolver-common: Failed to detect any resolvers");
     return models;
   }
 

--- a/src/app/services/baw-api/saved-search/saved-searches.service.spec.ts
+++ b/src/app/services/baw-api/saved-search/saved-searches.service.spec.ts
@@ -1,16 +1,11 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { SavedSearch } from "@models/SavedSearch";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateSavedSearch } from "@test/fakes/SavedSearch";
-import { validateImmutableApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateImmutableApi,
+} from "@test/helpers/api-common";
 import { SavedSearchesService } from "./saved-searches.service";
 
 describe("SavedSearchesService", (): void => {
@@ -20,8 +15,8 @@ describe("SavedSearchesService", (): void => {
   let spec: SpectatorService<SavedSearchesService>;
   const createService = createServiceFactory({
     service: SavedSearchesService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/script/scripts.service.spec.ts
+++ b/src/app/services/baw-api/script/scripts.service.spec.ts
@@ -1,17 +1,12 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { ScriptsService } from "@baw-api/script/scripts.service";
 import { Script } from "@models/Script";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateScript } from "@test/fakes/Script";
-import { validateNonDestructableApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateNonDestructableApi,
+} from "@test/helpers/api-common";
 
 describe("ScriptsService", function () {
   const createModel = () => new Script(generateScript({ id: 5 }));
@@ -20,8 +15,8 @@ describe("ScriptsService", function () {
   let spec: SpectatorService<ScriptsService>;
   const createService = createServiceFactory({
     service: ScriptsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/site/sites-shallow.service.spec.ts
+++ b/src/app/services/baw-api/site/sites-shallow.service.spec.ts
@@ -1,23 +1,16 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { IdOr } from "@baw-api/api-common";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
 import { User } from "@models/User";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateSite } from "@test/fakes/Site";
 import {
+  mockServiceImports,
+  mockServiceProviders,
   validateCustomApiFilter,
   validateCustomApiList,
   validateStandardApi,
 } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
 import { ShallowSitesService } from "./sites.service";
 
 type Model = Site;
@@ -30,8 +23,8 @@ describe("ShallowSitesService", (): void => {
   let spec: SpectatorService<ShallowSitesService>;
   const createService = createServiceFactory({
     service: ShallowSitesService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/site/sites.service.spec.ts
+++ b/src/app/services/baw-api/site/sites.service.spec.ts
@@ -1,24 +1,17 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { IdOr, setTimezoneQSP } from "@baw-api/api-common";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { API_ROOT } from "@helpers/app-initializer/app-initializer";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
-import {
-  SpectatorService,
-  createServiceFactory,
-  mockProvider,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateProject } from "@test/fakes/Project";
 import { generateSite } from "@test/fakes/Site";
 import {
-  validateStandardApi,
+  mockServiceImports,
+  mockServiceProviders,
   validateCustomApiFilter,
+  validateStandardApi,
 } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
 import { SitesService } from "./sites.service";
 
 type Model = Site;
@@ -34,8 +27,8 @@ describe("SitesService", (): void => {
   let spec: SpectatorService<SitesService>;
   const createService = createServiceFactory({
     service: SitesService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/statistics/statistics.service.spec.ts
+++ b/src/app/services/baw-api/statistics/statistics.service.spec.ts
@@ -1,16 +1,11 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Statistics } from "@models/Statistics";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateStatistics } from "@test/fakes/Statistics";
-import { validateApiShow } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateApiShow,
+} from "@test/helpers/api-common";
 import { StatisticsService } from "./statistics.service";
 
 describe("StatisticsService", (): void => {
@@ -19,8 +14,8 @@ describe("StatisticsService", (): void => {
   let spec: SpectatorService<StatisticsService>;
   const createService = createServiceFactory({
     service: StatisticsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/study/questions-shallow.service.spec.ts
+++ b/src/app/services/baw-api/study/questions-shallow.service.spec.ts
@@ -1,16 +1,11 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Question } from "@models/Question";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateQuestion } from "@test/fakes/Question";
-import { validateStandardApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateStandardApi,
+} from "@test/helpers/api-common";
 import { ShallowQuestionsService } from "./questions.service";
 
 describe("ShallowQuestionsService", (): void => {
@@ -20,8 +15,8 @@ describe("ShallowQuestionsService", (): void => {
   let spec: SpectatorService<ShallowQuestionsService>;
   const createService = createServiceFactory({
     service: ShallowQuestionsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/study/questions.service.spec.ts
+++ b/src/app/services/baw-api/study/questions.service.spec.ts
@@ -1,18 +1,13 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { IdOr } from "@baw-api/api-common";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Question } from "@models/Question";
 import { Study } from "@models/Study";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateQuestion } from "@test/fakes/Question";
-import { validateStandardApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateStandardApi,
+} from "@test/helpers/api-common";
 import { QuestionsService } from "./questions.service";
 
 type Model = Question;
@@ -26,8 +21,8 @@ describe("QuestionsService", (): void => {
   let spec: SpectatorService<QuestionsService>;
   const createService = createServiceFactory({
     service: QuestionsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/study/responses-shallow.service.spec.ts
+++ b/src/app/services/baw-api/study/responses-shallow.service.spec.ts
@@ -1,16 +1,11 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Response } from "@models/Response";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateResponse } from "@test/fakes/Response";
-import { validateStandardApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateStandardApi,
+} from "@test/helpers/api-common";
 import { ShallowResponsesService } from "./responses.service";
 
 describe("ShallowResponsesService", (): void => {
@@ -20,8 +15,8 @@ describe("ShallowResponsesService", (): void => {
   let spec: SpectatorService<ShallowResponsesService>;
   const createService = createServiceFactory({
     service: ShallowResponsesService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/study/responses.service.spec.ts
+++ b/src/app/services/baw-api/study/responses.service.spec.ts
@@ -1,18 +1,13 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { IdOr } from "@baw-api/api-common";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Response } from "@models/Response";
 import { Study } from "@models/Study";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateResponse } from "@test/fakes/Response";
-import { validateStandardApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateStandardApi,
+} from "@test/helpers/api-common";
 import { ResponsesService } from "./responses.service";
 
 type Model = Response;
@@ -26,8 +21,8 @@ describe("ResponsesService", (): void => {
   let spec: SpectatorService<ResponsesService>;
   const createService = createServiceFactory({
     service: ResponsesService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/study/studies.service.spec.ts
+++ b/src/app/services/baw-api/study/studies.service.spec.ts
@@ -1,16 +1,11 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Study } from "@models/Study";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateStudy } from "@test/fakes/Study";
-import { validateStandardApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateStandardApi,
+} from "@test/helpers/api-common";
 import { StudiesService } from "./studies.service";
 
 describe("StudiesService", (): void => {
@@ -20,8 +15,8 @@ describe("StudiesService", (): void => {
   let spec: SpectatorService<StudiesService>;
   const createService = createServiceFactory({
     service: StudiesService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/tag/tag-group.service.spec.ts
+++ b/src/app/services/baw-api/tag/tag-group.service.spec.ts
@@ -1,17 +1,12 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { TagGroupsService } from "@baw-api/tag/tag-group.service";
 import { TagGroup } from "@models/TagGroup";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateTagGroup } from "@test/fakes/TagGroup";
-import { validateStandardApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateStandardApi,
+} from "@test/helpers/api-common";
 
 describe("TagGroupService", (): void => {
   const createModel = () => new TagGroup(generateTagGroup({ id: 5 }));
@@ -20,8 +15,8 @@ describe("TagGroupService", (): void => {
   let spec: SpectatorService<TagGroupsService>;
   const createService = createServiceFactory({
     service: TagGroupsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/tag/taggings.service.spec.ts
+++ b/src/app/services/baw-api/tag/taggings.service.spec.ts
@@ -1,19 +1,14 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { IdOr } from "@baw-api/api-common";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { AnalysisJob } from "@models/AnalysisJob";
 import { AudioEvent } from "@models/AudioEvent";
 import { Tagging } from "@models/Tagging";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateTagging } from "@test/fakes/Tagging";
-import { validateStandardApi } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateStandardApi,
+} from "@test/helpers/api-common";
 import { TaggingsService } from "./taggings.service";
 
 type Model = Tagging;
@@ -27,8 +22,8 @@ describe("TaggingsService", (): void => {
   let spec: SpectatorService<TaggingsService>;
   const createService = createServiceFactory({
     service: TaggingsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach(function () {

--- a/src/app/services/baw-api/tag/tags.service.spec.ts
+++ b/src/app/services/baw-api/tag/tags.service.spec.ts
@@ -1,21 +1,14 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { IdOr } from "@baw-api/api-common";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Tag } from "@models/Tag";
 import { User } from "@models/User";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateTag } from "@test/fakes/Tag";
 import {
+  mockServiceImports,
+  mockServiceProviders,
   validateCustomApiFilter,
   validateStandardApi,
 } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
 import { TagsService } from "./tags.service";
 
 describe("TagsService", (): void => {
@@ -25,8 +18,8 @@ describe("TagsService", (): void => {
   let spec: SpectatorService<TagsService>;
   const createService = createServiceFactory({
     service: TagsService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [BawApiService, BawSessionService, mockProvider(ToastrService)],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach((): void => {

--- a/src/app/services/baw-api/user/user.service.spec.ts
+++ b/src/app/services/baw-api/user/user.service.spec.ts
@@ -1,17 +1,11 @@
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { BawApiService } from "@baw-api/baw-api.service";
-import { BawFormApiService } from "@baw-api/baw-form-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { User } from "@models/User";
-import {
-  createServiceFactory,
-  mockProvider,
-  SpectatorService,
-} from "@ngneat/spectator";
-import { MockAppConfigModule } from "@services/config/configMock.module";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateUser } from "@test/fakes/User";
-import { validateApiShow } from "@test/helpers/api-common";
-import { ToastrService } from "ngx-toastr";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateApiShow,
+} from "@test/helpers/api-common";
 import { UserService } from "./user.service";
 
 describe("UserService", (): void => {
@@ -20,13 +14,8 @@ describe("UserService", (): void => {
   let spec: SpectatorService<UserService>;
   const createService = createServiceFactory({
     service: UserService,
-    imports: [MockAppConfigModule, HttpClientTestingModule],
-    providers: [
-      BawApiService,
-      BawFormApiService,
-      BawSessionService,
-      mockProvider(ToastrService),
-    ],
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
   });
 
   beforeEach(() => {

--- a/src/app/services/cache/cache-logging.service.ts
+++ b/src/app/services/cache/cache-logging.service.ts
@@ -1,0 +1,43 @@
+import {
+  HttpContext,
+  HttpContextToken,
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+} from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { Observable } from "rxjs";
+import { cacheSettings } from "./cache-settings";
+
+const CACHE_LOGGING = new HttpContextToken<boolean>(() => false);
+
+/**
+ * Log that a request was cached. This should be used in conjunction with the
+ * `withCache()` context
+ *
+ * ```typescript
+ * return this.http.get("http://api/1", {
+      context: withCache({context: withCacheLogging()}),
+   });
+ * ```
+ */
+export const withCacheLogging = () =>
+  new HttpContext().set(CACHE_LOGGING, true);
+
+@Injectable()
+export class CacheLoggingService implements HttpInterceptor {
+  public constructor() {}
+
+  public intercept(
+    req: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    if (cacheSettings.showLogging && req.context.get(CACHE_LOGGING)) {
+      // eslint-disable-next-line no-console
+      console.debug("(CacheLoggingService) Caching requests for ", req.url);
+    }
+
+    return next.handle(req);
+  }
+}

--- a/src/app/services/cache/cache-settings.ts
+++ b/src/app/services/cache/cache-settings.ts
@@ -1,4 +1,7 @@
 class CacheSettings {
+  /** TTL for HTTP GET requests */
+  public httpGetTtlMs = 1000;
+
   public constructor(private _enabled: boolean, private withLogging: boolean) {}
 
   /** Is cache logging enabled */

--- a/src/app/services/cache/cache-settings.ts
+++ b/src/app/services/cache/cache-settings.ts
@@ -1,0 +1,28 @@
+class CacheSettings {
+  public constructor(private _enabled: boolean, private withLogging: boolean) {}
+
+  /** Is cache logging enabled */
+  public get showLogging(): boolean {
+    return this._enabled && this.withLogging;
+  }
+
+  /** Is caching enabled */
+  public get enabled(): boolean {
+    return this._enabled;
+  }
+
+  /** Enable/Disable caching */
+  public setCaching(enable: boolean): void {
+    this._enabled = enable;
+  }
+
+  /**
+   * Enable/Disable logging. Logging cannot be enabled without caching being
+   * enabled
+   */
+  public setLogging(enable: boolean): void {
+    this.withLogging = enable;
+  }
+}
+
+export const cacheSettings = new CacheSettings(true, false);

--- a/src/app/services/cache/cache.module.ts
+++ b/src/app/services/cache/cache.module.ts
@@ -1,0 +1,33 @@
+import { HTTP_INTERCEPTORS } from "@angular/common/http";
+import { NgModule } from "@angular/core";
+import { ApiResponse } from "@baw-api/baw-api.service";
+import { HttpCacheInterceptorModule } from "@ngneat/cashew";
+import { CacheLoggingService } from "./cache-logging.service";
+import { cacheSettings } from "./cache-settings";
+
+@NgModule({
+  imports: [
+    // Cache API requests
+    HttpCacheInterceptorModule.forRoot({
+      strategy: "explicit",
+      responseSerializer(body: ApiResponse<unknown>) {
+        if (cacheSettings.showLogging) {
+          // eslint-disable-next-line no-console
+          console.debug(
+            "(HttpCacheInterceptorModule) Returned cached response: ",
+            body
+          );
+        }
+        return body;
+      },
+    }),
+  ],
+  providers: [
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: CacheLoggingService,
+      multi: true,
+    },
+  ],
+})
+export class CacheModule {}

--- a/src/app/test/helpers/api-common.ts
+++ b/src/app/test/helpers/api-common.ts
@@ -1,9 +1,15 @@
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { BawFormApiService } from "@baw-api/baw-form-api.service";
+import { BawSessionService } from "@baw-api/baw-session.service";
 import { CmsService } from "@baw-api/cms/cms.service";
 import { MayBeAsync } from "@helpers/advancedTypes";
 import { Id } from "@interfaces/apiInterfaces";
 import { AbstractModel, AbstractModelConstructor } from "@models/AbstractModel";
-import { Spectator, SpectatorService } from "@ngneat/spectator";
+import { mockProvider, Spectator, SpectatorService } from "@ngneat/spectator";
+import { CacheModule } from "@services/cache/cache.module";
+import { MockAppConfigModule } from "@services/config/configMock.module";
 import { CmsComponent } from "@shared/cms/cms.component";
+import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject, Observable, Subject } from "rxjs";
 import {
   ApiCreate,
@@ -21,6 +27,19 @@ import {
 } from "../../services/baw-api/api-common";
 import { BawApiService, Filters } from "../../services/baw-api/baw-api.service";
 import { getCallArgs } from "./general";
+
+export const mockServiceImports = [
+  MockAppConfigModule,
+  HttpClientTestingModule,
+  CacheModule,
+];
+
+export const mockServiceProviders = [
+  BawApiService,
+  BawFormApiService,
+  BawSessionService,
+  mockProvider(ToastrService),
+];
 
 type CustomList<Model extends AbstractModel, Params extends any[]> = (
   ...urlParameters: Params


### PR DESCRIPTION
# Api Request Caching

Implemented caching for `show` API requests with a time to live of 50ms. This significantly improves the loading speed of pages which make multiple requests for the same resource.

## Issues

Closes #16

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
