### PR TITLE
Implemented CSV links in complete screen

### DIFF
--- a/src/app/components/harvest/components/shared/statistics.component.ts
+++ b/src/app/components/harvest/components/shared/statistics.component.ts
@@ -36,7 +36,7 @@ export interface Statistic {
     `
       .card-body {
         text-align: center;
-        min-width: 10rem;
+        min-width: 7.5rem;
       }
 
       .icon {

--- a/src/app/components/harvest/pages/details/details.component.ts
+++ b/src/app/components/harvest/pages/details/details.component.ts
@@ -8,7 +8,6 @@ import {
 } from "@components/harvest/harvest.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
-import { permissionsWidgetMenuItem } from "@menu/widget.menus";
 import { Harvest } from "@models/Harvest";
 import { Project } from "@models/Project";
 import { List } from "immutable";
@@ -49,10 +48,7 @@ class DetailsComponent
 
 DetailsComponent.linkToRoute({
   category: harvestsCategory,
-  menus: {
-    actions: List(harvestsMenuItemActions),
-    actionWidgets: List([permissionsWidgetMenuItem]),
-  },
+  menus: { actions: List(harvestsMenuItemActions) },
   pageRoute: harvestMenuItem,
   resolvers: {
     [projectKey]: projectResolvers.show,

--- a/src/app/components/harvest/pages/new/new.component.ts
+++ b/src/app/components/harvest/pages/new/new.component.ts
@@ -10,7 +10,6 @@ import { harvestRoute } from "@components/harvest/harvest.routes";
 import { projectMenuItemActions } from "@components/projects/pages/details/details.component";
 import { BawApiError } from "@helpers/custom-errors/baw-api-error";
 import { PageComponent } from "@helpers/page/pageComponent";
-import { permissionsWidgetMenuItem } from "@menu/widget.menus";
 import { Harvest, IHarvest } from "@models/Harvest";
 import { Project } from "@models/Project";
 import { List } from "immutable";
@@ -78,10 +77,7 @@ class NewComponent extends PageComponent implements OnInit {
 
 NewComponent.linkToRoute({
   category: harvestsCategory,
-  menus: {
-    actions: List(projectMenuItemActions),
-    actionWidgets: List([permissionsWidgetMenuItem]),
-  },
+  menus: { actions: List(projectMenuItemActions) },
   pageRoute: newHarvestMenuItem,
   resolvers: {
     [projectKey]: projectResolvers.show,

--- a/src/app/components/harvest/screens/complete/complete.component.html
+++ b/src/app/components/harvest/screens/complete/complete.component.html
@@ -2,11 +2,17 @@
 
 <baw-harvest-statistics [statistics]="getStatistics(report)">
   <baw-harvest-statistic-group>
-    <baw-harvest-statistic-item [statistic]="getDownloadStatistic()">
+    <baw-harvest-statistic-item [statistic]="downloadIcon">
       <span id="value">&nbsp;</span>
-      <baw-wip id="label">
-        <a href="/intentionally_broken">Download CSV</a>
-      </baw-wip>
+      <a id="label" [href]="recordingsReportUrl | safe: 'url'">
+        Recordings Report
+      </a>
+    </baw-harvest-statistic-item>
+    <baw-harvest-statistic-item [statistic]="downloadIcon">
+      <span id="value">&nbsp;</span>
+      <a id="label" [href]="harvestItemsReportUrl | safe: 'url'">
+        Upload Report
+      </a>
     </baw-harvest-statistic-item>
   </baw-harvest-statistic-group>
 </baw-harvest-statistics>

--- a/src/app/components/harvest/screens/complete/complete.component.ts
+++ b/src/app/components/harvest/screens/complete/complete.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from "@angular/core";
 import { AudioRecordingsService } from "@baw-api/audio-recording/audio-recordings.service";
 import { Filters } from "@baw-api/baw-api.service";
+import { ShallowHarvestItemsService } from "@baw-api/harvest/harvest-items.service";
 import { audioRecordingsRoutes } from "@components/audio-recordings/audio-recording.routes";
 import { Statistic } from "@components/harvest/components/shared/statistics.component";
 import { HarvestStagesService } from "@components/harvest/services/harvest-stages.service";
@@ -20,6 +21,7 @@ export class CompleteComponent implements OnInit {
 
   public constructor(
     public stages: HarvestStagesService,
+    private harvestItemsApi: ShallowHarvestItemsService,
     private recordingsApi: AudioRecordingsService
   ) {}
 
@@ -40,6 +42,14 @@ export class CompleteComponent implements OnInit {
 
   public get project(): Project {
     return this.stages.project;
+  }
+
+  public get recordingsReportUrl(): string {
+    return this.recordingsApi.harvestReportUrl(this.stages.harvest);
+  }
+
+  public get harvestItemsReportUrl(): string {
+    return this.harvestItemsApi.harvestReportUrl(this.stages.harvest);
   }
 
   public getStatistics(report: HarvestReport): Statistic[][] {
@@ -85,7 +95,7 @@ export class CompleteComponent implements OnInit {
     ];
   }
 
-  public getDownloadStatistic(): Statistic {
+  public get downloadIcon(): Statistic {
     return {
       bgColor: "highlight",
       icon: ["fas", "download"],

--- a/src/app/components/harvest/screens/complete/complete.component.ts
+++ b/src/app/components/harvest/screens/complete/complete.component.ts
@@ -45,11 +45,11 @@ export class CompleteComponent implements OnInit {
   }
 
   public get recordingsReportUrl(): string {
-    return this.recordingsApi.harvestReportUrl(this.stages.harvest);
+    return this.recordingsApi.harvestCsvReportUrl(this.stages.harvest);
   }
 
   public get harvestItemsReportUrl(): string {
-    return this.harvestItemsApi.harvestReportUrl(this.stages.harvest);
+    return this.harvestItemsApi.harvestCsvReportUrl(this.stages.harvest);
   }
 
   public getStatistics(report: HarvestReport): Statistic[][] {

--- a/src/app/components/harvest/services/harvest-stages.service.ts
+++ b/src/app/components/harvest/services/harvest-stages.service.ts
@@ -187,7 +187,7 @@ export class HarvestStagesService extends withUnsubscribe() {
     const defaultResponse: Observable<HarvestItem[]> = of([]);
     this.harvest$
       .pipe(
-        filter((): boolean => !this.isCurrentStage("metadataReview")),
+        filter((): boolean => this.isCurrentStage("metadataReview")),
         switchMap((harvest) => this.harvestItemsApi.list(harvest)),
         catchError(() => defaultResponse),
         takeUntil(this.unsubscribe)

--- a/src/app/services/baw-api/audio-recording/audio-recordings.service.ts
+++ b/src/app/services/baw-api/audio-recording/audio-recordings.service.ts
@@ -117,7 +117,7 @@ export class AudioRecordingsService implements ReadonlyApi<AudioRecording> {
     return this.api.getPath(audioRecordingOriginalEndpoint(audioRecording));
   }
 
-  public harvestReportUrl(harvest: IdOr<Harvest>): string {
+  public harvestCsvReportUrl(harvest: IdOr<Harvest>): string {
     const filter = this.api.filterThroughAssociation(
       {
         projection: {

--- a/src/app/services/baw-api/baw-api.service.ts
+++ b/src/app/services/baw-api/baw-api.service.ts
@@ -2,10 +2,12 @@ import { HttpClient, HttpHeaders } from "@angular/common/http";
 import { Inject, Injectable, Injector } from "@angular/core";
 import { KeysOfType, Writeable, XOR } from "@helpers/advancedTypes";
 import { API_ROOT } from "@helpers/app-initializer/app-initializer";
+import { toSnakeCase } from "@helpers/case-converter/case-converter";
 import {
   BawApiError,
   isBawApiError,
 } from "@helpers/custom-errors/baw-api-error";
+import { toBase64Url } from "@helpers/encoding/encoding";
 import {
   AbstractModel,
   AbstractModelConstructor,
@@ -374,6 +376,23 @@ export class BawApiService<
       responseType: "json",
       headers: options,
     });
+  }
+
+  public encodeFilter(filter: Filters<Model>, disablePaging?: boolean): string {
+    const body = {
+      // Base64 RFC 4648 §5 encoding
+      filterEncoded: toBase64Url(JSON.stringify(toSnakeCase(filter))),
+    };
+
+    if (disablePaging) {
+      body["disablePaging"] = "true";
+    }
+
+    if (this.session.isLoggedIn) {
+      body["authToken"] = this.session.authToken;
+    }
+
+    return new URLSearchParams(toSnakeCase(body)).toString();
   }
 
   /**

--- a/src/app/services/baw-api/harvest/harvest-items.service.ts
+++ b/src/app/services/baw-api/harvest/harvest-items.service.ts
@@ -98,6 +98,23 @@ export class ShallowHarvestItemsService
       shallowEndpoint(harvest, model.path, emptyParam)
     );
   }
+
+  public harvestReportUrl(harvest: IdOr<Harvest>): string {
+    const filter = this.api.filterThroughAssociation(
+      {
+        projection: {
+          include: ["id", "harvestId", "path", "status", "audioRecordingId"],
+        },
+      },
+      "harvests.id" as any,
+      harvest
+    );
+    return (
+      this.api.getPath(
+        shallowEndpoint(harvest, emptyParam, filterParam) + ".csv?"
+      ) + this.api.encodeFilter(filter, true)
+    );
+  }
 }
 
 export const harvestItemResolvers = new ListResolver<

--- a/src/app/services/baw-api/harvest/harvest-items.service.ts
+++ b/src/app/services/baw-api/harvest/harvest-items.service.ts
@@ -99,7 +99,7 @@ export class ShallowHarvestItemsService
     );
   }
 
-  public harvestReportUrl(harvest: IdOr<Harvest>): string {
+  public harvestCsvReportUrl(harvest: IdOr<Harvest>): string {
     const filter = this.api.filterThroughAssociation(
       {
         projection: {


### PR DESCRIPTION
# Harvest Complete CSV Links

Implemented CSV links in complete screen

## Changes

- Implemented links in harvest complete screen
- Removed project widget from harvest new/details pages (left on list page)
- Reduced size of complete screen statistics

## Problems

Closes #1946
Closes #1945
Closes #1944

## Visual Changes

![image](https://user-images.githubusercontent.com/3955116/176812823-9224c04d-e7f4-4b83-9463-d03b0a2a334e.png)

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
