### PR TITLE
Add recording filtering component and adjust existing filter form validations

### DIFF
--- a/src/app/components/audio-recordings/audio-recording.module.ts
+++ b/src/app/components/audio-recordings/audio-recording.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from "@angular/core";
 import { RouterModule } from "@angular/router";
 import { getRouteConfigForPage } from "@helpers/page/pageRouting";
+import { AudioRecordingsFilterComponent } from "@shared/date-time-filter/audio-recordings-filter.component";
 import { SharedModule } from "@shared/shared.module";
 import { audioRecordingsRoutes } from "./audio-recording.routes";
 import { DownloadTableComponent } from "./components/download-table/download-table.component";
@@ -18,6 +19,7 @@ const components = [
   AudioRecordingsListComponent,
   AudioRecordingsDetailsComponent,
   DownloadAudioRecordingsComponent,
+  AudioRecordingsFilterComponent,
 ];
 
 const routes = Object.values(audioRecordingsRoutes)

--- a/src/app/components/audio-recordings/pages/download/download.component.html
+++ b/src/app/components/audio-recordings/pages/download/download.component.html
@@ -7,228 +7,50 @@
   [project]="project"
 ></baw-sites-without-timezones>
 
-<form #form class="mb-3">
-  <!-- Project -->
-  <div *ngIf="project" class="mb-3">
-    <label id="project-label" for="project" class="form-label">Project</label>
-    <input
-      readonly
-      id="project"
-      name="project"
-      class="form-control-plaintext"
-      [ngModel]="project.name"
-    />
-  </div>
+<!-- Project -->
+<div *ngIf="project" class="mb-3">
+  <label id="project-label" for="project" class="form-label">Project</label>
+  <input
+    readonly
+    id="project"
+    name="project"
+    class="form-control-plaintext"
+    [ngModel]="project.name"
+  />
+</div>
 
-  <!-- Region -->
-  <div *ngIf="region" class="mb-3">
-    <label id="region-label" for="region" class="form-label">Site</label>
-    <input
-      readonly
-      id="region"
-      name="region"
-      class="form-control-plaintext"
-      [ngModel]="region.name"
-    />
-  </div>
+<!-- Region -->
+<div *ngIf="region" class="mb-3">
+  <label id="region-label" for="region" class="form-label">Site</label>
+  <input
+    readonly
+    id="region"
+    name="region"
+    class="form-control-plaintext"
+    [ngModel]="region.name"
+  />
+</div>
 
-  <!-- Site -->
-  <div *ngIf="site" class="mb-3">
-    <label id="site-label" for="site" class="form-label">{{
-      region ? "Point" : "Site"
-    }}</label>
-    <input
-      readonly
-      id="site"
-      name="site"
-      class="form-control-plaintext"
-      [ngModel]="site.name"
-    />
-  </div>
+<!-- Site -->
+<div *ngIf="site" class="mb-3">
+  <label id="site-label" for="site" class="form-label">{{
+    region ? "Point" : "Site"
+  }}</label>
+  <input
+    readonly
+    id="site"
+    name="site"
+    class="form-control-plaintext"
+    [ngModel]="site.name"
+  />
+</div>
 
-  <!-- Toggle filtering by date -->
-  <div class="form-check">
-    <input
-      id="date-filtering"
-      name="dateFiltering"
-      type="checkbox"
-      class="form-check-input"
-      [(ngModel)]="model.dateFiltering"
-    />
-
-    <label class="form-check-label" for="date-filtering">Filter by date</label>
-
-    <div class="form-text">Filter recordings over a date range</div>
-  </div>
-
-  <!-- Date filters -->
-  <div
-    id="date-filters-wrapper"
-    #collapse="ngbCollapse"
-    [ngbCollapse]="!model.dateFiltering"
-  >
-    <div class="card">
-      <div class="card-body">
-        <div class="row">
-          <!-- Start date input -->
-          <div class="col-md-6 mb-3 mb-md-0">
-            <div class="input-group">
-              <span class="input-group-text">Start Date</span>
-              <input
-                #dateStartedAfter="ngbDatepicker"
-                ngbDatepicker
-                id="date-started-after"
-                name="dateStartedAfter"
-                class="form-control"
-                placeholder="yyyy-mm-dd"
-                [class.is-invalid]="invalidDate(model.dateStartedAfter)"
-                [maxDate]="model.dateFinishedBefore"
-                [(ngModel)]="model.dateStartedAfter"
-              />
-              <button
-                class="btn btn-outline-secondary"
-                (click)="dateStartedAfter.toggle()"
-                type="button"
-              >
-                <fa-icon [icon]="['fas', 'calendar']"></fa-icon>
-              </button>
-              <div
-                *ngIf="invalidDate(model.dateStartedAfter)"
-                class="invalid-feedback"
-              >
-                The time should follow the format yyyy-mm-dd, e.g. 2022-12-01
-              </div>
-            </div>
-          </div>
-
-          <!-- End date input -->
-          <div class="col-md-6 mb-3 mb-md-0">
-            <div class="input-group">
-              <span class="input-group-text">End Date</span>
-              <input
-                #dateFinishedBefore="ngbDatepicker"
-                ngbDatepicker
-                id="date-finished-before"
-                name="dateFinishedBefore"
-                class="form-control"
-                placeholder="yyyy-mm-dd"
-                [class.is-invalid]="invalidDate(model.dateFinishedBefore)"
-                [minDate]="model.dateStartedAfter"
-                [(ngModel)]="model.dateFinishedBefore"
-              />
-              <button
-                class="btn btn-outline-secondary"
-                (click)="dateFinishedBefore.toggle()"
-                type="button"
-              >
-                <fa-icon [icon]="['fas', 'calendar']"></fa-icon>
-              </button>
-              <div
-                *ngIf="invalidDate(model.dateFinishedBefore)"
-                class="invalid-feedback"
-              >
-                The time should follow the format yyyy-mm-dd, e.g. 2022-12-01
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="form-text">
-          <strong>
-            The UTC (+00:00) time zone is used for all date filtering.
-          </strong>
-          If you're unsure if your data will be included in a filter, expand
-          your date range by one-day in either direction.
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Toggle filtering by time of day -->
-  <div class="form-check mt-3">
-    <input
-      id="tod-filtering"
-      name="todFiltering"
-      type="checkbox"
-      class="form-check-input"
-      [(ngModel)]="model.todFiltering"
-    />
-
-    <label class="form-check-label" for="tod-filtering">
-      Filter by time of day
-    </label>
-
-    <div class="form-text">
-      Filter recordings by the time of day they were recorded. If any part of a
-      recording overlaps these limits, then it will be included.
-    </div>
-  </div>
-
-  <!-- Time of day filters -->
-  <div
-    id="tod-filters-wrapper"
-    #collapse="ngbCollapse"
-    [ngbCollapse]="!model.todFiltering"
-  >
-    <div class="card">
-      <div class="card-body">
-        <div class="row mb-3">
-          <!-- Start time input -->
-          <div class="col-md-6 mb-3 mb-md-0">
-            <baw-time
-              id="tod-started-after"
-              name="todStartedAfter"
-              label="Start Time"
-              type="time"
-              [(ngModel)]="model.todStartedAfter"
-            ></baw-time>
-          </div>
-
-          <!-- End time input -->
-          <div class="col-md-6">
-            <baw-time
-              id="tod-finished-before"
-              name="todFinishedBefore"
-              label="End Time"
-              type="time"
-              [(ngModel)]="model.todFinishedBefore"
-            ></baw-time>
-          </div>
-
-          <div *ngIf="errors.todBoundaryError" class="form-error">
-            Time of day filtering does not currently support filtering past a
-            day boundary. Please adjust your request so that the start time is
-            before the end time.
-          </div>
-        </div>
-
-        <!-- Ignore daylight savings checkbox -->
-        <div class="form-check">
-          <input
-            id="tod-ignore-dst"
-            name="todIgnoreDst"
-            type="checkbox"
-            class="form-check-input"
-            [disabled]="!model.todFiltering"
-            [(ngModel)]="model.todIgnoreDst"
-          />
-
-          <label class="form-check-label" for="tod-ignore-dst">
-            Ignore day light savings (DST)
-          </label>
-
-          <div class="form-text">
-            Real world events, like dawn chorus, or the vocalization of fauna
-            are not affected by daylight savings time. Ignoring DST is advised
-            to ensure audio is filtered consistently. If any recordings occur
-            during a DST period, the base offset, that is the time it would be
-            if DST were not in effect, will be used.
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</form>
+<baw-audio-recordings-filter
+  [project]="project"
+  [region]="region"
+  [site]="site"
+  [constructedFilters]="filters$"
+></baw-audio-recordings-filter>
 
 <div class="clearfix">
   <a

--- a/src/app/components/audio-recordings/pages/download/download.component.ts
+++ b/src/app/components/audio-recordings/pages/download/download.component.ts
@@ -1,23 +1,15 @@
-import { AfterViewInit, Component, OnInit, ViewChild } from "@angular/core";
+import { Component, OnInit, ViewChild } from "@angular/core";
 import { NgForm } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
 import { AudioRecordingsService } from "@baw-api/audio-recording/audio-recordings.service";
-import {
-  Comparisons,
-  DateExpressions,
-  Filters,
-  InnerFilter
-} from "@baw-api/baw-api.service";
+import { Filters } from "@baw-api/baw-api.service";
 import { BawSessionService } from "@baw-api/baw-session.service";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { regionResolvers } from "@baw-api/region/regions.service";
 import { ResolvedModelList, retrieveResolvers } from "@baw-api/resolver-common";
 import { siteResolvers } from "@baw-api/site/sites.service";
 import { contactUsMenuItem } from "@components/about/about.menus";
-import {
-  audioRecordingMenuItems,
-  audioRecordingsCategory
-} from "@components/audio-recordings/audio-recording.menus";
+import { audioRecordingMenuItems, audioRecordingsCategory } from "@components/audio-recordings/audio-recording.menus";
 import { myAccountMenuItem } from "@components/profile/profile.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { IPageInfo } from "@helpers/page/pageInfo";
@@ -26,52 +18,25 @@ import { AudioRecording } from "@models/AudioRecording";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
-import {
-  NgbCalendar,
-  NgbDate,
-  NgbDateParserFormatter
-} from "@ng-bootstrap/ng-bootstrap";
-import {
-  BehaviorSubject,
-  debounceTime,
-  distinctUntilChanged, takeUntil
-} from "rxjs";
-import { defaultDebounceTime } from "src/app/app.helper";
-import { loginMenuItem } from "src/app/components/security/security.menus"
+import { NgbDate } from "@ng-bootstrap/ng-bootstrap";
+import { BehaviorSubject, takeUntil } from "rxjs";
+import { loginMenuItem } from "src/app/components/security/security.menus";
 
 const projectKey = "project";
 const regionKey = "region";
 const siteKey = "site";
 
