### PR TITLE
Implement Harvest abort button

### DIFF
--- a/src/app/components/harvest/components/modal/confirmation.component.ts
+++ b/src/app/components/harvest/components/modal/confirmation.component.ts
@@ -21,7 +21,12 @@ import { NgbActiveModal } from "@ng-bootstrap/ng-bootstrap";
         <button id="cancel-btn" class="btn btn-outline-primary float-start" (click)="close()">
           {{ cancelLabel }}
         </button>
-        <button id="next-btn" class="btn btn-primary float-end" (click)="continue()">
+        <button
+          id="next-btn"
+          class="btn float-end"
+          [ngClass]="this.isDanger === 'true' ? 'btn-danger text-white' : 'btn-primary'"
+          (click)="continue()"
+        >
           {{ nextLabel }}
         </button>
       </div>
@@ -31,6 +36,7 @@ import { NgbActiveModal } from "@ng-bootstrap/ng-bootstrap";
 export class ConfirmationComponent {
   @Input() public nextLabel: string;
   @Input() public cancelLabel = "Cancel";
+  @Input() public isDanger;
   @Input() public modal: NgbActiveModal;
 
   public close(): void {

--- a/src/app/components/harvest/pages/list/list.component.html
+++ b/src/app/components/harvest/pages/list/list.component.html
@@ -8,7 +8,7 @@
 
 <ngx-datatable
   bawDatatableDefaults
-  [bawDatatablePagination]="{ filters: filters, getModels: getModels }"
+  [bawDatatablePagination]="{ filters: filters$, getModels: getModels }"
 >
   <ngx-datatable-column prop="createdAt">
     <ng-template let-column="column" ngx-datatable-header-template>
@@ -42,6 +42,28 @@
       <a class="btn btn-sm btn-primary" [bawUrl]="row.viewUrl">
         {{ asHarvest(row).status !== "complete" ? "Continue" : "View" }}
       </a>
+      <a
+        name="list-abort-button"
+        *ngIf="asHarvest(row).isAbortable()"
+        class="btn btn-sm btn-outline-danger ms-1"
+        (click)="abortUpload(abortUploadModal, asHarvest(row))"
+      >
+        Abort
+      </a>
     </ng-template>
   </ngx-datatable-column>
 </ngx-datatable>
+
+<ng-template #abortUploadModal let-modal>
+  <baw-harvest-confirmation-modal
+    nextLabel="Abort Upload"
+    cancelLabel="Return"
+    isDanger="true"
+    [modal]="modal"
+  >
+    <p>
+      Are you sure you want to abort this upload? Aborting will not process any
+      uploaded files, and cannot be undone.
+    </p>
+  </baw-harvest-confirmation-modal>
+</ng-template>

--- a/src/app/components/harvest/pages/list/list.component.spec.ts
+++ b/src/app/components/harvest/pages/list/list.component.spec.ts
@@ -1,0 +1,153 @@
+import { Injector } from "@angular/core";
+import { discardPeriodicTasks, fakeAsync, flush, tick } from "@angular/core/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { HARVEST } from "@baw-api/ServiceTokens";
+import { ConfirmationComponent } from "@components/harvest/components/modal/confirmation.component";
+import { Harvest } from "@models/Harvest";
+import { Project } from "@models/Project";
+import { NgbModal, NgbModalConfig } from "@ng-bootstrap/ng-bootstrap";
+import {
+  createRoutingFactory,
+  SpectatorRouting,
+} from "@ngneat/spectator";
+import { SharedModule } from "@shared/shared.module";
+import { generateHarvest } from "@test/fakes/Harvest";
+import {
+  generateProject,
+  generateProjectMeta
+} from "@test/fakes/Project";
+import { ToastrService } from "ngx-toastr";
+import { of } from "rxjs";
+import { ListComponent } from "./list.component";
+
+describe("ListComponent", () => {
+  let spec: SpectatorRouting<ListComponent>;
+  let defaultProject: Project;
+  let defaultHarvest: Harvest;
+  let modalService: NgbModal;
+  let modalConfigService: NgbModalConfig;
+
+  const createComponent = createRoutingFactory({
+    declarations: [ConfirmationComponent],
+    component: ListComponent,
+    imports: [MockBawApiModule, SharedModule],
+    mocks: [ToastrService],
+  });
+
+  function setup(
+    project: Project,
+    mockHarvest: Harvest
+  ) {
+    spec = createComponent({
+      detectChanges: false,
+      data: {
+        project: { model: project },
+      },
+    });
+
+    const injector = spec.inject(Injector);
+    project["injector"] = injector;
+
+    const mockHarvestApi = spec.inject(HARVEST.token);
+    mockHarvest.addMetadata({
+      paging: { items: 1, page: 0, total: 1, maxPage: 5 },
+    });
+
+    // inject the NgbModal service so that we can
+    // dismiss all modals at the end of every test
+    modalService = spec.inject(NgbModal);
+
+    // inject the boostrap modal config service so that we can disable animations
+    // this is needed so that buttons can be clicked without waiting for the async animation
+    modalConfigService = spec.inject(NgbModalConfig);
+    modalConfigService.animation = false;
+
+    // mock the harvest service filter API to populate the
+    // list component ngx-datatable
+    const mockResponse = of([mockHarvest]);
+    mockHarvestApi.filter.and.callFake(() => mockResponse);
+    mockHarvestApi.transitionStatus.and.callFake(() => of(mockHarvest));
+    spec.detectChanges();
+
+    return mockHarvestApi;
+  }
+
+  function getAbortButton(): HTMLButtonElement {
+    return spec.debugElement.query(
+      (el) => el.nativeElement.innerText === "Abort"
+    ).nativeElement as HTMLButtonElement;
+  }
+
+  function getModalNextButton() {
+    return spec.query<HTMLButtonElement>(
+      "baw-harvest-confirmation-modal #next-btn",
+      { root: true }
+    );
+  }
+
+  function getModalCancelButton() {
+    return spec.query<HTMLButtonElement>(
+      "baw-harvest-confirmation-modal #cancel-btn",
+      { root: true }
+    );
+  }
+
+  beforeEach(() => {
+    defaultProject = new Project(generateProject());
+    defaultProject.addMetadata(generateProjectMeta({}));
+    defaultHarvest = new Harvest(generateHarvest({ status: "uploading" }));
+  });
+
+  afterEach(() => {
+    // dismiss all bootstrap modals, so if a test fails
+    // it doesn't impact future tests by using a stale modal
+    modalService.dismissAll();
+  });
+
+  it("should create", () => {
+    setup(defaultProject, defaultHarvest);
+    expect(spec.component).toBeInstanceOf(ListComponent);
+  });
+
+  it("should not show abort button when harvest cannot be aborted", () => {
+    // ensure harvest status is not an abortable state
+    const unAbortableHarvest = new Harvest( generateHarvest({ status: "scanning" }) );
+
+    setup(
+      defaultProject,
+      unAbortableHarvest
+    );
+
+    // assert abort button is not rendered
+    expect(spec.query("button[name='list-abort-button']")).toBeFalsy();
+  });
+
+  it("should not change the status of a Harvest if the 'cancel' button is clicked in the abort modal", fakeAsync(() => {
+    const harvestApi = setup(defaultProject, defaultHarvest);
+
+    getAbortButton().click();
+    tick();
+
+    getModalCancelButton().click();
+    tick();
+
+    expect(harvestApi.transitionStatus).not.toHaveBeenCalled();
+    discardPeriodicTasks();
+    flush();
+  }));
+
+  it("should abort Harvest by changing status to 'complete' if the 'Abort Harvest' button is clicked in the abort modal", fakeAsync(() => {
+    const harvestApi = setup(defaultProject, defaultHarvest);
+
+    getAbortButton().click();
+    tick();
+
+    getModalNextButton().click();
+    tick();
+
+    expect(harvestApi.transitionStatus).toHaveBeenCalledWith(defaultHarvest, "complete");
+    discardPeriodicTasks();
+    flush();
+  }));
+
+});

--- a/src/app/components/harvest/screens/metadata-review/metadata-review.component.html
+++ b/src/app/components/harvest/screens/metadata-review/metadata-review.component.html
@@ -75,33 +75,49 @@
 </div>
 
 <div class="mt-3 d-flex justify-content-between">
-  <button
+  <div>
+    <button
+      id="harvest-abort-button"
+      class="btn btn-outline-danger me-2"
+      [disabled]="transitioningStage"
+      (click)="abortUpload(abortUploadModal)"
+    >
+      Abort
+    </button>
+
+    <button
     class="btn btn-outline-primary"
     [disabled]="transitioningStage"
     (click)="upload(uploadModal)"
-  >
-    Upload more files
-  </button>
-  <button
-    *ngIf="harvest.isMappingsDirty"
-    class="btn btn-primary"
-    [disabled]="transitioningStage"
-    (click)="extraction(extractionModal)"
-  >
-    Check changes
-  </button>
+    >
+      Upload more files
+    </button>
+  </div>
+
   <!-- TODO Modal popup when hasUnsavedChanges -->
-  <button
-    class="btn"
-    [class.btn-primary]="!harvest.isMappingsDirty"
-    [class.btn-warning]="harvest.isMappingsDirty"
-    [disabled]="transitioningStage"
-    (click)="processing(processingModal)"
-  >
-    {{
-      harvest.isMappingsDirty ? "Continue without checking changes" : "Continue"
-    }}
-  </button>
+  <div>
+    <button
+      *ngIf="harvest.isMappingsDirty"
+      class="btn btn-primary"
+      [disabled]="transitioningStage"
+      (click)="extraction(extractionModal)"
+    >
+      Check changes
+    </button>
+
+    <button
+      id="harvest-continue-button"
+      class="btn"
+      [class.btn-primary]="!harvest.isMappingsDirty"
+      [class.btn-warning]="harvest.isMappingsDirty"
+      [disabled]="transitioningStage"
+      (click)="processing(processingModal)"
+    >
+      {{
+        harvest.isMappingsDirty ? "Continue without checking changes" : "Continue"
+      }}
+    </button>
+  </div>
 </div>
 
 <ng-template #processingModal let-modal>
@@ -122,5 +138,19 @@
 <ng-template #extractionModal let-modal>
   <baw-harvest-confirmation-modal nextLabel="Check Changes" [modal]="modal">
     <p>Are you sure you want to check these changes to your uploaded files?</p>
+  </baw-harvest-confirmation-modal>
+</ng-template>
+
+<ng-template #abortUploadModal let-modal>
+  <baw-harvest-confirmation-modal
+    nextLabel="Abort Upload"
+    cancelLabel="Return"
+    isDanger="true"
+    [modal]="modal"
+  >
+    <p>
+      Are you sure you want to abort this upload? Aborting will not process
+      any uploaded files, and cannot be undone.
+    </p>
   </baw-harvest-confirmation-modal>
 </ng-template>

--- a/src/app/components/harvest/screens/metadata-review/metadata-review.component.spec.ts
+++ b/src/app/components/harvest/screens/metadata-review/metadata-review.component.spec.ts
@@ -1,0 +1,123 @@
+import { discardPeriodicTasks, fakeAsync, flush, tick } from "@angular/core/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { ConfirmationComponent } from "@components/harvest/components/modal/confirmation.component";
+import { HarvestStagesService } from "@components/harvest/services/harvest-stages.service";
+import {
+  Harvest,
+  HarvestStatus
+} from "@models/Harvest";
+import { Project } from "@models/Project";
+import { NgbModal, NgbModalConfig } from "@ng-bootstrap/ng-bootstrap";
+import {
+  createRoutingFactory,
+  SpectatorRouting,
+  SpyObject,
+} from "@ngneat/spectator";
+import { SharedModule } from "@shared/shared.module";
+import { generateHarvest } from "@test/fakes/Harvest";
+import {
+  generateProject,
+  generateProjectMeta
+} from "@test/fakes/Project";
+import { MockProvider } from "ng-mocks";
+import { ToastrService } from "ngx-toastr";
+import { MetadataReviewComponent } from "./metadata-review.component";
+
+describe("MetaDatReviewComponent", () => {
+  let spec: SpectatorRouting<MetadataReviewComponent>;
+  let modalService: NgbModal;
+  let modalConfigService: NgbModalConfig;
+  let stages: SpyObject<HarvestStagesService>;
+  let defaultProject: Project;
+  let defaultHarvest: Harvest;
+
+  const createComponent = createRoutingFactory({
+    declarations: [ConfirmationComponent],
+    component: MetadataReviewComponent,
+    providers: [
+      MockProvider(HarvestStagesService, {
+        project: defaultProject,
+        harvest: defaultHarvest,
+        transition: (_stage: HarvestStatus) => {}
+      }),
+    ],
+    imports: [MockBawApiModule, SharedModule],
+    mocks: [ToastrService],
+  });
+
+  function setup() {
+    spec = createComponent({ detectChanges: false });
+
+    // inject the NgbModal service so that we can
+    // dismiss all modals at the end of every test
+    modalService = spec.inject(NgbModal);
+
+    // inject the boostrap modal config service so that we can disable animations
+    // this is needed so that buttons can be clicked without waiting for the async animation
+    modalConfigService = spec.inject(NgbModalConfig);
+    modalConfigService.animation = false;
+
+    stages = spec.inject<SpyObject<HarvestStagesService>>( HarvestStagesService as any );
+    stages.transition = jasmine.createSpy("transition") as any;
+
+    return stages;
+  }
+
+  const getModalNextButton = (): HTMLButtonElement =>
+      spec.query<HTMLButtonElement>("baw-harvest-confirmation-modal #next-btn", { root: true });
+
+  const getModalCancelButton = (): HTMLButtonElement =>
+    spec.query<HTMLButtonElement>("baw-harvest-confirmation-modal #cancel-btn", { root: true });
+
+  function getAbortButton(): HTMLButtonElement {
+    return spec.debugElement.query(
+      (el) => el.nativeElement.innerText === "Abort"
+    ).nativeElement as HTMLButtonElement;
+  }
+
+  beforeEach(() => {
+    defaultProject = new Project(generateProject());
+    defaultProject.addMetadata(generateProjectMeta({}));
+    defaultHarvest = new Harvest(generateHarvest({ status: "metadataReview" }));
+  });
+
+  afterEach(() => {
+    // dismiss all bootstrap modals, so if a test fails
+    // it doesn't impact future tests by using a stale modal
+    modalService.dismissAll();
+  });
+
+  it("should create", () => {
+    setup();
+    expect(spec.component).toBeInstanceOf(MetadataReviewComponent);
+  });
+
+  it("should dismiss abort warning modal and not transition the Harvest status when the 'return' button is clicked", fakeAsync(() => {
+    setup();
+
+    getAbortButton().click();
+    tick();
+
+    getModalCancelButton().click();
+    tick();
+
+    expect(stages.transition).not.toHaveBeenCalled();
+    discardPeriodicTasks();
+    flush();
+  }));
+
+  it("should transition the Harvest to 'complete' when the 'Abort Harvest' button is clicked in abort warning modal", fakeAsync(() => {
+    setup();
+
+    getAbortButton().click();
+    tick();
+
+    getModalNextButton().click();
+    tick();
+
+    expect(stages.transition).toHaveBeenCalledWith("complete");
+    discardPeriodicTasks();
+    flush();
+  }));
+
+});

--- a/src/app/components/harvest/screens/metadata-review/metadata-review.component.ts
+++ b/src/app/components/harvest/screens/metadata-review/metadata-review.component.ts
@@ -221,6 +221,15 @@ export class MetadataReviewComponent
     }
   }
 
