### PR TITLE
Fix: "Created" date time on Harvest list page does not show date time in users local time zone

### DIFF
--- a/src/app/components/audio-recordings/pages/list/list.component.spec.ts
+++ b/src/app/components/audio-recordings/pages/list/list.component.spec.ts
@@ -1,24 +1,19 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { createRoutingFactory, SpectatorRouting } from "@ngneat/spectator";
+import { SharedModule } from "@shared/shared.module";
 import { AudioRecordingsListComponent } from "./list.component";
 
-// TODO
-xdescribe("AudioRecordingsListComponent", () => {
-  let component: AudioRecordingsListComponent;
-  let fixture: ComponentFixture<AudioRecordingsListComponent>;
+describe("AudioRecordingsListComponent", () => {
+  let spectator: SpectatorRouting<AudioRecordingsListComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [AudioRecordingsListComponent],
-    }).compileComponents();
+  const createComponent = createRoutingFactory({
+    component: AudioRecordingsListComponent,
+    imports: [MockBawApiModule, SharedModule],
   });
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AudioRecordingsListComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+  beforeEach(() => spectator = createComponent({ detectChanges: false }));
 
   it("should create", () => {
-    expect(component).toBeTruthy();
+    expect(spectator.component).toBeInstanceOf(AudioRecordingsListComponent);
   });
 });

--- a/src/app/components/harvest/pages/list/list.component.ts
+++ b/src/app/components/harvest/pages/list/list.component.ts
@@ -93,7 +93,7 @@ class ListComponent extends PageComponent implements OnInit {
   }
 
   public formatDate(date: DateTime): string {
-    return date.toFormat("yyyy-MM-dd HH:mm:ss");
+    return date.toLocal().toFormat("yyyy-MM-dd HH:mm:ss");
   }
 }
 


### PR DESCRIPTION
# Fix: "Created" date time on Harvest list page does not show date time in users local time zone

Currently, when a user uploads a Harvest, the created time will be shown in the UTC+0 time zone. The is incorrect as a it is a client side date / local date and should be shown in the users time zone.

## Changes

- Modified date formatter methods used in the Harvest list component to show all date times in the users local time zone
- Created tests to validate that the harvest created at column shows date / times in the users local time zone

_Minor Changes:_
- Created unit test bed for audio recording list component
  - This is limited to a "does create" test

## Issues

Fixes: #1977 

## Visual Changes

**Before**
![image](https://user-images.githubusercontent.com/33742269/222998980-a204aa42-8102-4014-b2fa-5bcdbe4764c5.png)

**After**
![image](https://user-images.githubusercontent.com/33742269/222998929-e2bd188a-ad2c-40d2-8aad-bb52c05e1f70.png)

_The above screenshot was taken from Brisbane, QLD (UTC+10). Therefore, all times after change are +10 hours_

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
