### PR TITLE
Created WIP download analyses button to recordings

### DIFF
--- a/src/app/components/audio-recordings/audio-recording.menus.ts
+++ b/src/app/components/audio-recordings/audio-recording.menus.ts
@@ -117,3 +117,12 @@ export const downloadAudioRecordingMenuItem = menuLink({
   uri: ({ audioRecordingId }) =>
     audioRecordingOriginalEndpoint(audioRecordingId),
 });
+
+// TODO: when this button is clicked it should action a download
+export const downloadAudioRecordingAnalysesMenuItem = menuLink({
+  icon: ["fas", "file"],
+  label: "Download Analyses",
+  tooltip: () => "Download audio recording analyses",
+  disabled: "BETA: Will be available soon.",
+  uri: () => "#"
+});

--- a/src/app/components/audio-recordings/pages/details/details.component.ts
+++ b/src/app/components/audio-recordings/pages/details/details.component.ts
@@ -12,6 +12,7 @@ import { siteResolvers } from "@baw-api/site/sites.service";
 import {
   audioRecordingMenuItems,
   audioRecordingsCategory,
+  downloadAudioRecordingAnalysesMenuItem,
   downloadAudioRecordingMenuItem,
 } from "@components/audio-recordings/audio-recording.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
@@ -77,7 +78,7 @@ function getPageInfo(
   return {
     pageRoute: audioRecordingMenuItems.details[subRoute],
     category: audioRecordingsCategory,
-    menus: { actions: List([downloadAudioRecordingMenuItem]) },
+    menus: { actions: List([downloadAudioRecordingMenuItem, downloadAudioRecordingAnalysesMenuItem]) },
     resolvers: {
       [audioRecordingKey]: audioRecordingResolvers.show,
       [projectKey]: projectResolvers.showOptional,

--- a/src/app/components/audio-recordings/pages/list/list.component.html
+++ b/src/app/components/audio-recordings/pages/list/list.component.html
@@ -67,8 +67,8 @@
     </ngx-datatable-column>
     <ngx-datatable-column
       name="Model"
-      [width]="127"
-      [maxWidth]="127"
+      [width]="170"
+      [maxWidth]="170"
       [sortable]="false"
     >
       <ng-template let-column="column" ngx-datatable-header-template>
@@ -83,7 +83,6 @@
           <fa-icon [icon]="['fas', 'play']"></fa-icon>
         </a>
         <a
-          class="btn btn-sm btn-default mx-1"
           class="btn btn-sm btn-default me-1"
           placement="left"
           [ngbTooltip]="'Download audio recording'"
@@ -91,6 +90,17 @@
         >
           <fa-icon [icon]="['fas', 'download']"></fa-icon>
         </a>
+
+        <span [ngbTooltip]="'BETA: Will be available soon. Download audio recording analyses'">
+          <button
+            class="btn btn-sm btn-default me-1"
+            placement="left"
+            [disabled]="true"
+          >
+            <fa-icon [icon]="['fas', 'file']"></fa-icon>
+          </button>
+        </span>
+
         <!-- Change this link dynamically -->
         <a
           class="btn btn-sm btn-default"


### PR DESCRIPTION
# Create a WIP download analyses button to the audio recording list table and the audio recording details page

This PR creates a disabled WIP button on the audio recording list table and the audio recording details page.

## Changes

* Adds a new disabled "Download Analyses" menu item to the audio recording details page
* Adds a new disabled "Download Analyses" row item to the audio recordings list table

## Problems
These buttons are current non-functional. Functionality needs to be completed as part of the wider epic #2008 

## Issues

Fixes: #2009 

## Visual Changes

Details page of audio recording with new disabled "Download Analyses" menu item, with WIP tooltip in line with design language also seen in the WIP menu items in the profiles component.
![image](https://user-images.githubusercontent.com/33742269/203889617-936833cd-e593-426f-aada-9899b06c153b.png)

Audio recordings list table with disabled file/report icon with the tool tip "Download audio recording analyses".
![image](https://user-images.githubusercontent.com/33742269/203889713-1652c1a9-7d0a-4305-bfdc-92ee9b48368e.png)

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [x] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