+  public async abortUpload(template: any): Promise<void> {
+    const ref = this.modals.open(template);
+    const success = await ref.result.catch((_) => false);
+
+    if (success) {
+      this.stages.transition("complete");
+    }
+  }
+
   public isFolder(row: MetaReviewRow): row is MetaReviewFolder {
     return row.rowType === RowType.folder;
   }

--- a/src/app/components/harvest/screens/uploading/batch-uploading.component.html
+++ b/src/app/components/harvest/screens/uploading/batch-uploading.component.html
@@ -234,11 +234,11 @@
 <div class="clearfix">
   <button
     id="cancel-btn"
-    class="btn btn-warning float-start"
+    class="btn btn-outline-danger float-start"
     [disabled]="loading"
-    (click)="cancelUpload(cancelUploadModal)"
+    (click)="abortUpload(abortUploadModal)"
   >
-    Cancel
+    Abort
   </button>
   <button
     id="finish-btn"
@@ -260,14 +260,15 @@
   </baw-harvest-confirmation-modal>
 </ng-template>
 
-<ng-template #cancelUploadModal let-modal>
+<ng-template #abortUploadModal let-modal>
   <baw-harvest-confirmation-modal
-    nextLabel="Cancel Upload"
+    nextLabel="Abort Upload"
     cancelLabel="Return"
