### PR TITLE
Fix remove image button

### DIFF
--- a/src/app/components/shared/formly/image-input.component.spec.ts
+++ b/src/app/components/shared/formly/image-input.component.spec.ts
@@ -35,7 +35,8 @@ describe("FormlyImageInput", () => {
   function setup(key: string = "file", options: FormlyFieldProps = {}) {
     formGroup = new FormGroup({ asFormControl: new FormControl("") });
     model = {
-      image: ""
+      image: "",
+      imageUrls: []
     };
 
     spectator = createHost(
@@ -67,9 +68,33 @@ describe("FormlyImageInput", () => {
   });
 
   describe("removeImage", () => {
-    it("should display the remove image button", () => {
+    it("should display the remove image button if the model has an image", () => {
+      setup();
+      // project_span4.png is the file name of the project default image
+      // if this test is not passing, it may be because the condition for the remove
+      // image button is dependent on the file name
+      model.image = new File([""], "project_span4.png");
+      spectator.detectChanges();
+
+      expect(getButton()).toBeTruthy();
+    });
+
+    it("should not display remove image button if the model does not have an image" , () => {
+      setup();
+      model.image = null;
+      spectator.detectChanges();
+
+      expect(getButton()).toBeNull();
+    });
+
+    it("should not display remove image button once the button has been clicked", () => {
       setup();
       expect(getButton()).toBeTruthy();
+
+      getButton().click();
+      spectator.detectChanges();
+
+      expect(getButton()).toBeNull();
     });
 
     it("should set model value to null on click", () => {

--- a/src/app/components/shared/formly/image-input.component.ts
+++ b/src/app/components/shared/formly/image-input.component.ts
@@ -1,5 +1,6 @@
-import { Component, ViewChild, ElementRef } from "@angular/core";
+import { Component, ViewChild, ElementRef, AfterViewInit } from "@angular/core";
 import { FieldType } from "@ngx-formly/core";
+import { ImageUrl } from "@interfaces/apiInterfaces";
 import { asFormControl } from "./helper";
 
 /**
@@ -14,10 +15,7 @@ import { asFormControl } from "./helper";
         {{ props.label + (props.required ? " *" : "") }}
       </label>
 
-      <div
-        class="input-group"
-        style="border: 1px solid #ced4da; border-radius: 0.25rem;"
-      >
+      <div class="form-control input-group p-0">
         <!-- Ensure only one file can be selected in input -->
         <input
           #imageInput
@@ -30,18 +28,63 @@ import { asFormControl } from "./helper";
         />
 
         <button
+          *ngIf="!usesDefaultImage"
           type="button"
           (click)="removeImage()"
-          class="btn btn-outline-danger"
-        >Remove</button>
+          class="btn btn-outline-danger pb-1"
+        >
+          Remove
+        </button>
       </div>
     </div>
   `,
 })
-export class ImageInputComponent extends FieldType {
+export class ImageInputComponent extends FieldType implements AfterViewInit {
   @ViewChild("imageInput")
   public imageInput: ElementRef;
   public asFormControl = asFormControl;
+
+  public ngAfterViewInit() {
+    if (!this.usesDefaultImage) {
+      const imageUrls = this.model.imageUrls as ImageUrl[];
+      const currentImage = imageUrls && imageUrls[0];
+      const imageFileName = this.fileName(currentImage?.url);
+
+      // if the current model has a different image to the default image, display the name of the file in the image input
+      // for security reasons, modern web browsers don't allow changing a file inputs value directly
+      // because of this we need to use a data transfer which is performed in "protected mode"
+      // https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/files
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(new File([""], imageFileName));
+      this.imageInput.nativeElement.files = dataTransfer.files;
+    }
+  }
+
+  /**
+   * A predicate that returns if the models image is a default image
+   */
+  public get usesDefaultImage(): boolean {
+    const imageUrls = this.model?.imageUrls as ImageUrl[];
+    const isUsingServerDefaultImage = imageUrls?.every((image: ImageUrl): boolean => image.default);
+
+    // returns true if the current image used is a default image and if the user hasn't redefined the image
+    // or returns true if the user explicitly sets the image as default, by setting the models image attribute to null
+    return (
+      (isUsingServerDefaultImage && this.model.image === undefined) ||
+      this.model.image === null
+    );
+  }
+
+  private fileName(filePath: string): string {
+    return (
+      filePath?.split("/")
+        .pop()
+        // remove URL parameters from the file name
+        .split("?")
+        .shift()
+    );
+  }
+
   public readFile(): void {
     // File input returns a list of files, grab the first file and set it as
     // the value of this field

--- a/src/app/interfaces/apiInterfaces.ts
+++ b/src/app/interfaces/apiInterfaces.ts
@@ -141,6 +141,7 @@ export interface ImageUrl {
   url: string;
   height?: number;
   width?: number;
+  default?: boolean;
 }
 
 /**

--- a/src/app/models/AttributeDecorators.spec.ts
+++ b/src/app/models/AttributeDecorators.spec.ts
@@ -233,6 +233,7 @@ describe("Attribute Decorators", () => {
       defaultImageUrl = {
         url: `${assetRoot}/broken_link.png`,
         size: ImageSizes.default,
+        default: true,
       };
     });
 

--- a/src/app/models/AttributeDecorators.ts
+++ b/src/app/models/AttributeDecorators.ts
@@ -83,7 +83,11 @@ export function bawImage<Model>(
   opts?: BawDecoratorOptions<Model>
 ) {
   // Retrieve default image and prepend site url if required
-  const defaultImage: ImageUrl = { size: ImageSizes.default, url: defaultUrl };
+  const defaultImage: ImageUrl = {
+    size: ImageSizes.default,
+    url: defaultUrl,
+    default: true,
+  };
 
   const sortImageUrls = (a: ImageUrl, b: ImageUrl): -1 | 0 | 1 => {
     // Default image should always be last in array
@@ -128,6 +132,19 @@ export function bawImage<Model>(
           defaultImage,
         ];
       } else if (imageUrls instanceof Array && imageUrls.length > 0) {
+        // TODO This code chunk is only a temporary hack and can be removed without modification when the baw-api issue below is resolved
+        // https://github.com/QutEcoacoustics/baw-server/issues/640
+        // at the moment, default images are defined by the baw-api by returning image urls matching the regex expression below
+        // in a future iteration of the api, the image urls attribute will not be returned when the image is a default image
+        const defaultImageMatchingRegex = new RegExp(
+          "^/images/(.*)/(\\1)_span.*.png$"
+        );
+        // iterate through the image url's validating if they match the default image url format. If they do, set the default flag
+        imageUrls = imageUrls.map((image) => ({
+          ...image,
+          ...(defaultImageMatchingRegex.test(image.url) && { default: true }),
+        }));
+
         // Copy and sort image urls
         const output = imageUrls
           .map((imageUrl) => ({


### PR DESCRIPTION
# Fix remove image button

The remove image button should only show when a project has an image

## Changes

- Displays the currently set image file name in the image input box
- Adds a `default` flag to baw images (outlined in `AttributeDecorators.ts`)
- Adds a _TODO_ to delete the code block [here](https://github.com/QutEcoacoustics/workbench-client/pull/2017/files#diff-5cf4eef2ac11e42d9b8698e07af25283f1d339b38cd87d8188bc87ad5984ae3bR135) once the baw-api issue baw-api#640 is resolved
- Fixes bug where remove button caused the file input containers height to expand
- Changes image input component to use classes from the baw stylesheet instead of hard coded inline css values

## Issues
Fixes: #1994 

## Visual Changes
From:
![image](https://user-images.githubusercontent.com/33742269/209920018-b1459b4b-4532-45ad-b8a6-a81d1b2c6f33.png)

To:
![image](https://user-images.githubusercontent.com/33742269/212229520-933119f1-a49f-44ad-97f8-46a1fe33c58a.png)

**Visual Changes List:**
- Image input component now uses boostrap classes for border colours (it had previously hard coded these values in a `style` attribute)
- The remove image button now fits inside it's parent item
- If the model does not have a default image, it now shows the file name in the input box

_Notes: First image was taken on Firefox, where the "Browse..." text is used, the second was taken from Edge where the "Choose File" text is used, hence the change in text_

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
