### PR TITLE
Harvest UI tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Normal development
 $ npm start
 ```
 
-Then open a web browser to `https://localhost:4200`.
+Then open a web browser to `https://development.ecosounds.org:4200`.
 
 Server side rendering
 

--- a/src/app/components/harvest/screens/uploading/batch-uploading.component.html
+++ b/src/app/components/harvest/screens/uploading/batch-uploading.component.html
@@ -29,6 +29,13 @@
           and we will check them for you
         </li>
         <li>
+          We advise that you use this
+          <a href="https://winscp.net/eng/docs/ui_pref_background#background_transfers">
+            guide
+          </a>
+          to enable the WinSCP background transfer by default option
+        </li>
+        <li>
           Once done uploading, close WinSCP before clicking on the Finished
           Uploading button below
         </li>
@@ -135,7 +142,7 @@
 
 <div [ngbNavOutlet]="nav" class="mt-2"></div>
 
-<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-4 mb-3">
+<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-2 g-4 mb-3">
   <div class="col">
     <div class="card h-100">
       <div class="card-body">
@@ -186,6 +193,7 @@
           Upload your data using whatever folder structure you would like.
           Filenames will need to follow this
           <a target="_blank" [href]="filenameGuide | safe: 'url'">guide</a>.
+          You will be able to assign a point/site to any folder later on.
         </p>
       </div>
     </div>


### PR DESCRIPTION
# Harvest UI tweaks

Modify the Harvest batch upload UI with changes specified in #1968 (below)
- Point out on "Upload your data" card that You can assign a point/site to any folder later on
- Change the card grid to 2x2
- Add advice to set WinSCP to background transfer by default

## Changes

- Discloses to the user that they assign points/sites to folders later
- Changes the card grid to 2x2
- Adds an extra step for windows users as a suggestion to enable WinSCP's background transfer by default option
  - Adds a link to a wiki article [https://github.com/QutEcoacoustics/workbench-client/wiki/Harvest-Proposal#WinSCP-Background-Transfer](https://github.com/QutEcoacoustics/workbench-client/wiki/Harvest-Proposal#WinSCP-Background-Transfer) outlining how to enable WinSCP's background transfer by default option.
- Updates the README.md to point users to the development environment `https://development.ecosounds.org:4200/` instead of `https://localhost:4200`

## Problems

- This requires the creation of a new wiki article located at [https://github.com/QutEcoacoustics/workbench-client/wiki/Harvest-Proposal#WinSCP-Background-Transfer](https://github.com/QutEcoacoustics/workbench-client/wiki/Harvest-Proposal#WinSCP-Background-Transfer) (pending approval that this is the correct approach)

## Issues

Fixes: #1968 

## Visual Changes

![image](https://user-images.githubusercontent.com/33742269/210303433-27d07c10-d03f-4cad-8005-5f831d4dbcfa.png)

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
