### PR TITLE
fixed create region api route bug

### DIFF
--- a/src/app/components/regions/pages/new/new.component.spec.ts
+++ b/src/app/components/regions/pages/new/new.component.spec.ts
@@ -88,9 +88,8 @@ describe("RegionsNewComponent", () => {
     it("should call api", () => {
       setup();
       api.create.and.callFake(() => new Subject());
-
       spectator.component.submit({});
-      expect(api.create).toHaveBeenCalled();
+      expect(api.create).toHaveBeenCalledWith(jasmine.any(Object), defaultProject);
     });
 
     it("should redirect to region", () => {

--- a/src/app/components/regions/pages/new/new.component.spec.ts
+++ b/src/app/components/regions/pages/new/new.component.spec.ts
@@ -1,11 +1,23 @@
+import { fakeAsync, tick } from "@angular/core/testing";
+import { Router, RouterOutlet } from "@angular/router";
+import { RouterTestingModule } from "@angular/router/testing";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
-import { projectResolvers } from "@baw-api/project/projects.service";
+import {
+  projectResolvers,
+  ProjectsService,
+} from "@baw-api/project/projects.service";
 import { RegionsService } from "@baw-api/region/regions.service";
+import {
+  regionsRoute,
+  shallowRegionsRoute,
+} from "@components/regions/regions.routes";
 import { BawApiError } from "@helpers/custom-errors/baw-api-error";
+import { getRouteConfigForPage } from "@helpers/page/pageRouting";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import {
   createRoutingFactory,
+  createSpyObject,
   SpectatorRouting,
   SpyObject,
 } from "@ngneat/spectator";
@@ -15,9 +27,14 @@ import { generateProject } from "@test/fakes/Project";
 import { generateRegion } from "@test/fakes/Region";
 import { testFormlyFields } from "@test/helpers/formly";
 import { assertErrorHandler } from "@test/helpers/html";
-import { testFormImports } from "@test/helpers/testbed";
+import {
+  addStandardFormImportsToMockBuilder,
+  testFormImports,
+} from "@test/helpers/testbed";
+import { MockBuilder, MockRender, ngMocks } from "ng-mocks";
 import { ToastrService } from "ngx-toastr";
-import { BehaviorSubject, Subject } from "rxjs";
+import { BehaviorSubject, of, Subject } from "rxjs";
+import { Location } from "@angular/common";
 import schema from "../../region.base.json";
 import { NewComponent } from "./new.component";
 
@@ -89,7 +106,10 @@ describe("RegionsNewComponent", () => {
       setup();
       api.create.and.callFake(() => new Subject());
       spectator.component.submit({});
-      expect(api.create).toHaveBeenCalledWith(jasmine.any(Object), defaultProject);
+      expect(api.create).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        defaultProject
+      );
     });
 
     it("should redirect to region", () => {
@@ -103,4 +123,70 @@ describe("RegionsNewComponent", () => {
       );
     });
   });
+});
+
+describe("routing and resolvers", () => {
+  const nestedRoutes = regionsRoute.compileRoutes(getRouteConfigForPage);
+  const shallowRoutes = shallowRegionsRoute.compileRoutes(
+    getRouteConfigForPage
+  );
+
+  let project: Project;
+  let defaultProject: Project;
+
+  beforeEach(() => {
+    // create 2 stub projects so we can clearly assert different ones are loaded
+    // on different routes
+    project = new Project(generateProject());
+    defaultProject = new Project(generateProject());
+
+    // stub both api methods that the two resolvers use
+    const api = createSpyObject(ProjectsService);
+    api.show.and.callFake(() => of(project));
+    api.filter.and.callFake(() => of([defaultProject]));
+
+    // set up ngMocks according to https://ng-mocks.sudo.eu/guides/routing-resolver
+    const builder = MockBuilder([
+      NewComponent,
+      RouterTestingModule.withRoutes([...nestedRoutes, ...shallowRoutes]),
+    ])
+      .keep(MockBawApiModule, { export: true })
+      .provide({ provide: ProjectsService, useValue: api });
+
+    // augment builder with out app level module imports
+    return addStandardFormImportsToMockBuilder(builder);
+  });
+
+  function setup(path) {
+    // boiler plate adapted from https://ng-mocks.sudo.eu/guides/route
+    const fixture = MockRender(RouterOutlet);
+    const router = fixture.point.injector.get(Router);
+    const location = fixture.point.injector.get(Location);
+
+    location.go(path);
+
+    router.initialNavigation();
+    tick();
+
+    expect(location.path()).toBe(path);
+
+    const component = ngMocks.find(fixture, NewComponent);
+    fixture.detectChanges();
+
+    return component;
+  }
+
+  it("should resolve with project id in the the route", fakeAsync(() => {
+    const path = `/projects/${project.id}/regions/new`;
+    const component = setup(path);
+
+    expect(component.componentInstance.project).toBe(project);
+  }));
+
+  it("should resolve the default project for the shallow route", fakeAsync(() => {
+    const path = "/regions/new";
+    const component = setup(path);
+
+    expect(component.componentInstance.project).toBe(defaultProject);
+  }));
 });

