### PR TITLE
Add more maps

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -162,10 +162,11 @@
     <ng-container *ngIf="allSites$ | withLoading | async as sites">
       <baw-loading *ngIf="sites.loading" [size]="lg"></baw-loading>
 
-      <div style="width: 100%; height: 600px">
+      <div style="width: 100%; height: 24em;">
         <baw-site-map
           *ngIf="!sites.loading && sites.value.size > 0"
-          [unstructuredLocations]="sites.value"
+          [projects]="projects(sites.value).toArray()"
+          [regions]="regions(sites.value).toArray()"
         ></baw-site-map>
       </div>
     </ng-container>

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -150,3 +150,18 @@
     </ng-container>
   </div>
 </section>
+
+<!-- Live an interactive map -->
+<section id="interactiveMap" class="pb-5 pt-5 border-top border-top text-bg-light">
+  <div class="container">
+    <h2>View the Live Site Map</h2>
+    
+    <ng-container *ngIf="models$ | withLoading | async as models">
+      <baw-loading *ngIf="models.loading" [size]="lg"></baw-loading>
+
+      <div style="width: 100%; height: 600px;">
+        <baw-site-map *ngIf="!models.loading" [unstructuredLocations]="models.value"></baw-site-map>
+      </div>
+    </ng-container>
+  </div>
+</section>

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -152,15 +152,21 @@
 </section>
 
 <!-- Live an interactive map -->
-<section id="interactiveMap" class="pb-5 pt-5 border-top border-top text-bg-light">
+<section
+  id="interactiveMap"
+  class="pb-5 pt-5 border-top border-top text-bg-light"
+>
   <div class="container">
     <h2>View the Live Site Map</h2>
-    
-    <ng-container *ngIf="models$ | withLoading | async as models">
-      <baw-loading *ngIf="models.loading" [size]="lg"></baw-loading>
 
-      <div style="width: 100%; height: 600px;">
-        <baw-site-map *ngIf="!models.loading" [unstructuredLocations]="models.value"></baw-site-map>
+    <ng-container *ngIf="allSites$ | withLoading | async as sites">
+      <baw-loading *ngIf="sites.loading" [size]="lg"></baw-loading>
+
+      <div style="width: 100%; height: 600px">
+        <baw-site-map
+          *ngIf="!sites.loading && sites.value.size > 0"
+          [unstructuredLocations]="sites.value"
+        ></baw-site-map>
       </div>
     </ng-container>
   </div>

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -231,8 +231,13 @@ describe("HomeComponent", () => {
       });
     });
 
-    it("should create live map", () => {
-      expect(spec.query("#interactiveMap")).toExist();
+    describe("site map", () => {
+      it("should create", () => {
+        expect(spec.query("#interactiveMap")).toExist();
+      });
+
+      it("should handle taking both projects and regions", async () => {
+      });
     });
   });
 });

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -147,11 +147,19 @@ class HomeComponent extends PageComponent implements OnInit {
       // find the max page number from the metadata
       this.allSites$
         .pipe(takeUntil(this.unsubscribe))
-        .subscribe((site) => maxPageNumber = site.toArray().shift().getMetadata()?.paging?.maxPage);
+        .subscribe((site) => maxPageNumber = site.toArray()?.shift()?.getMetadata()?.paging?.maxPage);
       pageNumber++;
     }
 
     return this.allSites$;
+  }
+
+  public projects(sites: List<Project | Region>): List<Project> {
+    return sites?.filter((location) => location.kind === "Project") as List<Project>;
+  }
+
+  public regions(sites: List<Project | Region>): List<Region> {
+    return sites?.filter((location) => location.kind === "Region") as List<Region>;
   }
 }
 

--- a/src/app/components/home/home.module.ts
+++ b/src/app/components/home/home.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from "@angular/core";
 import { RouterModule } from "@angular/router";
 import { getRouteConfigForPage } from "@helpers/page/pageRouting";
 import { SharedModule } from "@shared/shared.module";
