### PR TITLE
Backfill analyses recording models & services

### DIFF
--- a/src/app/components/audio-recordings/audio-recording.menus.ts
+++ b/src/app/components/audio-recordings/audio-recording.menus.ts
@@ -120,7 +120,7 @@ export const downloadAudioRecordingMenuItem = menuLink({
 
 // TODO: when this button is clicked it should action a download
 export const downloadAudioRecordingAnalysesMenuItem = menuLink({
-  icon: ["fas", "file"],
+  icon: ["fas", "file-arrow-down"],
   label: "Download Analyses",
   tooltip: () => "Download audio recording analyses",
   disabled: "BETA: Will be available soon.",

--- a/src/app/components/audio-recordings/pages/list/list.component.html
+++ b/src/app/components/audio-recordings/pages/list/list.component.html
@@ -97,7 +97,7 @@
             placement="left"
             [disabled]="true"
           >
-            <fa-icon [icon]="['fas', 'file']"></fa-icon>
+            <fa-icon [icon]="['fas', 'file-arrow-down']"></fa-icon>
           </button>
         </span>
 

--- a/src/app/models/AnalysisJobItemResult.ts
+++ b/src/app/models/AnalysisJobItemResult.ts
@@ -1,0 +1,60 @@
+import { Injector } from "@angular/core";
+import { ANALYSIS_JOB, AUDIO_RECORDING } from "@baw-api/ServiceTokens";
+import { Id, Param } from "@interfaces/apiInterfaces";
+import { AbstractModel } from "./AbstractModel";
+import { AnalysisJob } from "./AnalysisJob";
+import { hasOne } from "./AssociationDecorators";
+import { AudioRecording } from "./AudioRecording";
+
+export type ResultsItemType = "directory" | "file";
+
+export interface IAnalysisJobItemResult {
+  id?: Id;
+  resultsPath?: string;
+  analysisJobId?: Id;
+  audioRecordingId?: Id;
+  name?: string;
+  sizeBytes?: number;
+  hasChildren?: boolean;
+  hasZip?: boolean;
+  type?: ResultsItemType;
+  children?: AnalysisJobItemResult[];
+}
+
+export class AnalysisJobItemResult
+  extends AbstractModel
+  implements IAnalysisJobItemResult
+{
+  public constructor(
+    analysisJobItemResults: IAnalysisJobItemResult,
+    injector?: Injector
+  ) {
+    super(analysisJobItemResults, injector);
+  }
+
+  public readonly kind = "Analysis Job Item Results";
+  public readonly id?: Id;
+  public readonly name?: Param;
+  public readonly resultsPath?: Param;
+  public readonly analysisJobId?: Id;
+  public readonly audioRecordingId?: Id;
+  public readonly sizeBytes?: number;
+  public readonly mime?: Param;
+  public readonly hasChildren?: boolean;
+  public readonly hasZip?: boolean;
+  public readonly type?: ResultsItemType = "directory";
+  public readonly children?: AnalysisJobItemResult[];
+
+  // Associations
+  @hasOne<AnalysisJobItemResult, AnalysisJob>(ANALYSIS_JOB, "analysisJobId")
+  public analysisJob?: AnalysisJob;
+  @hasOne<AnalysisJobItemResult, AudioRecording>(
+    AUDIO_RECORDING,
+    "audioRecordingId"
+  )
+  public audioRecording?: AudioRecording;
+
+  public get viewUrl(): string {
+    throw new Error("AnalysisJobItemResult viewUrl not implemented.");
+  }
+}

--- a/src/app/services/baw-api/ServiceProviders.ts
+++ b/src/app/services/baw-api/ServiceProviders.ts
@@ -1,5 +1,9 @@
 import { accountResolvers, AccountsService } from "./account/accounts.service";
 import {
+  analysisJobItemResultResolvers,
+  AnalysisJobItemResultsService,
+} from "./analysis/analysis-job-item-result.service";
+import {
   analysisJobItemResolvers,
   AnalysisJobItemsService,
 } from "./analysis/analysis-job-items.service";
@@ -102,6 +106,11 @@ const serviceList = [
     serviceToken: Tokens.ANALYSIS_JOB_ITEM,
     service: AnalysisJobItemsService,
     resolvers: analysisJobItemResolvers,
+  },
+  {
+    serviceToken: Tokens.ANALYSIS_JOB_ITEM_RESULTS,
+    service: AnalysisJobItemResultsService,
+    resolvers: analysisJobItemResultResolvers,
   },
   {
     serviceToken: Tokens.AUDIO_EVENT,

--- a/src/app/services/baw-api/ServiceTokens.ts
+++ b/src/app/services/baw-api/ServiceTokens.ts
@@ -9,6 +9,7 @@ import { InjectionToken } from "@angular/core";
 import type { AbstractModel } from "@models/AbstractModel";
 import type { AnalysisJob } from "@models/AnalysisJob";
 import type { AnalysisJobItem } from "@models/AnalysisJobItem";
+import type { AnalysisJobItemResult } from "@models/AnalysisJobItemResult";
 import type { AudioEvent } from "@models/AudioEvent";
 import type { AudioRecording } from "@models/AudioRecording";
 import type { Bookmark } from "@models/Bookmark";
@@ -80,6 +81,7 @@ import type { TagGroupsService } from "./tag/tag-group.service";
 import type { TaggingsService } from "./tag/taggings.service";
 import type { TagsService } from "./tag/tags.service";
 import type { UserService } from "./user/user.service";
+import type { AnalysisJobItemResultsService } from "./analysis/analysis-job-item-result.service";
 
 /**
  * Wrapper for InjectionToken class. This is required because of
@@ -109,6 +111,10 @@ export const ANALYSIS_JOB_ITEM = new ServiceToken<
   AnalysisJobItemsService,
   AnalysisJobItem
 >("A_JOB_ITEM");
+export const ANALYSIS_JOB_ITEM_RESULTS = new ServiceToken<
+  AnalysisJobItemResultsService,
+  AnalysisJobItemResult
+>("A_JOB_ITEM_RESULTS");
 export const AUDIO_EVENT = new ServiceToken<AudioEventsService, AudioEvent>(
   "AUDIO"
 );

--- a/src/app/services/baw-api/analysis/analysis-job-item-result.service.ts
+++ b/src/app/services/baw-api/analysis/analysis-job-item-result.service.ts
@@ -1,0 +1,97 @@
+import { Injectable } from "@angular/core";
+import {
+  emptyParam,
+  filterParam,
+  IdOr,
+  id,
+  IdParamOptional,
+  option,
+  ReadonlyApi,
+  param,
+} from "@baw-api/api-common";
+import { BawApiService, Filters } from "@baw-api/baw-api.service";
+import { stringTemplate } from "@helpers/stringTemplate/stringTemplate";
+import { AnalysisJobItemResult } from "@models/AnalysisJobItemResult";
+import { AnalysisJob } from "@models/AnalysisJob";
+import { Observable } from "rxjs";
+import { AudioRecording } from "@models/AudioRecording";
+import { Resolvers } from "@baw-api/resolver-common";
+
+const analysisJobId: IdParamOptional<AnalysisJob> = id;
+const audioRecordingId: IdParamOptional<AudioRecording> = id;
+const analysisJobItemResultsPath = param;
+
+const endpoint = stringTemplate`/analysis_jobs/${analysisJobId}/results/${audioRecordingId}/${analysisJobItemResultsPath}${option}`;
+
+@Injectable()
+export class AnalysisJobItemResultsService
+  implements
+    ReadonlyApi<
+      AnalysisJobItemResult,
+      [IdOr<AnalysisJob>, IdOr<AudioRecording>]
+    >
+{
+  public constructor(private api: BawApiService<AnalysisJobItemResult>) {}
+
+  public list(
+    analysisJob: IdOr<AnalysisJob>,
+    audioRecording: IdOr<AudioRecording>,
+    // TODO: we should consider overloads that take a path or model
+    analysisJobItemResult?: AnalysisJobItemResult
+  ): Observable<AnalysisJobItemResult[]> {
+    return this.api.list(
+      AnalysisJobItemResult,
+      endpoint(
+        analysisJob,
+        audioRecording,
+        analysisJobItemResult?.resultsPath ?? emptyParam,
+        emptyParam
+      )
+    );
+  }
+
+  public filter(
+    filters: Filters<AnalysisJobItemResult>,
+    analysisJob: IdOr<AnalysisJob>,
+    audioRecording: IdOr<AudioRecording>,
+    // TODO: we should consider overloads that take a path or model
+    analysisJobItemResult?: AnalysisJobItemResult
+  ): Observable<AnalysisJobItemResult[]> {
+    return this.api.filter(
+      AnalysisJobItemResult,
+      endpoint(
+        analysisJob,
+        audioRecording,
+        analysisJobItemResult?.resultsPath ?? emptyParam,
+        filterParam
+      ),
+      filters
+    );
+  }
+
+  public show(
+    // TODO: we should consider overloads that take a path or model
+    analysisJobItemResult: AnalysisJobItemResult,
+    analysisJob: IdOr<AnalysisJob>,
+    audioRecording: IdOr<AudioRecording>
+  ): Observable<AnalysisJobItemResult> {
+    return this.api.show(
+      AnalysisJobItemResult,
+      endpoint(
+        analysisJob,
+        audioRecording,
+        analysisJobItemResult.resultsPath,
+        emptyParam
+      )
+    );
+  }
+}
+
+export const analysisJobItemResultResolvers = new Resolvers<
+  AnalysisJobItemResult,
+  [IdOr<AnalysisJob>, IdOr<AudioRecording>, IdOr<AnalysisJobItemResult>]
+>([AnalysisJobItemResultsService], "analysisJobItemResultsPath", [
+  "analysisJobId",
+  "audioRecordingId",
+  "analysisJobItemResultsPath",
+]).create("AnalysisJobItemResults");

--- a/src/app/services/baw-api/analysis/analysis-job-item-result.services.spec.ts
+++ b/src/app/services/baw-api/analysis/analysis-job-item-result.services.spec.ts
@@ -1,0 +1,57 @@
+import { AnalysisJobItemResult } from "@models/AnalysisJobItemResult";
+import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
+import { generateAnalysisJobResults } from "@test/fakes/AnalysisJobItemResult";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+  validateApiShow,
+  validateReadonlyApi,
+} from "@test/helpers/api-common";
+import { AnalysisJobItemResultsService } from "./analysis-job-item-result.service";
+
+describe("AnalysisJobItemsResultsService", (): void => {
+  let spec: SpectatorService<AnalysisJobItemResultsService>;
+  const baseUrl = "/analysis_jobs/10/results/15/";
+  const mockResultsPath = "testA/testB/fileA.csv";
+
+  const createModel = () =>
+    new AnalysisJobItemResult(
+      generateAnalysisJobResults({
+        id: 5,
+        resultsPath: mockResultsPath,
+      })
+    );
+
+  const createService = createServiceFactory({
+    service: AnalysisJobItemResultsService,
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
+  });
+
+  beforeEach((): void => {
+    spec = createService();
+  });
+
+  validateReadonlyApi(
+    () => spec,
+    AnalysisJobItemResult,
+    baseUrl, // list
+    baseUrl + "filter", // filter
+    baseUrl + mockResultsPath, // show
+    createModel,
+    undefined, // analysis job item results
+    10, // analysis job
+    15, // audio recording
+    undefined // options
+  );
+
+  validateApiShow(
+    () => spec as any,
+    AnalysisJobItemResult,
+    baseUrl + mockResultsPath,
+    undefined,
+    createModel,
+    10,
+    15
+  );
+});

--- a/src/app/test/fakes/AnalysisJobItemResult.ts
+++ b/src/app/test/fakes/AnalysisJobItemResult.ts
@@ -1,0 +1,25 @@
+import {
+  IAnalysisJobItemResult,
+  ResultsItemType,
+} from "@models/AnalysisJobItemResult";
+import { modelData } from "@test/helpers/faker";
+
+export function generateAnalysisJobResults(
+  data?: Partial<IAnalysisJobItemResult>
+): Required<IAnalysisJobItemResult> {
+  const resultItemTypes: ResultsItemType[] = ["directory", "file"];
+
+  return {
+    id: modelData.id(),
+    resultsPath: modelData.system.fileName(),
+    analysisJobId: modelData.id(),
+    audioRecordingId: modelData.id(),
+    name: modelData.param(),
+    sizeBytes: modelData.datatype.number(1000),
+    hasChildren: modelData.bool(),
+    hasZip: modelData.bool(),
+    type: modelData.helpers.arrayElement(resultItemTypes),
+    children: [],
+    ...data,
+  };
+}


### PR DESCRIPTION
# Backfill analyses recording models & services

The baw-server currently has existing API's and services for analysis jobs and analysis jobs items and analysis jobs items results. In preparation of being feature ready, we need to create the appropriate models and services.

## Changes

* Created `AnalysisJobItemResults` model & mocks
* Created `AnalysisJobItemResults` services
* Created tests for `AnalysisJobItemResults` services
* Created menu route for `AnalysisJobItem`

## Problems

There is currently no way to effectively test the models and services. The functionality of these models and services also needs to be implemented in later issues as part of #2008.

## Issues

Fixes: #2010 

## Visual Changes
NA.

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
