### PR TITLE
Add Support for Harvest Naming

### DIFF
--- a/src/app/components/harvest/components/shared/title.component.html
+++ b/src/app/components/harvest/components/shared/title.component.html
@@ -1,0 +1,36 @@
+<h1>
+<small class="text-muted">
+    Project: {{ project.name }}
+</small>
+<br />
+    <form #f="ngForm" (ngSubmit)="updateHarvestName(f)" class="form-group flexbox-align">
+        <div class="d-flex flex-row">
+            Upload Recordings: {{ !editingHarvestName ? harvest.name : '' }}
+            <div *ngIf="editingHarvestName" class="d-flex fit-content">
+                <input
+                    type="text"
+                    name="harvestNameInput"
+                    [ngModel]="harvest.name"
+                    class="form-control"
+                    placeholder="{{harvest.name}}"
+                    ngModel
+                />
+                <button type="submit" class="btn btn-primary ms-1">
+                <fa-icon [icon]="['fas', 'check']"></fa-icon>
+                </button>
+                <button type="button" class="btn btn-outline-danger ms-1" (click)="toggleHarvestNameEditing(false)">
+                <fa-icon [icon]="['fas', 'times']"></fa-icon>
+                </button>
+            </div>
+
+            <sub
+                *ngIf="harvest.canUpdate && !editingHarvestName"
+                (click)="toggleHarvestNameEditing(true)"
+                style="cursor: pointer;"
+                class="ms-2 mt-2"
+            >
+                <fa-icon [icon]="['fas', 'pencil']" size="xs"></fa-icon>
+            </sub>
+        </div>
+    </form>
+</h1>

--- a/src/app/components/harvest/components/shared/title.component.scss
+++ b/src/app/components/harvest/components/shared/title.component.scss
@@ -1,0 +1,19 @@
+// the following classes are needed to align items in the same positions across browsers
+// align the flexbox to the same position in all browsers
+.flexbox-align {
+  display: flex !important;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  align-items: baseline !important;
+  justify-content: left;
+  word-break: break-word;
+
+  // center the elements in the flexbox
+  // translateY(0.25rem) is equivalent to m-1 in ng-bootstrap
+  .fit-content {
+      transform: translateY(0.25rem);
+      height: fit-content;
+  }
+}

