### PR TITLE
Added ability to edit site position through map

### DIFF
--- a/src/app/components/shared/formly/location-input.component.spec.ts
+++ b/src/app/components/shared/formly/location-input.component.spec.ts
@@ -1,1 +1,176 @@
-// TODO
+import { fakeAsync, tick } from "@angular/core/testing";
+import {
+  FormControl,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule,
+} from "@angular/forms";
+import { GoogleMapsModule } from "@angular/google-maps";
+import { embedGoogleMaps } from "@helpers/embedScript/embedGoogleMaps";
+import { createHostFactory, SpectatorHost } from "@ngneat/spectator";
+import { FormlyBootstrapModule } from "@ngx-formly/bootstrap";
+import { FormlyFieldProps, FormlyModule } from "@ngx-formly/core";
+import { MapComponent } from "@shared/map/map.component";
+import { modelData } from "@test/helpers/faker";
+import { MockComponent, MockedComponent } from "ng-mocks";
+import { formlyConfig } from "./custom-inputs.module";
+import { LocationInputComponent } from "./location-input.component";
+
+const mockMapComponent = MockComponent(MapComponent);
+
+describe("FormlyLocationInput", () => {
+  let model: any;
+  let formGroup: FormGroup;
+  let spectator: SpectatorHost<LocationInputComponent>;
+
+  const createHost = createHostFactory({
+    declarations: [mockMapComponent],
+    component: LocationInputComponent,
+    imports: [
+      FormsModule,
+      ReactiveFormsModule,
+      FormlyModule.forRoot(formlyConfig),
+      FormlyBootstrapModule,
+      GoogleMapsModule,
+    ],
+  });
+
+  function setup(key: string = "input", options: FormlyFieldProps = {}) {
+    formGroup = new FormGroup({ input: new FormControl("") });
+    model = {};
+
+    spectator = createHost(
+      `
+      <form [formGroup]="formGroup">
+        <baw-location-input></baw-location-input>
+      </form>
+      `,
+      {
+        hostProps: { formGroup },
+        props: {
+          field: {
+            model,
+            key,
+            formControl: formGroup.get("input"),
+            props: options,
+          },
+        },
+      }
+    );
+    spectator.detectChanges();
+
+    return spectator;
+  }
+
+  beforeAll(async () => await embedGoogleMaps());
+
+  const getLatitudeInput = () => spectator.query<HTMLInputElement>("#latitude");
+
+  const getLongitudeInput = () =>
+    spectator.query<HTMLInputElement>("#longitude");
+
+  function updateMarkerThroughInput(longitude: number, latitude: number) {
+    const latitudeInput = getLatitudeInput();
+    const longitudeInput = getLongitudeInput();
+
+    longitudeInput.value = longitude.toString();
+    longitudeInput.dispatchEvent(new Event("input"));
+    latitudeInput.value = latitude.toString();
+    latitudeInput.dispatchEvent(new Event("input"));
+
+    spectator.detectChanges();
+  }
+
+  /**
+   * Changes the markers position by directly editing the model.
+   * This is used to initialize the marker to the correct position, when the input field might not work
+   */
+  function explicitlySetMarker(longitude: number, latitude: number) {
+    spectator.component.updateModel(longitude, latitude);
+    spectator.detectChanges();
+  }
+
+  function assertMapModelCoordinates(
+    map: MockedComponent<MapComponent>,
+    longitude: number,
+    latitude: number
+  ) {
+    expect(map.markers.toArray()[0]["position"]["lng"]).toEqual(longitude);
+    expect(map.markers.toArray()[0]["position"]["lat"]).toEqual(latitude);
+  }
+
+  it("should create", () => {
+    setup();
+    expect(spectator.component).toBeInstanceOf(LocationInputComponent);
+  });
+
+  it("should display the position of the marker in input boxes", fakeAsync(() => {
+    setup();
+    const defaultLongitudeValue = modelData.longitude();
+    const defaultLatitudeValue = modelData.latitude();
+
+    explicitlySetMarker(defaultLongitudeValue, defaultLatitudeValue);
+
+    tick();
+
+    expect(getLongitudeInput().value).toEqual(defaultLongitudeValue.toString());
+    expect(getLatitudeInput().value).toEqual(defaultLatitudeValue.toString());
+  }));
+
+  it("should update the marker model if the location is updated through the input field/form", () => {
+    setup();
+    const map = spectator.query(mockMapComponent);
+    const defaultLongitudeValue = modelData.longitude();
+    const defaultLatitudeValue = modelData.latitude();
+
+    // set the markers to a starting position
+    explicitlySetMarker(defaultLongitudeValue, defaultLatitudeValue);
+
+    // change the markers location through the input field
+    const updatedLongitudeValue = modelData.longitude();
+    const updatedLatitudeValue = modelData.latitude();
+
+    updateMarkerThroughInput(updatedLongitudeValue, updatedLatitudeValue);
+
+    // assert that the marker location has changed to the new location
+    assertMapModelCoordinates(map, updatedLongitudeValue, updatedLatitudeValue);
+  });
+
+  it("should update the marker model if the marker is dragged", () => {
+    setup();
+    const map = spectator.query(mockMapComponent);
+    const defaultLongitudeValue = modelData.longitude();
+    const defaultLatitudeValue = modelData.latitude();
+
+    // spy on the updateModel method so that we can assert later that it was called
+    // with the correct parameters
+    explicitlySetMarker(defaultLongitudeValue, defaultLatitudeValue);
+    spyOn<any>(spectator.component, "updateModel").and.callThrough();
+
+    // simulate moving the marker to a new position
+    const updatedLongitude = modelData.longitude();
+    const updatedLatitude = modelData.latitude();
+    // simulate dragging and dropping the marker by sending a drag event to the map
+    const newPosition = {
+      lng: () => updatedLongitude,
+      lat: () => updatedLatitude,
+      equals: () => null,
+      toJSON: () => null,
+      toUrlValue: () => null,
+    } as google.maps.LatLng;
+
+    map.newLocation.emit({
+      domEvent: new Event("mapDragend"),
+      latLng: newPosition,
+      stop: () => {},
+    });
+
+    spectator.detectChanges();
+
+    expect(spectator.component.updateModel).toHaveBeenCalledWith(
+      newPosition.lng(),
+      newPosition.lat()
+    );
+    assertMapModelCoordinates(map, updatedLongitude, updatedLatitude);
+  });
+});