--- a/src/app/components/regions/pages/new/new.component.ts
+++ b/src/app/components/regions/pages/new/new.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
-import { defaultProjectResolver, projectResolvers } from "@baw-api/project/projects.service";
+import { projectResolvers } from "@baw-api/project/projects.service";
 import { RegionsService } from "@baw-api/region/regions.service";
 import { projectMenuItemActions } from "@components/projects/pages/details/details.component";
 import { projectCategory } from "@components/projects/projects.menus";
@@ -21,7 +21,6 @@ import schema from "../../region.base.json";
 import { regionsMenuItemActions } from "../list/list.component";
 
 const projectKey = "project";
-const projectsKey = "projects";
 
 /**
  * New Region Component
@@ -57,11 +56,7 @@ class NewComponent extends FormTemplate<Region> {
   }
 
   public get project(): Project {
-    if (this.models[projectKey] === undefined) {
-      return this.models[projectsKey][0] as Project;
-    } else {
-      return this.models[projectKey] as Project;
-    }
+    return this.models[projectKey] as Project;
   }
 
   protected apiAction(model: Partial<Region>) {
@@ -74,14 +69,14 @@ NewComponent.linkToRoute({
   pageRoute: newRegionMenuItem,
   menus: { actions: List(projectMenuItemActions) },
   resolvers: {
-    [projectKey]: projectResolvers.show
+    [projectKey]: projectResolvers.show,
   },
 }).linkToRoute({
   category: shallowRegionsCategory,
   pageRoute: shallowNewRegionMenuItem,
   menus: { actions: List(regionsMenuItemActions) },
   resolvers: {
-    [projectsKey]: defaultProjectResolver.show
+    [projectKey]: projectResolvers.showDefault,
   },
 });
 

--- a/src/app/components/regions/pages/new/new.component.ts
+++ b/src/app/components/regions/pages/new/new.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
+import { defaultProjectResolver, projectResolvers } from "@baw-api/project/projects.service";
 import { RegionsService } from "@baw-api/region/regions.service";
 import { projectMenuItemActions } from "@components/projects/pages/details/details.component";
 import { projectCategory } from "@components/projects/projects.menus";
@@ -20,6 +21,7 @@ import schema from "../../region.base.json";
 import { regionsMenuItemActions } from "../list/list.component";
 
 const projectKey = "project";
+const projectsKey = "projects";
 
 /**
  * New Region Component
@@ -29,7 +31,7 @@ const projectKey = "project";
   template: `
     <baw-form
       *ngIf="!failure"
-      [title]="hideTitle ? '' : 'New Region'"
+      [title]="hideTitle ? '' : 'New Site'"
       [model]="model"
       [fields]="fields"
       [submitLoading]="loading"
@@ -55,7 +57,11 @@ class NewComponent extends FormTemplate<Region> {
   }
 
   public get project(): Project {
-    return this.models[projectKey] as Project;
+    if (this.models[projectKey] === undefined) {
+      return this.models[projectsKey][0] as Project;
+    } else {
+      return this.models[projectKey] as Project;
+    }
   }
 
   protected apiAction(model: Partial<Region>) {
@@ -67,10 +73,16 @@ NewComponent.linkToRoute({
   category: projectCategory,
   pageRoute: newRegionMenuItem,
   menus: { actions: List(projectMenuItemActions) },
+  resolvers: {
+    [projectKey]: projectResolvers.show
+  },
 }).linkToRoute({
   category: shallowRegionsCategory,
   pageRoute: shallowNewRegionMenuItem,
   menus: { actions: List(regionsMenuItemActions) },
+  resolvers: {
+    [projectsKey]: defaultProjectResolver.show
+  },
 });
 
 export { NewComponent };

--- a/src/app/components/regions/pages/new/new.component.ts
+++ b/src/app/components/regions/pages/new/new.component.ts
@@ -12,11 +12,14 @@ import {
   defaultSuccessMsg,
   FormTemplate,
 } from "@helpers/formTemplate/formTemplate";
+import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { List } from "immutable";
 import { ToastrService } from "ngx-toastr";
 import schema from "../../region.base.json";
 import { regionsMenuItemActions } from "../list/list.component";
+
+const projectKey = "project";
 
 /**
  * New Region Component
@@ -51,8 +54,12 @@ class NewComponent extends FormTemplate<Region> {
     });
   }
 
+  public get project(): Project {
+    return this.models[projectKey] as Project;
+  }
+
   protected apiAction(model: Partial<Region>) {
-    return this.api.create(new Region(model), this.model.projectId);
+    return this.api.create(new Region(model), this.project);
   }
 }
 

--- a/src/app/components/regions/regions.menus.ts
+++ b/src/app/components/regions/regions.menus.ts
@@ -31,7 +31,7 @@ export const shallowRegionsMenuItem = menuRoute({
 export const shallowNewRegionMenuItem = menuRoute({
   icon: defaultNewIcon,
   label: "New site",
-  parent: projectMenuItem,
+  parent: shallowRegionsMenuItem,
   predicate: isProjectEditorPredicate,
   route: shallowRegionsRoute.add("new"),
   tooltip: () => "Create a new site",

--- a/src/app/models/Region.ts
+++ b/src/app/models/Region.ts
@@ -72,7 +72,7 @@ export class Region extends AbstractModel<IRegion> implements IRegion {
   public readonly deletedAt?: DateTimeTimezone;
   @bawPersistAttr()
   public readonly projectId?: Id;
-  @bawCollection({ persist: true })
+  @bawCollection({ persist: false })
   public readonly siteIds?: Ids;
   @bawPersistAttr()
   public readonly notes?: Hash;

--- a/src/app/services/baw-api/ShowDefaultResolver.ts
+++ b/src/app/services/baw-api/ShowDefaultResolver.ts
@@ -1,0 +1,50 @@
+import { Type } from "@angular/core";
+import { Resolve } from "@angular/router";
+import { Tuple } from "@helpers/advancedTypes";
+import { Id } from "@interfaces/apiInterfaces";
+import { AbstractModel } from "@models/AbstractModel";
+import { map } from "rxjs";
+import { ApiFilter } from "./api-common";
+import { Filters } from "./baw-api.service";
+import { BawResolver, ResolvedModel } from "./resolver-common";
+
+
+/**
+ * Default Resolver Class.
+ * This handles generating the resolver required for fetching a the first model returned by a filter query.
+ */
+export class ShowDefaultResolver<
+  Model extends AbstractModel,
+  Params extends any[],
+  Service extends ApiFilter<Model, Params> = ApiFilter<
+    Model, Params
+  >
+  > extends BawResolver<Model, Model, Params, Service, { showDefault: string; }> {
+  public constructor(
+    deps: Type<Service>[],
+    uniqueId?: string,
+    params?: Tuple<string, Params["length"]>
+  ) {
+    super(deps, uniqueId, params);
+  }
+
+  public createProviders(
+    name: string,
+    resolver: Type<Resolve<ResolvedModel<Model>>>,
+    deps: Type<Service>[]
+  ) {
+    return {
+      showDefault: name + "DefaultShowResolver",
+      providers: [{ provide: name + "DefaultShowResolver", useClass: resolver, deps }],
+    };
+  }
+
+  public create(name: string, required: true = true) {
+    return super.create(name, required);
+  }
+
+  public resolverFn(_: any, api: Service, __: Id, ids: Params) {
+    const filters = { paging: { items: 1 } } as Filters<Model>;
+    return api.filter(filters, ...ids).pipe(map((data) => data[0]));
+  }
+}