--- a/src/app/components/harvest/components/shared/title.component.spec.ts
+++ b/src/app/components/harvest/components/shared/title.component.spec.ts
@@ -1,0 +1,122 @@
+import { fakeAsync, tick } from "@angular/core/testing";
+import { FormsModule } from "@angular/forms";
+import { By } from "@angular/platform-browser";
+import { ShallowHarvestsService } from "@baw-api/harvest/harvest.service";
+import { Harvest } from "@models/Harvest";
+import { Project } from "@models/Project";
+import { SpectatorHost, createHostFactory, SpyObject } from "@ngneat/spectator";
+import { generateHarvest } from "@test/fakes/Harvest";
+import { generateProject } from "@test/fakes/Project";
+import { MockProvider } from "ng-mocks";
+import { ToastrService } from "ngx-toastr";
+import { TitleComponent } from "./title.component";
+
+describe("titleComponent", () => {
+  let spectator: SpectatorHost<TitleComponent>;
+  let mockHarvest: Harvest;
+  let mockProject: Project;
+
+  const createHost = createHostFactory({
+    component: TitleComponent,
+    imports: [FormsModule],
+    mocks: [ToastrService],
+  });
+
+  function setup(): SpyObject<ShallowHarvestsService> {
+    spectator = createHost(
+      `
+      <baw-harvest-title></baw-harvest-title>
+      `,
+      {
+        props: {
+          project: mockProject,
+          harvest: mockHarvest
+        },
+        providers: [
+          MockProvider(ShallowHarvestsService, {}),
+        ],
+      }
+    );
+
+    const mockHarvestApi = spectator.inject<SpyObject<ShallowHarvestsService>>( ShallowHarvestsService as any );
+    mockHarvestApi.updateName = jasmine.createSpy("updateName") as any;
+
+    spectator.detectChanges();
+
+    return mockHarvestApi;
+  }
+
+  const getHarvestTitle = (): HTMLElement =>
+    spectator.query("form");
+
+  const getNameEditButton = (): HTMLElement =>
+    spectator.query("sub");
+
+  const getNameEditInput = (): HTMLInputElement =>
+    spectator.debugElement.query(By.css("input[name='harvestNameInput']")).nativeElement;
+
+  beforeEach(() => {
+    mockHarvest = new Harvest(generateHarvest({ status: "metadataReview" }));
+    mockProject = new Project(generateProject());
+  });
+
+  it("should create", () => {
+    setup();
+    expect(spectator.component).toBeInstanceOf(TitleComponent);
+  });
+
+  it("should display the name of the project and harvest", () => {
+    setup();
+    const expectedTitle = `Upload Recordings: ${mockHarvest.name}`;
+
+    expect(getHarvestTitle().innerText).toEqual(expectedTitle);
+  });
+
+  it("should display an input box with the name of the Harvest when the pencil edit icon is clicked", fakeAsync(() => {
+    setup();
+
+    getNameEditButton().click();
+    spectator.detectChanges();
+
+    // we have to wait for the edit button to be clicked before the edit input exists
+    const nameEditInput = getNameEditInput();
+    expect(nameEditInput).toExist();
+
+    spectator.detectChanges();
+    tick();
+    spectator.detectChanges();
+
+    expect(nameEditInput.value).toEqual(mockHarvest.name);
+  }));
+
+  it("should call the updateName() harvest service when the harvest name is changed", fakeAsync(() => {
+    const newHarvestName = "this is a new name";
+    const mockHarvestApi = setup();
+
+    getNameEditButton().click();
+    spectator.detectChanges();
+    tick();
+    spectator.detectChanges();
+
+    const nameEditInput = getNameEditInput();
+
+    // change the value/text of the harvest name editor input box
+    nameEditInput.value = newHarvestName;
+    // changing the input box value doesn't trigger the "input" event needed to
+    // trigger the ng change detection, so trigger the event manually
+    nameEditInput.dispatchEvent(new Event("input"));
+
+    spectator.detectChanges();
+    tick();
+    spectator.detectChanges();
+
+    // submit the ngForm. This should trigger the harvest name to be updated
+    spectator.debugElement.query(By.css("form")).triggerEventHandler("submit", null);
+
+    spectator.detectChanges();
+    tick();
+    spectator.detectChanges();
+
+    expect(mockHarvestApi.updateName).toHaveBeenCalledWith(mockHarvest, newHarvestName);
+  }));
+});

--- a/src/app/components/harvest/components/shared/title.component.ts
+++ b/src/app/components/harvest/components/shared/title.component.ts
@@ -1,17 +1,48 @@
 import { Component, Input } from "@angular/core";
+import { NgForm } from "@angular/forms";
+import { ShallowHarvestsService } from "@baw-api/harvest/harvest.service";
+import { BawApiError } from "@helpers/custom-errors/baw-api-error";
+import { Harvest } from "@models/Harvest";
 import { Project } from "@models/Project";