+import { ProjectsModule } from "../projects/projects.module";
 import { HomeComponent } from "./home.component";
 import { homeRoute } from "./home.menus";
 
@@ -9,8 +10,8 @@ const components = [HomeComponent];
 const routes = homeRoute.compileRoutes(getRouteConfigForPage);
 
 @NgModule({
-  declarations: components,
-  imports: [SharedModule, RouterModule.forChild(routes)],
-  exports: [RouterModule, ...components],
+    declarations: components,
+    exports: [RouterModule, ...components],
+    imports: [SharedModule, RouterModule.forChild(routes), ProjectsModule]
 })
 export class HomeModule {}

--- a/src/app/components/projects/components/site-map/site-map.component.spec.ts
+++ b/src/app/components/projects/components/site-map/site-map.component.spec.ts
@@ -41,7 +41,7 @@ describe("SiteMapComponent", () => {
   function setup(project: Project, region?: Region) {
     spec = createComponent({
       detectChanges: false,
-      props: { projects: project, regions: region },
+      props: { projects: [project], regions: [region] },
     });
     api = spec.inject(SitesService);
   }
@@ -90,10 +90,9 @@ describe("SiteMapComponent", () => {
   function interceptApiRequest(
     responses: Errorable<Site[]>[],
     expectations?: ((filter: Filters<ISite>, project: Project) => void)[],
-    hasRegion?: boolean
   ): Promise<void>[] {
     return interceptRepeatApiRequests<ISite, Site[]>(
-      hasRegion ? api.filterByRegion : api.filter,
+      api.filterByRegion,
       responses,
       expectations
     );
@@ -216,8 +215,7 @@ describe("SiteMapComponent", () => {
       const promise = Promise.all(
         interceptApiRequest(
           sites,
-          [assertFilter(1, defaultProject, defaultRegion)],
-          true
+          [assertFilter(1, defaultProject, defaultRegion)]
         )
       );
 

--- a/src/app/components/projects/components/site-map/site-map.component.spec.ts
+++ b/src/app/components/projects/components/site-map/site-map.component.spec.ts
@@ -41,7 +41,7 @@ describe("SiteMapComponent", () => {
   function setup(project: Project, region?: Region) {
     spec = createComponent({
       detectChanges: false,
-      props: { project, region },
+      props: { projects: project, regions: region },
     });
     api = spec.inject(SitesService);
   }

--- a/src/app/components/projects/components/site-map/site-map.component.ts
+++ b/src/app/components/projects/components/site-map/site-map.component.ts
@@ -20,8 +20,9 @@ import { switchMap, takeUntil } from "rxjs/operators";
 export class SiteMapComponent extends withUnsubscribe() implements OnInit {
   // TODO Implement system to change colour of selected sites
   @Input() public selected: List<Site>;
-  @Input() public project: Project;
-  @Input() public region: Region;
+  @Input() public unstructuredLocations: List<Project | Region> | undefined;
+  @Input() public projects: Project[] | undefined;
+  @Input() public regions: Region[] | undefined;
   public markers: List<MapMarkerOptions> = List([]);
 
   public constructor(private sitesApi: SitesService) {
@@ -29,11 +30,51 @@ export class SiteMapComponent extends withUnsubscribe() implements OnInit {
   }
 
   public ngOnInit(): void {
+    // sometimes an unstructured array of locations can be passed to the map component
+    // therefore, it is necessary that the data is structured before
+    if (this.unstructuredLocations) {
+      const locationsArray = this.unstructuredLocations.toArray();
+
+      locationsArray.forEach((location) => {
+        if (location["type"] === "Region") {
+          if (!this.regions) {
+            this.regions = [];
+          }
+
+          this.regions.push(location as Region);
+        } else {
+          if (!this.projects) {
+            this.projects = [];
+          }
+
+          this.projects.push(location as Project);
+        }
+      });
+    }
+
+    // a list of regions will only ever have one project, while a project will never have a region
+    // therefore, we can decide how to iterate through a list of items on the predicate if there is a region
+    if (this.regions) {
+      this.regions.forEach((region) => {
+        this.addSingleLocationMarkers(this.projects[0], region);
+      });
+    } else {
+      this.projects.forEach((project) => {
+        this.addSingleLocationMarkers(project, undefined);
+      });
+    }
+  }
+
+  /**
+   * Fetches the markers and adds the markers to the `markers` list for a single location
+   * e.g. A project or region
+   */
+  private addSingleLocationMarkers(project: Project, region: Region): void {
     const filters: Filters<ISite> = { paging: { page: 1 } };
 
-    this.getFilter(filters, this.project, this.region)
+    this.getFilter(filters, project, region)
       .pipe(
-        switchMap((models) => this.getMarkers(models)),
+        switchMap((models) => this.getMarkers(models, project, region)),
         takeUntil(this.unsubscribe)
       )
       .subscribe({
@@ -44,10 +85,10 @@ export class SiteMapComponent extends withUnsubscribe() implements OnInit {
 
   private getFilter(
     filters: Filters<ISite>,
-    project: Project,
-    region?: Region
-  ) {
-    return this.region
+    project: Project | undefined,
+    region?: Region | undefined
+  ): Observable<Site[]> {
+    return this.regions
       ? this.sitesApi.filterByRegion(filters, project, region)
       : this.sitesApi.filter(filters, project);
   }
@@ -55,15 +96,17 @@ export class SiteMapComponent extends withUnsubscribe() implements OnInit {
   /**
    * Retrieve map markers from api
    */
-  private getMarkers(sites: Site[]) {
+  private getMarkers(
+    sites: Site[],
+    project: Project,
+    region: Region
+  ): Observable<Site[]> {
     const numPages = sites?.[0]?.getMetadata()?.paging?.maxPage || 1;
     const observables: Observable<Site[]>[] = [];
 
     // Can skip first page because initial filter produces the results
     for (let page = 2; page <= numPages; page++) {
-      observables.push(
-        this.getFilter({ paging: { page } }, this.project, this.region)
-      );
+      observables.push(this.getFilter({ paging: { page } }, project, region));
     }
 
     this.pushMarkers(sites);
@@ -73,7 +116,7 @@ export class SiteMapComponent extends withUnsubscribe() implements OnInit {
   /**
    * Push new sites to markers list
    */
-  private pushMarkers(sites: Site[]) {
+  private pushMarkers(sites: Site[]): void {
     this.markers = this.markers.concat(
       sanitizeMapMarkers(sites.map((site) => site.getMapMarker()))
     );

--- a/src/app/components/projects/pages/details/details.component.spec.ts
+++ b/src/app/components/projects/pages/details/details.component.spec.ts
@@ -237,7 +237,7 @@ describe("ProjectDetailsComponent", () => {
       );
       spectator.detectChanges();
       await awaitChanges(promise);
-      expect(getMap().project).toEqual(defaultProject);
+      expect(getMap().projects).toEqual(defaultProject);
     });
   });
 

--- a/src/app/components/projects/pages/details/details.component.spec.ts
+++ b/src/app/components/projects/pages/details/details.component.spec.ts
@@ -237,7 +237,7 @@ describe("ProjectDetailsComponent", () => {
       );
       spectator.detectChanges();
       await awaitChanges(promise);
-      expect(getMap().projects).toEqual(defaultProject);
+      expect(getMap().projects).toEqual([defaultProject]);
     });
   });
 

--- a/src/app/components/projects/pages/details/details.component.ts
+++ b/src/app/components/projects/pages/details/details.component.ts
@@ -92,7 +92,7 @@ const projectKey = "project";
       <ul id="model-grid" class="list-group">
         <!-- Google Maps -->
         <div *ngIf="hasSites || hasRegions || loading" class="item map">
-          <baw-site-map [project]="project"></baw-site-map>
+          <baw-site-map [projects]="[project]"></baw-site-map>
         </div>
 
         <!-- Regions -->

--- a/src/app/components/projects/pages/list/list.component.spec.ts
+++ b/src/app/components/projects/pages/list/list.component.spec.ts
@@ -22,6 +22,7 @@ import { assertErrorHandler } from "@test/helpers/html";
 import { MockComponent } from "ng-mocks";
 import { Subject } from "rxjs";
 import { SiteMapComponent } from "@components/projects/components/site-map/site-map.component";
+import { modelData } from "@test/helpers/faker";
 import { ListComponent } from "./list.component";
 
 const mockCardsComponent = MockComponent(CardsComponent);
@@ -198,10 +199,29 @@ describe("ProjectsListComponent", () => {
     });
   });
 
-  it("should display a baw-map", async () => {
-    const projects = generateProjects(1);
-    await handleApiRequest(projects);
+  describe("site map", () => {
+    it("should create", async () => {
+      const projects = generateProjects(modelData.datatype.number({ min: 1 }));
+      await handleApiRequest(projects);
 
-    expect(spec.query(SiteMapComponent)).toExist();
+      expect(spec.query(SiteMapComponent)).toExist();
+    });
+
+    it("should display the same projects that are displayed in the filtered list", async () => {
+      const projects = generateProjects(modelData.datatype.number({ min: 1 }));
+      await handleApiRequest(projects);
+
+      const mapComponent = spec.query(SiteMapComponent);
+
+      const shownProjects = spec.component.models.toArray();
+      const mapProjects = mapComponent.projects;
+      const mapRegions = mapComponent.regions;
+
+      expect(mapProjects).toEqual(shownProjects);
+
+      // since there are no regions specified in the project component, there should not be any regions in the map component
+      // if this assertion fails, there is a problem with the `ngOnInit()` method
+      expect(mapRegions).toBeUndefined();
+    });
   });
 });

--- a/src/app/components/projects/pages/list/list.component.spec.ts
+++ b/src/app/components/projects/pages/list/list.component.spec.ts
@@ -21,6 +21,7 @@ import { nStepObservable } from "@test/helpers/general";
 import { assertErrorHandler } from "@test/helpers/html";
 import { MockComponent } from "ng-mocks";
 import { Subject } from "rxjs";
+import { SiteMapComponent } from "@components/projects/components/site-map/site-map.component";
 import { ListComponent } from "./list.component";
 
 const mockCardsComponent = MockComponent(CardsComponent);
@@ -41,6 +42,7 @@ describe("ProjectsListComponent", () => {
         },
       ],
     ],
+    declarations: [MockComponent(SiteMapComponent)],
     imports: [SharedModule, RouterTestingModule, MockBawApiModule],
   });
 
@@ -194,5 +196,12 @@ describe("ProjectsListComponent", () => {
       getFilter().filter.next("custom value");
       expect(spec.component.onFilter).toHaveBeenCalled();
     });
+  });
+
+  it("should display a baw-map", async () => {
+    const projects = generateProjects(1);
+    await handleApiRequest(projects);
+
+    expect(spec.query(SiteMapComponent)).toExist();
   });
 });

--- a/src/app/components/projects/pages/list/list.component.ts
+++ b/src/app/components/projects/pages/list/list.component.ts
@@ -25,7 +25,7 @@ export const projectsMenuItemActions = [
   template: `
     <ng-container *ngIf="!error">
       <ng-container *ngIf="!loading && models.size > 0;">
-        <div style="width: 100%; height: 500px;">
+        <div id="site-map" style="width: 100%; height: 24em;">
           <baw-site-map [projects]="models.toArray()"></baw-site-map>
         </div>
       </ng-container>

--- a/src/app/components/projects/pages/list/list.component.ts
+++ b/src/app/components/projects/pages/list/list.component.ts
@@ -24,6 +24,12 @@ export const projectsMenuItemActions = [
   selector: "baw-projects-list",
   template: `
     <ng-container *ngIf="!error">
+      <ng-container *ngIf="!loading && models.size > 0;">
+        <div style="width: 100%; height: 500px;">
+          <baw-site-map [projects]="models.toArray()"></baw-site-map>
+        </div>
+      </ng-container>
+
       <baw-debounce-input
         label="Filter"
         placeholder="Filter Projects"

--- a/src/app/components/regions/pages/details/details.component.spec.ts
+++ b/src/app/components/regions/pages/details/details.component.spec.ts
@@ -159,7 +159,7 @@ describe("RegionDetailsComponent", () => {
       spectator.detectChanges();
       await promise;
       spectator.detectChanges();
-      expect(getMap().projects).toEqual(defaultProject);
+      expect(getMap().projects).toEqual([defaultProject]);
     });
 
     it("should provide region to maps component", async () => {
@@ -168,7 +168,7 @@ describe("RegionDetailsComponent", () => {
       spectator.detectChanges();
       await promise;
       spectator.detectChanges();
-      expect(getMap().regions).toEqual(defaultRegion);
+      expect(getMap().regions).toEqual([defaultRegion]);
     });
   });
 

--- a/src/app/components/regions/pages/details/details.component.spec.ts
+++ b/src/app/components/regions/pages/details/details.component.spec.ts
@@ -159,7 +159,7 @@ describe("RegionDetailsComponent", () => {
       spectator.detectChanges();
       await promise;
       spectator.detectChanges();
-      expect(getMap().project).toEqual(defaultProject);
+      expect(getMap().projects).toEqual(defaultProject);
     });
 
     it("should provide region to maps component", async () => {
@@ -168,7 +168,7 @@ describe("RegionDetailsComponent", () => {
       spectator.detectChanges();
       await promise;
       spectator.detectChanges();
-      expect(getMap().region).toEqual(defaultRegion);
+      expect(getMap().regions).toEqual(defaultRegion);
     });
   });
 

--- a/src/app/components/regions/pages/details/details.component.ts
+++ b/src/app/components/regions/pages/details/details.component.ts
@@ -78,7 +78,7 @@ const regionKey = "region";
       <ul id="model-grid" class="list-group">
         <!-- Google Maps -->
         <div *ngIf="hasSites()" class="item map">
-          <baw-site-map [project]="project" [region]="region"></baw-site-map>
+          <baw-site-map [projects]="[project]" [regions]="[region]"></baw-site-map>
         </div>
 
         <!-- Sites -->

--- a/src/app/components/regions/pages/list/list.component.spec.ts
+++ b/src/app/components/regions/pages/list/list.component.spec.ts
@@ -22,6 +22,7 @@ import { assertErrorHandler } from "@test/helpers/html";
 import { MockComponent } from "ng-mocks";
 import { Subject } from "rxjs";
 import { SiteMapComponent } from "@components/projects/components/site-map/site-map.component";
+import { modelData } from "@test/helpers/faker";
 import { ListComponent } from "./list.component";
 
 const mockCardsComponent = MockComponent(CardsComponent);
@@ -200,10 +201,30 @@ describe("RegionsListComponent", () => {
     });
   });
 
-  it("should display a baw-map", async () => {
-    const regions = generateRegions(1);
-    await handleApiRequest(regions);
+  describe("site map", () => {
+    it("should create", async () => {
+      const regions = generateRegions(modelData.datatype.number({ min: 1 }));
+      await handleApiRequest(regions);
 
-    expect(spec.query(SiteMapComponent)).toExist();
+      expect(spec.query(SiteMapComponent)).toExist();
+    });
+
+    it("should display the same projects that are displayed in the filtered list", async () => {
+      const regions = generateRegions(modelData.datatype.number({ min: 1 }));
+      await handleApiRequest(regions);
+
+      const mapComponent = spec.query(SiteMapComponent);
+
+      const listedRegions = spec.component.models.toArray();
+      const mapProjects = mapComponent.projects;
+      const mapRegions = mapComponent.regions;
+
+      expect(mapRegions).toEqual(listedRegions);
+
+      // since there are no projects specified in the region component, there should not be any projects in the map component
+      // if this assertion fails, there is a problem with the `ngOnInit()` method
+      expect(mapProjects).toBeUndefined();
+    });
   });
+
 });

--- a/src/app/components/regions/pages/list/list.component.spec.ts
+++ b/src/app/components/regions/pages/list/list.component.spec.ts
@@ -21,6 +21,7 @@ import { nStepObservable } from "@test/helpers/general";
 import { assertErrorHandler } from "@test/helpers/html";
 import { MockComponent } from "ng-mocks";
 import { Subject } from "rxjs";
+import { SiteMapComponent } from "@components/projects/components/site-map/site-map.component";
 import { ListComponent } from "./list.component";
 
 const mockCardsComponent = MockComponent(CardsComponent);
@@ -40,6 +41,9 @@ describe("RegionsListComponent", () => {
           },
         },
       ],
+    ],
+    declarations: [
+      MockComponent(SiteMapComponent)
     ],
     imports: [SharedModule, RouterTestingModule, MockBawApiModule],
   });
@@ -194,5 +198,12 @@ describe("RegionsListComponent", () => {
       getFilter().filter.next("custom value");
       expect(spec.component.onFilter).toHaveBeenCalled();
     });
+  });
+
+  it("should display a baw-map", async () => {
+    const regions = generateRegions(1);
+    await handleApiRequest(regions);
+
+    expect(spec.query(SiteMapComponent)).toExist();
   });
 });

