### PR TITLE
Fix library navbar inheriting component route params

### DIFF
--- a/src/app/components/library/library.menus.ts
+++ b/src/app/components/library/library.menus.ts
@@ -1,6 +1,10 @@
 import { Category, menuRoute } from "@interfaces/menusInterfaces";
 import { StrongRoute } from "@interfaces/strongRoute";
 
+// there is a clear distinction between the nav route and the library route because the nav route should never have knowledge of the current
+// component route params. The library nav route should instead always act as if its creating a new instance of the library view.
+export const libraryNavRoute = StrongRoute.newRoot().add("library");
+
 export const libraryRoute = StrongRoute.newRoot().add("library", (params) =>
   !params
     ? {}
@@ -29,7 +33,7 @@ export const libraryCategory: Category = {
 export const libraryMenuItem = menuRoute({
   icon: libraryCategory.icon,
   label: "Library",
-  route: libraryRoute,
+  route: libraryNavRoute,
   order: 6,
   tooltip: () => "Library of annotations",
 });

--- a/src/app/components/library/library.module.ts
+++ b/src/app/components/library/library.module.ts
@@ -2,13 +2,13 @@ import { NgModule } from "@angular/core";
 import { RouterModule } from "@angular/router";
 import { getRouteConfigForPage } from "@helpers/page/pageRouting";
 import { SharedModule } from "@shared/shared.module";
-import { libraryRoute } from "./library.menus";
+import { libraryNavRoute } from "./library.menus";
 import { AnnotationComponent } from "./pages/details/details.component";
 import { LibraryComponent } from "./pages/list/list.component";
 
 const components = [LibraryComponent, AnnotationComponent];
 
-const routes = libraryRoute.compileRoutes(getRouteConfigForPage);
+const routes = libraryNavRoute.compileRoutes(getRouteConfigForPage);
 
 @NgModule({
   declarations: components,

--- a/src/app/components/shared/menu/primary-menu/primary-menu.component.spec.ts
+++ b/src/app/components/shared/menu/primary-menu/primary-menu.component.spec.ts
@@ -158,6 +158,19 @@ describe("PrimaryMenuComponent", () => {
             expect(element).toContainText(menuItem.label);
             expect(element).toHaveStrongRoute(menuItem.route);
           });
+
+          // this assertion assumes navbar menu items use routes with no knowledge of parent routes (routes always act as a new instance)
+          // if this test is failing and your navbar item is designed to inherit routeParams, disable this test for the navbar menu item
+          it(`should not inherit route params to use in ${link} route`, fakeAsync(() => {
+            setup({ hideProjects, user: defaultUser });
+            spec.component["router"].routerState.snapshot.root.queryParams = { page: 1 };
+            spec.detectChanges();
+
+            const expectedRoute = menuItem.route.queryParams();
+            const realizedRoute = menuItem.route.queryParams(spec.component["router"]);
+
+            expect(realizedRoute).toEqual(expectedRoute);
+          }));
         });
 
         it("should create header links from external config", () => {

--- a/src/app/components/shared/menu/primary-menu/primary-menu.component.ts
+++ b/src/app/components/shared/menu/primary-menu/primary-menu.component.ts
@@ -97,7 +97,7 @@ export class PrimaryMenuComponent extends withUnsubscribe() implements OnInit {
       });
   }
 
-  private setHeaderLinks() {
+  private setHeaderLinks(): void {
     this.links = List([
       this.config.settings.hideProjects
         ? shallowRegionsMenuItem


### PR DESCRIPTION
# Fix library navbar inheriting component routeParams from view model

The library navbar menu item inherited the current view models `routeParams`. This caused a wide range of bugs that wouldn't normally be spotted unless the user inspects the URL.

e.g. Navigating to page 3 of the projects page then clicking on "Library" would navigate the user to page 3 of the library page.

## Changes

- Adds a `libraryNavRoute` `StrongRoute` to `library.menu.ts`
- Adds a unit test to assert that navbar menu items do not use component `routeParams` in their routes
- (Minor Change) adds method return type `void` to method `setHeaderLinks` _This change is optional, however, I found this useful while looking for solutions, and other developers may find the same_

See my full justification on why I chose this solution over others [here](https://github.com/QutEcoacoustics/workbench-client/issues/2028#issuecomment-1430744696)

### Assumptions

I have fixed the issue related to the library item by creating a new libraryNav route. This is similar to how the projects nav menu item works.

However, an alternative solution that I have thought of is "sanitizing" / cleaning all baw-primary-menu > baw-header, baw-header-dropdown input strong routes (Maybe using a directive?) so they have no context of the current view. This would be more "correct" if all nav bar items are supposed to act as a navigation to a completely new view / session.

I have chosen not to use this solution as I believe that menu items routes should follow the same format / conventions as other parts of the client, and should not have their own special rules associated, and that menu routes should instead be explicitly defined as not carrying component route information at the route level, not baw-primary-menu level. By explicitly defining no routeParams in the library nav menu item, I have also conserved the possibility of a future nav bar item that can navigate with knowledge of the current route / component.

I will be adding code comments to document this for future developers and will add tests asserting that this change does not get accidentally reverted in future revisions.

## Problems

None

## Issues

Fixes: #2028 

## Visual Changes

None

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
