### PR TITLE
Fixed deprecated usage of RXJS subscribe

### DIFF
--- a/src/app/components/about/pages/contact-us/contact-us.component.ts
+++ b/src/app/components/about/pages/contact-us/contact-us.component.ts
@@ -60,14 +60,14 @@ class ContactUsComponent extends FormTemplate<ContactUs> implements OnInit {
     this.api
       .seed()
       .pipe(takeUntil(this.unsubscribe))
-      .subscribe(
-        ({ seed, action }) =>
+      .subscribe({
+        next: ({ seed, action }) =>
           (this.recaptchaSeed = { state: "loaded", action, seed }),
-        (err) => {
+        error: (err) => {
           console.error(err);
           this.notifications.error("Failed to load form");
-        }
-      );
+        },
+      });
   }
 
   protected apiAction(model: IContactUs) {

--- a/src/app/components/data-request/data-request.component.ts
+++ b/src/app/components/data-request/data-request.component.ts
@@ -68,14 +68,14 @@ class DataRequestComponent extends FormTemplate<DataRequest> implements OnInit {
     this.api
       .seed()
       .pipe(takeUntil(this.unsubscribe))
-      .subscribe(
-        ({ seed, action }) =>
+      .subscribe({
+        next: ({ seed, action }) =>
           (this.recaptchaSeed = { state: "loaded", seed, action }),
-        (err) => {
+        error: (err) => {
           console.error(err);
           this.notifications.error("Failed to load form");
-        }
-      );
+        },
+      });
   }
 
   protected apiAction(model: IDataRequest): Observable<void> {

--- a/src/app/components/harvest/components/shared/title.component.ts
+++ b/src/app/components/harvest/components/shared/title.component.ts
@@ -2,17 +2,18 @@ import { Component, Input } from "@angular/core";
 import { NgForm } from "@angular/forms";
 import { ShallowHarvestsService } from "@baw-api/harvest/harvest.service";
 import { BawApiError } from "@helpers/custom-errors/baw-api-error";
+import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
 import { Harvest } from "@models/Harvest";
 import { Project } from "@models/Project";
 import { ToastrService } from "ngx-toastr";
-import { throwError } from "rxjs";
+import { takeUntil, throwError } from "rxjs";
 
 @Component({
   selector: "baw-harvest-title",
   templateUrl: "./title.component.html",
   styleUrls: ["./title.component.scss"],
 })
-export class TitleComponent {
+export class TitleComponent extends withUnsubscribe()  {
   @Input() public project: Project;
   @Input() public harvest: Harvest;
 
@@ -21,16 +22,15 @@ export class TitleComponent {
   public constructor(
     public harvestService: ShallowHarvestsService,
     private notifications: ToastrService,
-  ){}
+  ){ super() }
 
   public updateHarvestName(form: NgForm) {
     const newHarvestName = form.value["harvestNameInput"];
 
     if (newHarvestName !== this.harvest.name) {
       this.harvestService.updateName(this.harvest, newHarvestName)
-      // eslint-disable-next-line rxjs-angular/prefer-takeuntil
+      .pipe(takeUntil(this.unsubscribe))
       .subscribe({
-        next: (): void => {},
         error: (err: BawApiError): void => {
           throwError(() => err);
         },

--- a/src/app/components/profile/pages/profile/my-profile.component.ts
+++ b/src/app/components/profile/pages/profile/my-profile.component.ts
@@ -197,8 +197,8 @@ class MyProfileComponent
     api
       .filterByCreator(additionalFilters, user)
       .pipe(takeUntil(this.unsubscribe))
-      .subscribe(
-        (models) => {
+      .subscribe({
+        next: (models) => {
           const total = models.length > 0 ? getPageTotal(models[0]) : 0;
           this.userStatistics = this.userStatistics.update(
             index,
@@ -206,8 +206,8 @@ class MyProfileComponent
           );
           callback?.(models);
         },
-        () => this.handleError(index)
-      );
+        error: () => this.handleError(index),
+      });
   }
 
   /** Set failed statistic value to unknown */

--- a/src/app/components/report-problem/report-problem.component.ts
+++ b/src/app/components/report-problem/report-problem.component.ts
@@ -61,14 +61,14 @@ class ReportProblemComponent
     this.api
       .seed()
       .pipe(takeUntil(this.unsubscribe))
-      .subscribe(
-        ({ seed, action }) =>
+      .subscribe({
+        next: ({ seed, action }) =>
           (this.recaptchaSeed = { state: "loaded", seed, action }),
-        (err) => {
+        error: (err) => {
           console.error(err);
           this.notifications.error("Failed to load form");
-        }
-      );
+        },
+      });
   }
 
   protected apiAction(model: ReportProblem) {

--- a/src/app/components/shared/detail-view/render-field/render-field.component.ts
+++ b/src/app/components/shared/detail-view/render-field/render-field.component.ts
@@ -229,15 +229,13 @@ export class RenderFieldComponent
   ) {
     this.setLoading();
 
-    value.pipe(takeUntil(this.unsubscribe)).subscribe(
-      (models) => {
+    value.pipe(takeUntil(this.unsubscribe)).subscribe({
+      next: (models) => {
         this.humanize(models);
         this.ref.detectChanges();
       },
-      () => {
-        this.setError();
-      }
-    );
+      error: () => this.setError(),
+    });
   }
 
   /**


### PR DESCRIPTION
# Fixed depricated usage of RXJS subscribe

What is the purpose of this PR?

## Changes

- Changes rxjs `subscribe` methods to use observable in replacement of deprecated usage of multiple parameters
- Fixes `subscribe` in the Harvest title component not unsubscribing

## Problems

None

## Issues

Fixes: #1765 

## Visual Changes

No visual changes

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