-interface Model {
-  projects?: Project[];
-  regions?: Region[];
-  sites?: Site[];
-  dateFiltering?: boolean;
-  dateStartedAfter?: NgbDate;
-  dateFinishedBefore?: NgbDate;
-  todFiltering?: boolean;
-  todIgnoreDst?: boolean;
-  todStartedAfter?: string;
-  todFinishedBefore?: string;
-}
-
 @Component({
   selector: "baw-download",
   templateUrl: "download.component.html",
-  styleUrls: ["download.component.scss"],
 })
-class DownloadAudioRecordingsComponent
-  extends PageComponent
-  implements OnInit, AfterViewInit
-{
+class DownloadAudioRecordingsComponent extends PageComponent implements OnInit {
   @ViewChild(NgForm) public form: NgForm;
 
-  public filters$: BehaviorSubject<Filters<AudioRecording>>;
+  public filters$: BehaviorSubject<Filters<AudioRecording>> = new BehaviorSubject({});
 
   public contactUs = contactUsMenuItem;
   public href = "";
-  public model: Model = { todIgnoreDst: true };
   public models: ResolvedModelList;
   public profile = myAccountMenuItem;
   public hoveredDate: NgbDate;
@@ -84,28 +49,18 @@ class DownloadAudioRecordingsComponent
     public session: BawSessionService,
     private route: ActivatedRoute,
     private recordingsApi: AudioRecordingsService,
-    private formatter: NgbDateParserFormatter,
-    private calendar: NgbCalendar
   ) {
     super();
   }
 
   public ngOnInit(): void {
-    this.filters$ = new BehaviorSubject({});
     this.models = retrieveResolvers(this.route.snapshot.data);
-    this.updateHref(this.model);
-  }
 
-  public ngAfterViewInit(): void {
-    this.form.valueChanges
-      .pipe(
-        debounceTime(defaultDebounceTime),
-        distinctUntilChanged(),
-        takeUntil(this.unsubscribe)
-      )
-      .subscribe((model: Model): void => {
-        this.updateHref(model);
-      });
+    this.filters$
+      .pipe(takeUntil(this.unsubscribe))
+      .subscribe(
+        (filters: Filters<AudioRecording>) => this.href = this.recordingsApi.batchDownloadUrl(filters)
+      );
   }
 
   public get project(): Project {
@@ -128,91 +83,8 @@ class DownloadAudioRecordingsComponent
     return loginMenuItem.route;
   }
 
-  public updateHref(model: Model): void {
-    const filters = this.generateFilter(model);
-    this.filters$.next(filters);
-    this.href = this.recordingsApi.batchDownloadUrl(filters);
-  }
-
   public invalidForm(errors: any): boolean {
     return Object.entries(errors).some((value) => value[1]);
-  }
-
-  public invalidDate(date: string | NgbDate): boolean {
-    return typeof date === "string";
-  }
-
-  private generateFilter(model: Model): Filters<AudioRecording> {
-    const filter: InnerFilter<AudioRecording> = {};
-
-    if (this.site) {
-      filter["sites.id"] = { eq: this.site.id };
-    } else if (this.region) {
-      filter["regions.id"] = { eq: this.region.id };
-    } else if (this.project) {
-      filter["projects.id"] = { eq: this.project.id };
-    }
-
-    this.setDateFilter(filter, model);
-    this.setTimeOfDayFilter(filter, model);
-    return { filter };
-  }
-
-  private setDateFilter(
-    filter: InnerFilter<AudioRecording>,
-    model: Model
-  ): void {
-    if (!model.dateFiltering) {
-      return;
-    }
-
-    if (this.calendar.isValid(model.dateStartedAfter)) {
-      filter["recordedDate"] ??= {};
-      filter["recordedDate"].greaterThanOrEqual = this.formatter.format(
-        model.dateStartedAfter
-      );
-    }
-
-    if (this.calendar.isValid(model.dateFinishedBefore)) {
-      filter["recordedEndDate"] ??= {};
-      (filter["recordedEndDate"] as Comparisons).lessThanOrEqual =
-        this.formatter.format(model.dateFinishedBefore);
-    }
-  }
-
-  private setTimeOfDayFilter(
-    filter: InnerFilter<AudioRecording>,
-    model: Model
-  ): void {
-    if (!model.todFiltering) {
-      return;
-    }
-
-    const expressions: DateExpressions[] = model.todIgnoreDst
-      ? ["local_offset", "time_of_day"]
-      : ["local_tz", "time_of_day"];
-
-    if (model.todStartedAfter) {
-      filter["recordedEndDate"] ??= {};
-      (filter["recordedEndDate"] as Comparisons).greaterThanOrEqual = {
-        expressions,
-        value: model.todStartedAfter,
-      };
-    }
-
-    if (model.todFinishedBefore) {
-      filter["recordedDate"] ??= {};
-      filter["recordedDate"].lessThanOrEqual = {
-        expressions,
-        value: model.todFinishedBefore,
-      };
-    }
-
-    // TODO Add support for timezones which overflow a boundary
-    this.errors.todBoundaryError =
-      model.todFinishedBefore &&
-      model.todStartedAfter &&
-      model.todFinishedBefore < model.todStartedAfter;
   }
 }
 

--- a/src/app/components/audio-recordings/pages/list/list.component.html
+++ b/src/app/components/audio-recordings/pages/list/list.component.html
@@ -6,6 +6,13 @@
     <strong>all {{ totalModels }}</strong> audio recordings.
   </p>
 
+  <baw-audio-recordings-filter
+    [project]="project"
+    [region]="region"
+    [site]="site"
+    [constructedFilters]="filters$"
+  ></baw-audio-recordings-filter>
+
   <ngx-datatable
     #table
     bawDatatableDefaults

--- a/src/app/components/shared/date-time-filter/audio-recordings-filter.component.html
+++ b/src/app/components/shared/date-time-filter/audio-recordings-filter.component.html
@@ -1,0 +1,180 @@
+<form #form class="mb-3">
+  <!-- Toggle filtering by date -->
+  <div class="form-check">
+    <input
+      id="date-filtering"
+      name="dateFiltering"
+      type="checkbox"
+      class="form-check-input"
+      [(ngModel)]="model.dateFiltering"
+    />
+
+    <label class="form-check-label" for="date-filtering">Filter by date</label>
+
+    <div class="form-text">Filter recordings over a date range</div>
+  </div>
+
+  <!-- Date filters -->
+  <div
+    id="date-filters-wrapper"
+    #collapse="ngbCollapse"
+    [ngbCollapse]="!model.dateFiltering"
+  >
+    <div class="card">
+      <div class="card-body">
+        <div class="row">
+          <!-- Start date input -->
+          <div class="col-md-6 mb-3 mb-md-0">
+            <div class="input-group">
+              <span class="input-group-text">Start Date</span>
+              <input
+                #dateStartedAfter="ngbDatepicker"
+                #dateStartedAfterForm="ngModel"
+                ngbDatepicker
+                id="date-started-after"
+                name="dateStartedAfter"
+                class="form-control"
+                placeholder="yyyy-mm-dd"
+                [maxDate]="model.dateFinishedBefore"
+                [class.is-invalid]="dateStartedAfterForm.errors?.ngbDate?.invalid"
+                [(ngModel)]="model.dateStartedAfter"
+              />
+              <button
+                class="btn btn-outline-secondary"
+                (click)="dateStartedAfter.toggle()"
+                type="button"
+              >
+                <fa-icon [icon]="['fas', 'calendar']"></fa-icon>
+              </button>
+              <div class="invalid-feedback">
+                The date should follow the format yyyy-mm-dd, e.g. 2022-12-01
+              </div>
+            </div>
+          </div>
+
+          <!-- End date input -->
+          <div class="col-md-6 mb-3 mb-md-0">
+            <div class="input-group">
+              <span class="input-group-text">End Date</span>
+              <input
+                #dateFinishedBefore="ngbDatepicker"
+                #dateFinishedBeforeForm="ngModel"
+                ngbDatepicker
+                id="date-finished-before"
+                name="dateFinishedBefore"
+                class="form-control"
+                placeholder="yyyy-mm-dd"
+                [class.is-invalid]="dateFinishedBeforeForm.errors?.ngbDate?.invalid"
+                [minDate]="model.dateStartedAfter"
+                [(ngModel)]="model.dateFinishedBefore"
+              />
+              <button
+                class="btn btn-outline-secondary"
+                (click)="dateFinishedBefore.toggle()"
+                type="button"
+              >
+                <fa-icon [icon]="['fas', 'calendar']"></fa-icon>
+              </button>
+              <div class="invalid-feedback">
+                The date should follow the format yyyy-mm-dd, e.g. 2022-12-01
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div
+          *ngIf="dateFinishedBeforeForm.errors?.ngbDate?.minDate"
+          class="form-error"
+        >
+          The filter dates are outside the date boundary. Ensure that the start
+          date occurs before the end date.
+        </div>
+
+        <div class="form-text">
+          <strong>
+            The UTC (+00:00) time zone is used for all date filtering.
+          </strong>
+          If you're unsure if your data will be included in a filter, expand
+          your date range by one-day in either direction.
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Toggle filtering by time of day -->
+  <div class="form-check mt-3">
+    <input
+      id="time-filtering"
+      name="timeFiltering"
+      type="checkbox"
+      class="form-check-input"
+      [(ngModel)]="model.timeFiltering"
+    />
+
+    <label class="form-check-label" for="time-filtering">
+      Filter by time of day
+    </label>
+
+    <div class="form-text">
+      Filter recordings by the time of day they were recorded. If any part of a
+      recording overlaps these limits, then it will be included.
+    </div>
+  </div>
+
+  <!-- Time of day filters -->
+  <div
+    id="time-filters-wrapper"
+    #collapse="ngbCollapse"
+    [ngbCollapse]="!model.timeFiltering"
+  >
+    <div class="card">
+      <div class="card-body">
+        <div class="row mb-3">
+          <!-- Start time input -->
+          <div class="col-md-6 mb-3 mb-md-0">
+            <baw-time
+              id="time-started-after"
+              name="timeStartedAfter"
+              label="Start Time"
+              [(ngModel)]="model.timeStartedAfter"
+            ></baw-time>
+          </div>
+
+          <!-- End time input -->
+          <div class="col-md-6">
+            <baw-time
+              id="time-finished-before"
+              name="timeFinishedBefore"
+              label="End Time"
+              [(ngModel)]="model.timeFinishedBefore"
+            ></baw-time>
+          </div>
+        </div>
+
+        <!-- Ignore daylight savings checkbox -->
+        <div class="form-check">
+          <input
+            id="ignore-daylight-savings"
+            name="ignoreDaylightSavings"
+            type="checkbox"
+            class="form-check-input"
+            [disabled]="!model.timeFiltering"
+            [(ngModel)]="model.ignoreDaylightSavings"
+          />
+
+          <label class="form-check-label" for="ignore-daylight-savings">
+            Ignore day light savings (DST)
+          </label>
+
+          <div class="form-text">
+            Real world events, like dawn chorus, or the vocalization of fauna
+            are not affected by daylight savings time. Ignoring DST is advised
+            to ensure audio is filtered consistently. If any recordings occur
+            during a DST period, the base offset, that is the time it would be
+            if DST were not in effect, will be used.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>

