### PR TITLE
Unique Route titles

### DIFF
--- a/scripts/ssr-tests.ps1
+++ b/scripts/ssr-tests.ps1
@@ -81,7 +81,7 @@ Format-Info "Retrieve home page"
 $indexFile = "index.html"
 Get-Page "" $indexFile
 Format-Info "Validate title"
-Assert-Contains "<title>&lt;&lt;brandName&gt;&gt;</title>" $indexFile
+Assert-Contains "<title>&lt;&lt;brandName&gt;&gt; | Home</title>" $indexFile
 Format-Info "Validate routing"
 Assert-Contains "<\/router-outlet><baw-home.*<\/baw-home>" $indexFile
 Format-Info "Validate footer contains version"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,8 +20,9 @@ import { BawTimeoutModule } from "@services/timeout/timeout.module";
 import { formlyConfig } from "@shared/formly/custom-inputs.module";
 import { ToastrModule } from "ngx-toastr";
 import { environment } from "src/environments/environment";
+import { TitleStrategy } from "@angular/router";
 import { AppRoutingModule } from "./app-routing.module";
-import { AppComponent } from "./app.component";
+import { AppComponent, PageTitleStrategy } from "./app.component";
 import { toastrRoot } from "./app.helper";
 import { AboutModule } from "./components/about/about.module";
 import { AdminModule } from "./components/admin/admin.module";
@@ -93,6 +94,7 @@ export const appImports = [
     ...appImports,
   ],
   providers: [
+    { provide: TitleStrategy, useClass: PageTitleStrategy },
     // Show loading animation after 3 seconds
     { provide: LOADING_BAR_CONFIG, useValue: { latencyThreshold: 200 } },
   ],

--- a/src/app/components/admin/analysis-jobs/analysis-jobs.menus.ts
+++ b/src/app/components/admin/analysis-jobs/analysis-jobs.menus.ts
@@ -1,3 +1,4 @@
+import { RouterStateSnapshot } from "@angular/router";
 import { Category, menuRoute } from "@interfaces/menusInterfaces";
 import { isAdminPredicate } from "src/app/app.menus";
 import { adminDashboardMenuItem, adminRoute } from "../admin.menus";
@@ -28,4 +29,8 @@ export const adminAnalysisJobMenuItem = menuRoute({
   tooltip: () => "Manage analysis job",
   parent: adminAnalysisJobsMenuItem,
   predicate: isAdminPredicate,
+  title: (routeData: RouterStateSnapshot): string => {
+    const componentModel = routeData.root.firstChild.data;
+    return componentModel.analysisJob.model.name;
+  }
 });

--- a/src/app/components/admin/analysis-jobs/details/details.component.spec.ts
+++ b/src/app/components/admin/analysis-jobs/details/details.component.spec.ts
@@ -17,8 +17,10 @@ import { generateScript } from "@test/fakes/Script";
 import { generateUser } from "@test/fakes/User";
 import { assertDetail, Detail } from "@test/helpers/detail-view";
 import { nStepObservable } from "@test/helpers/general";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { Subject } from "rxjs";
