### PR TITLE
Download pwsh step

### DIFF
--- a/src/app/components/audio-recordings/pages/download/download.component.html
+++ b/src/app/components/audio-recordings/pages/download/download.component.html
@@ -309,13 +309,19 @@
 
   <h3>4. Open PowerShell</h3>
 
-  <p>
-    <a
-      href="https://www.groovypost.com/howto/open-command-window-terminal-window-specific-folder-windows-mac-linux/"
-      >Open a PowerShell shell</a
-    >
-    in the folder containing the download script
-  </p>
+  <ul>
+    <li>
+      <a
+        href="https://www.groovypost.com/howto/open-command-window-terminal-window-specific-folder-windows-mac-linux/"
+      >
+        Open a Powershell shell
+      </a>
+      in the folder containing the download script
+    </li>
+    <li>
+      If you are on Linux/MacOS, run the <code>pwsh</code> command from your terminal to start PowerShell.
+    </li>
+  </ul>
 
   <!-- TODO Show users how with asciicast -->
 


### PR DESCRIPTION
# Communicate extra `pwsh` step to MacOS & Linux users on how to start Powershell

At the moment, batch downloading audio recordings on MacOS and Linux outlines how to start a terminal / Powershell window in the folder containing the download script, however, it does not express that MacOS & Linux users are required to type the `pwsh` command into the CLI to start Powershell.

## Changes

- Adds the step to run the pwsh command on MacOS/Linux from the terminal to start Powershell
- Adds terminology to start "Terminal" from the folder containing

## Problems

None

## Issues

Fixes: #1931 

## Visual Changes

![image](https://user-images.githubusercontent.com/33742269/210307770-d3bfefe4-bcfe-485b-b567-0782f46253a0.png)

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