--- a/src/app/components/shared/date-time-filter/audio-recordings-filter.component.scss
+++ b/src/app/components/shared/date-time-filter/audio-recordings-filter.component.scss
@@ -1,7 +1,7 @@
 label {
   font-weight: bold;
 
-  .form-check label {
+  .form-check {
     font-weight: normal;
   }
 }

--- a/src/app/components/shared/date-time-filter/audio-recordings-filter.component.spec.ts
+++ b/src/app/components/shared/date-time-filter/audio-recordings-filter.component.spec.ts
@@ -1,0 +1,791 @@
+import {
+  Spectator,
+  createRoutingFactory,
+  mockProvider,
+} from "@ngneat/spectator";
+import { NgbCollapse, NgbCollapseModule } from "@ng-bootstrap/ng-bootstrap";
+import { CacheModule } from "@services/cache/cache.module";
+import { MockConfigModule } from "@services/config/configMock.module";
+import { SharedModule } from "@shared/shared.module";
+import { ToastrService } from "ngx-toastr";
+import { fakeAsync } from "@angular/core/testing";
+import { Project } from "@models/Project";
+import { generateProject } from "@test/fakes/Project";
+import { TimeComponent } from "@shared/input/time/time.component";
+import { BehaviorSubject } from "rxjs";
+import { Filters } from "@baw-api/baw-api.service";
+import { AudioRecording } from "@models/AudioRecording";
+import { AudioRecordingsFilterComponent } from "./audio-recordings-filter.component";
+
+describe("AudioRecordingsFilter", () => {
+  let spectator: Spectator<AudioRecordingsFilterComponent>;
+  let defaultProject: Project;
+  let filterChangeSpy: jasmine.Spy;
+
+  const createComponent = createRoutingFactory({
+    component: AudioRecordingsFilterComponent,
+    imports: [SharedModule, NgbCollapseModule, MockConfigModule, CacheModule],
+    declarations: [TimeComponent],
+    providers: [mockProvider(ToastrService)],
+  });
+
+  function setup(project: Project): void {
+    const resolvers = {};
+    const models = {};
+
+    resolvers["project"] = "resolver";
+    models["project"] = { model: project };
+
+    spectator = createComponent({
+      data: { resolvers, ...models },
+      detectChanges: false,
+    });
+
+    spectator.component.constructedFilters = new BehaviorSubject<
+      Filters<AudioRecording>
+    >({});
+    filterChangeSpy = spyOn(spectator.component.constructedFilters, "next");
+    updateForm();
+  }
+
+  beforeEach(fakeAsync(() => {
+    defaultProject = new Project(generateProject());
+
+    setup(defaultProject);
+    updateForm();
+  }));
+
+  // helper methods
+  function updateForm() {
+    spectator.detectChanges();
+    // Have to do this tick because of
+    // https://github.com/angular/angular/issues/22606#issuecomment-377390233
+    // Also because the observable which updates the filter has a debounce timer
+    spectator.tick(1000);
+    spectator.detectChanges();
+  }
+
+  function getElementByInnerText(innerText: string): HTMLElement {
+    return spectator.debugElement.query(
+      (el) => el.nativeElement.innerText === innerText
+    )?.nativeElement as HTMLButtonElement;
+  }
+
+  const getDateToggleInput = () =>
+    spectator.query<HTMLInputElement>("#date-filtering");
+  const getDateInputWrapper = () =>
+    spectator.query("#date-filters-wrapper", { read: NgbCollapse });
+  const getDateStartedAfterInput = () =>
+    spectator.query<HTMLInputElement>("#date-started-after");
+  const getDateFinishedBeforeInput = () =>
+    spectator.query<HTMLInputElement>("#date-finished-before");
+  const getTimeOfDayInputWrapper = () =>
+    spectator.query("#time-filters-wrapper", { read: NgbCollapse });
+  const getTimeOfDayToggleInput = () =>
+    spectator.query<HTMLInputElement>("#time-filtering");
+  const getIgnoreDaylightSavingsInput = () =>
+    spectator.query<HTMLInputElement>("#ignore-daylight-savings");
+  const getTimeOfDayStartedAfterInput = () =>
+    spectator.query<HTMLInputElement>("#time-started-after input");
+  const getTimeOfDayFinishedBeforeInput = () =>
+    spectator.query<HTMLInputElement>("#time-finished-before input");
+
+  function typeInElement(element: HTMLInputElement, value: string): void {
+    spectator.typeInElement(value, element);
+    spectator.dispatchTouchEvent(element, "blur");
+    updateForm();
+  }
+
+  function toggleTimeOfDayFilters() {
+    const input = getTimeOfDayToggleInput();
+    input.click();
+    input.dispatchEvent(new Event("input"));
+
+    updateForm();
+  }
+
+  function toggleDateFilters() {
+    const input = getDateToggleInput();
+    input.click();
+    input.dispatchEvent(new Event("input"));
+
+    updateForm();
+  }
+
+  function toggleIgnoreDaylightSavings() {
+    const input = getIgnoreDaylightSavingsInput();
+    input.click();
+    input.dispatchEvent(new Event("input"));
+
+    updateForm();
+  }
+
+  // start of assertion
+  it("should create", () => {
+    expect(spectator.component).toBeInstanceOf(AudioRecordingsFilterComponent);
+  });
+
+  describe("date filter input", () => {
+    it("should initially hide date filter input", fakeAsync(() => {
+      expect(getDateToggleInput()).toExist();
+      expect(getDateInputWrapper().collapsed).toBeTrue();
+    }));
+
+    it("should show date filter input when the date filter checkbox is set", fakeAsync(() => {
+      toggleDateFilters();
+      expect(getDateToggleInput()).toBeTruthy();
+      expect(getDateInputWrapper().collapsed).toBeFalse();
+    }));
+
+    it("should hide date filter input when the date filter checkbox is clicked twice", fakeAsync(() => {
+      toggleDateFilters();
+      toggleDateFilters();
+      expect(getDateToggleInput()).toExist();
+      expect(getDateInputWrapper().collapsed).toBeTrue();
+    }));
+  });
+
+  describe("time filter input", () => {
+    it("should initially hide time of day filters", fakeAsync(() => {
+      expect(getTimeOfDayToggleInput()).toExist();
+      expect(getTimeOfDayInputWrapper().collapsed).toBeTrue();
+    }));
+
+    it("should show time of day filter input when the time of day filter checkbox is set", fakeAsync(() => {
+      toggleTimeOfDayFilters();
+      expect(getTimeOfDayToggleInput()).toExist();
+      expect(getTimeOfDayInputWrapper().collapsed).toBeFalse();
+    }));
+
+    it("should hide timeOfDay filter input when the time of day filter checkbox is clicked twice", fakeAsync(() => {
+      toggleTimeOfDayFilters();
+      toggleTimeOfDayFilters();
+      expect(getTimeOfDayToggleInput()).toExist();
+      expect(getTimeOfDayInputWrapper().collapsed).toBeTrue();
+    }));
+
+    it("should initially have day light savings time enabled", fakeAsync(() => {
+      toggleTimeOfDayFilters();
+      expect(getIgnoreDaylightSavingsInput().checked).toBeTrue();
+    }));
+  });
+
+  describe("date format validation", () => {
+    const invalidDateErrorMessage =
+      "The date should follow the format yyyy-mm-dd, e.g. 2022-12-01";
+
+    beforeEach(fakeAsync(() => toggleDateFilters()));
+
+    it("should not show an invalid date error if the user has not input a date", fakeAsync(() => {
+      updateForm();
+      expect(getElementByInnerText(invalidDateErrorMessage)).not.toExist();
+    }));
+
+    it("should display an error if the user inputs an invalid date into the start date input", fakeAsync(() => {
+      const invalidDate = "-1999-13-02";
+      typeInElement(getDateStartedAfterInput(), invalidDate);
+      expect(getElementByInnerText(invalidDateErrorMessage)).toExist();
+    }));
+
+    it("should not display an error if the user inputs a valid date into the start date input", fakeAsync(() => {
+      const validDate = "2020-12-31";
+      typeInElement(getDateStartedAfterInput(), validDate);
+      expect(getElementByInnerText(invalidDateErrorMessage)).not.toExist();
+    }));
+
+    it("should display an error if the user types in an invalid date into the end date input", fakeAsync(() => {
+      // in this test, the user mixed their month and day, where the month (21) is greater than 12
+      const invalidDate = "2020-21-12";
+      typeInElement(getDateFinishedBeforeInput(), invalidDate);
+      expect(getElementByInnerText(invalidDateErrorMessage)).toExist();
+    }));
+
+    it("should not display an error if the user inputs a valid date into the end date input", fakeAsync(() => {
+      const validDate = "2020-12-31";
+      typeInElement(getDateFinishedBeforeInput(), validDate);
+      expect(getElementByInnerText(invalidDateErrorMessage)).not.toExist();
+    }));
+  });
+
+  describe("date bounds validation", () => {
+    const outOfBoundsDateErrorMessage =
+      "The filter dates are outside the date boundary. Ensure that the start date occurs before the end date.";
+
+    beforeEach(fakeAsync(() => toggleDateFilters()));
+
+    it("should show an error if the user inputs an out of bounds date filter", fakeAsync(() => {
+      const startDate = "2020-10-10";
+      const endDate = "2019-12-10";
+
+      typeInElement(getDateStartedAfterInput(), startDate);
+      typeInElement(getDateFinishedBeforeInput(), endDate);
+
+      expect(getElementByInnerText(outOfBoundsDateErrorMessage)).toExist();
+    }));
+
+    it("should not show an error if the user inputs a valid date range", fakeAsync(() => {
+      const startDate = "2019-12-10";
+      const endDate = "2020-10-10";
+
+      typeInElement(getDateStartedAfterInput(), startDate);
+      typeInElement(getDateFinishedBeforeInput(), endDate);
+
+      expect(getElementByInnerText(outOfBoundsDateErrorMessage)).not.toExist();
+    }));
+
+    it("should not show an out of bounds date error if the user has only input a start date", fakeAsync(() => {
+      const startDate = "2021-10-12";
+      typeInElement(getDateStartedAfterInput(), startDate);
+      expect(getElementByInnerText(outOfBoundsDateErrorMessage)).not.toExist();
+    }));
+
+    it("should not show an out of bounds date error if the user has only input an end date", fakeAsync(() => {
+      const endDate = "2021-09-01";
+      typeInElement(getDateFinishedBeforeInput(), endDate);
+      expect(getElementByInnerText(outOfBoundsDateErrorMessage)).not.toExist();
+    }));
+
+    it("should not show an out of bounds date error if the user has not input any dates", fakeAsync(() => {
+      updateForm();
+      expect(getElementByInnerText(outOfBoundsDateErrorMessage)).not.toExist();
+    }));
+
+    it("should not show an error if both the start and end dates are the same", fakeAsync(() => {
+      const startDate = "2020-10-10";
+      const endDate = "2020-10-10";
+
+      typeInElement(getDateStartedAfterInput(), startDate);
+      typeInElement(getDateFinishedBeforeInput(), endDate);
+
+      expect(getElementByInnerText(outOfBoundsDateErrorMessage)).not.toExist();
+    }));
+  });
+
+  describe("time bound validations", () => {
+    it("should allow a user to input a start time less than the end time without displaying an error", fakeAsync(() => {
+      const startTime = "01:00";
+      const endTime = "11:34";
+      const invalidInputClass = "is-invalid";
+
+      typeInElement(getTimeOfDayStartedAfterInput(), startTime);
+      typeInElement(getTimeOfDayFinishedBeforeInput(), endTime);
+
+      // is-invalid is a bootstrap validation class that will be added to an invalid time input (added by time.component.ts)
+      expect(getTimeOfDayStartedAfterInput()).not.toHaveClass(
+        invalidInputClass
+      );
+      expect(getTimeOfDayFinishedBeforeInput()).not.toHaveClass(
+        invalidInputClass
+      );
+    }));
+
+    it("should allow a user to input an end time less than the start time without displaying an error", fakeAsync(() => {
+      const startTime = "11:34";
+      const endTime = "01:56";
+      const invalidInputClass = "is-invalid";
+
+      typeInElement(getTimeOfDayStartedAfterInput(), startTime);
+      typeInElement(getTimeOfDayFinishedBeforeInput(), endTime);
+
+      expect(getTimeOfDayStartedAfterInput()).not.toHaveClass(
+        invalidInputClass
+      );
+      expect(getTimeOfDayFinishedBeforeInput()).not.toHaveClass(
+        invalidInputClass
+      );
+    }));
+  });
+
+  describe("filters events", () => {
+    function assertLastFilterUpdate(expectedFilter: Filters<AudioRecording>): void {
+      const mostRecentFilterUpdate = filterChangeSpy.calls.mostRecent().args[0];
+
+      const expectedFilterSerialized = JSON.stringify(expectedFilter);
+      const mostRecentFilterUpdateSerialized = JSON.stringify(mostRecentFilterUpdate);
+
+      expect(mostRecentFilterUpdateSerialized).toEqual(expectedFilterSerialized);
+    }
+
+    // date events where a filter update should not be emitted
+    it("should only emit one filter update event if the user hasn't input anything into the filter condition fields", fakeAsync(() => {
+      toggleDateFilters();
+      toggleTimeOfDayFilters();
+      // there is a filter update event emitted when the component is initialized
+      // this is done for the batch downloading component which needs the initial filter state for its batch downloading script
+      // therefore, if the user has not input any filters, there should only be the initial filter update
+      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it("should not emit a filter update if the start date is a bad format", fakeAsync(() => {
+      // in this assertion, the user has typed a string into the date input. This will pass *some* assertions
+      // if this test is failing, the raw input from the input field is being passed to the date filter without its type being validated
+      const malformedStartDate = "testing";
+
+      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
+
+      toggleDateFilters();
+      typeInElement(getDateStartedAfterInput(), malformedStartDate);
+      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it("should not emit a filter update if the end date is a bad format", fakeAsync(() => {
+      // in this test, the day (12) and month (20) are swapped. It should not reformat the date or emit a filter update event in this case
+      const malformedEndDate = "2021-20-12";
+
+      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
+      toggleDateFilters();
+      typeInElement(getDateStartedAfterInput(), malformedEndDate);
+      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it("should not emit a filter update if the dates are out of bounds", fakeAsync(() => {
+      const startDate = "2022-10-10";
+      const endDate = "2021-09-02";
+
+      toggleDateFilters();
+      typeInElement(getDateStartedAfterInput(), startDate);
+      typeInElement(getDateFinishedBeforeInput(), endDate);
+
+      // a filter change event would have been emitted once due to the correctly formatted and valid start date
+      // we therefore have to assert that two filter events didn't get emitted from the second date input (which is out of bounds)
+      expect(filterChangeSpy).toHaveBeenCalledTimes(2);
+    }));
+
+    // date filter update events
+    it("should construct the correct filter if the start date is set", fakeAsync(() => {
+      const startDate = "2018-01-12";
+
+      const expectedFilters = {
+        filter: {
+          recordedEndDate: { greaterThan: "2018-01-12T00:00:00.000Z" },
+        },
+      } as Filters<AudioRecording>;
+
+      toggleDateFilters();
+      typeInElement(getDateStartedAfterInput(), startDate);
+
+      assertLastFilterUpdate(expectedFilters);
+    }));
+
+    it("should construct the correct filter if only the end date is set", fakeAsync(() => {
+      const endDate = "2020-07-11";
+      const expectedFilters = {
+        filter: {
+          recordedDate: { lessThan: `${endDate}T00:00:00.000Z` },
+        },
+      };
+
+      toggleDateFilters();
+      typeInElement(getDateFinishedBeforeInput(), endDate);
+
+      assertLastFilterUpdate(expectedFilters);
+    }));
+
+    it("should construct the correct filter if the start and end date is set", fakeAsync(() => {
+      // this test uses the same start and end date for the assertion
+      // if this test if failing, it might be because the component cannot accept the same start and end date
+      const startDate = "2021-01-01";
+      const endDate = "2021-01-01";
+      const expectedFilters: Filters<AudioRecording> = {
+        filter: {
+          and: [
+            {
+              recordedEndDate: { greaterThan: "2021-01-01T00:00:00.000Z" },
+            },
+            {
+              recordedDate: { lessThan: "2021-01-01T00:00:00.000Z" },
+            },
+          ],
+        },
+      };
+
+      toggleDateFilters();
+      typeInElement(getDateStartedAfterInput(), startDate);
+      typeInElement(getDateFinishedBeforeInput(), endDate);
+
+      assertLastFilterUpdate(expectedFilters);
+    }));
+
+    // if the user inputs a date filter, then removes the date filter there should be no filter conditions
+    it("should emit an empty filter if a date condition is set, then unset", fakeAsync(() => {
+      const startDate = "2021-03-15";
+      const endDate = "2022-03-18";
+
+      toggleDateFilters();
+      typeInElement(getDateStartedAfterInput(), startDate);
+      typeInElement(getDateFinishedBeforeInput(), endDate);
+
+      toggleDateFilters();
+
+      assertLastFilterUpdate({ });
+    }));
+
+    // time events where a filter update should not be emitted
+    it("should not emit a filter update if the start time is a bad format", fakeAsync(() => {
+      const startTime = "25:00";
+
+      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
+      toggleTimeOfDayFilters();
+      typeInElement(getTimeOfDayStartedAfterInput(), startTime);
+
+      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it("should not emit a filter update if the end time is a bad format", fakeAsync(() => {
+      const endTime = "01:98";
+
+      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
+
+      toggleTimeOfDayFilters();
+      typeInElement(getTimeOfDayFinishedBeforeInput(), endTime);
+
+      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it("should emit an empty filter update if the time condition is set, then unset", fakeAsync(() => {
+      const startTime = "12:12";
+      const endTime = "12:12";
+
+      toggleTimeOfDayFilters();
+      typeInElement(getTimeOfDayStartedAfterInput(), startTime);
+      typeInElement(getTimeOfDayFinishedBeforeInput(), endTime);
+
+      toggleTimeOfDayFilters();
+
+      assertLastFilterUpdate({ });
+    }));
+
+    it("should not emit time filters if the time bounds are set, but the 'Filter by time of day' checkbox is not checked", fakeAsync(() => {
+      const startTime = "12:12";
+      const startDate = "2015-12-15";
+
+      // the date input is still shown, and therefore, only the date filters should still be emitted in the filter update, but not time
+      const expectedFilters = {
+        filter: {
+          recordedEndDate: { greaterThan: `${startDate}T00:00:00.000Z` },
+        },
+      } as Filters<AudioRecording>;
+
+      toggleTimeOfDayFilters();
+      typeInElement(getTimeOfDayStartedAfterInput(), startTime);
+      toggleDateFilters();
+      typeInElement(getDateStartedAfterInput(), startDate);
+
+      // the time of day filters are now hidden and should not be emitted in the filter update
+      toggleTimeOfDayFilters();
+
+      assertLastFilterUpdate(expectedFilters);
+    }));
+
+    it("should not emit date filters if the date bounds are set, but the 'Filter by date' checkbox is not checked", fakeAsync(() => {
+      const startTime = "12:12";
+      const startDate = "2015-12-15";
+
+      const expectedFilters = {
+        filter: {
+          recordedEndDate: {
+            greaterThan: {
+              expressions: ["local_offset", "time_of_day"],
+              value: "12:12",
+            },
+          },
+        },
+      } as Filters<AudioRecording>;
+
+      toggleDateFilters();
+      typeInElement(getDateStartedAfterInput(), startDate);
+      toggleTimeOfDayFilters();
+      typeInElement(getTimeOfDayStartedAfterInput(), startTime);
+
+      // the date filters are now hidden and should not be emitted in the filter update
+      toggleDateFilters();
+
+      assertLastFilterUpdate(expectedFilters);
+    }));
+
+    // time filters depend on daylight savings, therefore, it is required that all time assertions are tested against dst settings
+    [false, true].forEach((ignoreDayLightSavings: boolean) => {
+      const expectedOffsetExpression = ignoreDayLightSavings
+        ? "local_tz"
+        : "local_offset";
+      const expressions = [expectedOffsetExpression, "time_of_day"];
+
+      it(`can filter recordings past a day boundary with a composition of filters, 10PM to 1 AM with ignore day light savings ${
+        ignoreDayLightSavings ? "set" : "unset"
+      }`, fakeAsync(() => {
+        const startTime = "22:00";
+        const endTime = "01:00";
+        const startDate = "2021-10-03";
+        const endDate = "2021-10-04";
+
+        const expectedFilter: Filters<AudioRecording> = {
+          filter: {
+            and: [
+              {
+                recordedEndDate: {
+                  greaterThan: `${startDate}T00:00:00.000Z`,
+                },
+              },
+              {
+                recordedDate: { lessThan: `${endDate}T00:00:00.000Z` },
+              },
+              {
+                or: [
+                  {
+                    recordedEndDate: {
+                      greaterThanOrEqual: { expressions, value: startTime },
+                    },
+                  },
+                  {
+                    recordedDate: {
+                      lessThanOrEqual: { expressions, value: endTime },
+                    },
+                  },
+                  {
+                    recordedEndDate: {
+                      lessThanOrEqual: { expressions, value: endTime },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        };
+
+        toggleTimeOfDayFilters();
+        if (ignoreDayLightSavings) {
+          toggleIgnoreDaylightSavings();
+          updateForm();
+        }
+
+        typeInElement(getTimeOfDayStartedAfterInput(), startTime);
+        typeInElement(getTimeOfDayFinishedBeforeInput(), endTime);
+        toggleDateFilters();
+        typeInElement(getDateStartedAfterInput(), startDate);
+        typeInElement(getDateFinishedBeforeInput(), endDate);
+
+        assertLastFilterUpdate(expectedFilter);
+      }));
+
+      it(`should include the start time in the filter with ignore day light savings ${
+        ignoreDayLightSavings ? "set" : "unset"
+      }`, fakeAsync(() => {
+        const startTime = "11:11";
+
+        // since this filter only has one condition, it should not be contained within an and: [] filter condition array
+        const expectedFilters = {
+          filter: {
+            recordedEndDate: {
+              greaterThan: {
+                expressions: [expectedOffsetExpression, "time_of_day"],
+                value: "11:11",
+              },
+            },
+          },
+        } as Filters<AudioRecording>;
+
+        toggleTimeOfDayFilters();
+        if (ignoreDayLightSavings) {
+          toggleIgnoreDaylightSavings();
+          updateForm();
+        }
+
+        typeInElement(getTimeOfDayStartedAfterInput(), startTime);
+
+        assertLastFilterUpdate(expectedFilters);
+      }));
+
+      it(`should include the end time in the filter with ignore day light savings time ${
+        ignoreDayLightSavings ? "set" : "unset"
+      }`, fakeAsync(() => {
+        const endTime = "03:21";
+        const expectedFilters = {
+          filter: {
+            recordedDate: {
+              lessThan: {
+                expressions,
+                value: "03:21",
+              },
+            },
+          },
+        };
+
+        toggleTimeOfDayFilters();
+        if (ignoreDayLightSavings) {
+          toggleIgnoreDaylightSavings();
+          updateForm();
+        }
+
+        typeInElement(getTimeOfDayFinishedBeforeInput(), endTime);
+
+        assertLastFilterUpdate(expectedFilters);
+      }));
+
+      it(`should include start and end time in the filter with ignore day light savings time ${
+        ignoreDayLightSavings ? "set" : "unset"
+      }`, fakeAsync(() => {
+        const startTime = "12:11";
+        const endTime = "15:00";
+        const expectedFilters: Filters<AudioRecording> = {
+          filter: {
+            // since there are multiple conditions to these filters, they should be contained within an and: [] filter condition array
+            and: [
+              {
+                recordedEndDate: {
+                  greaterThan: {
+                    expressions,
+                    value: startTime,
+                  },
+                },
+              },
+              {
+                recordedDate: {
+                  lessThan: {
+                    expressions,
+                    value: endTime,
+                  },
+                },
+              },
+            ],
+          },
+        };
+
+        toggleTimeOfDayFilters();
+        if (ignoreDayLightSavings) {
+          toggleIgnoreDaylightSavings();
+          updateForm();
+        }
+
+        typeInElement(getTimeOfDayStartedAfterInput(), startTime);
+        typeInElement(getTimeOfDayFinishedBeforeInput(), endTime);
+
+        assertLastFilterUpdate(expectedFilters);
+      }));
+
+      it(`should construct the correct filters for a start date and start time with day light savings ${
+        ignoreDayLightSavings ? "set" : "unset"
+      }`, fakeAsync(() => {
+        const startTime = "13:22";
+        const startDate = "2112-11-01";
+
+        const expectedFilters: Filters<AudioRecording> = {
+          filter: {
+            and: [
+              {
+                recordedEndDate: {
+                  greaterThan: "2112-11-01T00:00:00.000Z",
+                },
+              },
+              {
+                recordedEndDate: {
+                  greaterThan: {
+                    expressions,
+                    value: startTime,
+                  },
+                },
+              },
+            ],
+          },
+        };
+
+        toggleTimeOfDayFilters();
+        if (ignoreDayLightSavings) {
+          toggleIgnoreDaylightSavings();
+          updateForm();
+        }
+
+        toggleDateFilters();
+        typeInElement(getDateStartedAfterInput(), startDate);
+        typeInElement(getTimeOfDayStartedAfterInput(), startTime);
+
+        assertLastFilterUpdate(expectedFilters);
+      }));
+
+      // this test asserts that time and date filters can be combined into a single value in the and: [] filter condition array
+      // e.g. the start date and start times should both be under the and: [ { greaterThan: {} } ] condition
+      // if this test is failing, the conditions are most likely not being combined correctly
+      it(`should construct the correct filters for date and time range with day light savings ${
+        ignoreDayLightSavings ? "set" : "unset"
+      }`, fakeAsync(() => {
+        const startTime = "08:12";
+        const endTime = "12:12";
+        const startDate = "1989-11-08";
+        const endDate = "2043-12-12";
+
+        const expectedFilters: Filters<AudioRecording> = {
+          filter: {
+            and: [
+              {
+                recordedEndDate: {
+                  greaterThan: `${startDate}T00:00:00.000Z`,
+                },
+              },
+              {
+                recordedDate: {
+                  lessThan: `${endDate}T00:00:00.000Z`,
+                },
+              },
+              {
+                recordedEndDate: {
+                  greaterThan: {
+                    expressions,
+                    value: startTime,
+                  },
+                },
+              },
+              {
+                recordedDate: {
+                  lessThan: {
+                    expressions,
+                    value: endTime,
+                  },
+                },
+              },
+            ],
+          },
+        };
+
+        toggleTimeOfDayFilters();
+        if (ignoreDayLightSavings) {
+          toggleIgnoreDaylightSavings();
+          updateForm();
+        }
+
+        toggleDateFilters();
+        typeInElement(getDateStartedAfterInput(), startDate);
+        typeInElement(getDateFinishedBeforeInput(), endDate);
+        typeInElement(getTimeOfDayStartedAfterInput(), startTime);
+        typeInElement(getTimeOfDayFinishedBeforeInput(), endTime);
+
+        assertLastFilterUpdate(expectedFilters);
+      }));
+
+      it("should emit an empty filter if filter conditions are set then removed", fakeAsync(() => {
+        const startTime = "08:12";
+        const endTime = "12:12";
+        const startDate = "1989-11-08";
+        const endDate = "2043-12-12";
+
+        const expectedFilters: Filters<AudioRecording> = {};
+
+        toggleTimeOfDayFilters();
+        if (ignoreDayLightSavings) {
+          toggleIgnoreDaylightSavings();
+          updateForm();
+        }
+
+        toggleDateFilters();
+        typeInElement(getDateStartedAfterInput(), startDate);
+        typeInElement(getDateFinishedBeforeInput(), endDate);
+        typeInElement(getTimeOfDayStartedAfterInput(), startTime);
+        typeInElement(getTimeOfDayFinishedBeforeInput(), endTime);
+
+        // remove the filters
+        toggleDateFilters();
+        toggleTimeOfDayFilters();
+
+        assertLastFilterUpdate(expectedFilters);
+      }));
+    });
+  });
+});

--- a/src/app/components/shared/date-time-filter/audio-recordings-filter.component.ts
+++ b/src/app/components/shared/date-time-filter/audio-recordings-filter.component.ts
@@ -1,0 +1,166 @@
+import {
+  AfterContentChecked,
+  AfterViewInit,
+  Component,
+  Input,
+  ViewChild,
+  ChangeDetectorRef,
+} from "@angular/core";
+import { NgForm } from "@angular/forms";
+import { Filters, InnerFilter } from "@baw-api/baw-api.service";
+import { filterDate, filterTime } from "@helpers/filters/audioRecordingFilters";
+import { filterModel } from "@helpers/filters/filters";
+import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
+import { AudioRecording } from "@models/AudioRecording";
+import { Project } from "@models/Project";
+import { Region } from "@models/Region";
+import { Site } from "@models/Site";
+import { NgbDate } from "@ng-bootstrap/ng-bootstrap";
+import { fromJS } from "immutable";
+import { DateTime, Duration } from "luxon";
+import {
+  BehaviorSubject,
+  debounceTime,
+  distinctUntilChanged,
+  takeUntil,
+} from "rxjs";
+import { defaultDebounceTime } from "src/app/app.helper";
+
+export interface Model {
+  projects?: Project[];
+  regions?: Region[];
+  sites?: Site[];
+  dateFiltering?: boolean;
+  dateStartedAfter?: NgbDate;
+  dateFinishedBefore?: NgbDate;
+  timeFiltering?: boolean;
+  ignoreDaylightSavings?: boolean;
+  timeStartedAfter?: Duration;
+  timeFinishedBefore?: Duration;
+}
+
+@Component({
+  selector: "baw-audio-recordings-filter",
+  templateUrl: "audio-recordings-filter.component.html",
+  styleUrls: ["audio-recordings-filter.component.scss"],
+})
+export class AudioRecordingsFilterComponent
+  extends withUnsubscribe()
+  implements AfterViewInit, AfterContentChecked
+{
+  public constructor(private changeDetector: ChangeDetectorRef) {
+    super();
+  }
+
+  @ViewChild(NgForm) public form: NgForm;
+  @Input() public project: Project;
+  @Input() public region: Region;
+  @Input() public site: Site;
+  @Input() public constructedFilters: BehaviorSubject<Filters<AudioRecording>>;
+
+  public model: Model = { ignoreDaylightSavings: true };
+  private previousFilters: Immutable.Collection<unknown, unknown>;
+
+  public ngAfterViewInit(): void {
+    this.form.valueChanges
+      .pipe(
+        debounceTime(defaultDebounceTime),
+        distinctUntilChanged(),
+        takeUntil(this.unsubscribe)
+      )
+      .subscribe((model: Model) => this.emitFilterUpdate(model));
+  }
+
+  // TODO: Refactor the following hacky code block
+  // without this code block, the ExpressionChangedAfterItHasBeenCheckedError warning is thrown in development mode
+  public ngAfterContentChecked(): void {
+    // since we are using angular form validation & bootstrap validation, the errors attribute of the form is updated with change detection
+    // this causes the form state to update with change detection so we need to add an extra change detection cycle
+    // to ensure the updated form state (with errors) is a part of the model at end of change detection
+    this.changeDetector.detectChanges();
+  }
+
+  public emitFilterUpdate(model: Model): void {
+    // we should only send new filter requests when the user has not input any "bad" / incorrect values into the input fields
+    // e.g. 2020-31-31 is not a valid date should display an error, and not send a new filter request
+    if (!this.form.valid) {
+      return;
+    }
+
+    const [changed, newFilters] = this.generateFilters(this.previousFilters, model);
+
+    if (changed) {
+      this.constructedFilters.next(newFilters);
+      this.previousFilters = fromJS(newFilters);
+    }
+  }
+
+  private generateFilters(previousFilters: Immutable.Collection<unknown, unknown>, model: Model): [boolean, Filters] {
+    let newInnerFilters: InnerFilter<AudioRecording> = {};
+
+    newInnerFilters = this.setModelFilters(newInnerFilters);
+    newInnerFilters = this.setDateFilters(model, newInnerFilters);
+    newInnerFilters = this.setTimeOfDayFilters(model, newInnerFilters);
+
+    // if there are no filters, we should allow a filter event to be emitted with zero filter conditions
+    // without this check, a filter with no conditions would have an inner filter of undefined rather than zero conditions
+    const newFilters = Object.keys(newInnerFilters).length === 0 ? {} : { filter: newInnerFilters };
+
+    // to prevent duplicate filters from being emitted, we compare the new filter to the previous filter's value
+    // e.g. if a user types in a valid filter condition, inputs an invalid filter condition, then inputs a valid filter condition
+    const changed = !fromJS(newFilters)?.equals(previousFilters) && newFilters !== previousFilters;
+
+    if (Object.keys(newInnerFilters).length === 0) {
+      return [changed, newFilters];
+    }
+
+    return [changed, newFilters];
+  }
+
+  private setModelFilters(filters: InnerFilter<AudioRecording>): InnerFilter<AudioRecording> {
+    if (this.site) {
+      filters = filterModel<Site, AudioRecording>("sites", this.site, filters);
+    } else if (this.region) {
+      filters = filterModel<Region, AudioRecording>("regions", this.region, filters);
+    } else if (this.project) {
+      filters = filterModel<Project, AudioRecording>("projects", this.project, filters);
+    }
+
+    return filters;
+  }
+
+  private setDateFilters(model: Model, filters: InnerFilter<AudioRecording>): InnerFilter<AudioRecording> {
+    const modelStartDate = model?.dateStartedAfter;
+    const modelEndDate = model?.dateFinishedBefore;
+
+    // there will be no additional filters if the user hasn't input any dates. Therefore, we can bail out without calculating a date filter
+    if (!model?.dateFiltering || (!modelStartDate && !modelEndDate)) {
+      return filters;
+    }
+
+    // using the Luxon DateTime object emits both the time and date. This prevents us from explicitly adding it later on
+    const startDate =
+      modelStartDate && DateTime.fromObject(modelStartDate, { zone: "utc" });
+    const endDate =
+      modelEndDate && DateTime.fromObject(modelEndDate, { zone: "utc" });
+
+    return filterDate(filters, startDate, endDate);
+  }
+
+  private setTimeOfDayFilters(model: Model, filters: InnerFilter<AudioRecording>): InnerFilter<AudioRecording> {
+    const modelStartTime = model?.timeStartedAfter;
+    const modelEndTime = model?.timeFinishedBefore;
+
+    // we can save ourselves from calculating a new time filters (improving performance) if the user hasn't input a start time or end time
+    if (!model?.timeFiltering || (!modelStartTime && !modelEndTime)) {
+      return filters;
+    }
+
+    return filterTime(
+      filters,
+      model.ignoreDaylightSavings,
+      modelStartTime,
+      modelEndTime
+    );
+  }
+}

--- a/src/app/helpers/case-converter/case-converter.spec.ts
+++ b/src/app/helpers/case-converter/case-converter.spec.ts
@@ -1,6 +1,15 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { toCamelCase, toSnakeCase } from "./case-converter";
 
+interface IConversionCallback {
+  name: string;
+  callback: (obj: any) => any;
+  fieldOne: string;
+  fieldTwo: string;
+  allowListKey: string;
+  allowListValue: string;
+}
+
 const conversionCallbacks = [
   {
     name: "to camelCase",
@@ -20,13 +29,14 @@ const conversionCallbacks = [
   },
 ];
 
-conversionCallbacks.forEach((test) => {
+conversionCallbacks.forEach((test: IConversionCallback) => {
   const fieldOne = test.fieldOne;
   const fieldTwo = test.fieldTwo;
   const allowedKey = test.allowListKey;
   const allowedValues = test.allowListValue;
 
   describe(test.name, () => {
+    // this test asserts that an object without a toJSON implementation is correctly case-converted and simplified
     it("simple objects", () => {
       const before = { field_one: "content one", "field-two": "content two" };
       const expected = { [fieldOne]: "content one", [fieldTwo]: "content two" };
@@ -144,6 +154,142 @@ conversionCallbacks.forEach((test) => {
       expect(expected).toEqual(result);
     });
 
+    it("should be idempotent", () => {
+      const before = { field_one: "content one", field_two: "content two" };
+      const expected = { [fieldOne]: "content one", [fieldTwo]: "content two" };
+
+      const processedBefore = test.callback(test.callback(before));
+      const result = test.callback(test.callback(processedBefore));
+
+      expect(result).toEqual(expected);
+    });
+
+    it("should call toJSON on simple objects that implement toJSON", () => {
+    const before = {
+        field_one: "content one",
+        "field-two": "content two",
+        toJSON: () => "toJsonResult",
+      };
+      const expected = "toJsonResult";
+
+      const result = test.callback(before);
+      expect(result).toEqual(expected);
+    });
+
+    it("should call toJSON on simple objects that implement toJSON in their prototypes", () => {
+      const before = {
+        field_one: "content one",
+        "field-two": "content two",
+      };
+      const expected = "toJsonResult";
+
+      Object.setPrototypeOf(before, {
+        toJSON: () => expected,
+      });
+
+      const result = test.callback(before);
+      expect(result).toEqual(expected);
+    });
+
+    it("should only call toJSON on nested objects that implement toJSON", () => {
+      const before = {
+        field_one: {
+          "field-one": "content one",
+          field_two: "content two",
+        },
+        field_two: {
+          field_one: "content one",
+          "field-two": "content two",
+          toJSON: () => "toJsonResult",
+        },
+      };
+      const expected = {
+        [fieldOne]: {
+          [fieldOne]: "content one",
+          [fieldTwo]: "content two",
+        },
+        [fieldTwo]: "toJsonResult",
+      };
+
+      const result = test.callback(before);
+      expect(result).toEqual(expected);
+    });
+
+    it("should simplify to to the highest level object in a composed object structure that implements toJSON", () => {
+      const before = {
+        field_one: {
+          "field-one": "content one",
+          field_two: {
+            "field-one": "content one",
+            field_two: "content two",
+            toJSON: () => "this method should not be called",
+          },
+          toJSON: () => "toJsonResult",
+        },
+        field_two: {
+          field_one: "content one",
+          "field-two": "content two",
+        },
+      };
+
+      const expected = {
+        [fieldOne]: "toJsonResult",
+        [fieldTwo]: {
+          [fieldOne]: "content one",
+          [fieldTwo]: "content two",
+        },
+      };
+
+      const result = test.callback(before);
+      expect(result).toEqual(expected);
+    });
+
+    it("should only call toJSON on array objects that implement toJSON", () => {
+      const before = [
+        {
+          field_one: "content one one",
+          field_two: "content two two",
+        },
+        {
+          "field-one": "content two one",
+          "field-two": "content two two",
+          toJSON: () => "toJsonResult",
+        },
+      ];
+      const expected = [
+        { [fieldOne]: "content one one", [fieldTwo]: "content two two" },
+        "toJsonResult",
+      ];
+
+      const result = test.callback(before);
+      expect(expected).toEqual(result);
+    });
+
+    it("should only call toJSON on objects in multi-dimensional arrays that implement toJSON", () => {
+      const before = [
+        [
+          {
+            field_one: "content one one",
+            field_two: "content two two",
+            toJSON: () => "toJsonResult",
+          },
+        ],
+        [
+          {
+            "field-one": "content two one",
+            "field-two": "content two two",
+          },
+        ],
+      ];
+      const expected = [
+        ["toJsonResult"],
+        [{ [fieldOne]: "content two one", [fieldTwo]: "content two two" }],
+      ];
+
+      const result = test.callback(before);
+      expect(expected).toEqual(result);
+    });
+
     // TODO Add checking for allowed key after conversion
     describe("allowlist", () => {
       it("should convert allowed value", () => {
@@ -165,6 +311,22 @@ conversionCallbacks.forEach((test) => {
         const expected = { [allowedKey]: [allowedValues] };
         const result = test.callback(before);
         expect(expected).toEqual(result);
+      });
+
+      it("should call toJSON before converting allowed value objects", () => {
+        // the content one and content two fields should be converted to the correct casing however, because toJSON should be called
+        // on the "allow-list-key" values first, the content one and content two fields should not exist, and only emit to toJson string
+        const before = {
+          ["allow-list-key"]: {
+            firstName: "content one",
+            lastName: "content two",
+            toJSON: () => allowedValues,
+          },
+        };
+        const expected = { [allowedKey]: allowedValues };
+
+        const result = test.callback(before);
+        expect(result).toEqual(expected);
       });
     });
   });

--- a/src/app/helpers/filters/audioRecordingFilters.spec.ts
+++ b/src/app/helpers/filters/audioRecordingFilters.spec.ts
@@ -1,0 +1,282 @@
+import { DateExpressions, InnerFilter } from "@baw-api/baw-api.service";
+import { AudioRecording } from "@models/AudioRecording";
+import { DateTime, Duration } from "luxon";
+import { filterDate, filterTime } from "./audioRecordingFilters";
+
+describe("AudioRecordingFilters", () => {
+  const createUTCDate = (year: number, month: number, day: number): DateTime =>
+    DateTime.fromObject({ year, month, day }, { zone: "utc" });
+  const emptyFilter: InnerFilter<AudioRecording> = {};
+
+  describe("addDateFilters", () => {
+    // inner filters created by the filter helper functions do not produce expected filters until JSON.stringify() is applied
+    // to make this assertion easier, we can mock an API calling .toJSON() on nested sub objects by stringifying the result
+    function assertFilters(
+      observedResult: InnerFilter<unknown>,
+      expectedResult: InnerFilter<AudioRecording>
+    ): void {
+      const observedResultString = JSON.stringify(observedResult);
+      const expectedResultString = JSON.stringify(expectedResult);
+
+      expect(observedResultString).toEqual(expectedResultString);
+    }
+
+    it("should create the correct date filter for a single start date", () => {
+      const startDate = createUTCDate(2020, 1, 1);
+      const expectedFilter = {
+        // if there are not multiple filter conditions, the singular condition should not be contained within an and: [] conditional block
+        // to ensure correctness, the time should be explicitly emitted with a value of 00:00:00
+        recordedEndDate: { greaterThan: "2020-01-01T00:00:00.000Z" },
+      } as InnerFilter<AudioRecording>;
+
+      const observedResult = filterDate(emptyFilter, startDate);
+      assertFilters(observedResult, expectedFilter);
+    });
+
+    it("should create the correct date filter for a single end date", () => {
+      const endDate = createUTCDate(2022, 11, 9);
+      const expectedFilter: InnerFilter<AudioRecording> = {
+        recordedDate: { lessThan: "2022-11-09T00:00:00.000Z" },
+      };
+
+      // in real world examples, if the user has not specified a start date into an input box, the start date will be undefined
+      // therefore, we can replicate this behavior by explicitly passing undefined as the start date
+      const observedResult = filterDate(emptyFilter, undefined, endDate);
+      assertFilters(observedResult, expectedFilter);
+    });
+
+    it("should create an array condition for a filter with a start and end date", () => {
+      const startDate = createUTCDate(2020, 1, 1);
+      const endDate = createUTCDate(2022, 11, 9);
+
+      // if there are multiple filter conditions, the conditions should be contained within an and: [] conditional block
+      const expectedFilters: InnerFilter<AudioRecording> = {
+        and: [
+          { recordedEndDate: { greaterThan: "2020-01-01T00:00:00.000Z" } },
+          { recordedDate: { lessThan: "2022-11-09T00:00:00.000Z" } },
+        ],
+      };
+
+      const observedResult = filterDate(emptyFilter, startDate, endDate);
+      assertFilters(observedResult, expectedFilters);
+    });
+
+    it("should not create a new filter if no date filter conditions are defined", () => {
+      const observedResult = filterDate(emptyFilter);
+      assertFilters(observedResult, emptyFilter);
+    });
+
+    it("should format short dates correctly by padding the start of the year to match the YYYY format", () => {
+      const startDate = createUTCDate(20, 1, 1);
+      const endDate = createUTCDate(22, 11, 9);
+      const expectedFilters: InnerFilter<AudioRecording> = {
+        and: [
+          { recordedEndDate: { greaterThan: "0020-01-01T00:00:00.000Z" } },
+          { recordedDate: { lessThan: "0022-11-09T00:00:00.000Z" } },
+        ],
+      };
+
+      const observedResult = filterDate(emptyFilter, startDate, endDate);
+      assertFilters(observedResult, expectedFilters);
+    });
+  });
+
+  describe("createTimeFilter", () => {
+    [false, true].forEach((ignoringDaylightSavings: boolean) => {
+      const expressions: DateExpressions[] = ignoringDaylightSavings
+        ? ["local_offset", "time_of_day"]
+        : ["local_tz", "time_of_day"];
+
+      it(`should create the correct time filter for a single start time, ${
+        ignoringDaylightSavings ? "ignoring" : "using"
+      } daylight savings time`, () => {
+        // since the what the user inputs and what the time.component.ts emits are different
+        // we need to declare two variables for assertion, one for the user input and one for the emitted value
+        //! these variables should be logically equivalent
+        const startTimeInput = "03:00";
+        const startTimeObject: Duration = Duration.fromObject({ hours: 3 });
+
+        const expectedFilter = {
+          recordedEndDate: {
+            greaterThan: {
+              expressions,
+              value: startTimeInput,
+            },
+          },
+        };
+
+        const observedResult = filterTime(
+          emptyFilter,
+          ignoringDaylightSavings,
+          startTimeObject
+        );
+        expect(observedResult).toEqual(expectedFilter);
+      });
+
+      it(`should create the correct time filter for a single end time, ${
+        ignoringDaylightSavings ? "ignoring" : "using"
+      } daylight savings time`, () => {
+        const endTimeInput = "09:11";
+        const endTimeObject: Duration = Duration.fromObject({
+          hours: 9,
+          minutes: 11,
+        });
+
+        const expectedFilter: InnerFilter<AudioRecording> = {
+          recordedDate: {
+            lessThan: {
+              expressions,
+              value: endTimeInput,
+            },
+          },
+        };
+
+        const observedResult = filterTime(
+          emptyFilter,
+          ignoringDaylightSavings,
+          // we can put undefined here because in real world scenarios, the start time input will return undefined
+          // if there is an invalid input (e.g. no input or incorrectly formatted time)
+          undefined,
+          endTimeObject
+        );
+        expect(observedResult).toEqual(expectedFilter);
+      });
+
+      it(`should create an array condition for a filter with multiple times, ${
+        ignoringDaylightSavings ? "ignoring" : "using"
+      } daylight savings time`, () => {
+        const startTimeInput = "03:00";
+        const endTimeInput = "05:00";
+
+        const startTimeObject: Duration = Duration.fromObject({ hours: 3 });
+        const endTimeObject: Duration = Duration.fromObject({ hours: 5 });
+
+        const expectedFilter: InnerFilter<AudioRecording> = {
+          and: [
+            {
+              recordedEndDate: {
+                greaterThan: {
+                  expressions,
+                  value: startTimeInput,
+                },
+              },
+            },
+            {
+              recordedDate: {
+                lessThan: {
+                  expressions,
+                  value: endTimeInput,
+                },
+              },
+            },
+          ],
+        };
+
+        const observedResult = filterTime(
+          emptyFilter,
+          ignoringDaylightSavings,
+          startTimeObject,
+          endTimeObject
+        );
+        expect(observedResult).toEqual(expectedFilter);
+      });
+
+      it(`should create the correct time filter if the time range goes over midnight, ${
+        ignoringDaylightSavings ? "ignoring" : "using"
+      } daylight savings time`, () => {
+        const startTimeInput = "22:00";
+        const endTimeInput = "02:00";
+        const startTimeObject = Duration.fromObject({ hours: 22 });
+        const endTimeObject = Duration.fromObject({ hours: 2 });
+
+        const initialFilters: InnerFilter<AudioRecording> = {};
+        const expectedFilter: InnerFilter<AudioRecording> = {
+          or: [
+            {
+              recordedEndDate: {
+                greaterThanOrEqual: {
+                  expressions,
+                  value: startTimeInput,
+                },
+              },
+            },
+            {
+              recordedDate: {
+                lessThanOrEqual: {
+                  expressions,
+                  value: endTimeInput,
+                },
+              },
+            },
+            {
+              recordedEndDate: {
+                lessThanOrEqual: {
+                  expressions,
+                  value: endTimeInput,
+                },
+              },
+            },
+          ],
+        };
+
+        const observedResult = filterTime(
+          initialFilters,
+          ignoringDaylightSavings,
+          startTimeObject,
+          endTimeObject
+        );
+        expect(observedResult).toEqual(expectedFilter);
+      });
+
+      it(`should not use the midnight filter if the time range ends at midnight ${
+        ignoringDaylightSavings ? "ignoring" : "using"
+      } daylight savings time`, () => {
+        const startTimeInput = "22:00";
+        const endTimeInput = "24:00";
+        const startTimeObject: Duration = Duration.fromObject({ hours: 22 });
+        const endTimeObject: Duration = Duration.fromObject({ hours: 24 });
+
+        const initialFilters: InnerFilter<AudioRecording> = {};
+        const expectedFilter: InnerFilter<AudioRecording> = {
+          and: [
+            {
+              recordedEndDate: {
+                greaterThan: {
+                  expressions,
+                  value: startTimeInput,
+                },
+              },
+            },
+            {
+              recordedDate: {
+                lessThan: {
+                  expressions,
+                  value: endTimeInput,
+                },
+              },
+            },
+          ],
+        };
+
+        const observedResult = filterTime(
+          initialFilters,
+          ignoringDaylightSavings,
+          startTimeObject,
+          endTimeObject
+        );
+        expect(observedResult).toEqual(expectedFilter);
+      });
+
+      it(`should return an empty filter if no start or end times are specified ${
+        ignoringDaylightSavings ? "ignoring" : "using"
+      } daylight savings time`, () => {
+        const initialFilters: InnerFilter<AudioRecording> = {};
+        const observedResult = filterTime(
+          initialFilters,
+          ignoringDaylightSavings
+        );
+        expect(observedResult).toEqual(initialFilters);
+      });
+    });
+  });
+});

--- a/src/app/helpers/filters/audioRecordingFilters.ts
+++ b/src/app/helpers/filters/audioRecordingFilters.ts
@@ -1,0 +1,116 @@
+import { DateExpressions, InnerFilter } from "@baw-api/baw-api.service";
+import { AudioRecording } from "@models/AudioRecording";
+import { DateTime, Duration } from "luxon";
+import { filterAnd } from "./filters";
+
+/**
+ * Adds date range conditions to an existing filter in the ISO8601 date format
+ *
+ * @param filters An existing filter to add the date range conditions to. If no filter is provided, a new filter will be created
+ * @param startDate (optional) The minimum `recordedDate` of the date range
+ * @param endDate (optional) The maximum `recordedEndDate` allowed
+ * @returns A new filter with all the same conditions as the initial filter, with the date range conditions added in an `and` expression
+ */
+export function filterDate(
+  filters: InnerFilter<AudioRecording>,
+  startDate?: DateTime,
+  endDate?: DateTime
+): InnerFilter<AudioRecording> {
+  if (startDate) {
+    // to return the most data that matches the date range interval we want to return any audio recordings that have any audio that overlaps
+    // with the date range interval. But we don't want to return any recordings that just touch on the ends
+    // therefore, the conditions should be `recordedEndDate > startFilterDate && recordedDate < endFilterDate`
+    const startDateFilter = {
+      recordedEndDate: { greaterThan: startDate },
+    } as InnerFilter<AudioRecording>;
+
+    filters = filterAnd<AudioRecording>(filters, startDateFilter);
+  }
+
+  if (endDate) {
+    const endDateFilters: InnerFilter<AudioRecording> = {
+      recordedDate: { lessThan: endDate },
+    };
+
+    filters = filterAnd<AudioRecording>(filters, endDateFilters);
+  }
+
+  return filters;
+}
+
+/**
+ * Adds time range conditions to an existing filter
+ *
+ * @param filters An existing filter to add the time range conditions to. If no filter is provided, a new filter will be created
+ * @param ignoreDayLightSavings Describes if the time filters use local (daylight savings) time
+ * @param startTime (optional) The minimum `recordedDate` allowed
+ * @param endTime (optional) The maximum `recordedEndDate` allowed
+ * @returns A new filter with all the same conditions as the initial filter, with the time range conditions added in an `and` expression
+ */
+export function filterTime(
+  filters: InnerFilter<AudioRecording>,
+  ignoreDayLightSavings: boolean,
+  startTime?: Duration,
+  endTime?: Duration
+): InnerFilter<AudioRecording> {
+  // the api expects time filters to be in the format of "hh:mm" (e.g. 08:12)
+  // since Luxon's Duration toJSON() method outputs the times in the ISO 8601 period format (e.g. P23DT23H)
+  // we have to format times at filter creation to the expected hh:mm format
+  const timeFormat = "hh:mm";
+  const expressions: DateExpressions[] = ignoreDayLightSavings
+    ? ["local_offset", "time_of_day"]
+    : ["local_tz", "time_of_day"];
+
+  const formattedStartTime = startTime?.toFormat(timeFormat);
+  const formattedEndTime = endTime?.toFormat(timeFormat);
+
+  // a midnight filter is a filter circumstance where the time range overlaps two days e.g. 10PM to 1AM
+  // therefore, midnight filters can only occur if both a start and end time are specified and the start time occurs after the end time
+  const isMidnightFilter = startTime && endTime && startTime > endTime;
+
+  if (isMidnightFilter) {
+    const timeInnerFilter: InnerFilter<AudioRecording> = {
+      or: [
+        {
+          recordedEndDate: {
+            greaterThanOrEqual: { expressions, value: formattedStartTime },
+          },
+        },
+        {
+          recordedDate: {
+            lessThanOrEqual: { expressions, value: formattedEndTime },
+          },
+        },
+        {
+          recordedEndDate: {
+            lessThanOrEqual: { expressions, value: formattedEndTime },
+          },
+        },
+      ],
+    };
+
+    filters = filterAnd<AudioRecording>(filters, timeInnerFilter);
+  } else {
+    if (startTime) {
+      const startTimeFilter = {
+        recordedEndDate: {
+          greaterThan: { expressions, value: formattedStartTime },
+        },
+      };
+
+      filters = filterAnd<AudioRecording>(filters, startTimeFilter);
+    }
+
+    if (endTime) {
+      const endTimeFilter = {
+        recordedDate: {
+          lessThan: { expressions, value: formattedEndTime },
+        },
+      };
+
+      filters = filterAnd<AudioRecording>(filters, endTimeFilter);
+    }
+  }
+
+  return filters;
+}

--- a/src/app/helpers/filters/filters.ts
+++ b/src/app/helpers/filters/filters.ts
@@ -1,0 +1,64 @@
+import { InnerFilter } from "@baw-api/baw-api.service";
+import { Writeable } from "@helpers/advancedTypes";
+import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
+import { AbstractModel } from "@models/AbstractModel";
+
+/**
+ * Adds an inner filter to the root of an existing filter in an `and` expression
+ *
+ * @param filter The current inner filter conditions
+ * @param newFilter A new inner filter condition that will be added in an `and` expression
+ * @returns A new filter which satisfies the intersection between the two filters
+ */
+export function filterAnd<T extends AbstractModel>(
+  filter: InnerFilter,
+  newFilter: InnerFilter
+): InnerFilter<Writeable<T>> {
+  if (!newFilter || Object.keys(newFilter).length === 0) {
+    return filter;
+  }
+
+  // because the api is expecting multiple conditions with the and combinator condition
+  // if there are multiple conditions, we need to wrap the filter in an and: [] combinator
+  // if there is only a single condition, the filter should be returned without the and block
+  if (!filter || Object.keys(filter).length === 0) {
+    return newFilter;
+  } else {
+    // if the current filter already contains an "and" conditional block, the additional filter should be added to the existing "and" block
+    // otherwise, the current and additional filters should be wrapped in an "and" conditional block together
+    return {
+      and: filter.and
+        ? [...(filter.and as InnerFilter[]), newFilter]
+        : [filter, newFilter],
+    };
+  }
+}
+
+/**
+ * Adds a new filter to an existing filter that filters by a model's id
+ *
+ * @param key The key identifier of the model, most likely the type
+ * @example key = "projects"
+ * @param model The model to filter by
+ * @param currentFilter (optional) A filter that model condition will be added to. If no filter is provided, a new filter will be created
+ * @returns A new filter with the model condition added
+ */
+export function filterModel<T extends AbstractModel, U extends AbstractModel>(
+  key: string,
+  model: T,
+  currentFilter: InnerFilter
+): InnerFilter<Writeable<U>> {
+  // all model filters condition on the id attribute. While it is very rare for a model to not have an id, it is possible
+  // this bailout is typically evoked if the model is undefined
+  if (!isInstantiated(model?.id)) {
+    return currentFilter;
+  }
+
+  const additionalFilter: InnerFilter = {
+    [`${key}.id`]: {
+      eq: model.id,
+    },
+  };
+
+  return filterAnd(currentFilter, additionalFilter);
+}

--- a/src/app/helpers/tableTemplate/pagedTableTemplate.ts
+++ b/src/app/helpers/tableTemplate/pagedTableTemplate.ts
@@ -81,11 +81,11 @@ export abstract class PagedTableTemplate<TableRow, M extends AbstractModel>
         distinctUntilChanged(),
         takeUntil(this.unsubscribe)
       )
-      .subscribe(
-        () => this.getPageData(),
+      .subscribe({
+        next: () => this.getPageData(),
         // Filter event doesn't have an error output
-        (err) => console.error(err)
-      );
+        error: (err) => console.error(err),
+      });
   }
 
   public ngOnInit() {

--- a/src/app/services/baw-api/baw-api.service.ts
+++ b/src/app/services/baw-api/baw-api.service.ts
@@ -545,6 +545,17 @@ export interface Combinations<T> {
 }
 
 /**
+ * A serializable object that can be directly passed as the body for an API call
+ *
+ * @description
+ * Objects that implement `.toJSON` or `.toString` are considered serializable as they are serialized by Angular's request body serializer
+ */
+export interface SerializableObject {
+  toJSON(): string;
+  toString(): string;
+}
+
+/**
  * Date filter expressions
  * https://github.com/QutEcoacoustics/baw-server/wiki/API:-Filtering#supported-expressions
  *
@@ -567,26 +578,26 @@ export interface Expression {
 }
 
 export interface Comparisons {
-  eq?: string | number | boolean;
-  equal?: string | number | boolean;
-  notEq?: string | number | boolean;
-  notEqual?: string | number | boolean;
-  lt?: string | number | Expression;
-  lessThan?: string | number | Expression;
-  notLt?: string | number | Expression;
-  notLessThan?: string | number | Expression;
-  gt?: string | number | Expression;
-  greaterThan?: string | number | Expression;
-  notGt?: string | number | Expression;
-  notGreaterThan?: string | number | Expression;
-  lteq?: string | number | Expression;
-  lessThanOrEqual?: string | number | Expression;
-  notLteq?: string | number | Expression;
-  notLessThanOrEqual?: string | number | Expression;
-  gteq?: string | number | Expression;
-  greaterThanOrEqual?: string | number | Expression;
-  notGteq?: string | number | Expression;
-  notGreaterThanOrEqual?: string | number | Expression;
+  eq?: string | number | boolean | SerializableObject;
+  equal?: string | number | boolean | SerializableObject;
+  notEq?: string | number | boolean | SerializableObject;
+  notEqual?: string | number | boolean | SerializableObject;
+  lt?: string | number | Expression | SerializableObject;
+  lessThan?: string | number | Expression | SerializableObject;
+  notLt?: string | number | Expression | SerializableObject;
+  notLessThan?: string | number | Expression | SerializableObject;
+  gt?: string | number | Expression | SerializableObject;
+  greaterThan?: string | number | Expression | SerializableObject;
+  notGt?: string | number | Expression | SerializableObject;
+  notGreaterThan?: string | number | Expression | SerializableObject;
+  lteq?: string | number | Expression | SerializableObject;
+  lessThanOrEqual?: string | number | Expression | SerializableObject;
+  notLteq?: string | number | Expression | SerializableObject;
+  notLessThanOrEqual?: string | number | Expression | SerializableObject;
+  gteq?: string | number | Expression | SerializableObject;
+  greaterThanOrEqual?: string | number | Expression | SerializableObject;
+  notGteq?: string | number | Expression | SerializableObject;
+  notGreaterThanOrEqual?: string | number | Expression | SerializableObject;
 }
 
 /**


### PR DESCRIPTION
# Add recording filtering component and adjust existing filter form validations

An audio recording filter component already exists on the batch download page, but it is not generalised for use on the audio recordings list page and in other places in the client.

In the old batch download filter component, we were relying on the Angular-Boostrap validations for date inputs. However, dates with less than 4 characters are not valid and cause an internal server error when the api is called.

Therefore, we want to pad dates with less than 4 characters using the ISO 8601 format.

## Changes

**Pages & Components**
- Creates an `audio-recording-filter` component that emits a filter update event
- Adds an `audio-recording-filter` component to the audio recordings list page

- Adds a midnight time filter, allowing users to filter times past day ranges
- Adds filter helper method to filter by model id's
- Adds audio recording filter helper methods
  - Adds filter helper method to filter audio recordings by a time range/interval
  - Adds filter helper method to filter audio recordings by date range/interval
- With the addition of the `and[]` filter array condition to the api 🎉, there is now an `addFilter` method which adds an inner filter condition to an additional filter using the `and` filter operator.
- Recording filter component now uses Angular form validation 🎉

---

**Time Component**

- Now emits a Luxon `Duration` type

---

**Case Converter**
- modifies `caseConverter` to simplify object values through their `toJSON` implementations
- Adds a `SerializableObject` interface type that can be used with inner filters

---

**Tests & Unit Tests**

- Creates tests for the batch download component to validate that the client displays the correct errors when an invalid date is added
- Creates tests for the new `audio-recording-filter.component.ts` component to ensure filter updates are only emitted when needed
- Creates tests for the new `audio-recording-filter.component.ts` component to ensure the correct errors are displayed and no filter update is emitted when the user inputs a "bad" date/time
  - Start date comes after the end date
  - The time is not in the correct format
  - The date is not in the correct format

- Creates tests to ensure the `addFilter` condition uses the `and` filter operation correctly
- Creates tests for the audio recording filter helper functions

---

**Minor Changes**

- Changes wording used for invalid dates to use the word "date" instead of "time" in errors

## Problems

None

## Issues

Fixes: #2018 
Fixes: #1724 
Fixes: #1927 

## Visual Changes

**Invalid dates:**
![image](https://user-images.githubusercontent.com/33742269/212818479-679a789b-2139-4e49-9896-0e52603d054b.png)

**Error if the start date > end date:**
![image](https://user-images.githubusercontent.com/33742269/212818577-95ca8679-35be-4bd5-b39d-f0473cff3001.png)
  
---
  
**Filter component on audio recordings list page (collapsed):**
![image](https://user-images.githubusercontent.com/33742269/217995676-4608b178-8163-4ad2-b617-9b5bda6ff7c7.png)

**Filter component on audio recordings list page (expanded):**
![image](https://user-images.githubusercontent.com/33742269/217995917-8288c6aa-ea79-4f2a-8740-7c3a77e80c7e.png)

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