--- a/src/app/components/shared/formly/location-input.component.ts
+++ b/src/app/components/shared/formly/location-input.component.ts
@@ -11,6 +11,7 @@ import { asFormControl } from "./helper";
 /**
  * Location Input
  * ! Warning, test manually after changes
+ * Modifying the location through map clicks and drag are not fully tested through the unit tests and should be tested manually
  */
 @Component({
   selector: "baw-location-input",
@@ -66,7 +67,11 @@ import { asFormControl } from "./helper";
     </div>
 
     <div class="mb-3" style="height: 400px">
-      <baw-map [markers]="marker"></baw-map>
+      <baw-map
+        [markers]="marker"
+        [markerOptions]="{ draggable: true }"
+        (newLocation)="updateModel($event.latLng.lng(), $event.latLng.lat())"
+      ></baw-map>
     </div>
   `,
 })
@@ -92,7 +97,10 @@ export class LocationInputComponent extends FieldType implements OnInit {
   /**
    * Update hidden input
    */
-  public updateModel() {
+  public updateModel(longitude?: number, latitude?: number) {
+    this.latitude = latitude ?? this.latitude;
+    this.longitude = longitude ?? this.longitude;
+
     this.formControl.setValue({
       latitude: this.latitude,
       longitude: this.longitude,

--- a/src/app/components/shared/map/map.component.ts
+++ b/src/app/components/shared/map/map.component.ts
@@ -1,8 +1,10 @@
 import {
   AfterViewChecked,
   Component,
+  EventEmitter,
   Input,
   OnChanges,
+  Output,
   QueryList,
   ViewChild,
   ViewChildren,
@@ -22,11 +24,17 @@ import { takeUntil } from "rxjs/operators";
   template: `
     <!-- Display map -->
     <ng-container *ngIf="hasMarkers && googleMapsLoaded">
-      <google-map height="100%" width="100%" [options]="mapOptions">
+      <google-map
+        height="100%"
+        width="100%"
+        [options]="mapOptions"
+        (mapClick)="markerOptions.draggable && newLocation.emit($event)"
+      >
         <map-marker
           *ngFor="let marker of filteredMarkers"
           [options]="markerOptions"
           [position]="marker.position"
+          (mapDragend)="newLocation.emit($event)"
         >
         </map-marker>
         <map-info-window>{{ infoContent }}</map-info-window>
@@ -54,13 +62,15 @@ export class MapComponent
   @ViewChildren(MapMarker) public mapMarkers: QueryList<MapMarker>;
 
   @Input() public markers: List<MapMarkerOptions>;
+  @Input() public markerOptions: MapMarkerOptions;
+  @Output() public newLocation = new EventEmitter<google.maps.MapMouseEvent>();
+
   public filteredMarkers: MapMarkerOptions[];
   public hasMarkers = false;
   public infoContent = "";
 
   // Setting to "hybrid" can increase load times and looks like the map is bugged
   public mapOptions: MapOptions = { mapTypeId: "satellite" };
-  public markerOptions: MapMarkerOptions = {};
   public bounds: google.maps.LatLngBounds;
   private updateMap: boolean;
 


### PR DESCRIPTION
# Added ability to edit site position through map

The ability to change the position of a site through the embedded Google map was not functional. This PR adds the functionality required to edit the location of a site using the map provided in the `location-input.component.ts`

## Changes

* Made marker attributes an optional `@Input()` / attribute of the `baw-map`
* Modified `updateModel()` method in `location-input.component.ts` to optionally take a new longitude and latitude
* Made the `baw-map` markers emit an event every time the marker is moved
* Created unit tests for changes made to the `location-input.component.ts`

## Problems
N/A

## Issues

#2001 

## Visual Changes
N/A

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