--- a/src/app/services/baw-api/project/projects.service.ts
+++ b/src/app/services/baw-api/project/projects.service.ts
@@ -1,16 +1,9 @@
-import { Injectable, Type } from "@angular/core";
-import { Resolve } from "@angular/router";
-import { Tuple } from "@helpers/advancedTypes";
+import { Injectable } from "@angular/core";
 import { stringTemplate } from "@helpers/stringTemplate/stringTemplate";
-import { Id } from "@interfaces/apiInterfaces";
-import { AbstractModel } from "@models/AbstractModel";
 import { IProject, Project } from "@models/Project";
 import type { User } from "@models/User";
-import { map, Observable } from "rxjs";
+import { Observable } from "rxjs";
 import {
-  ApiFilter,
-  ApiList,
-  ApiShow,
   emptyParam,
   filterParam,
   id,
@@ -20,7 +13,8 @@ import {
   StandardApi,
 } from "../api-common";
 import { BawApiService, Filters } from "../baw-api.service";
-import { BawResolver, ListResolver, ResolvedModel, Resolvers } from "../resolver-common";
+import { Resolvers } from "../resolver-common";
+import { ShowDefaultResolver } from "../ShowDefaultResolver";
 
 const projectId: IdParamOptional<Project> = id;
 const endpoint = stringTemplate`/projects/${projectId}${option}`;
@@ -73,50 +67,13 @@ export class ProjectsService implements StandardApi<Project> {
   }
 }
 