+import { ToastrService } from "ngx-toastr";
+import { throwError } from "rxjs";
 
 @Component({
   selector: "baw-harvest-title",
-  template: `
-    <h1>
-      <small class="text-muted"> Project: {{ project.name }} </small>
-      <br />
-      Upload Recordings
-      <!-- TODO Show stage here -->
-    </h1>
-  `,
+  templateUrl: "./title.component.html",
+  styleUrls: ["./title.component.scss"],
 })
 export class TitleComponent {
   @Input() public project: Project;
+  @Input() public harvest: Harvest;
+
+  public editingHarvestName = false;
+
+  public constructor(
+    public harvestService: ShallowHarvestsService,
+    private notifications: ToastrService,
+  ){}
+
+  public updateHarvestName(form: NgForm) {
+    const newHarvestName = form.value["harvestNameInput"];
+
+    if (newHarvestName !== this.harvest.name) {
+      this.harvestService.updateName(this.harvest, newHarvestName)
+      // eslint-disable-next-line rxjs-angular/prefer-takeuntil
+      .subscribe({
+        next: (): void => {},
+        error: (err: BawApiError): void => {
+          throwError(() => err);
+        },
+      });
+
+      this.harvest.name = newHarvestName;
+      this.notifications.success(`Successfully Renamed Upload to ${this.harvest.name}`);
+    }
+
+    this.toggleHarvestNameEditing(false);
+  }
+
+  public toggleHarvestNameEditing = (state: boolean) =>
+    this.editingHarvestName = state;
 }

--- a/src/app/components/harvest/pages/details/details.component.html
+++ b/src/app/components/harvest/pages/details/details.component.html
@@ -1,4 +1,4 @@
-<baw-harvest-title [project]="project"></baw-harvest-title>
+<baw-harvest-title [project]="project" [harvest]="harvest"></baw-harvest-title>
 
 <baw-stepper
   [steps]="stages.stages"

