### PR TITLE
Do not show bulk audio download command if the user is not logged in

### DIFF
--- a/src/app/components/audio-recordings/pages/download/download.component.html
+++ b/src/app/components/audio-recordings/pages/download/download.component.html
@@ -329,14 +329,15 @@
 
   <p id="run-script-description">
     Copy and paste the following command into your PowerShell session.
-    <span *ngIf="!session.authToken">
-      Login to see the command filled with your authentication token.
-    </span>
   </p>
 
-  <code id="guest-run-script" *ngIf="!session.authToken">{{
-    runScriptCommand
-  }}</code>
+  <div
+    id="guest-run-script"
+    class="alert alert-warning"
+    *ngIf="!session.authToken"
+  >
+    <i><a [strongRoute]="loginStrongRoute">Log in</a> to see this command.</i>
+  </div>
 
   <baw-hidden-copy
     *ngIf="session.authToken"

--- a/src/app/components/audio-recordings/pages/download/download.component.spec.ts
+++ b/src/app/components/audio-recordings/pages/download/download.component.spec.ts
@@ -589,12 +589,13 @@ describe("DownloadAudioRecordingsComponent", () => {
       expect(spec.query("section")).toContainText("Instructions");
     });
 
-    it("should show instructions for guest users", () => {
+    it("should show a prompt to log in for guest users", () => {
       setup(defaultProject);
       spec.detectChanges();
-      expect(spec.query("#run-script-description")).toContainText("Login");
       expect(spec.query("#guest-run-script")).toBeTruthy();
       expect(spec.query(HiddenCopyComponent)).toBeFalsy();
+
+      expect((spec.query("#guest-run-script") as HTMLElement).innerText).toEqual("Log in to see this command.");
     });
 
     it("should show instructions for logged in users", () => {
@@ -602,7 +603,6 @@ describe("DownloadAudioRecordingsComponent", () => {
       setup(defaultProject, undefined, undefined, authToken);
       spec.detectChanges();
 
-      expect(spec.query("#run-script-description")).not.toContainText("Login");
       expect(spec.query("#guest-run-script")).toBeFalsy();
 
       const hiddenCopy = spec.query(HiddenCopyComponent);
@@ -622,7 +622,6 @@ describe("DownloadAudioRecordingsComponent", () => {
         guestAuthToken;
       spec.detectChanges();
 
-      expect(spec.query("#run-script-description")).toContainText("Login");
       expect(spec.query("#guest-run-script")).toBeTruthy();
       expect(spec.query(HiddenCopyComponent)).toBeFalsy();
     });

--- a/src/app/components/audio-recordings/pages/download/download.component.ts
+++ b/src/app/components/audio-recordings/pages/download/download.component.ts
@@ -21,6 +21,7 @@ import {
 import { myAccountMenuItem } from "@components/profile/profile.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { IPageInfo } from "@helpers/page/pageInfo";
+import { StrongRoute } from "@interfaces/strongRoute";
 import { AudioRecording } from "@models/AudioRecording";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
@@ -36,6 +37,7 @@ import {
   distinctUntilChanged, takeUntil
 } from "rxjs";
 import { defaultDebounceTime } from "src/app/app.helper";
+import { loginMenuItem } from "src/app/components/security/security.menus"
 
 const projectKey = "project";
 const regionKey = "region";
@@ -119,9 +121,11 @@ class DownloadAudioRecordingsComponent
   }
 
   public get runScriptCommand(): string {
-    return `./download_audio_files.ps1 -auth_token "${
-      this.session.authToken ?? "INSERT_AUTH_TOKEN_HERE"
-    }"`;
+    return `./download_audio_files.ps1 -auth_token "${this.session.authToken}"`;
+  }
+
+  public get loginStrongRoute(): StrongRoute {
+    return loginMenuItem.route;
   }
 
   public updateHref(model: Model): void {


### PR DESCRIPTION
# Do not show bulk audio download command if the user is not logged in

It has been reported that users are regularly pasting the bulk audio download command directly into their shell without replacing the `"INSERT_AUTH_TOKEN_HERE"` placeholder. To fix this, we should require users to log in before this command is shown.

## Changes

- Requires the user to log in to see the bulk download audio command
- Removes redundant information above command stating that they need to "Login to see the command filled with your authentication token." This is now replaced by the command not showing, but alerting the user to log in through an embedded anchor that redirects back to the view once the user is authenticated.

## Problems

None

## Issues

Fixes: #1930 

## Visual Changes

![image](https://user-images.githubusercontent.com/33742269/210720792-1551f128-f72b-4a28-80e4-c958f72348ed.png)

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
