### PR TITLE
Issue 1687 Add remove image option for image fields in forms.

### DIFF
--- a/src/app/components/shared/formly/image-input.component.ts
+++ b/src/app/components/shared/formly/image-input.component.ts
@@ -1,4 +1,4 @@
-import { Component } from "@angular/core";
+import { Component, ViewChild, ElementRef } from "@angular/core";
 import { FieldType } from "@ngx-formly/core";
 import { asFormControl } from "./helper";
 
@@ -20,6 +20,7 @@ import { asFormControl } from "./helper";
       >
         <!-- Ensure only one file can be selected in input -->
         <input
+          #imageInput
           type="file"
           accept="image/*"
           class="form-control"
@@ -27,11 +28,19 @@ import { asFormControl } from "./helper";
           [formlyAttributes]="field"
           (ngModelChange)="readFile()"
         />
+
+        <button
+          type="button"
+          (click)="removeImage()"
+          class="btn btn-outline-danger"
+        >Remove</button>
       </div>
     </div>
   `,
 })
 export class ImageInputComponent extends FieldType {
+  @ViewChild("imageInput")
+  public imageInput: ElementRef;
   public asFormControl = asFormControl;
   public readFile(): void {
     // File input returns a list of files, grab the first file and set it as
@@ -50,5 +59,9 @@ export class ImageInputComponent extends FieldType {
     }
 
     this.formControl.setValue(images.item(0));
+  }
+  public removeImage(): void {
+    this.model.image = null;
+    this.imageInput.nativeElement.value = null;
   }
 }

--- a/src/app/models/AbstractModel.spec.ts
+++ b/src/app/models/AbstractModel.spec.ts
@@ -132,7 +132,116 @@ describe("AbstractModel", () => {
     });
   });
 
+  describe("emitting file or null in formdata or json requests", () => {
+    const testFile = new File([""], "testFileName.png");
+
+    it("should emit null when serializing a model via JSON and deleting a file", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: null });
+      const actual = model.getJsonAttributes({ create: true });
+      expect(actual).toEqual(jasmine.objectContaining({
+        image: null
+      }));
+    });
+
+    it("should not emit file type objects in JSON attributes", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: testFile });
+      const actual = model.getJsonAttributes({ create: true });
+      expect(Object.keys(actual)).not.toContain("image");
+    });
+
+    it("should emit file type objects when serializing a model via formData", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: testFile });
+      const actual = model.getFormDataOnlyAttributes({ create: true });
+      expect(actual.get("mock_model[image]")).toEqual(model.image);
+    });
+
+    it("should not emit null values when serializing a model via formData", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: null });
+      const actual = model.getFormDataOnlyAttributes({ create: true });
+      expect(actual.has("mock_model[image]")).toBeFalse();
+      expect(actual.keys()).toHaveSize(0);
+    });
+
+    it("toJSON emits values as is (null case)", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: null });
+      const actual = model.toJSON();
+      expect(actual.image).toBeNull();
+    });
+
+    it("toJSON emits values as is (File type object case)", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: testFile });
+      const actual = model.toJSON();
+      expect(actual.image).toBeInstanceOf(File);
+    });
+
+    it("should emit file type objects when serializing a model via formData", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: testFile });
+      const actual = model.getFormDataOnlyAttributes({ create: true });
+      expect(actual.get("mock_model[image]")).toEqual(model.image);
+    });
+
+    it("should not emit null values when serializing a model via formData", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: null });
+      const actual = model.getFormDataOnlyAttributes({ create: true });
+      expect(actual.has("mock_model[image]")).toBeFalse();
+      expect(actual.keys()).toHaveSize(0);
+    });
+
+    it("toJSON emits values as is (null case)", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: null });
+      const actual = model.toJSON();
+      expect(actual.image).toBeNull();
+    });
+
+    it("toJSON emits values as is (File type object case)", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: testFile });
+      const actual = model.toJSON();
+      expect(actual.image).toBeInstanceOf(File);
+    });
+  });
+
   describe("hasFormData", () => {
+    const testFile = new File([""], "testFileName.png");
     [
       { label: "create: true", create: true },
       { label: "update: true", update: true },
@@ -172,6 +281,7 @@ describe("AbstractModel", () => {
           const model = new Model({ value0: "value" });
           expect(hasFormDataOnlyAttributes(model)).toBeTrue();
         });
+
         it("should return false is no attributes are instantiated", () => {
           class Model extends MockModel {
             @bawPersistAttr({ supportedFormats: ["formData"] })
@@ -187,6 +297,24 @@ describe("AbstractModel", () => {
           class Model extends MockModel {}
           const model = new Model({});
           expect(hasFormDataOnlyAttributes(model)).toBeFalse();
+        });
+
+        it("should not want to send a formdata request if attribute is null", () => {
+          class Model extends MockModel {
+            @bawPersistAttr({ supportedFormats: ["json", "formData"] })
+            public image: any;
+          }
+          const model = new Model({image: null});
+          expect(hasFormDataOnlyAttributes(model)).toBeFalse();
+        });
+
+        it("should want to send FormData request if attribute is a File type object", () => {
+          class Model extends MockModel {
+            @bawPersistAttr({ supportedFormats: ["json", "formData"] })
+            public image: any;
+          }
+          const model = new Model({image: testFile});
+          expect(hasFormDataOnlyAttributes(model)).toBeTrue();
         });
       });
     });

--- a/src/app/models/AbstractModel.ts
+++ b/src/app/models/AbstractModel.ts
@@ -111,7 +111,6 @@ export abstract class AbstractModelWithoutId<Model = Record<string, any>> {
     }
 
     for (const attr of Object.keys(data)) {
-      // Do not include undefined/null data
       if (!isInstantiated(data[attr])) {
         continue;
       }
@@ -207,6 +206,11 @@ export abstract class AbstractModelWithoutId<Model = Record<string, any>> {
     if (opts?.create || opts?.update) {
       return this.getPersistentAttributes()
         .filter((meta) => (opts.create ? meta.create : meta.update))
+        // The following filter splits values for attributes that support both json and formData formats
+        // when a  null value is present, we send the value in the json request
+        // when a File value is present, we send the value in the formData request
+        // The null/json scenario is used to support deleting images.
+        .filter((meta) => this[meta.key] instanceof(File) ? opts.formData : true)
         .filter((meta) =>
           meta.supportedFormats.includes(opts.formData ? "formData" : "json")
         )

--- a/src/app/models/Project.ts
+++ b/src/app/models/Project.ts
@@ -59,7 +59,7 @@ export class Project extends AbstractModel<IProject> implements IProject {
   public readonly descriptionHtmlTagline?: Description;
   @bawImage<IProject>(`${assetRoot}/images/project/project_span4.png`)
   public readonly imageUrls!: ImageUrl[];
-  @bawPersistAttr({ supportedFormats: ["formData"] })
+  @bawPersistAttr({ supportedFormats: ["formData", "json"] })
   public readonly image?: File;
   public readonly accessLevel?: PermissionLevel;
   public readonly creatorId?: Id;

--- a/src/app/models/Region.ts
+++ b/src/app/models/Region.ts
@@ -55,7 +55,7 @@ export class Region extends AbstractModel<IRegion> implements IRegion {
   public readonly name?: Param;
   @bawImage<IRegion>(`${assetRoot}/images/site/site_span4.png`)
   public readonly imageUrls!: ImageUrl[];
-  @bawPersistAttr({ supportedFormats: ["formData"] })
+  @bawPersistAttr({ supportedFormats: ["formData", "json"] })
   public readonly image?: File;
   @bawPersistAttr()
   public readonly description?: Description;

--- a/src/app/models/Site.ts
+++ b/src/app/models/Site.ts
@@ -63,7 +63,7 @@ export class Site extends AbstractModel<ISite> implements ISite {
   public readonly name?: Param;
   @bawImage<ISite>(`${assetRoot}/images/site/site_span4.png`)
   public readonly imageUrls!: ImageUrl[];
-  @bawPersistAttr({ supportedFormats: ["formData"] })
+  @bawPersistAttr({ supportedFormats: ["formData", "json"] })
   public readonly image?: File;
   @bawPersistAttr()
   public readonly description?: Description;

--- a/src/app/services/baw-api/baw-api.service.ts
+++ b/src/app/services/baw-api/baw-api.service.ts
@@ -291,6 +291,7 @@ export class BawApiService<
         map(this.handleSingleResponse(classBuilder))
       );
     }
+
     return request.pipe(
       catchError((err) => this.handleError(err, opts?.disableNotification))
     );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
-    "lib": ["ES2020", "dom"],
+    "lib": ["ES2020", "dom", "dom.iterable"],
     "module": "ES2020",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
# Add remove image option for image fields in forms.

What is the purpose of this PR?
Adds the ability for clients to delete an image (and use the default) for image inputs

## Changes

* Created button on image input field component
* Fixed corrupted images in dev environment

## Problems
There is currently no user feedback that their image has been deleted, or feedback showing the current image.

## Issues

Fixes #1687 

## Visual Changes
![remove button](https://user-images.githubusercontent.com/33742269/191867748-05bc1de4-2685-49bd-ac0e-dec402975837.png)


## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