+    isDanger="true"
     [modal]="modal"
   >
     <p>
-      Are you sure you want to cancel this upload? Cancelling will not process
+      Are you sure you want to abort this upload? Aborting will not process
       any uploaded files, and cannot be undone.
     </p>
   </baw-harvest-confirmation-modal>

--- a/src/app/components/harvest/screens/uploading/batch-uploading.component.spec.ts
+++ b/src/app/components/harvest/screens/uploading/batch-uploading.component.spec.ts
@@ -206,8 +206,11 @@ describe("BatchUploadingComponent", () => {
         modalService.dismissAll();
     });
 
-    it ("should cancel upload when cancel is clicked and the 'cancel upload' modal button is clicked", (done) => {
-      launchModal("#cancel-btn", "Are you sure you want to cancel this upload");
+    it ("should abort upload when abort is clicked and the 'abort upload' modal button is clicked", (done) => {
+      launchModal(
+        "#cancel-btn",
+        "Are you sure you want to abort this upload? Aborting will not process any uploaded files, and cannot be undone."
+      );
       clickModalNext(() => {
         expect(stages.transition).toHaveBeenCalledWith("complete");
         done();
@@ -223,7 +226,10 @@ describe("BatchUploadingComponent", () => {
     });
 
     it ("should launch and cancel modal when 'cancel' button is clicked and then 'return' is clicked", (done) => {
-      launchModal("#cancel-btn", "Are you sure you want to cancel this upload");
+      launchModal(
+        "#cancel-btn",
+        "Are you sure you want to abort this upload? Aborting will not process any uploaded files, and cannot be undone."
+      );
       cancelModal(done);
     });
 

--- a/src/app/components/harvest/screens/uploading/batch-uploading.component.ts
+++ b/src/app/components/harvest/screens/uploading/batch-uploading.component.ts
@@ -62,7 +62,7 @@ export class BatchUploadingComponent implements OnInit {
     }
   }
 
-  public async cancelUpload(template: any): Promise<void> {
+  public async abortUpload(template: any): Promise<void> {
     const ref = this.modals.open(template);
     const success = await ref.result.catch((_) => false);
 

--- a/src/app/components/shared/formly/image-input.component.ts
+++ b/src/app/components/shared/formly/image-input.component.ts
@@ -1,4 +1,4 @@
-import { Component } from "@angular/core";
+import { Component, ViewChild, ElementRef } from "@angular/core";
 import { FieldType } from "@ngx-formly/core";
 import { asFormControl } from "./helper";
 
@@ -20,6 +20,7 @@ import { asFormControl } from "./helper";
       >
         <!-- Ensure only one file can be selected in input -->
         <input
+          #imageInput
           type="file"
           accept="image/*"
           class="form-control"
@@ -27,11 +28,19 @@ import { asFormControl } from "./helper";
           [formlyAttributes]="field"
           (ngModelChange)="readFile()"
         />
+
+        <button
+          type="button"
+          (click)="removeImage()"
+          class="btn btn-outline-danger"
+        >Remove</button>
       </div>
     </div>
   `,
 })
 export class ImageInputComponent extends FieldType {
+  @ViewChild("imageInput")
+  public imageInput: ElementRef;
   public asFormControl = asFormControl;
   public readFile(): void {
     // File input returns a list of files, grab the first file and set it as
@@ -50,5 +59,9 @@ export class ImageInputComponent extends FieldType {
     }
 
     this.formControl.setValue(images.item(0));
+  }
+  public removeImage(): void {
+    this.model.image = null;
+    this.imageInput.nativeElement.value = null;
   }
 }

--- a/src/app/models/AbstractModel.spec.ts
+++ b/src/app/models/AbstractModel.spec.ts
@@ -132,7 +132,116 @@ describe("AbstractModel", () => {
     });
   });
 
+  describe("emitting file or null in formdata or json requests", () => {
+    const testFile = new File([""], "testFileName.png");
+
+    it("should emit null when serializing a model via JSON and deleting a file", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: null });
+      const actual = model.getJsonAttributes({ create: true });
+      expect(actual).toEqual(jasmine.objectContaining({
+        image: null
+      }));
+    });
+
+    it("should not emit file type objects in JSON attributes", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: testFile });
+      const actual = model.getJsonAttributes({ create: true });
+      expect(Object.keys(actual)).not.toContain("image");
+    });
+
+    it("should emit file type objects when serializing a model via formData", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: testFile });
+      const actual = model.getFormDataOnlyAttributes({ create: true });
+      expect(actual.get("mock_model[image]")).toEqual(model.image);
+    });
+
+    it("should not emit null values when serializing a model via formData", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: null });
+      const actual = model.getFormDataOnlyAttributes({ create: true });
+      expect(actual.has("mock_model[image]")).toBeFalse();
+      expect(actual.keys()).toHaveSize(0);
+    });
+
+    it("toJSON emits values as is (null case)", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: null });
+      const actual = model.toJSON();
+      expect(actual.image).toBeNull();
+    });
+
+    it("toJSON emits values as is (File type object case)", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: testFile });
+      const actual = model.toJSON();
+      expect(actual.image).toBeInstanceOf(File);
+    });
+
+    it("should emit file type objects when serializing a model via formData", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: testFile });
+      const actual = model.getFormDataOnlyAttributes({ create: true });
+      expect(actual.get("mock_model[image]")).toEqual(model.image);
+    });
+
+    it("should not emit null values when serializing a model via formData", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: null });
+      const actual = model.getFormDataOnlyAttributes({ create: true });
+      expect(actual.has("mock_model[image]")).toBeFalse();
+      expect(actual.keys()).toHaveSize(0);
+    });
+
+    it("toJSON emits values as is (null case)", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: null });
+      const actual = model.toJSON();
+      expect(actual.image).toBeNull();
+    });
+
+    it("toJSON emits values as is (File type object case)", () => {
+      class Model extends MockModel {
+        @bawPersistAttr({ create: true, supportedFormats: ["json", "formData"] })
+        public image: any;
+      }
+      const model = new Model({ id: 1, image: testFile });
+      const actual = model.toJSON();
+      expect(actual.image).toBeInstanceOf(File);
+    });
+  });
+
   describe("hasFormData", () => {
+    const testFile = new File([""], "testFileName.png");
     [
       { label: "create: true", create: true },
       { label: "update: true", update: true },
@@ -172,6 +281,7 @@ describe("AbstractModel", () => {
           const model = new Model({ value0: "value" });
           expect(hasFormDataOnlyAttributes(model)).toBeTrue();
         });
+
         it("should return false is no attributes are instantiated", () => {
           class Model extends MockModel {
             @bawPersistAttr({ supportedFormats: ["formData"] })
@@ -187,6 +297,24 @@ describe("AbstractModel", () => {
           class Model extends MockModel {}
           const model = new Model({});
           expect(hasFormDataOnlyAttributes(model)).toBeFalse();
+        });
+
+        it("should not want to send a formdata request if attribute is null", () => {
+          class Model extends MockModel {
+            @bawPersistAttr({ supportedFormats: ["json", "formData"] })
+            public image: any;
+          }
+          const model = new Model({image: null});
+          expect(hasFormDataOnlyAttributes(model)).toBeFalse();
+        });
+
+        it("should want to send FormData request if attribute is a File type object", () => {
+          class Model extends MockModel {
+            @bawPersistAttr({ supportedFormats: ["json", "formData"] })
+            public image: any;
+          }
+          const model = new Model({image: testFile});
+          expect(hasFormDataOnlyAttributes(model)).toBeTrue();
         });
       });
     });

--- a/src/app/models/AbstractModel.ts
+++ b/src/app/models/AbstractModel.ts
@@ -111,7 +111,6 @@ export abstract class AbstractModelWithoutId<Model = Record<string, any>> {
     }
 
     for (const attr of Object.keys(data)) {
-      // Do not include undefined/null data
       if (!isInstantiated(data[attr])) {
         continue;
       }
@@ -207,6 +206,11 @@ export abstract class AbstractModelWithoutId<Model = Record<string, any>> {
     if (opts?.create || opts?.update) {
       return this.getPersistentAttributes()
         .filter((meta) => (opts.create ? meta.create : meta.update))
+        // The following filter splits values for attributes that support both json and formData formats
+        // when a  null value is present, we send the value in the json request
+        // when a File value is present, we send the value in the formData request
+        // The null/json scenario is used to support deleting images.
+        .filter((meta) => this[meta.key] instanceof(File) ? opts.formData : true)
         .filter((meta) =>
           meta.supportedFormats.includes(opts.formData ? "formData" : "json")
         )

--- a/src/app/models/Harvest.spec.ts
+++ b/src/app/models/Harvest.spec.ts
@@ -1,0 +1,32 @@
+import { Harvest, HarvestStatus } from "@models/Harvest";
+import { generateHarvest } from "@test/fakes/Harvest";
+
+describe("isAbortable", () => {
+  const createModel = (harvestStatus: HarvestStatus) =>
+    new Harvest(generateHarvest({ status: harvestStatus }));
+
+  const transitionalHarvestStates: HarvestStatus[] = [
+    "metadataReview",
+    "uploading",
+    "newHarvest"
+  ];
+
+  const notTransitionalHarvestStates: HarvestStatus[] = [
+    "scanning",
+    "metadataExtraction",
+    "processing",
+    "complete"
+  ];
+
+  transitionalHarvestStates.forEach((harvestStatus: HarvestStatus) => {
+    it(`should return true for a Harvest with the status of ${harvestStatus}`, () => {
+      expect(createModel(harvestStatus).isAbortable()).toBeTrue();
+    });
+  });
+
+  notTransitionalHarvestStates.forEach((harvestStatus: HarvestStatus) => {
+    it(`should return false for a Harvest with the status of ${harvestStatus}`, () => {
+      expect(createModel(harvestStatus).isAbortable()).toBeFalse();
+    });
+  });
+});

--- a/src/app/models/Harvest.ts
+++ b/src/app/models/Harvest.ts
@@ -167,6 +167,16 @@ export class Harvest extends AbstractModel implements IHarvest {
     );
   }
 
+  public isAbortable(): boolean {
+    const notTransitionableStates: HarvestStatus[] = [
+      "scanning",
+      "metadataExtraction",
+      "processing",
+      "complete"
+    ];
+
+    return !notTransitionableStates.includes(this.status);
+  }
 }
 
 export interface IHarvestReport {

--- a/src/app/models/Project.ts
+++ b/src/app/models/Project.ts
@@ -59,7 +59,7 @@ export class Project extends AbstractModel<IProject> implements IProject {
   public readonly descriptionHtmlTagline?: Description;
   @bawImage<IProject>(`${assetRoot}/images/project/project_span4.png`)
   public readonly imageUrls!: ImageUrl[];
-  @bawPersistAttr({ supportedFormats: ["formData"] })
+  @bawPersistAttr({ supportedFormats: ["formData", "json"] })
   public readonly image?: File;
   public readonly accessLevel?: PermissionLevel;
   public readonly creatorId?: Id;

--- a/src/app/models/Region.ts
+++ b/src/app/models/Region.ts
@@ -55,7 +55,7 @@ export class Region extends AbstractModel<IRegion> implements IRegion {
   public readonly name?: Param;
   @bawImage<IRegion>(`${assetRoot}/images/site/site_span4.png`)
   public readonly imageUrls!: ImageUrl[];
-  @bawPersistAttr({ supportedFormats: ["formData"] })
+  @bawPersistAttr({ supportedFormats: ["formData", "json"] })
   public readonly image?: File;
   @bawPersistAttr()
   public readonly description?: Description;

--- a/src/app/models/Site.ts
+++ b/src/app/models/Site.ts
@@ -63,7 +63,7 @@ export class Site extends AbstractModel<ISite> implements ISite {
   public readonly name?: Param;
   @bawImage<ISite>(`${assetRoot}/images/site/site_span4.png`)
   public readonly imageUrls!: ImageUrl[];
-  @bawPersistAttr({ supportedFormats: ["formData"] })
+  @bawPersistAttr({ supportedFormats: ["formData", "json"] })
   public readonly image?: File;
   @bawPersistAttr()
   public readonly description?: Description;

--- a/src/app/services/baw-api/baw-api.service.ts
+++ b/src/app/services/baw-api/baw-api.service.ts
@@ -291,6 +291,7 @@ export class BawApiService<
         map(this.handleSingleResponse(classBuilder))
       );
     }
+
     return request.pipe(
       catchError((err) => this.handleError(err, opts?.disableNotification))
     );

--- a/src/app/services/baw-api/baw-apiMock.module.ts
+++ b/src/app/services/baw-api/baw-apiMock.module.ts
@@ -20,6 +20,10 @@ import { BookmarksService } from "./bookmark/bookmarks.service";
 import { CmsService } from "./cms/cms.service";
 import { DatasetItemsService } from "./dataset/dataset-items.service";
 import { DatasetsService } from "./dataset/datasets.service";
+import {
+  HarvestsService,
+  ShallowHarvestsService,
+} from "./harvest/harvest.service";
 import { MockSecurityService } from "./mock/securityMock.service";
 import { ProgressEventsService } from "./progress-event/progress-events.service";
 import { ProjectsService } from "./project/projects.service";
@@ -47,6 +51,12 @@ import { TaggingsService } from "./tag/taggings.service";
 import { TagsService } from "./tag/tags.service";
 import { UserService } from "./user/user.service";
 
+// If you get the following error while trying to stub a service:
+//
+// TypeError: Cannot read properties of undefined (reading 'callFake')
+//
+// ...it is likely because your new service has not been setup for automatic
+// mocking. Add it to the list below!
 const mockProviders: Provider[] = [
   { provide: SecurityService, useClass: MockSecurityService },
   mockProvider(BawApiService),
@@ -61,6 +71,8 @@ const mockProviders: Provider[] = [
   mockProvider(BookmarksService),
   mockProvider(DatasetsService),
   mockProvider(DatasetItemsService),
+  mockProvider(HarvestsService),
+  mockProvider(ShallowHarvestsService),
   mockProvider(ProgressEventsService),
   mockProvider(ProjectsService),
   mockProvider(QuestionsService),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
-    "lib": ["ES2020", "dom"],
+    "lib": ["ES2020", "dom", "dom.iterable"],
     "module": "ES2020",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
# Implement Harvest Abort Button on Various Screens

What is the purpose of this PR?
This PR creates and implements an "Abort" button and corresponding modal on the harvest upload list page, batch upload screen, and metadata review screens.

## Changes

* Creates an "Abort" button and modal
* Creates transition() method in list.component.ts

## Problems

N/A

## Issues

Fixes #1991

## Visual Changes

Project harvest list view
![image](https://user-images.githubusercontent.com/33742269/194226774-97cc0055-2175-471b-a71a-8a192e89986c.png)

Harvest upload screen
![image](https://user-images.githubusercontent.com/33742269/194226818-15517f0f-e0c0-48ce-bdbd-0114f39226bd.png)

Harvest metadata review screen
![image](https://user-images.githubusercontent.com/33742269/194437393-4293133f-1e93-4d6b-8f08-495e145831be.png)

Abort conformation modal
![image](https://user-images.githubusercontent.com/33742269/194436637-35e0edf9-8479-48c1-b844-5338d428d061.png)

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
