### PR TITLE
Fixed title  querying uninitialized Harvet model

### DIFF
--- a/src/app/components/harvest/components/shared/title.component.html
+++ b/src/app/components/harvest/components/shared/title.component.html
@@ -3,7 +3,7 @@
     Project: {{ project.name }}
 </small>
 <br />
-    <form #f="ngForm" (ngSubmit)="updateHarvestName(f)" class="form-group flexbox-align">
+    <form *ngIf="harvest !== undefined" #f="ngForm" (ngSubmit)="updateHarvestName(f)" class="form-group flexbox-align">
         <div class="d-flex flex-row">
             Upload Recordings: {{ !editingHarvestName ? harvest.name : '' }}
             <div *ngIf="editingHarvestName" class="d-flex fit-content">

--- a/src/app/components/harvest/components/shared/title.component.spec.ts
+++ b/src/app/components/harvest/components/shared/title.component.spec.ts
@@ -72,6 +72,13 @@ describe("titleComponent", () => {
     expect(getHarvestTitle().innerText).toEqual(expectedTitle);
   });
 
+  it("should not attempt to load the harvest name when a Harvest model is not initialized" , () => {
+    mockHarvest = undefined;
+    setup();
+
+    expect(getHarvestTitle()).toBeNull();
+  });
+
   it("should display an input box with the name of the Harvest when the pencil edit icon is clicked", fakeAsync(() => {
     setup();
 


### PR DESCRIPTION
Fixes: #2000

# Fixed title querying uninitialized Harvet model

Fix regression in Harvest naming which produced JavaScript runtime errors from querying uninitialised Harvest model.

## Changes

The title component will no longer try to render the Harvest name if the Harvest model is undefined.

## Issues

#2000 

## Visual Changes

na.

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [x] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