+import { PageTitleStrategy } from "src/app/app.component";
 import { AdminAnalysisJobComponent } from "./details.component";
 
 describe("AdminAnalysisJobComponent", () => {
@@ -27,6 +29,12 @@ describe("AdminAnalysisJobComponent", () => {
   const createComponent = createComponentFactory({
     component: AdminAnalysisJobComponent,
     imports: [SharedModule, MockBawApiModule, RouterTestingModule],
+  });
+
+  assertPageInfo<AnalysisJob>(AdminAnalysisJobComponent, "test name", {
+    analysisJob: {
+      model: new AnalysisJob(generateAnalysisJob({ name: "test name" }))
+    },
   });
 
   function setup(model: AnalysisJob, error?: BawApiError) {
@@ -39,6 +47,9 @@ describe("AdminAnalysisJobComponent", () => {
             { analysisJob: "resolver" },
             { analysisJob: { model, error } }
           ),
+        },
+        {
+          provide: PageTitleStrategy,
         },
       ],
     });

--- a/src/app/components/admin/analysis-jobs/list/list.component.spec.ts
+++ b/src/app/components/admin/analysis-jobs/list/list.component.spec.ts
@@ -6,6 +6,7 @@ import { AnalysisJob } from "@models/AnalysisJob";
 import { createComponentFactory, Spectator } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { generateAnalysisJob } from "@test/fakes/AnalysisJob";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { assertPagination } from "@test/helpers/pagedTableTemplate";
 import { AdminAnalysisJobsComponent } from "./list.component";
 
@@ -34,6 +35,12 @@ describe("AdminAnalysisJobsComponent", () => {
   });
 
   assertPagination<AnalysisJob, AnalysisJobsService>();
+
+  assertPageInfo(AdminAnalysisJobsComponent, "Analysis Jobs")
+
+  it("should create", () => {
+    expect(spec.component).toBeInstanceOf(AdminAnalysisJobsComponent);
+  });
 
   // TODO Write Tests
   xdescribe("rows", () => {});

--- a/src/app/components/admin/orphan/details/details.component.spec.ts
+++ b/src/app/components/admin/orphan/details/details.component.spec.ts
@@ -17,6 +17,7 @@ import { generateBawApiError } from "@test/fakes/BawApiError";
 import { generateSite } from "@test/fakes/Site";
 import { assertDetail, Detail } from "@test/helpers/detail-view";
 import { nStepObservable } from "@test/helpers/general";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
@@ -81,6 +82,12 @@ describe("AdminOrphanComponent", () => {
 
     return promise;
   }
+
+  assertPageInfo<Site>(AdminOrphanComponent, "Test Orphaned Site", {
+    site: {
+      model: new Site(generateSite({ name: "Test Orphaned Site" })),
+    }
+  });
 
   it("should create", () => {
     configureTestingModule(new Site(generateSite()));

--- a/src/app/components/admin/orphan/list/list.component.spec.ts
+++ b/src/app/components/admin/orphan/list/list.component.spec.ts
@@ -6,6 +6,7 @@ import { ShallowSitesService } from "@baw-api/site/sites.service";
 import { Site } from "@models/Site";
 import { SharedModule } from "@shared/shared.module";
 import { generateSite } from "@test/fakes/Site";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { assertPagination } from "@test/helpers/pagedTableTemplate";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminOrphansComponent } from "./list.component";
@@ -41,6 +42,12 @@ describe("AdminOrphansComponent", () => {
 
   // TODO Write Tests
   assertPagination<Site, ShallowSitesService>("orphanFilter");
+
+  assertPageInfo(AdminOrphansComponent, "Orphan Sites");
+
+  it("should create", () => {
+    expect(fixture.componentInstance).toBeInstanceOf(AdminOrphansComponent);
+  });
 
   xdescribe("rows", () => {});
   xdescribe("actions", () => {});

--- a/src/app/components/admin/orphan/orphans.menus.ts
+++ b/src/app/components/admin/orphan/orphans.menus.ts
@@ -1,3 +1,4 @@
+import { RouterStateSnapshot } from "@angular/router";
 import { Category, menuRoute } from "@interfaces/menusInterfaces";
 import { isAdminPredicate } from "src/app/app.menus";
 import { adminDashboardMenuItem, adminRoute } from "../admin.menus";
@@ -26,4 +27,9 @@ export const adminOrphanMenuItem = menuRoute({
   tooltip: () => "Manage orphaned site",
   parent: adminOrphansMenuItem,
   predicate: isAdminPredicate,
+  title: (routeData: RouterStateSnapshot): string => {
+    const componentModel = routeData.root.firstChild.data;
+    const orphanSiteName = componentModel.site.model.name;
+    return orphanSiteName;
+  }
 });

--- a/src/app/components/admin/scripts/details/details.component.spec.ts
+++ b/src/app/components/admin/scripts/details/details.component.spec.ts
@@ -18,6 +18,7 @@ import { generateBawApiError } from "@test/fakes/BawApiError";
 import { generateScript } from "@test/fakes/Script";
 import { assertDetail, Detail } from "@test/helpers/detail-view";
 import { nStepObservable } from "@test/helpers/general";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
@@ -79,6 +80,12 @@ describe("ScriptComponent", () => {
       ),
     ]);
   }
+
+  assertPageInfo<Script>(AdminScriptComponent, "Test Script", {
+    script: {
+      model: new Script(generateScript({ name: "Test Script" })),
+    }
+  });
 
   it("should create", () => {
     configureTestingModule(new Script(generateScript()));

--- a/src/app/components/admin/scripts/edit/edit.component.spec.ts
+++ b/src/app/components/admin/scripts/edit/edit.component.spec.ts
@@ -13,6 +13,7 @@ import { SharedModule } from "@shared/shared.module";
 import { generateBawApiError } from "@test/fakes/BawApiError";
 import { generateScript } from "@test/fakes/Script";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { Subject } from "rxjs";
@@ -59,6 +60,8 @@ describe("AdminScriptsEditComponent", () => {
 
     fixture.detectChanges();
   }
+
+  assertPageInfo<Script>(AdminScriptsEditComponent, "Edit");
 
   beforeEach(() => {
     defaultModel = new Script(generateScript());

--- a/src/app/components/admin/scripts/list/list.component.spec.ts
+++ b/src/app/components/admin/scripts/list/list.component.spec.ts
@@ -6,6 +6,7 @@ import { ScriptsService } from "@baw-api/script/scripts.service";
 import { Script } from "@models/Script";
 import { SharedModule } from "@shared/shared.module";
 import { generateScript } from "@test/fakes/Script";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { assertPagination } from "@test/helpers/pagedTableTemplate";
 import { appLibraryImports } from "src/app/app.module";
 import { AdminScriptsComponent } from "./list.component";
@@ -41,6 +42,12 @@ describe("AdminScriptsComponent", () => {
 
   // TODO Write tests
   assertPagination<Script, ScriptsService>();
+
+  assertPageInfo(AdminScriptsComponent, "Scripts");
+
+  it("should create", () => {
+    expect(fixture.componentInstance).toBeInstanceOf(AdminScriptsComponent);
+  });
 
   xdescribe("rows", () => {});
   xdescribe("actions", () => {});

--- a/src/app/components/admin/scripts/new/new.component.spec.ts
+++ b/src/app/components/admin/scripts/new/new.component.spec.ts
@@ -5,6 +5,7 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { ScriptsService } from "@baw-api/script/scripts.service";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { ToastrService } from "ngx-toastr";
 import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
@@ -16,6 +17,8 @@ describe("AdminScriptsNewComponent", () => {
   let fixture: ComponentFixture<AdminScriptsNewComponent>;
   let notifications: ToastrService;
   let router: Router;
+
+  assertPageInfo(AdminScriptsNewComponent, "New Script");
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/src/app/components/admin/scripts/scripts.menus.ts
+++ b/src/app/components/admin/scripts/scripts.menus.ts
@@ -1,9 +1,11 @@
+import { RouterStateSnapshot } from "@angular/router";
 import { Category, menuRoute } from "@interfaces/menusInterfaces";
 import {
   defaultEditIcon,
   defaultNewIcon,
   isAdminPredicate,
 } from "src/app/app.menus";
+import { CommonRouteTitles } from "src/app/stringConstants";
 import { adminDashboardMenuItem, adminRoute } from "../admin.menus";
 
 export const adminScriptsRoute = adminRoute.addFeatureModule("scripts");
@@ -41,6 +43,11 @@ export const adminScriptMenuItem = menuRoute({
   tooltip: () => "Manage script",
   parent: adminScriptsMenuItem,
   predicate: isAdminPredicate,
+  title: (routeData: RouterStateSnapshot): string => {
+    const componentModel = routeData.root.firstChild.data;
+    const scriptName = componentModel.script.model.name;
+    return scriptName;
+  }
 });
 
 export const adminEditScriptMenuItem = menuRoute({
@@ -50,4 +57,5 @@ export const adminEditScriptMenuItem = menuRoute({
   tooltip: () => "Create new version of this script",
   parent: adminScriptMenuItem,
   predicate: isAdminPredicate,
+  title: () => CommonRouteTitles.routeEditTitle,
 });

--- a/src/app/components/admin/tag-group/edit/edit.component.spec.ts
+++ b/src/app/components/admin/tag-group/edit/edit.component.spec.ts
@@ -13,6 +13,7 @@ import { SharedModule } from "@shared/shared.module";
 import { generateBawApiError } from "@test/fakes/BawApiError";
 import { generateTagGroup } from "@test/fakes/TagGroup";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { of, Subject } from "rxjs";
@@ -59,6 +60,8 @@ describe("AdminTagGroupsEditComponent", () => {
 
     fixture.detectChanges();
   }
+
+  assertPageInfo(AdminTagGroupsEditComponent, "Edit");
 
   beforeEach(() => {
     defaultTagGroup = new TagGroup(generateTagGroup());

--- a/src/app/components/admin/tag-group/list/list.component.spec.ts
+++ b/src/app/components/admin/tag-group/list/list.component.spec.ts
@@ -8,6 +8,7 @@ import { NgbModal, NgbModalConfig } from "@ng-bootstrap/ng-bootstrap";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { generateTagGroup } from "@test/fakes/TagGroup";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { assertPagination } from "@test/helpers/pagedTableTemplate";
 import { ToastrService } from "ngx-toastr";
 import { of } from "rxjs";
@@ -57,6 +58,8 @@ describe("AdminTagGroupsComponent", () => {
   });
 
   assertPagination<TagGroup, TagGroupsService>();
+
+  assertPageInfo(AdminTagGroupsComponent, "Tag Group");
 
   it("should create", () => {
     expect(fixture.componentInstance).toBeInstanceOf(AdminTagGroupsComponent);

--- a/src/app/components/admin/tag-group/new/new.component.spec.ts
+++ b/src/app/components/admin/tag-group/new/new.component.spec.ts
@@ -5,6 +5,7 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { TagGroupsService } from "@baw-api/tag/tag-group.service";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { Subject } from "rxjs";
@@ -17,6 +18,8 @@ describe("AdminTagGroupsNewComponent", () => {
   let fixture: ComponentFixture<AdminTagGroupsNewComponent>;
   let notifications: ToastrService;
   let router: Router;
+
+  assertPageInfo(AdminTagGroupsNewComponent, "New Tag Group")
 
   xdescribe("form", () => {});
 

--- a/src/app/components/admin/tag-group/tag-group.menus.ts
+++ b/src/app/components/admin/tag-group/tag-group.menus.ts
@@ -4,6 +4,7 @@ import {
   defaultNewIcon,
   isAdminPredicate,
 } from "src/app/app.menus";
+import { CommonRouteTitles } from "src/app/stringConstants";
 import { adminDashboardMenuItem, adminRoute } from "../admin.menus";
 
 export const adminTagGroupsRoute = adminRoute.addFeatureModule("tag_groups");
@@ -41,4 +42,5 @@ export const adminEditTagGroupMenuItem = menuRoute({
   tooltip: () => "Update an existing tag group",
   parent: adminTagGroupsMenuItem,
   predicate: isAdminPredicate,
+  title: () => CommonRouteTitles.routeEditTitle,
 });

--- a/src/app/components/admin/tags/edit/edit.component.spec.ts
+++ b/src/app/components/admin/tags/edit/edit.component.spec.ts
@@ -10,6 +10,7 @@ import { SharedModule } from "@shared/shared.module";
 import { generateBawApiError } from "@test/fakes/BawApiError";
 import { generateTag } from "@test/fakes/Tag";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { of, Subject } from "rxjs";
@@ -68,6 +69,8 @@ describe("AdminTagsEditComponent", () => {
 
     fixture.detectChanges();
   }
+
+  assertPageInfo(AdminTagsEditComponent, "Edit");
 
   beforeEach(() => {
     defaultTag = new Tag(generateTag());

--- a/src/app/components/admin/tags/list/list.component.spec.ts
+++ b/src/app/components/admin/tags/list/list.component.spec.ts
@@ -8,6 +8,7 @@ import { NgbModal, NgbModalConfig } from "@ng-bootstrap/ng-bootstrap";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { generateTag } from "@test/fakes/Tag";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { assertPagination } from "@test/helpers/pagedTableTemplate";
 import { ToastrService } from "ngx-toastr";
 import { of } from "rxjs";
@@ -56,6 +57,8 @@ describe("AdminTagsComponent", () => {
   });
 
   assertPagination<Tag, TagsService>();
+
+  assertPageInfo(AdminTagsComponent, "Tags");
 
   it("should create", () => {
     expect(fixture.componentInstance).toBeInstanceOf(AdminTagsComponent);

--- a/src/app/components/admin/tags/new/new.component.spec.ts
+++ b/src/app/components/admin/tags/new/new.component.spec.ts
@@ -9,6 +9,7 @@ import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { generateBawApiError } from "@test/fakes/BawApiError";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { Subject } from "rxjs";
@@ -55,6 +56,8 @@ describe("AdminTagsNewComponent", () => {
 
     fixture.detectChanges();
   }
+
+  assertPageInfo(AdminTagsNewComponent, "New Tag");
 
   beforeEach(() => {
     defaultTagTypes = [

--- a/src/app/components/admin/tags/tags.menus.ts
+++ b/src/app/components/admin/tags/tags.menus.ts
@@ -4,6 +4,7 @@ import {
   defaultNewIcon,
   isAdminPredicate,
 } from "src/app/app.menus";
+import { CommonRouteTitles } from "src/app/stringConstants";
 import { adminDashboardMenuItem, adminRoute } from "../admin.menus";
 
 export const adminTagsRoute = adminRoute.addFeatureModule("tags");
@@ -41,4 +42,5 @@ export const adminEditTagMenuItem = menuRoute({
   tooltip: () => "Edit an existing tag",
   parent: adminTagsMenuItem,
   predicate: isAdminPredicate,
+  title: () => CommonRouteTitles.routeEditTitle,
 });

--- a/src/app/components/audio-analysis/audio-analysis.menus.ts
+++ b/src/app/components/audio-analysis/audio-analysis.menus.ts
@@ -1,3 +1,4 @@
+import { RouterStateSnapshot } from "@angular/router";
 import { retrieveResolvedModel } from "@baw-api/resolver-common";
 import { Category, menuAction, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
@@ -38,6 +39,10 @@ export const audioAnalysisMenuItem = menuRoute({
   parent: audioAnalysesMenuItem,
   breadcrumbResolve: (pageInfo) =>
     retrieveResolvedModel(pageInfo, AnalysisJob)?.name,
+  title: (routeData: RouterStateSnapshot): string => {
+    const componentModel = routeData.root.firstChild.data;
+    return componentModel.analysisJob.model.name;
+  },
 });
 
 export const audioAnalysisResultsMenuItem = menuRoute({

--- a/src/app/components/audio-analysis/pages/details/details.component.spec.ts
+++ b/src/app/components/audio-analysis/pages/details/details.component.spec.ts
@@ -4,6 +4,7 @@ import { AudioAnalysisModule } from "@components/audio-analysis/audio-analysis.m
 import { AnalysisJob } from "@models/AnalysisJob";
 import { generateAnalysisJob } from "@test/fakes/AnalysisJob";
 import { validateBawClientPage } from "@test/helpers/baw-client";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { BehaviorSubject } from "rxjs";
 import { AudioAnalysisComponent } from "./details.component";
 
@@ -22,4 +23,10 @@ describe("AudioAnalysisComponent", () => {
       );
     }
   );
+
+  assertPageInfo<AnalysisJob>(AudioAnalysisComponent, "Test Analysis Job", {
+    analysisJob: {
+      model: new AnalysisJob(generateAnalysisJob({ name: "Test Analysis Job" })),
+    }
+  });
 });

--- a/src/app/components/audio-analysis/pages/list/list.component.spec.ts
+++ b/src/app/components/audio-analysis/pages/list/list.component.spec.ts
@@ -1,6 +1,7 @@
 import { audioAnalysesRoute } from "@components/audio-analysis/audio-analysis.menus";
 import { AudioAnalysisModule } from "@components/audio-analysis/audio-analysis.module";
 import { validateBawClientPage } from "@test/helpers/baw-client";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { AudioAnalysesComponent } from "./list.component";
 
 describe("AudioAnalysesComponent", () => {
@@ -11,4 +12,6 @@ describe("AudioAnalysesComponent", () => {
     "/audio_analysis",
     "This is a list of analysis jobs you have access to."
   );
+
+  assertPageInfo(AudioAnalysesComponent, "Audio Analysis");
 });

--- a/src/app/components/audio-analysis/pages/new/new.component.spec.ts
+++ b/src/app/components/audio-analysis/pages/new/new.component.spec.ts
@@ -1,6 +1,7 @@
 import { audioAnalysesRoute } from "@components/audio-analysis/audio-analysis.menus";
 import { AudioAnalysisModule } from "@components/audio-analysis/audio-analysis.module";
 import { validateBawClientPage } from "@test/helpers/baw-client";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { NewAudioAnalysisComponent } from "./new.component";
 
 describe("NewAudioAnalysisComponent", () => {
@@ -11,4 +12,6 @@ describe("NewAudioAnalysisComponent", () => {
     "/audio_analysis/new",
     "Use this page to select the data to analyze, choose the analysis to run"
   );
+
+  assertPageInfo(NewAudioAnalysisComponent, "New Analysis Job");
 });

--- a/src/app/components/audio-recordings/audio-recording.menus.ts
+++ b/src/app/components/audio-recordings/audio-recording.menus.ts
@@ -1,3 +1,4 @@
+import { RouterStateSnapshot } from "@angular/router";
 import { audioRecordingOriginalEndpoint } from "@baw-api/audio-recording/audio-recordings.service";
 import { retrieveResolvedModel } from "@baw-api/resolver-common";
 import { projectMenuItem } from "@components/projects/projects.menus";
@@ -49,6 +50,10 @@ function makeDetailsMenuItem(subRoute: RecordingRoute): MenuRoute {
     // TODO #346 Show local date time of recording date using timezone where sensor was. Should show timezone on highlight?
     breadcrumbResolve: (pageInfo) =>
       retrieveResolvedModel(pageInfo, AudioRecording)?.id.toFixed(0),
+    title: (routeData: RouterStateSnapshot): string => {
+      const componentModel = routeData.root.firstChild.data;
+      return componentModel.audioRecording.model.id.toString();
+    },
   });
 }
 

--- a/src/app/components/audio-recordings/pages/details/details.component.spec.ts
+++ b/src/app/components/audio-recordings/pages/details/details.component.spec.ts
@@ -1,24 +1,37 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { AudioRecording } from "@models/AudioRecording";
+import { createRoutingFactory, Spectator } from "@ngneat/spectator";
+import { SharedModule } from "@shared/shared.module";
+import { generateAudioRecording } from "@test/fakes/AudioRecording";
+import { assertPageInfo } from "@test/helpers/pageRoute";
+import { PageTitleStrategy } from "src/app/app.component";
 import { AudioRecordingsDetailsComponent } from "./details.component";
 
-// TODO
-xdescribe("AudioRecordingsDetailsComponent", () => {
-  let component: AudioRecordingsDetailsComponent;
-  let fixture: ComponentFixture<AudioRecordingsDetailsComponent>;
+describe("AudioRecordingsDetailsComponent", () => {
+  let spectator: Spectator<AudioRecordingsDetailsComponent>;
+  let defaultAudioRecording: AudioRecording;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [AudioRecordingsDetailsComponent],
-    }).compileComponents();
+  const createComponent = createRoutingFactory({
+    component: AudioRecordingsDetailsComponent,
+    providers: [PageTitleStrategy],
+    imports: [MockBawApiModule, SharedModule],
   });
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AudioRecordingsDetailsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  assertPageInfo<AudioRecording>(AudioRecordingsDetailsComponent, "11", {
+    audioRecording: {
+      model: new AudioRecording(generateAudioRecording({ id: 11 }))
+    },
   });
+
+  function setup() {
+    defaultAudioRecording = new AudioRecording(generateAudioRecording());
+    spectator = createComponent({ detectChanges: false });
+    spyOnProperty(spectator.component, "recording", "get").and.callFake(() => defaultAudioRecording);
+  }
+
+  beforeEach(() => setup());
 
   it("should create", () => {
-    expect(component).toBeTruthy();
+    expect(spectator.component).toBeInstanceOf(AudioRecordingsDetailsComponent);
   });
 });

--- a/src/app/components/audio-recordings/pages/list/list.component.spec.ts
+++ b/src/app/components/audio-recordings/pages/list/list.component.spec.ts
@@ -1,17 +1,24 @@
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
-import { createRoutingFactory, SpectatorRouting } from "@ngneat/spectator";
+import { createRoutingFactory, Spectator } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { AudioRecordingsListComponent } from "./list.component";
 
 describe("AudioRecordingsListComponent", () => {
-  let spectator: SpectatorRouting<AudioRecordingsListComponent>;
+  let spectator: Spectator<AudioRecordingsListComponent>;
 
   const createComponent = createRoutingFactory({
     component: AudioRecordingsListComponent,
     imports: [MockBawApiModule, SharedModule],
   });
 
-  beforeEach(() => spectator = createComponent({ detectChanges: false }));
+  function setup(): void {
+    spectator = createComponent({ detectChanges: false });
+  }
+
+  beforeEach(() => setup());
+
+  assertPageInfo(AudioRecordingsListComponent, "Audio Recordings")
 
   it("should create", () => {
     expect(spectator.component).toBeInstanceOf(AudioRecordingsListComponent);

--- a/src/app/components/harvest/harvest.menus.ts
+++ b/src/app/components/harvest/harvest.menus.ts
@@ -1,3 +1,4 @@
+import { RouterStateSnapshot } from "@angular/router";
 import { retrieveResolvedModel } from "@baw-api/resolver-common";
 import { projectMenuItem } from "@components/projects/projects.menus";
 import { IPageInfo } from "@helpers/page/pageInfo";
@@ -40,4 +41,8 @@ export const harvestMenuItem = menuRoute({
   ...newHarvestMenuItem,
   icon: ["fas", "cloud-arrow-up"],
   route: harvestRoute,
+  title: (routeData: RouterStateSnapshot): string => {
+    const componentModel = routeData.root.firstChild.data;
+    return componentModel.harvest.model.name;
+  },
 });

--- a/src/app/components/harvest/pages/details/details.component.spec.ts
+++ b/src/app/components/harvest/pages/details/details.component.spec.ts
@@ -1,3 +1,4 @@
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { CompleteComponent } from "@components/harvest/screens/complete/complete.component";
 import { MetadataExtractionComponent } from "@components/harvest/screens/metadata-extraction/metadata-extraction.component";
 import { MetadataReviewComponent } from "@components/harvest/screens/metadata-review/metadata-review.component";
@@ -5,19 +6,24 @@ import { ProcessingComponent } from "@components/harvest/screens/processing/proc
 import { ScanningComponent } from "@components/harvest/screens/scanning/scanning.component";
 import { BatchUploadingComponent } from "@components/harvest/screens/uploading/batch-uploading.component";
 import { StreamUploadingComponent } from "@components/harvest/screens/uploading/stream-uploading.component";
-import { HarvestStatus } from "@models/Harvest";
+import { HarvestStagesService } from "@components/harvest/services/harvest-stages.service";
+import { Harvest, HarvestStatus } from "@models/Harvest";
 import { Project } from "@models/Project";
-import { createRoutingFactory, SpectatorRouting } from "@ngneat/spectator";
+import { createRoutingFactory, mockProvider, SpectatorRouting } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { StepperComponent } from "@shared/stepper/stepper.component";
+import { generateHarvest } from "@test/fakes/Harvest";
 import { generateProject } from "@test/fakes/Project";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { MockComponents } from "ng-mocks";
+import { ToastrService } from "ngx-toastr";
+import { PageTitleStrategy } from "src/app/app.component";
 import { DetailsComponent } from "./details.component";
 
-// TODO Re-implement
-xdescribe("DetailsComponent", () => {
-  let defaultProject: Project;
+describe("DetailsComponent", () => {
   let spec: SpectatorRouting<DetailsComponent>;
+  let defaultProject: Project;
+
   const createComponent = createRoutingFactory({
     component: DetailsComponent,
     declarations: MockComponents(
@@ -29,7 +35,18 @@ xdescribe("DetailsComponent", () => {
       MetadataReviewComponent,
       CompleteComponent
     ),
-    imports: [SharedModule],
+    providers: [
+      mockProvider(HarvestStagesService),
+      PageTitleStrategy,
+    ],
+    imports: [MockBawApiModule, SharedModule],
+    mocks: [ToastrService],
+  });
+
+  assertPageInfo<Harvest>(DetailsComponent, "test name", {
+    harvest: {
+      model: new Harvest(generateHarvest({ name: "test name" }))
+    },
   });
 
   beforeEach(() => {
@@ -41,21 +58,22 @@ xdescribe("DetailsComponent", () => {
       detectChanges: false,
       data: { project: { model: project } },
     });
+    spec.detectChanges();
   }
 
   it("should create", () => {
     setup();
-    spec.detectChanges();
     expect(spec.component).toBeInstanceOf(DetailsComponent);
   });
 
-  it("should show project name", () => {
+  xit("should show project name", () => {
     setup();
     spec.detectChanges();
     expect(spec.query("h1")).toHaveText(defaultProject.name);
   });
 
-  describe("stages", () => {
+  // TODO: Re-implement tests
+  xdescribe("stages", () => {
     function setStage(stage: HarvestStatus) {
       setup();
       spec.detectChanges();

--- a/src/app/components/harvest/pages/list/list.component.spec.ts
+++ b/src/app/components/harvest/pages/list/list.component.spec.ts
@@ -13,6 +13,7 @@ import { generateProject, generateProjectMeta } from "@test/fakes/Project";
 import { ToastrService } from "ngx-toastr";
 import { of } from "rxjs";
 import { DateTime, Settings } from "luxon";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { ListComponent } from "./list.component";
 
 describe("ListComponent", () => {
@@ -104,10 +105,12 @@ describe("ListComponent", () => {
   afterEach(() => {
     // dismiss all bootstrap modals, so if a test fails
     // it doesn't impact future tests by using a stale modal
-    modalService.dismissAll();
+    modalService?.dismissAll();
     // some tests mock the luxon timezone. To ensure all tests default to using the users timezone, set luxon.Settings.defaultTime to null
     Settings.defaultZone = null;
   });
+
+  assertPageInfo(ListComponent, "Recording Uploads");
 
   it("should create", () => {
     setup(defaultProject, defaultHarvest);

--- a/src/app/components/harvest/pages/new/new.component.spec.ts
+++ b/src/app/components/harvest/pages/new/new.component.spec.ts
@@ -1,0 +1,34 @@
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { HarvestsService } from "@baw-api/harvest/harvest.service";
+import { TitleComponent } from "@components/harvest/components/shared/title.component";
+import {
+  createRoutingFactory,
+  mockProvider,
+  Spectator,
+} from "@ngneat/spectator";
+import { SharedModule } from "@shared/shared.module";
+import { assertPageInfo } from "@test/helpers/pageRoute";
+import { ToastrService } from "ngx-toastr";
+import { NewComponent } from "./new.component";
+
+describe("newHarvestComponent", () => {
+  let spectator: Spectator<NewComponent>;
+
+  const createComponent = createRoutingFactory({
+    component: NewComponent,
+    declarations: [TitleComponent],
+    providers: [
+      mockProvider(HarvestsService),
+    ],
+    imports: [MockBawApiModule, SharedModule],
+    mocks: [ToastrService],
+  });
+
+  assertPageInfo(NewComponent, "New Upload");
+
+  beforeEach(() => spectator = createComponent({ detectChanges: false }));
+
+  it("should create", () => {
+    expect(spectator.component).toBeInstanceOf(NewComponent);
+  });
+});

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -27,6 +27,7 @@ import { generateBawApiError } from "@test/fakes/BawApiError";
 import { generateProject } from "@test/fakes/Project";
 import { generateRegion } from "@test/fakes/Region";
 import { interceptFilterApiRequest } from "@test/helpers/general";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { MockComponent } from "ng-mocks";
 import { BehaviorSubject } from "rxjs";
 import { HomeComponent } from "./home.component";
@@ -111,6 +112,8 @@ describe("HomeComponent", () => {
     cmsService = spec.inject(CmsService);
     cmsService.get.and.callFake(() => new BehaviorSubject("cms content"));
   }
+
+  assertPageInfo(HomeComponent, "Home");
 
   beforeEach(() => {
     spec = createComponent({ detectChanges: false });

--- a/src/app/components/library/pages/details/details.component.spec.ts
+++ b/src/app/components/library/pages/details/details.component.spec.ts
@@ -7,6 +7,7 @@ import { AudioRecording } from "@models/AudioRecording";
 import { generateAudioEvent } from "@test/fakes/AudioEvent";
 import { generateAudioRecording } from "@test/fakes/AudioRecording";
 import { validateBawClientPage } from "@test/helpers/baw-client";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { BehaviorSubject } from "rxjs";
 import { AnnotationComponent } from "./details.component";
 
@@ -33,4 +34,6 @@ describe("AnnotationComponent", () => {
       );
     }
   );
+
+  assertPageInfo(AnnotationComponent, "Annotation");
 });

--- a/src/app/components/library/pages/list/list.component.spec.ts
+++ b/src/app/components/library/pages/list/list.component.spec.ts
@@ -1,6 +1,7 @@
 import { libraryRoute } from "@components/library/library.menus";
 import { LibraryModule } from "@components/library/library.module";
 import { validateBawClientPage } from "@test/helpers/baw-client";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { LibraryComponent } from "./list.component";
 
 describe("LibraryComponent", () => {
@@ -11,4 +12,6 @@ describe("LibraryComponent", () => {
     "/library",
     "Annotation Library"
   );
+
+  assertPageInfo(LibraryComponent, "Library");
 });

--- a/src/app/components/listen/pages/details/details.component.spec.ts
+++ b/src/app/components/listen/pages/details/details.component.spec.ts
@@ -4,6 +4,7 @@ import { ListenModule } from "@components/listen/listen.module";
 import { AudioRecording } from "@models/AudioRecording";
 import { generateAudioRecording } from "@test/fakes/AudioRecording";
 import { validateBawClientPage } from "@test/helpers/baw-client";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { BehaviorSubject } from "rxjs";
 import { ListenRecordingComponent } from "./details.component";
 
@@ -25,4 +26,6 @@ describe("ListenRecordingComponent", () => {
       );
     }
   );
+
+  assertPageInfo(ListenRecordingComponent, "Play");
 });

--- a/src/app/components/listen/pages/list/list.component.spec.ts
+++ b/src/app/components/listen/pages/list/list.component.spec.ts
@@ -1,6 +1,7 @@
 import { listenRoute } from "@components/listen/listen.menus";
 import { ListenModule } from "@components/listen/listen.module";
 import { validateBawClientPage } from "@test/helpers/baw-client";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { ListenComponent } from "./list.component";
 
 describe("ListenComponent", () => {
@@ -11,4 +12,6 @@ describe("ListenComponent", () => {
     "/listen",
     "Recent Audio Recordings"
   );
+
+  assertPageInfo(ListenComponent, "Listen");
 });

--- a/src/app/components/profile/pages/annotations/my-annotations.component.spec.ts
+++ b/src/app/components/profile/pages/annotations/my-annotations.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { MyAnnotationsComponent } from "./my-annotations.component";
 
 xdescribe("MyAnnotationsComponent", () => {
@@ -14,6 +15,8 @@ xdescribe("MyAnnotationsComponent", () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
+
+  assertPageInfo(MyAnnotationsComponent, "Annotations");
 
   it("should create", () => {
     expect(component).toBeTruthy();

--- a/src/app/components/profile/pages/bookmarks/my-bookmarks.component.spec.ts
+++ b/src/app/components/profile/pages/bookmarks/my-bookmarks.component.spec.ts
@@ -15,6 +15,7 @@ import { generateBawApiError } from "@test/fakes/BawApiError";
 import { generateBookmark } from "@test/fakes/Bookmark";
 import { generateUser } from "@test/fakes/User";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { BehaviorSubject } from "rxjs";
 import { MyBookmarksComponent } from "./my-bookmarks.component";
 
@@ -28,6 +29,8 @@ describe("MyBookmarksComponent", () => {
     imports: [SharedModule, RouterTestingModule, MockBawApiModule],
     stubsEnabled: false,
   });
+
+  assertPageInfo(MyBookmarksComponent, "Bookmarks");
 
   function setup(model: User, error?: BawApiError) {
     spec = createComponent({

--- a/src/app/components/profile/pages/bookmarks/their-bookmarks.component.spec.ts
+++ b/src/app/components/profile/pages/bookmarks/their-bookmarks.component.spec.ts
@@ -15,6 +15,7 @@ import { generateBawApiError } from "@test/fakes/BawApiError";
 import { generateBookmark } from "@test/fakes/Bookmark";
 import { generateUser } from "@test/fakes/User";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { BehaviorSubject } from "rxjs";
 import { TheirBookmarksComponent } from "./their-bookmarks.component";
 
@@ -28,6 +29,8 @@ describe("TheirBookmarksComponent", () => {
     imports: [SharedModule, RouterTestingModule, MockBawApiModule],
     stubsEnabled: false,
   });
+
+  assertPageInfo(TheirBookmarksComponent, "Bookmarks");
 
   function setup(model: User, error?: BawApiError) {
     spec = createComponent({

--- a/src/app/components/profile/pages/my-edit/my-edit.component.spec.ts
+++ b/src/app/components/profile/pages/my-edit/my-edit.component.spec.ts
@@ -7,6 +7,7 @@ import { BawApiError } from "@helpers/custom-errors/baw-api-error";
 import { User } from "@models/User";
 import { SharedModule } from "@shared/shared.module";
 import { generateUser } from "@test/fakes/User";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { appLibraryImports } from "src/app/app.module";
 import { MyEditComponent } from "./my-edit.component";
@@ -41,6 +42,8 @@ describe("MyProfileEditComponent", () => {
 
     fixture.detectChanges();
   }
+
+  assertPageInfo(MyEditComponent, "Edit My Profile");
 
   beforeEach(() => {
     // TODO Handle image urls

--- a/src/app/components/profile/pages/my-password/my-password.component.spec.ts
+++ b/src/app/components/profile/pages/my-password/my-password.component.spec.ts
@@ -1,0 +1,30 @@
+import { AccountsService } from "@baw-api/account/accounts.service";
+import { createRoutingFactory, mockProvider, Spectator } from "@ngneat/spectator";
+import { assertPageInfo } from "@test/helpers/pageRoute";
+import { ToastrService } from "ngx-toastr";
+import { MyPasswordComponent } from "./my-password.component";
+
+describe("MyPasswordComponent", () => {
+  let spectator: Spectator<MyPasswordComponent>;
+
+  const createComponent = createRoutingFactory({
+    component: MyPasswordComponent,
+    providers: [
+      mockProvider(AccountsService),
+    ],
+    mocks: [ToastrService],
+  });
+
+  function setup(): void {
+    spectator = createComponent();
+    spectator.detectChanges();
+  }
+
+  beforeEach(() => setup());
+
+  assertPageInfo(MyPasswordComponent, "Edit My Password");
+
+  it("should create", () => {
+    expect(spectator.component).toBeInstanceOf(MyPasswordComponent);
+  });
+});

--- a/src/app/components/profile/pages/profile/my-profile.component.spec.ts
+++ b/src/app/components/profile/pages/profile/my-profile.component.spec.ts
@@ -37,6 +37,7 @@ import { nStepObservable } from "@test/helpers/general";
 import { assertErrorHandler } from "@test/helpers/html";
 import { ToastrService } from "ngx-toastr";
 import { of, Subject } from "rxjs";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { MyProfileComponent } from "./my-profile.component";
 
 describe("MyProfileComponent", () => {
@@ -117,6 +118,12 @@ describe("MyProfileComponent", () => {
 
   beforeEach(() => {
     defaultUser = new User(generateUser());
+  });
+
+  assertPageInfo<User>(MyProfileComponent, "test user's Profile", {
+    account: {
+      model: new User(generateUser({ userName: "test user" })),
+    }
   });
 
   it("should create", () => {

--- a/src/app/components/profile/pages/profile/their-profile.component.spec.ts
+++ b/src/app/components/profile/pages/profile/their-profile.component.spec.ts
@@ -32,6 +32,7 @@ import { generateUser } from "@test/fakes/User";
 import { modelData } from "@test/helpers/faker";
 import { nStepObservable } from "@test/helpers/general";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { Subject } from "rxjs";
 import { TheirProfileComponent } from "./their-profile.component";
 
@@ -107,6 +108,12 @@ describe("TheirProfileComponent", () => {
       interceptApiRequest(tagsApi, "filterByCreator", models.tags),
     ]);
   }
+
+  assertPageInfo<User>(TheirProfileComponent, "test user's Profile", {
+    account: {
+      model: new User(generateUser({ userName: "test user" })),
+    }
+  });
 
   beforeEach(() => {
     defaultUser = new User(generateUser());

--- a/src/app/components/profile/pages/projects/my-projects.component.spec.ts
+++ b/src/app/components/profile/pages/projects/my-projects.component.spec.ts
@@ -17,6 +17,7 @@ import { generateBawApiError } from "@test/fakes/BawApiError";
 import { generateProject } from "@test/fakes/Project";
 import { generateUser } from "@test/fakes/User";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { BehaviorSubject } from "rxjs";
 import { MyProjectsComponent } from "./my-projects.component";
 
@@ -30,6 +31,8 @@ describe("MyProjectsComponent", () => {
     imports: [SharedModule, RouterTestingModule, MockBawApiModule],
     stubsEnabled: false,
   });
+
+  assertPageInfo(MyProjectsComponent, "Projects");
 
   function setup(model: User, error?: BawApiError) {
     spec = createComponent({

--- a/src/app/components/profile/pages/projects/their-projects.component.spec.ts
+++ b/src/app/components/profile/pages/projects/their-projects.component.spec.ts
@@ -17,6 +17,7 @@ import { generateBawApiError } from "@test/fakes/BawApiError";
 import { generateProject } from "@test/fakes/Project";
 import { generateUser } from "@test/fakes/User";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { BehaviorSubject } from "rxjs";
 import { TheirProjectsComponent } from "./their-projects.component";
 
@@ -30,6 +31,8 @@ describe("TheirProjectsComponent", () => {
     imports: [SharedModule, RouterTestingModule, MockBawApiModule],
     stubsEnabled: false,
   });
+
+  assertPageInfo(TheirProjectsComponent, "Projects");
 
   function setup(model: User, error?: BawApiError) {
     spec = createComponent({

--- a/src/app/components/profile/pages/sites/my-sites.component.spec.ts
+++ b/src/app/components/profile/pages/sites/my-sites.component.spec.ts
@@ -25,6 +25,7 @@ import { generateSite } from "@test/fakes/Site";
 import { generateUser } from "@test/fakes/User";
 import { nStepObservable } from "@test/helpers/general";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { BehaviorSubject, Subject } from "rxjs";
 import { MySitesComponent } from "./my-sites.component";
 
@@ -40,6 +41,8 @@ describe("MySitesComponent", () => {
     imports: [SharedModule, RouterTestingModule, MockBawApiModule],
     stubsEnabled: false,
   });
+
+  assertPageInfo(MySitesComponent, "Sites");
 
   function setup(model: User, error?: BawApiError) {
     spec = createComponent({

--- a/src/app/components/profile/pages/sites/their-sites.component.spec.ts
+++ b/src/app/components/profile/pages/sites/their-sites.component.spec.ts
@@ -25,6 +25,7 @@ import { generateSite } from "@test/fakes/Site";
 import { generateUser } from "@test/fakes/User";
 import { nStepObservable } from "@test/helpers/general";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { BehaviorSubject, Subject } from "rxjs";
 import { TheirSitesComponent } from "./their-sites.component";
 
@@ -75,6 +76,8 @@ describe("TheirSitesComponent", () => {
     projectsApi.filter.and.callFake(() => subject);
     return nStepObservable(subject, () => projects || error, !projects);
   }
+
+  assertPageInfo(TheirSitesComponent, "Sites");
 
   beforeEach(() => {
     defaultUser = new User(generateUser());

--- a/src/app/components/profile/pages/their-edit/their-edit.component.spec.ts
+++ b/src/app/components/profile/pages/their-edit/their-edit.component.spec.ts
@@ -6,6 +6,7 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { BawApiError } from "@helpers/custom-errors/baw-api-error";
 import { User } from "@models/User";
 import { SharedModule } from "@shared/shared.module";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { appLibraryImports } from "src/app/app.module";
 import { TheirEditComponent } from "./their-edit.component";
@@ -40,6 +41,8 @@ describe("TheirProfileEditComponent", () => {
 
     fixture.detectChanges();
   }
+
+  assertPageInfo(TheirEditComponent, "Edit Profile");
 
   beforeEach(() => {
     defaultUser = new User({

--- a/src/app/components/profile/profile.menus.ts
+++ b/src/app/components/profile/profile.menus.ts
@@ -1,3 +1,4 @@
+import { RouterStateSnapshot } from "@angular/router";
 import { retrieveResolvedModel } from "@baw-api/resolver-common";
 import { Category, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
@@ -34,6 +35,10 @@ export const myAccountMenuItem = menuRoute({
   tooltip: () => "View profile",
   breadcrumbResolve: (pageInfo) =>
     retrieveResolvedModel(pageInfo, User)?.userName,
+  title: (routeData: RouterStateSnapshot): string => {
+    const componentModel = routeData.root.firstChild.data;
+    return `${componentModel.account.model.userName}'s Profile`;
+  },
 });
 
 export const myEditMenuItem = menuRoute({
@@ -63,6 +68,7 @@ export const myProjectsMenuItem = menuRoute({
   predicate: isLoggedInPredicate,
   route: myAccountMenuItem.route.add("projects"),
   tooltip: (user) => `Projects ${getUserName(user)} can access`,
+  title: () => "Projects",
 });
 
 export const mySitesMenuItem = menuRoute({
@@ -72,6 +78,7 @@ export const mySitesMenuItem = menuRoute({
   predicate: isLoggedInPredicate,
   route: myAccountMenuItem.route.add("sites"),
   tooltip: (user) => `Sites ${getUserName(user)} can access`,
+  title: () => "Sites",
 });
 
 export const myBookmarksMenuItem = menuRoute({
@@ -81,6 +88,7 @@ export const myBookmarksMenuItem = menuRoute({
   predicate: isLoggedInPredicate,
   route: myAccountMenuItem.route.add("bookmarks"),
   tooltip: (user) => `Bookmarks created by ${getUserName(user)}`,
+  title: () => "Bookmarks",
 });
 
 export const myAnnotationsMenuItem = menuRoute({
@@ -90,6 +98,7 @@ export const myAnnotationsMenuItem = menuRoute({
   predicate: isLoggedInPredicate,
   route: myAccountMenuItem.route.add("annotations"),
   tooltip: (user) => `Annotations created by ${getUserName(user)}`,
+  title: () => "Annotations",
 });
 
 /**
@@ -114,6 +123,10 @@ export const theirProfileMenuItem = menuRoute({
   tooltip: () => "View their profile",
   breadcrumbResolve: (pageInfo) =>
     retrieveResolvedModel(pageInfo, User)?.userName,
+  title: (routeData: RouterStateSnapshot): string => {
+    const componentModel = routeData.root.firstChild.data;
+    return `${componentModel.account.model.userName}'s Profile`;
+  }
 });
 
 export const theirEditMenuItem = menuRoute({
@@ -124,6 +137,7 @@ export const theirEditMenuItem = menuRoute({
   route: theirProfileMenuItem.route.add("edit"),
   tooltip: () => "Change the details for this profile",
   disabled: "BETA: Will be available soon.",
+  title: () => "Edit Profile",
 });
 
 export const theirProjectsMenuItem = menuRoute({
@@ -133,6 +147,7 @@ export const theirProjectsMenuItem = menuRoute({
   predicate: isAdminPredicate,
   route: theirProfileMenuItem.route.add("projects"),
   tooltip: () => "Projects they can access",
+  title: () => "Projects",
 });
 
 export const theirSitesMenuItem = menuRoute({
@@ -142,6 +157,7 @@ export const theirSitesMenuItem = menuRoute({
   predicate: isAdminPredicate,
   route: theirProfileMenuItem.route.add("sites"),
   tooltip: () => "Sites they can access",
+  title: () => "Sites",
 });
 
 export const theirBookmarksMenuItem = menuRoute({
@@ -151,6 +167,7 @@ export const theirBookmarksMenuItem = menuRoute({
   predicate: isAdminPredicate,
   route: theirProfileMenuItem.route.add("bookmarks"),
   tooltip: () => "Bookmarks created by them",
+  title: () => "Bookmarks",
 });
 
 export const theirAnnotationsMenuItem = menuRoute({
@@ -160,4 +177,5 @@ export const theirAnnotationsMenuItem = menuRoute({
   predicate: isAdminPredicate,
   route: theirProfileMenuItem.route.add("annotations"),
   tooltip: () => "Annotations created by them",
+  title: () => "Annotations",
 });

--- a/src/app/components/projects/pages/assign/assign.component.spec.ts
+++ b/src/app/components/projects/pages/assign/assign.component.spec.ts
@@ -9,6 +9,7 @@ import { Project } from "@models/Project";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { generateProject } from "@test/fakes/Project";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
@@ -52,6 +53,8 @@ describe("AssignComponent", () => {
   beforeEach(() => {
     defaultProject = new Project(generateProject());
   });
+
+  assertPageInfo(AssignComponent, "Assign Sites");
 
   it("should create", () => {
     configureTestingModule(defaultProject);

--- a/src/app/components/projects/pages/details/details.component.spec.ts
+++ b/src/app/components/projects/pages/details/details.component.spec.ts
@@ -25,10 +25,12 @@ import {
   FilterExpectations,
   interceptRepeatApiRequests,
 } from "@test/helpers/general";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { assertPaginationTemplate } from "@test/helpers/paginationTemplate";
 import { MockComponent } from "ng-mocks";
 import { ToastrService } from "ngx-toastr";
 import { of } from "rxjs";
+import { PageTitleStrategy } from "src/app/app.component";
 import { DetailsComponent } from "./details.component";
 
 const mock = {
@@ -49,8 +51,15 @@ describe("ProjectDetailsComponent", () => {
     declarations: [mock.map, mock.card],
     mocks: [ToastrService],
     component: DetailsComponent,
+    providers: [PageTitleStrategy],
   });
   const emptyResponse = [[]];
+
+  assertPageInfo<Project>(DetailsComponent, "test name", {
+    project: {
+      model: new Project(generateProject({ name: "test name" }))
+    }
+  });
 
   function createModelWithMeta<M extends AbstractModel>(
     construct: (id: number) => M,

--- a/src/app/components/projects/pages/edit/edit.component.spec.ts
+++ b/src/app/components/projects/pages/edit/edit.component.spec.ts
@@ -10,6 +10,7 @@ import {
 import { FormComponent } from "@shared/form/form.component";
 import { generateProject, generateProjectMeta } from "@test/fakes/Project";
 import { testFormlyFields } from "@test/helpers/formly";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { MockComponent } from "ng-mocks";
 import { ToastrService } from "ngx-toastr";
 import { Subject } from "rxjs";
@@ -27,6 +28,8 @@ describe("ProjectsEditComponent", () => {
     imports: [MockBawApiModule],
     mocks: [ToastrService],
   });
+
+  assertPageInfo(EditComponent, "Edit");
 
   function setup(project: Project): void {
     spec = createComponent({

--- a/src/app/components/projects/pages/list/list.component.spec.ts
+++ b/src/app/components/projects/pages/list/list.component.spec.ts
@@ -19,6 +19,7 @@ import { generateBawApiError } from "@test/fakes/BawApiError";
 import { generateProject } from "@test/fakes/Project";
 import { nStepObservable } from "@test/helpers/general";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { MockComponent } from "ng-mocks";
 import { Subject } from "rxjs";
 import { ListComponent } from "./list.component";
@@ -93,6 +94,8 @@ describe("ProjectsListComponent", () => {
     spec = createComponent({ detectChanges: false });
     api = spec.inject(ProjectsService);
   });
+
+  assertPageInfo(ListComponent, "Projects");
 
   it("should initially request page 1", async () => {
     await handleApiRequest([], (filter) => expect(filter.paging.page).toBe(1));

--- a/src/app/components/projects/pages/new/new.component.spec.ts
+++ b/src/app/components/projects/pages/new/new.component.spec.ts
@@ -7,6 +7,7 @@ import {
 } from "@ngneat/spectator";
 import { FormComponent } from "@shared/form/form.component";
 import { testFormlyFields } from "@test/helpers/formly";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { MockComponent } from "ng-mocks";
 import { ToastrService } from "ngx-toastr";
 import { Subject } from "rxjs";
@@ -23,6 +24,8 @@ describe("ProjectsNewComponent", () => {
     imports: [MockBawApiModule],
     mocks: [ToastrService],
   });
+
+  assertPageInfo(NewComponent, "New Project");
 
   function setup(): void {
     spec = createComponent();

--- a/src/app/components/projects/pages/permissions/permissions.component.spec.ts
+++ b/src/app/components/projects/pages/permissions/permissions.component.spec.ts
@@ -2,17 +2,20 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { PermissionsService } from "@baw-api/permissions/permissions.service";
 import { projectResolvers } from "@baw-api/project/projects.service";
 import { BawApiError } from "@helpers/custom-errors/baw-api-error";
 import { Project } from "@models/Project";
+import { mockProvider } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { generateProject } from "@test/fakes/Project";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { appLibraryImports } from "src/app/app.module";
 import { PermissionsComponent } from "./permissions.component";
 
 // TODO Implement tests
-xdescribe("PermissionsComponent", () => {
+describe("PermissionsComponent", () => {
   let component: PermissionsComponent;
   let defaultProject: Project;
   let fixture: ComponentFixture<PermissionsComponent>;
@@ -27,6 +30,7 @@ xdescribe("PermissionsComponent", () => {
       ],
       declarations: [PermissionsComponent],
       providers: [
+        mockProvider(PermissionsService),
         {
           provide: ActivatedRoute,
           useValue: mockActivatedRoute(
@@ -39,13 +43,13 @@ xdescribe("PermissionsComponent", () => {
 
     fixture = TestBed.createComponent(PermissionsComponent);
     component = fixture.componentInstance;
-
-    fixture.detectChanges();
   }
 
   beforeEach(() => {
     defaultProject = new Project(generateProject());
   });
+
+  assertPageInfo(PermissionsComponent, "Edit Permissions");
 
   it("should create", () => {
     configureTestingModule(defaultProject);

--- a/src/app/components/projects/pages/request/request.component.spec.ts
+++ b/src/app/components/projects/pages/request/request.component.spec.ts
@@ -11,6 +11,7 @@ import { Project } from "@models/Project";
 import { SpyObject } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { generateProject } from "@test/fakes/Project";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { Subject } from "rxjs";
 import { appLibraryImports } from "src/app/app.module";
@@ -54,8 +55,10 @@ describe("ProjectsRequestComponent", () => {
     defaultProject = new Project(generateProject());
   });
 
-  xit("should create", () => {
+  assertPageInfo(RequestComponent, "Request Access");
+
+  it("should create", () => {
     configureTestingModule(defaultProject);
-    expect(component).toBeTruthy();
+    expect(component).toBeInstanceOf(RequestComponent);
   });
 });

--- a/src/app/components/projects/pages/upload-annotations/upload-annotations.component.spec.ts
+++ b/src/app/components/projects/pages/upload-annotations/upload-annotations.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { UploadAnnotationsComponent } from "./upload-annotations.component";
 
 describe("UploadAnnotationsComponent", () => {
@@ -16,6 +17,8 @@ describe("UploadAnnotationsComponent", () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
+
+  assertPageInfo(UploadAnnotationsComponent, "Batch Upload Annotations");
 
   it("should create", () => {
     expect(component).toBeTruthy();

--- a/src/app/components/projects/projects.menus.ts
+++ b/src/app/components/projects/projects.menus.ts
@@ -1,3 +1,4 @@
+import { RouterStateSnapshot } from "@angular/router";
 import { retrieveResolvedModel } from "@baw-api/resolver-common";
 import { Category, menuRoute } from "@interfaces/menusInterfaces";
 import { Project } from "@models/Project";
@@ -9,6 +10,7 @@ import {
   isLoggedInPredicate,
   isProjectEditorPredicate,
 } from "src/app/app.menus";
+import { CommonRouteTitles } from "src/app/stringConstants";
 import {
   editProjectPermissionsRoute,
   projectRoute,
@@ -30,6 +32,7 @@ export const projectsMenuItem = menuRoute({
   order: 4,
   route: projectsRoute,
   tooltip: () => "View projects I have access to",
+  title: () => "Projects",
 });
 
 export const newProjectMenuItem = menuRoute({
@@ -68,6 +71,10 @@ export const projectMenuItem = menuRoute({
   tooltip: () => "The current project",
   breadcrumbResolve: (pageInfo) =>
     retrieveResolvedModel(pageInfo, Project)?.name,
+  title: (routeData: RouterStateSnapshot): string => {
+    const componentModel = routeData.root.firstChild.data;
+    return componentModel.project.model.name;
+  },
 });
 
 export const editProjectMenuItem = menuRoute({
@@ -77,6 +84,7 @@ export const editProjectMenuItem = menuRoute({
   predicate: isProjectEditorPredicate,
   route: projectMenuItem.route.add("edit"),
   tooltip: () => "Change the details for this project",
+  title: () => CommonRouteTitles.routeEditTitle,
 });
 
 export const editProjectPermissionsMenuItem = menuRoute({

--- a/src/app/components/regions/pages/details/details.component.spec.ts
+++ b/src/app/components/regions/pages/details/details.component.spec.ts
@@ -21,11 +21,13 @@ import { generateRegion } from "@test/fakes/Region";
 import { generateSite } from "@test/fakes/Site";
 import { interceptRepeatApiRequests } from "@test/helpers/general";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { assertPaginationTemplate } from "@test/helpers/paginationTemplate";
 import { MockComponent } from "ng-mocks";
 import { ToastrService } from "ngx-toastr";
 import { of } from "rxjs";
 import { ConfigService } from "@services/config/config.service";
+import { PageTitleStrategy } from "src/app/app.component";
 import { DetailsComponent } from "./details.component";
 
 const mock = {
@@ -46,6 +48,13 @@ describe("RegionDetailsComponent", () => {
     declarations: [mock.map, mock.card],
     mocks: [ToastrService],
     component: DetailsComponent,
+    providers: [PageTitleStrategy],
+  });
+
+  assertPageInfo(DetailsComponent, "test name", {
+    region: {
+      model: new Region(generateRegion({ name: "test name" }))
+    },
   });
 
   function setup(

--- a/src/app/components/regions/pages/edit/edit.component.spec.ts
+++ b/src/app/components/regions/pages/edit/edit.component.spec.ts
@@ -18,6 +18,7 @@ import { generateProject } from "@test/fakes/Project";
 import { generateRegion } from "@test/fakes/Region";
 import { testFormlyFields } from "@test/helpers/formly";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { testFormImports } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject, Subject } from "rxjs";
@@ -34,6 +35,8 @@ describe("RegionsEditComponent", () => {
     mocks: [ToastrService],
     stubsEnabled: true,
   });
+
+  assertPageInfo(EditComponent, "Edit");
 
   describe("form", () => {
     testFormlyFields([

--- a/src/app/components/regions/pages/list/list.component.spec.ts
+++ b/src/app/components/regions/pages/list/list.component.spec.ts
@@ -19,6 +19,7 @@ import { generateBawApiError } from "@test/fakes/BawApiError";
 import { generateRegion } from "@test/fakes/Region";
 import { nStepObservable } from "@test/helpers/general";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { MockComponent } from "ng-mocks";
 import { Subject } from "rxjs";
 import { ListComponent } from "./list.component";
@@ -93,6 +94,8 @@ describe("RegionsListComponent", () => {
     spec = createComponent({ detectChanges: false });
     api = spec.inject(ShallowRegionsService);
   });
+
+  assertPageInfo(ListComponent, "Sites");
 
   it("should initially request page 1", async () => {
     await handleApiRequest([], (filter) => expect(filter.paging.page).toBe(1));

--- a/src/app/components/regions/pages/new/new.component.spec.ts
+++ b/src/app/components/regions/pages/new/new.component.spec.ts
@@ -32,6 +32,7 @@ import {
   testFormImports,
 } from "@test/helpers/testbed";
 import { MockBuilder, MockRender, ngMocks } from "ng-mocks";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject, of, Subject } from "rxjs";
 import { Location } from "@angular/common";
@@ -91,6 +92,8 @@ describe("RegionsNewComponent", () => {
     beforeEach(() => {
       defaultProject = new Project(generateProject());
     });
+
+    assertPageInfo(NewComponent, "New Site");
 
     it("should create", () => {
       setup();

--- a/src/app/components/regions/regions.menus.ts
+++ b/src/app/components/regions/regions.menus.ts
@@ -1,4 +1,5 @@
 import { retrieveResolvedModel } from "@baw-api/resolver-common";
+import { RouterStateSnapshot } from "@angular/router";
 import { projectMenuItem } from "@components/projects/projects.menus";
 import { Category, menuRoute } from "@interfaces/menusInterfaces";
 import { Region } from "@models/Region";
@@ -7,6 +8,7 @@ import {
   defaultNewIcon,
   isProjectEditorPredicate,
 } from "src/app/app.menus";
+import { CommonRouteTitles } from "src/app/stringConstants";
 import {
   regionRoute,
   regionsRoute,
@@ -49,6 +51,10 @@ export const regionMenuItem = menuRoute({
   tooltip: () => "The current site",
   breadcrumbResolve: (pageInfo) =>
     retrieveResolvedModel(pageInfo, Region)?.name,
+  title: (routeData: RouterStateSnapshot): string => {
+    const componentModel = routeData.root.firstChild.data;
+    return componentModel.region.model.name;
+  },
 });
 
 export const newRegionMenuItem = menuRoute({
@@ -63,4 +69,5 @@ export const editRegionMenuItem = menuRoute({
   predicate: isProjectEditorPredicate,
   route: regionMenuItem.route.add("edit"),
   tooltip: () => "Change the details for this site",
+  title: () => CommonRouteTitles.routeEditTitle,
 });

--- a/src/app/components/report-problem/report-problem.component.spec.ts
+++ b/src/app/components/report-problem/report-problem.component.spec.ts
@@ -1,33 +1,27 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { RouterTestingModule } from "@angular/router/testing";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import {
+  createRoutingFactory,
+  Spectator,
+} from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
-import { appLibraryImports } from "src/app/app.module";
+import { assertPageInfo } from "@test/helpers/pageRoute";
+import { ToastrService } from "ngx-toastr";
 import { ReportProblemComponent } from "./report-problem.component";
 
-// TODO Implement tests
+describe("ReportProblemComponent", () => {
+  let spectator: Spectator<ReportProblemComponent>;
 
-xdescribe("ReportProblemComponent", () => {
-  let component: ReportProblemComponent;
-  let fixture: ComponentFixture<ReportProblemComponent>;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        ...appLibraryImports,
-        SharedModule,
-        MockBawApiModule,
-        RouterTestingModule,
-      ],
-      declarations: [ReportProblemComponent],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(ReportProblemComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  const createComponent = createRoutingFactory({
+    component: ReportProblemComponent,
+    imports: [MockBawApiModule, SharedModule],
+    mocks: [ToastrService],
   });
 
+  beforeEach(() => (spectator = createComponent({ detectChanges: false })));
+
+  assertPageInfo(ReportProblemComponent, "Report Problem");
+
   it("should create", () => {
-    expect(component).toBeTruthy();
+    expect(spectator.component).toBeInstanceOf(ReportProblemComponent);
   });
 });

--- a/src/app/components/security/pages/confirm-account/confirm-account.component.spec.ts
+++ b/src/app/components/security/pages/confirm-account/confirm-account.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { FormComponent } from "@shared/form/form.component";
 import { testFormlyFields } from "@test/helpers/formly";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { testFormImports } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { ConfirmPasswordComponent } from "./confirm-account.component";
@@ -42,6 +43,8 @@ describe("ConfirmPasswordComponent", () => {
       spyOn(notifications, "success").and.stub();
       spyOn(notifications, "error").and.stub();
     });
+
+    assertPageInfo(ConfirmPasswordComponent, "Confirm Account");
 
     it("should create", () => {
       expect(component).toBeTruthy();

--- a/src/app/components/security/pages/login/login.component.spec.ts
+++ b/src/app/components/security/pages/login/login.component.spec.ts
@@ -10,6 +10,7 @@ import { FormComponent } from "@shared/form/form.component";
 import { generateBawApiError } from "@test/fakes/BawApiError";
 import { testFormlyFields } from "@test/helpers/formly";
 import { nStepObservable } from "@test/helpers/general";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { testFormImports } from "@test/helpers/testbed";
 import { UNAUTHORIZED } from "http-status";
 import { ToastrService } from "ngx-toastr";
@@ -89,6 +90,8 @@ describe("LoginComponent", () => {
   });
 
   describe("component", () => {
+    assertPageInfo(LoginComponent, "Log In");
+
     it("should create", () => {
       setup();
       isSignedIn(false);

--- a/src/app/components/security/pages/register/register.component.spec.ts
+++ b/src/app/components/security/pages/register/register.component.spec.ts
@@ -10,6 +10,7 @@ import { generateRegisterDetails } from "@test/fakes/RegisterDetails";
 import { modelData } from "@test/helpers/faker";
 import { testFormlyFields } from "@test/helpers/formly";
 import { nStepObservable } from "@test/helpers/general";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { testFormImports } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { Subject } from "rxjs";
@@ -72,6 +73,8 @@ describe("RegisterComponent", () => {
       spyOn(toastr, "success").and.stub();
       spyOn(toastr, "error").and.stub();
     });
+
+    assertPageInfo(RegisterComponent, "Register");
 
     it("should create", () => {
       isSignedIn(false);

--- a/src/app/components/security/pages/reset-password/reset-password.component.spec.ts
+++ b/src/app/components/security/pages/reset-password/reset-password.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { FormComponent } from "@shared/form/form.component";
 import { testFormlyFields } from "@test/helpers/formly";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { testFormImports } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { ResetPasswordComponent } from "./reset-password.component";
@@ -42,6 +43,8 @@ describe("ResetPasswordComponent", () => {
       spyOn(notifications, "success").and.stub();
       spyOn(notifications, "error").and.stub();
     });
+
+    assertPageInfo(ResetPasswordComponent, "Reset Password");
 
     it("should create", () => {
       expect(component).toBeTruthy();

--- a/src/app/components/security/pages/unlock-account/unlock-account.component.spec.ts
+++ b/src/app/components/security/pages/unlock-account/unlock-account.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { FormComponent } from "@shared/form/form.component";
 import { testFormlyFields } from "@test/helpers/formly";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { testFormImports } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { UnlockAccountComponent } from "./unlock-account.component";
@@ -42,6 +43,8 @@ describe("UnlockAccountComponent", () => {
       spyOn(notifications, "success").and.stub();
       spyOn(notifications, "error").and.stub();
     });
+
+    assertPageInfo(UnlockAccountComponent, "Unlock Account");
 
     it("should create", () => {
       expect(component).toBeTruthy();

--- a/src/app/components/send-audio/send-audio.component.spec.ts
+++ b/src/app/components/send-audio/send-audio.component.spec.ts
@@ -4,6 +4,7 @@ import { CMS } from "@baw-api/cms/cms.service";
 import { createComponentFactory, Spectator } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { assertCms } from "@test/helpers/api-common";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { SendAudioComponent } from "./send-audio.component";
 
 describe("SendAudioComponent", () => {
@@ -16,4 +17,6 @@ describe("SendAudioComponent", () => {
   beforeEach(() => (spectator = createComponent({ detectChanges: false })));
 
   assertCms<SendAudioComponent>(() => spectator, CMS.dataUpload);
+
+  assertPageInfo(SendAudioComponent, "Send Audio");
 });

--- a/src/app/components/sites/pages/details/details.component.spec.ts
+++ b/src/app/components/sites/pages/details/details.component.spec.ts
@@ -22,6 +22,8 @@ import { Router } from "@angular/router";
 import { of } from "rxjs";
 import { SitesService } from "@baw-api/site/sites.service";
 import { ConfigService } from "@services/config/config.service";
+import { PageTitleStrategy } from "src/app/app.component";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { SiteDetailsComponent } from "./details.component";
 
 const mockSiteComponent = MockComponent(SiteComponent);
@@ -38,6 +40,7 @@ describe("SiteDetailsComponent", () => {
 
   const createComponent = createRoutingFactory({
     imports: [SharedModule, MockBawApiModule],
+    providers: [PageTitleStrategy],
     declarations: [mockSiteComponent],
     mocks: [ToastrService],
     component: SiteDetailsComponent,
@@ -75,6 +78,13 @@ describe("SiteDetailsComponent", () => {
   beforeEach(() => {
     defaultProject = new Project(generateProject());
     defaultError = generateBawApiError();
+  });
+
+  // since sites and points use the same client model class, we can assert that both the site and point details page use the same title
+  assertPageInfo<Site>(SiteDetailsComponent, "test name", {
+    site: {
+      model: new Site(generateSite({ name: "test name" }))
+    },
   });
 
   [true, false].forEach((withRegion) => {

--- a/src/app/components/sites/pages/edit/edit.component.spec.ts
+++ b/src/app/components/sites/pages/edit/edit.component.spec.ts
@@ -19,6 +19,7 @@ import { generateRegion } from "@test/fakes/Region";
 import { generateSite } from "@test/fakes/Site";
 import { testFormlyFields } from "@test/helpers/formly";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { testFormImports } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject, Subject } from "rxjs";
@@ -84,6 +85,8 @@ describe("SiteEditComponent", () => {
     let defaultProject: Project;
     let defaultRegion: Region;
     let defaultSite: Site;
+
+    assertPageInfo(SiteEditComponent, "Edit")
 
     function setup(
       project: Errorable<Project>,

--- a/src/app/components/sites/pages/new/new.component.spec.ts
+++ b/src/app/components/sites/pages/new/new.component.spec.ts
@@ -14,6 +14,7 @@ import { generateProject } from "@test/fakes/Project";
 import { generateRegion } from "@test/fakes/Region";
 import { generateSite } from "@test/fakes/Site";
 import { testFormlyFields } from "@test/helpers/formly";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { testFormImports } from "@test/helpers/testbed";
 import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject, Subject } from "rxjs";
@@ -29,6 +30,9 @@ describe("SiteNewComponent", () => {
     declarations: [FormComponent],
     mocks: [ToastrService],
   });
+
+  // Only sites with regions have their own page, normal sites are part of a wizard
+  assertPageInfo(SiteNewComponent, "New Point");
 
   describe("form", () => {
     [true, false].forEach((withRegion) => {

--- a/src/app/components/sites/pages/wizard/wizard.component.spec.ts
+++ b/src/app/components/sites/pages/wizard/wizard.component.spec.ts
@@ -8,6 +8,7 @@ import { SharedModule } from "@shared/shared.module";
 import { generateBawApiError } from "@test/fakes/BawApiError";
 import { generateProject } from "@test/fakes/Project";
 import { assertErrorHandler } from "@test/helpers/html";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { MockComponent } from "ng-mocks";
 import { SiteNewComponent } from "../new/new.component";
 import { WizardComponent } from "./wizard.component";
@@ -51,6 +52,8 @@ describe("WizardComponent", () => {
   beforeEach(() => {
     defaultProject = new Project(generateProject());
   });
+
+  assertPageInfo(WizardComponent, "New Site");
 
   it("should create", () => {
     setup(defaultProject);

--- a/src/app/components/sites/sites.menus.ts
+++ b/src/app/components/sites/sites.menus.ts
@@ -1,3 +1,4 @@
+import { RouterStateSnapshot } from "@angular/router";
 import { retrieveResolvedModel } from "@baw-api/resolver-common";
 import { Category, menuItem, menuRoute } from "@interfaces/menusInterfaces";
 import { Site } from "@models/Site";
@@ -7,6 +8,7 @@ import {
   defaultNewIcon,
   isProjectEditorPredicate,
 } from "src/app/app.menus";
+import { CommonRouteTitles } from "src/app/stringConstants";
 import { projectMenuItem } from "../projects/projects.menus";
 import { siteRoute, sitesRoute } from "./sites.routes";
 
@@ -23,6 +25,10 @@ export const siteMenuItem = menuRoute({
   route: sitesCategory.route,
   tooltip: () => "The current site",
   breadcrumbResolve: (pageInfo) => retrieveResolvedModel(pageInfo, Site)?.name,
+  title: (routeData: RouterStateSnapshot) => {
+    const componentModel = routeData.root.firstChild.data;
+    return componentModel.site.model.name;
+  }
 });
 
 export const newSiteMenuItem = menuRoute({
@@ -48,4 +54,5 @@ export const editSiteMenuItem = menuRoute({
   predicate: isProjectEditorPredicate,
   route: siteMenuItem.route.add("edit"),
   tooltip: () => "Change the details for this site",
+  title: () => CommonRouteTitles.routeEditTitle,
 });

--- a/src/app/components/statistics/pages/statistics.component.spec.ts
+++ b/src/app/components/statistics/pages/statistics.component.spec.ts
@@ -27,6 +27,7 @@ import {
   interceptFilterApiRequest,
   interceptShowApiRequest,
 } from "@test/helpers/general";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { MockComponent } from "ng-mocks";
 import { RecentAnnotationsComponent } from "../components/recent-annotations/recent-annotations.component";
 import { RecentAudioRecordingsComponent } from "../components/recent-audio-recordings/recent-audio-recordings.component";
@@ -51,6 +52,8 @@ describe("StatisticsComponent", () => {
       mock.recentAudioRecordingsComponent,
     ],
   });
+
+  assertPageInfo(StatisticsComponent, "Statistics");
 
   function interceptStatisticsRequest(
     data: Errorable<IStatistics>

--- a/src/app/components/visualize/pages/details/details.component.spec.ts
+++ b/src/app/components/visualize/pages/details/details.component.spec.ts
@@ -1,6 +1,7 @@
 import { visualizeRoute } from "@components/visualize/visualize.routes";
 import { VisualizeModule } from "@components/visualize/visualize.module";
 import { validateBawClientPage } from "@test/helpers/baw-client";
+import { assertPageInfo } from "@test/helpers/pageRoute";
 import { VisualizeComponent } from "./details.component";
 
 describe("VisualizeComponent", () => {
@@ -11,4 +12,6 @@ describe("VisualizeComponent", () => {
     "/visualize",
     "Audio distribution"
   );
+
+  assertPageInfo(VisualizeComponent, "View Timeline");
 });

--- a/src/app/interfaces/menusInterfaces.ts
+++ b/src/app/interfaces/menusInterfaces.ts
@@ -1,5 +1,5 @@
 import { Injector } from "@angular/core";
-import { Params } from "@angular/router";
+import { Params, RouterStateSnapshot } from "@angular/router";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { IPageInfo } from "@helpers/page/pageInfo";
 import { MenuModalWithoutAction, WidgetMenuItem } from "@menu/widgetItem";
@@ -161,6 +161,9 @@ export interface MenuRoute extends MenuItem {
   kind: "MenuRoute";
   /** The internal route this menu item points to */
   route: StrongRoute;
+
+  /** A computed tab title callback that should be used to identify the route */
+  title?: (routerState?: RouterStateSnapshot) => string
 
   /** Custom label when shown in the breadcrumb */
   breadcrumbResolve?: (pageInfo: IPageInfo, injector: Injector) => string;

--- a/src/app/stringConstants.ts
+++ b/src/app/stringConstants.ts
@@ -1,0 +1,3 @@
+export const enum CommonRouteTitles {
+  routeEditTitle = "Edit",
+}

--- a/src/app/test/fakes/MenuItem.ts
+++ b/src/app/test/fakes/MenuItem.ts
@@ -28,6 +28,7 @@ export function generateMenuRoute(data?: Partial<MenuRoute>): MenuRoute {
     label: modelData.random.word(),
     route: StrongRoute.newRoot().addFeatureModule(modelData.random.word()),
     tooltip: () => tooltip,
+    title: () => modelData.word.noun(),
     ...data,
   });
 }

--- a/src/app/test/helpers/pageRoute.ts
+++ b/src/app/test/helpers/pageRoute.ts
@@ -1,0 +1,92 @@
+import { Type } from "@angular/core";
+import { RouterStateSnapshot } from "@angular/router";
+import { titleCase } from "@helpers/case-converter/case-converter";
+import { getPageInfos, IPageComponent } from "@helpers/page/pageComponent";
+import { IPageInfo, PageInfo } from "@helpers/page/pageInfo";
+import { MenuRoute } from "@interfaces/menusInterfaces";
+
+/**
+ * Asserts that the specified page component has the correct page title when mounted at all locations
+ *
+ * @param componentType Page component to test
+ * @param expectedPageTitles An array of titles expected at each page mounting point
+ * @param modelState Optional model state to pass to the page component
+ */
+export function assertPageInfo<T>(
+  componentType: Type<IPageComponent>,
+  expectedPageTitles: string[] | string,
+  modelState?: IRouteModel<T>,
+) {
+  describe("pageRoute", () => {
+    const componentPageInfo: PageInfo[] = getPageInfos(componentType);
+    const componentPageRoutes: MenuRoute[] = componentPageInfo.map((pageInfo: IPageInfo) => pageInfo.pageRoute);
+
+    const mockRouteState: RouterStateSnapshot = Object({
+      root: {
+        firstChild: {
+          data: {
+            pageRoute: {
+              route: {
+                pageComponent: {
+                  pageInfos: componentPageInfo,
+                },
+              },
+            },
+            ...modelState,
+          },
+        },
+      },
+    }) as RouterStateSnapshot;
+
+    beforeAll(() => {
+      if (typeof expectedPageTitles === "string") {
+        // if one title is provided, assume that this title is used at all route locations
+        expectedPageTitles = Array(componentPageInfo.length).fill(expectedPageTitles);
+      }
+    });
+
+    it("should have page info", () => {
+      expect(componentPageInfo).toBeDefined();
+    });
+
+    it("should have a page route", () => {
+      expect(componentPageRoutes).toBeDefined();
+    });
+
+    // some pages have multiple mounting points (e.g. sites & points).
+    // Therefore, it should be asserted that the correct page title is used when mounted at all locations
+    componentPageRoutes.forEach((pageRoute: MenuRoute, i: number) => {
+      const pageRoutePath = pageRoute.route.angularRouteConfig.path;
+
+      // some page routes do not have a page title, therefore there is no use in an assertion of page title
+      if (pageRoute.title) {
+        it(`should use the correct page title for the route "/${pageRoutePath}"`, () => {
+          const expectedTitle = expectedPageTitles[i];
+          const observedTitle = pageRoute.title(mockRouteState);
+          expect(observedTitle).toEqual(expectedTitle);
+        });
+      } else {
+        it(`should use the correct fallback menu route label for the route "/${pageRoutePath}"`, () => {
+          const expectedTitle = expectedPageTitles[i];
+          const observedTitle = titleCase(pageRoute.label);
+          expect(observedTitle).toEqual(expectedTitle);
+        });
+      }
+
+      // all page routes should have a fallback in the case that the page does not have a title
+      it(`should have a fallback menuRoute label for the route "/${pageRoutePath}"`, () => {
+        expect(pageRoute.label).toBeInstanceOf(String);
+      });
+
+      // These tests do not assert that the title is constructed correctly at all route locations, only that the correct title is used
+      // Assertions that the titleStrategy can construct the correct hierarchical title is located in the `app.component.spec.ts`
+      // TODO: Add tests to assert that the correct hierarchical title is constructed at all route locations
+    });
+  });
+}
+
+interface IRouteModel<T> {
+  [key: string]: {
+    model: T;
+  }
+}


### PR DESCRIPTION
# Unique Route titles

At the moment, navigating through the workbench client does not change the user agent title.

Users have expressed this as a point of issue when they are navigating through their browser history trying to find a web page.

### e.g.

**Navigating through the website using the back navigation button**
![image](https://user-images.githubusercontent.com/33742269/215389888-6a5f1095-4b01-47c9-83dd-1a7bf6c5a734.png)
  
**Trying to find a page through browser history**
![image](https://user-images.githubusercontent.com/33742269/215919247-f4c89388-3512-4004-8b79-7aa99019f712.png)

## Changes

* Adds the `title` callback method to component page info
* Adds unit tests for page routes at the app level, not component level. Tests for route titles at the component can be completed at request, however, this will require an estimated 1000 lines of code, and I do not see a beneficial ROI for this to be tested by CI.
* Adds a `TitleStrategy` injectable at the app level

## Problems

None

## Issues

Fixes: #1980 

## Visual Changes

**For components directly under the root app (example.com/projects) `<<BrandName>> | Projects`:**
![image](https://user-images.githubusercontent.com/33742269/215400369-1c7f1965-234c-41c3-aece-fe8b9e3f29a1.png)

**For nested components (example.com/projects/123) `<<BrandName>> | Projects | 2022 Symposium Example`:**
![image](https://user-images.githubusercontent.com/33742269/215400426-5a899d7e-9e16-4192-8185-6691d17ad61d.png)

**For the root app `<<BrandName>>`:**
![image](https://user-images.githubusercontent.com/33742269/215400471-01544081-be2f-449f-9e11-db8c16cb3f5b.png)

For components that do not have a title, it will construct the title to the lowest level possible (example.com/projects/321/audio-recordings/1) (in a hypothetical case where audio-recordings component does not have a title specified in its `PageInfo`) `<<BrandName>> | Projects | 321`

## Additional Information

We may want to consider using the Angular `TitleCasePipe` for each title. This pipe ensures a string has a capital letter after each space. However, I have decided against it because I believe that it will cause titles to not be exactly the same as components.

e.g. a project named "hello world" would have the browser title "Hello World"

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