--- a/src/app/components/regions/pages/list/list.component.ts
+++ b/src/app/components/regions/pages/list/list.component.ts
@@ -23,7 +23,7 @@ export const regionsMenuItemActions = [
   template: `
     <ng-container *ngIf="!error">
       <ng-container *ngIf="!loading && models.size > 0;">
-        <div style="width: 100%; height: 500px;">
+        <div style="width: 100%; height: 24em;">
           <baw-site-map [regions]="models.toArray()"></baw-site-map>
         </div>
       </ng-container>

--- a/src/app/components/regions/pages/list/list.component.ts
+++ b/src/app/components/regions/pages/list/list.component.ts
@@ -22,6 +22,12 @@ export const regionsMenuItemActions = [
   selector: "baw-regions",
   template: `
     <ng-container *ngIf="!error">
+      <ng-container *ngIf="!loading && models.size > 0;">
+        <div style="width: 100%; height: 500px;">
+          <baw-site-map [regions]="models.toArray()"></baw-site-map>
+        </div>
+      </ng-container>
+
       <baw-debounce-input
         label="Filter"
         placeholder="Filter Sites"

--- a/src/app/components/shared/map/map.component.ts
+++ b/src/app/components/shared/map/map.component.ts
@@ -28,7 +28,7 @@ import { takeUntil } from "rxjs/operators";
         height="100%"
         width="100%"
         [options]="mapOptions"
-        (mapClick)="markerOptions.draggable && newLocation.emit($event)"
+        (mapClick)="markerOptions?.draggable && newLocation.emit($event)"
       >
         <map-marker
           *ngFor="let marker of filteredMarkers"


### PR DESCRIPTION
# Add more maps

Users have expressed a lack of geographical information from the list and home pages. Therefore, to show more geographical information, I have added a map to the home page and list pages.

## Changes

- Adds a `baw-site-map` to the home page
- Adds a `baw-site-map` to the project and list pages that displays all sites in the filter (if the filter is updated, the sites update)
- Adds tests for maps on home, project & region list pages
- Fixes a bug where if a used clicked on a non-clickable map, it'd throw a JavaScript console error

## Problems

_Pending design review_

## Issues

Fixes: #2027 

## Visual Changes

**Project and list site pages:**
![image](https://user-images.githubusercontent.com/33742269/216556750-cbcced71-4cbe-460f-8bd5-f0316ec50d03.png)

**Home Page:**
![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/06cbc7db-ead2-4ba2-ba33-e36f45ce088c)

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