+const defaultProjectResolver = new ShowDefaultResolver<
+  Project,
+  [],
+  ProjectsService
+>([ProjectsService], null).create("Project");
+
 export const projectResolvers = new Resolvers<Project, []>(
   [ProjectsService],
   "projectId"
-).create("Project");
-
-
-export class ShowDefaultResolver<
-  Model extends AbstractModel,
-  Params extends any[],
-  Service extends ApiFilter<Model, Params> = ApiFilter<
-    Model,
-    Params
-  >
-> extends BawResolver<Model, Model, Params, Service, { show: string }> {
-  public constructor(
-    deps: Type<Service>[],
-    uniqueId?: string,
-    params?: Tuple<string, Params["length"]>
-  ) {
-    super(deps, uniqueId, params);
-  }
-
-  public createProviders(
-    name: string,
-    resolver: Type<Resolve<ResolvedModel<Model>>>,
-    deps: Type<Service>[]
-  ) {
-    return {
-      show: name + "DefaultShowResolver",
-      providers: [{ provide: name + "DefaultShowResolver", useClass: resolver, deps }],
-    };
-  }
-
-  public create(name: string, required: true = true) {
-    return super.create(name, required);
-  }
-
-  public resolverFn(_: any, api: Service, __: Id, ids: Params) {
-    const filters = { paging: { items: 1 } } as Filters<Model>
-    return api.filter(filters, ...ids).pipe(map((data) => data[0]));
-  }
-}
-
-export const defaultProjectResolver = new ShowDefaultResolver<Project, [], ProjectsService>(
-  [ProjectsService],
-  null
-).create("Project");
+).create("Project", defaultProjectResolver);

--- a/src/app/services/baw-api/project/projects.service.ts
+++ b/src/app/services/baw-api/project/projects.service.ts
@@ -1,9 +1,16 @@
-import { Injectable } from "@angular/core";
+import { Injectable, Type } from "@angular/core";
+import { Resolve } from "@angular/router";
+import { Tuple } from "@helpers/advancedTypes";
 import { stringTemplate } from "@helpers/stringTemplate/stringTemplate";
+import { Id } from "@interfaces/apiInterfaces";
+import { AbstractModel } from "@models/AbstractModel";
 import { IProject, Project } from "@models/Project";
 import type { User } from "@models/User";