--- a/src/app/components/harvest/pages/details/details.component.ts
+++ b/src/app/components/harvest/pages/details/details.component.ts
@@ -28,6 +28,7 @@ class DetailsComponent
   implements OnInit, OnDestroy
 {
   public project: Project;
+  public harvest: Harvest;
 
   public constructor(
     public stages: HarvestStagesService,
@@ -38,9 +39,9 @@ class DetailsComponent
 
   public ngOnInit(): void {
     const routeData = this.route.snapshot.data;
-    const harvest: Harvest = routeData[harvestKey]?.model;
+    this.harvest = routeData[harvestKey]?.model;
     this.project = routeData[projectKey].model;
-    this.stages.initialize(this.project, harvest);
+    this.stages.initialize(this.project, this.harvest);
   }
 
   public ngOnDestroy(): void {

--- a/src/app/components/harvest/pages/list/list.component.html
+++ b/src/app/components/harvest/pages/list/list.component.html
@@ -10,6 +10,15 @@
   bawDatatableDefaults
   [bawDatatablePagination]="{ filters: filters$, getModels: getModels }"
 >
+  <ngx-datatable-column prop="name">
+    <ng-template let-column="column" ngx-datatable-header-template>
+      Name
+    </ng-template>
+    <ng-template let-value="value" ngx-datatable-cell-template>
+      <span>{{ value }}</span>
+    </ng-template>
+  </ngx-datatable-column>
+
   <ngx-datatable-column prop="createdAt">
     <ng-template let-column="column" ngx-datatable-header-template>
       Created

--- a/src/app/models/Harvest.spec.ts
+++ b/src/app/models/Harvest.spec.ts
@@ -1,32 +1,59 @@
 import { Harvest, HarvestStatus } from "@models/Harvest";
 import { generateHarvest } from "@test/fakes/Harvest";
 
-describe("isAbortable", () => {
-  const createModel = (harvestStatus: HarvestStatus) =>
+const createModel = (harvestStatus: HarvestStatus) =>
     new Harvest(generateHarvest({ status: harvestStatus }));
 
-  const transitionalHarvestStates: HarvestStatus[] = [
+describe("isAbortable", () => {
+  const abortableHarvestStates: HarvestStatus[] = [
     "metadataReview",
     "uploading",
     "newHarvest"
   ];
 
-  const notTransitionalHarvestStates: HarvestStatus[] = [
+  const notAbortableHarvestStates: HarvestStatus[] = [
     "scanning",
     "metadataExtraction",
     "processing",
     "complete"
   ];
 
-  transitionalHarvestStates.forEach((harvestStatus: HarvestStatus) => {
+  abortableHarvestStates.forEach((harvestStatus: HarvestStatus) => {
     it(`should return true for a Harvest with the status of ${harvestStatus}`, () => {
       expect(createModel(harvestStatus).isAbortable()).toBeTrue();
     });
   });
 
-  notTransitionalHarvestStates.forEach((harvestStatus: HarvestStatus) => {
+  notAbortableHarvestStates.forEach((harvestStatus: HarvestStatus) => {
     it(`should return false for a Harvest with the status of ${harvestStatus}`, () => {
       expect(createModel(harvestStatus).isAbortable()).toBeFalse();
+    });
+  });
+});
+
+describe("canUpdate", () => {
+  const transitionableHarvestStates: HarvestStatus[] = [
+    "metadataReview",
+    "uploading",
+    "newHarvest",
+    "complete"
+  ];
+
+  const notTransitionableHarvestStates: HarvestStatus[] = [
+    "scanning",
+    "metadataExtraction",
+    "processing"
+  ];
+
+  transitionableHarvestStates.forEach((harvestStatus: HarvestStatus) => {
+    it(`should return true for a Harvest with the status of ${harvestStatus}`, () => {
+      expect(createModel(harvestStatus).canUpdate).toBeTrue();
+    });
+  });
+
+  notTransitionableHarvestStates.forEach((harvestStatus: HarvestStatus) => {
+    it(`should return false for a Harvest with the status of ${harvestStatus}`, () => {
+      expect(createModel(harvestStatus).canUpdate).toBeFalse();
     });
   });
 });

--- a/src/app/models/Harvest.ts
+++ b/src/app/models/Harvest.ts
@@ -78,6 +78,7 @@ export class HarvestMapping
 
 export interface IHarvest extends HasCreatorAndUpdater {
   id?: Id;
+  name?: string;
   streaming?: boolean;
   status?: HarvestStatus;
   projectId?: Id;
@@ -101,6 +102,8 @@ export interface HarvestUploadConnectionArguments {
 export class Harvest extends AbstractModel implements IHarvest {
   public readonly kind = "Harvest";
   public readonly id?: Id;
+  @bawPersistAttr()
+  public name?: string;
   @bawPersistAttr({ create: true, update: false })
   public readonly streaming?: boolean;
   @bawPersistAttr({ convertCase: true })
@@ -167,15 +170,18 @@ export class Harvest extends AbstractModel implements IHarvest {
     );
   }
 
-  public isAbortable(): boolean {
+  public get canUpdate(): boolean {
     const notTransitionableStates: HarvestStatus[] = [
       "scanning",
       "metadataExtraction",
-      "processing",
-      "complete"
+      "processing"
     ];
 
     return !notTransitionableStates.includes(this.status);
+  }
+
+  public isAbortable(): boolean {
+    return this.canUpdate && this.status !== "complete";
   }
 }
 

--- a/src/app/services/baw-api/harvest/harvest.service.spec.ts
+++ b/src/app/services/baw-api/harvest/harvest.service.spec.ts
@@ -1,3 +1,4 @@
+import { BawApiService } from "@baw-api/baw-api.service";
 import { Harvest } from "@models/Harvest";
 import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { generateHarvest } from "@test/fakes/Harvest";
@@ -6,6 +7,7 @@ import {
   mockServiceProviders,
   validateStandardApi,
 } from "@test/helpers/api-common";
+import { of } from "rxjs";
 import { HarvestsService, ShallowHarvestsService } from "./harvest.service";
 
 describe("HarvestsService", () => {
@@ -13,14 +15,18 @@ describe("HarvestsService", () => {
   const createModel = () => new Harvest(generateHarvest({ id: harvestId }));
   const baseUrl = "/projects/5/harvests/";
   let spec: SpectatorService<HarvestsService>;
+  let shallowSpectator: SpectatorService<ShallowHarvestsService>;
+
   const createService = createServiceFactory({
     service: HarvestsService,
     imports: mockServiceImports,
     providers: [...mockServiceProviders, ShallowHarvestsService],
   });
 
-  beforeEach((): void => {
-    spec = createService();
+  const createShallowService = createServiceFactory({
+    service: ShallowHarvestsService,
+    imports: mockServiceImports,
+    providers: [...mockServiceProviders, ShallowHarvestsService],
   });
 
   validateStandardApi(
@@ -33,4 +39,34 @@ describe("HarvestsService", () => {
     harvestId, // harvest
     5 //project
   );
+
+  beforeEach((): void => {
+    spec = createService();
+    shallowSpectator = createShallowService();
+  });
+
+  function setup() {
+    const mockHarvestApi: BawApiService<Harvest> = spec.inject<BawApiService<Harvest>>(BawApiService);
+    spyOn(mockHarvestApi, "httpPatch").and.callFake((_path, _body, _options) => of());
+
+    return mockHarvestApi;
+  }
+
+  describe("updateName", () => {
+    it("should send a patch request to the server with the name property only as the body", () => {
+      const mockHarvestApi = setup();
+      const newHarvestName = "this is a test name";
+      const mockHarvest = new Harvest(generateHarvest());
+
+      shallowSpectator.service.updateName(mockHarvest, newHarvestName);
+
+      expect(mockHarvestApi.httpPatch).toHaveBeenCalledWith(
+        `/harvests/${mockHarvest.id}`,
+        // disable eslint for this line because the harvest value
+        // hasn't passed through the http interceptor api yet
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        { Harvest: { name: newHarvestName } }
+      );
+    });
+  });
 });

--- a/src/app/services/baw-api/harvest/harvest.service.ts
+++ b/src/app/services/baw-api/harvest/harvest.service.ts
@@ -164,6 +164,22 @@ export class ShallowHarvestsService implements StandardApi<Harvest> {
   }
 
   /**
+   * Updates the name of a harvest
+   *
+   * @param name New name of the harvest
+   */
+  public updateName(
+    model: Harvest,
+    newHarvestName: string
+  ): Observable<Harvest> {
+    return this.api
+      .httpPatch(shallowEndpoint(model, emptyParam), {
+        [this.harvestKind]: { name: newHarvestName }
+      })
+      .pipe(map(this.api.handleSingleResponse(Harvest)));
+  }
+
+  /**
    * Update the mappings of a harvest
    *
    * @param mappings Mappings of folders to sites

--- a/src/app/test/fakes/Harvest.ts
+++ b/src/app/test/fakes/Harvest.ts
@@ -41,6 +41,7 @@ export function generateHarvestReport(
 export function generateHarvest(data?: Partial<IHarvest>): Required<IHarvest> {
   return {
     id: modelData.id(),
+    name: modelData.random.word(),
     streaming: modelData.datatype.boolean(),
     status: modelData.helpers.arrayElement<HarvestStatus>([
       "uploading",


### PR DESCRIPTION
# Add Support for Harvest Naming

What is the purpose of this PR?
This PR adds a name attribute to Harvest models, displays this name in the harvest list for each project, and adds a way to edit the name of the harvest from the detailed harvest view.

## Changes

* Adds a Harvest name column to the harvest list view
* Adds the Harvest name in the harvest title component
* Creates a new shallow `updateName()` Harvest service
* Separates `isAbortable()` `canUpdate()` Harvest model methods

## Problems

No

## Issues

Fixes #1996 

## Visual Changes
  
Harvest list view with name in far left column
![image](https://user-images.githubusercontent.com/33742269/197948139-8823a585-d7ec-4e7c-adb1-0d70646e4943.png)

An example harvest detail view with pencil edit button next to the project & harvest name
![image](https://user-images.githubusercontent.com/33742269/198427856-adeac3b2-c37e-4b17-b9a4-e64a1c19c258.png)

View after the pencil edit button is clicked
![image](https://user-images.githubusercontent.com/33742269/198505920-ce494eda-cdcc-4fa0-9362-5a9f2719a99e.png)

Toast notification once the name is changed
![image](https://user-images.githubusercontent.com/33742269/198444111-a0b694d0-1863-4712-894c-88c4439fe6b2.png)

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [x] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
