### PR TITLE
Extracted re-usable publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+
+name: "Publish"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      github_actor:
+        required: true
+        type: string
+      release_tag:
+        required: true
+        type: string
+    secrets:
+      docker_username:
+        required: true
+      docker_password:
+        required: true
+
+jobs:
+  publish:
+    name: "Publish Docker Container"
+    runs-on: "ubuntu-latest"
+    # cancel any other CI attempting to publish to docker
+    concurrency:
+      group: publish-container
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout Workbench Client
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+          fetch-depth: 50
+
+      # fetch more tag info so git_version.ps1 works properly
+      - name: Ensure tags are fetched
+        # Retrieve annotated tags.
+        run: git fetch --tags --force
+
+      - name: Checkout LFS objects
+        run: git lfs checkout
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build and push Docker image
+        shell: pwsh
+        run: ./scripts/build_docker.ps1 -github_actor '${{ inputs.github_actor }}' -release_tag '${{ inputs.release_tag }}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,17 +5,9 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
-      github_actor:
-        required: true
-        type: string
       release_tag:
         required: true
         type: string
-    secrets:
-      docker_username:
-        required: true
-      docker_password:
-        required: true
 
 jobs:
   publish:
@@ -49,4 +41,4 @@ jobs:
 
       - name: Build and push Docker image
         shell: pwsh
-        run: ./scripts/build_docker.ps1 -github_actor '${{ inputs.github_actor }}' -release_tag '${{ inputs.release_tag }}'
+        run: ./scripts/build_docker.ps1 -github_actor '${{ github.actor }}' -release_tag '${{ inputs.release_tag }}'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -220,40 +220,14 @@ jobs:
           deduplicate_classes_by_file_name: true
 
   publish:
-    name: "Publish Docker Container"
-    runs-on: "ubuntu-latest"
-    needs: [test, ssr, build]
-    # cancel any other CI attempting to publish to docker
-    concurrency:
-      group: publish-container
-      cancel-in-progress: true
-    # only on tag or commit to master and not created by dependabot
     if: >
       github.actor != 'dependabot[bot]' &&
       github.actor != 'kodiakhq[bot]' &&
       (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tag'))
-
-    steps:
-      - name: Checkout Workbench Client
-        uses: actions/checkout@v2
-        with:
-          lfs: true
-          fetch-depth: 50
-
-      # fetch more tag info so git_version.ps1 works properly
-      - name: Ensure tags are fetched
-        # Retrieve annotated tags.
-        run: git fetch --tags --force
-
-      - name: Checkout LFS objects
-        run: git lfs checkout
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-      - name: Build and push Docker image
-        shell: pwsh
-        run: ./scripts/build_docker.ps1 -github_actor '${{ github.actor }}' -release_tag 'beta'
+    uses: ./.github/workflows/publish.yml
+    with:
+      github_actor: ${{ github.actor }}
+      release_tag: 'beta'
+    secrets:
+      docker_username: ${{ secrets.DOCKER_HUB_USER }}
+      docker_password: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -226,8 +226,5 @@ jobs:
       (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tag'))
     uses: ./.github/workflows/publish.yml
     with:
-      github_actor: ${{ github.actor }}
       release_tag: 'beta'
-    secrets:
-      docker_username: ${{ secrets.DOCKER_HUB_USER }}
-      docker_password: ${{ secrets.DOCKER_HUB_TOKEN }}
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Normal development
 $ npm start
 ```
 
-Then open a web browser to `http://localhost:4200`.
+Then open a web browser to `https://localhost:4200`.
 
 Server side rendering
 
@@ -61,35 +61,7 @@ This website can be customised through the environment file located at `./src/as
 | `settings.links`         | This is a list of external links used throughout the website. Check the template for the list of modifiable links                          |
 | `settings.customMenu`    | This is a list of custom menu items which changes the contents of the header with instance specific links. Check the template for examples |
 
-### Access the ng tool
-
-```bash
-$ npx ng
-```
-
-or
-
-```bash
-$ npm run ng
-```
-
 ### Testing
-
-#### End to End Testing
-
-To run the application end to end test suite:
-
-```bash
-$ npm run e2e
-```
-
-Note: Make sure you are running the 64 bit version of chrome installed to the following folder: `C:/Program Files/Google/Chrome/Application/chrome.exe`. Otherwise the e2e tests will fail with the following error: `E/launcher - WebDriverError: unknown error: cannot find Chrome binary`
-
-To debug the e2e tests, read the following [guide](https://medium.com/@scott.williams.dev/how-to-debug-protractor-tests-a19568e9016f) and run the following command:
-
-```bash
-$ npm run e2e:debug
-```
 
 #### Unit tests
 


### PR DESCRIPTION
# Extracted re-usable publish workflow

Currently it is impossible to force publish a commit to docker. This aims to fix that by extracting the workflow to make it reusable, and enable `workflow_dispatch` directly on it

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