-import { Observable } from "rxjs";
+import { map, Observable } from "rxjs";
 import {
+  ApiFilter,
+  ApiList,
+  ApiShow,
   emptyParam,
   filterParam,
   id,
@@ -13,7 +20,7 @@ import {
   StandardApi,
 } from "../api-common";
 import { BawApiService, Filters } from "../baw-api.service";
-import { Resolvers } from "../resolver-common";
+import { BawResolver, ListResolver, ResolvedModel, Resolvers } from "../resolver-common";
 
 const projectId: IdParamOptional<Project> = id;
 const endpoint = stringTemplate`/projects/${projectId}${option}`;
@@ -69,4 +76,47 @@ export class ProjectsService implements StandardApi<Project> {
 export const projectResolvers = new Resolvers<Project, []>(
   [ProjectsService],
   "projectId"
+).create("Project");
+
+
+export class ShowDefaultResolver<
+  Model extends AbstractModel,
+  Params extends any[],
+  Service extends ApiFilter<Model, Params> = ApiFilter<
+    Model,
+    Params
+  >
+> extends BawResolver<Model, Model, Params, Service, { show: string }> {
+  public constructor(
+    deps: Type<Service>[],
+    uniqueId?: string,
+    params?: Tuple<string, Params["length"]>
+  ) {
+    super(deps, uniqueId, params);
+  }
+
+  public createProviders(
+    name: string,
+    resolver: Type<Resolve<ResolvedModel<Model>>>,
+    deps: Type<Service>[]
+  ) {
+    return {
+      show: name + "DefaultShowResolver",
+      providers: [{ provide: name + "DefaultShowResolver", useClass: resolver, deps }],
+    };
+  }
+
+  public create(name: string, required: true = true) {
+    return super.create(name, required);
+  }
+
+  public resolverFn(_: any, api: Service, __: Id, ids: Params) {
+    const filters = { paging: { items: 1 } } as Filters<Model>
+    return api.filter(filters, ...ids).pipe(map((data) => data[0]));
+  }
+}
+
+export const defaultProjectResolver = new ShowDefaultResolver<Project, [], ProjectsService>(
+  [ProjectsService],
+  null
 ).create("Project");

--- a/src/app/services/baw-api/resolver-common.ts
+++ b/src/app/services/baw-api/resolver-common.ts
@@ -180,7 +180,10 @@ export class Resolvers<
    *
    * @param name Name of provider
    */
-  public create(name: string) {
+  public create<T extends object & { providers: BawProvider[] }>(
+    name: string,
+    extra: T = null
+  ) {
     const { serviceDeps, uniqueId, params } = this;
     const listResolver = new ListResolver<Model, Params, Service>(
       serviceDeps,
@@ -201,10 +204,12 @@ export class Resolvers<
       ...listResolver,
       ...showResolver,
       ...showOptionalResolver,
+      ...extra,
       providers: [
         ...listResolver.providers,
         ...showResolver.providers,
         ...showOptionalResolver.providers,
+        ...(extra?.providers || []),
       ],
     };
   }

--- a/src/app/test/helpers/testbed.ts
+++ b/src/app/test/helpers/testbed.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from "@angular/common";
 import { HttpHeaders } from "@angular/common/http";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { TestBed } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
 import { BrowserModule } from "@angular/platform-browser";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
@@ -12,6 +13,7 @@ import { FormlyBootstrapModule } from "@ngx-formly/bootstrap";
 import { FormlyModule } from "@ngx-formly/core";
 import { formlyConfig } from "@shared/formly/custom-inputs.module";
 import { LoadingModule } from "@shared/loading/loading.module";
+import { IMockBuilder } from "ng-mocks";
 import { NgxCaptchaModule } from "ngx-captcha";
 import { ToastrModule } from "ngx-toastr";
 import { BehaviorSubject } from "rxjs";
@@ -27,10 +29,19 @@ export const testFormImports = [
   FormlyBootstrapModule,
   ToastrModule.forRoot(toastrRoot),
   HttpClientTestingModule,
-  RouterTestingModule,
   LoadingModule,
   NgxCaptchaModule,
+  RouterTestingModule,
 ];
+
+export function addStandardFormImportsToMockBuilder(builder: IMockBuilder) {
+  const module = builder.build();
+
+  // https://github.com/help-me-mom/ng-mocks/issues/197#issuecomment-705431358
+  module.imports = [...module.imports, ...testFormImports];
+
+  return TestBed.configureTestingModule(module).compileComponents();
+}
 
 /**
  * Create a mock ActivatedRoute class


### PR DESCRIPTION
# Title of PR

Fixed create region api route bug

## Changes

Changed the 2nd parameter on the region service create function call to use the project object rather than the (missing) project id property on the form model.

Also added a test for the value of this 2nd parameter. 

## Problems

Any problems caused by the PR that will need to be address in another PR. For example, these issues may be caused by another branch which will change how this branch functions.

## Issues

fixes #1985 

## Visual Changes

none

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
