### PR TITLE
Fix: project shown in titles when projects hidden

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -243,7 +243,7 @@ describe("AppComponent", () => {
     });
 
     it("should have an injected page title strategy", () => {
-      expect(titleStrategyInjectable).toBeTruthy();
+      expect(titleStrategyInjectable).toBeInstanceOf(PageTitleStrategy);
     });
 
     // a route without a hierarchy is a route with no `parent` property

--- a/src/app/components/projects/pages/details/details.component.spec.ts
+++ b/src/app/components/projects/pages/details/details.component.spec.ts
@@ -1,7 +1,10 @@
 import { Router } from "@angular/router";
 import { defaultApiPageSize } from "@baw-api/baw-api.service";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
-import { projectResolvers, ProjectsService } from "@baw-api/project/projects.service";
+import {
+  projectResolvers,
+  ProjectsService,
+} from "@baw-api/project/projects.service";
 import { RegionsService } from "@baw-api/region/regions.service";
 import { SitesService } from "@baw-api/site/sites.service";
 import { SiteCardComponent } from "@components/projects/components/site-card/site-card.component";
@@ -57,8 +60,8 @@ describe("ProjectDetailsComponent", () => {
 
   assertPageInfo<Project>(DetailsComponent, "test name", {
     project: {
-      model: new Project(generateProject({ name: "test name" }))
-    }
+      model: new Project(generateProject({ name: "test name" })),
+    },
   });
 
   function createModelWithMeta<M extends AbstractModel>(

--- a/src/app/components/projects/pages/list/list.component.spec.ts
+++ b/src/app/components/projects/pages/list/list.component.spec.ts
@@ -22,6 +22,7 @@ import { assertErrorHandler } from "@test/helpers/html";
 import { assertPageInfo } from "@test/helpers/pageRoute";
 import { MockComponent } from "ng-mocks";
 import { Subject } from "rxjs";
+import { shallowRegionsMenuItem } from "@components/regions/regions.menus";
 import { ListComponent } from "./list.component";
 
 const mockCardsComponent = MockComponent(CardsComponent);
@@ -95,7 +96,7 @@ describe("ProjectsListComponent", () => {
     api = spec.inject(ProjectsService);
   });
 
-  assertPageInfo(ListComponent, "Projects");
+  assertPageInfo(ListComponent, ["Projects", shallowRegionsMenuItem.label]);
 
   it("should initially request page 1", async () => {
     await handleApiRequest([], (filter) => expect(filter.paging.page).toBe(1));

--- a/src/app/components/projects/projects.menus.ts
+++ b/src/app/components/projects/projects.menus.ts
@@ -1,6 +1,6 @@
 import { RouterStateSnapshot } from "@angular/router";
 import { retrieveResolvedModel } from "@baw-api/resolver-common";
-import { Category, menuRoute } from "@interfaces/menusInterfaces";
+import { Category, menuRoute, TitleOptionsHash } from "@interfaces/menusInterfaces";
 import { Project } from "@models/Project";
 import {
   defaultEditIcon,
@@ -32,7 +32,8 @@ export const projectsMenuItem = menuRoute({
   order: 4,
   route: projectsRoute,
   tooltip: () => "View projects I have access to",
-  title: () => "Projects",
+  title: (_routerState: RouterStateSnapshot, titleOptions: TitleOptionsHash) =>
+    titleOptions.hideProjects ? "Sites" : "Projects",
 });
 
 export const newProjectMenuItem = menuRoute({

--- a/src/app/interfaces/menusInterfaces.ts
+++ b/src/app/interfaces/menusInterfaces.ts
@@ -151,6 +151,10 @@ export function menuLink<T extends Omit<MenuLink, "kind">>(item: T): MenuLink {
   });
 }
 
+export interface TitleOptionsHash {
+  hideProjects: boolean;
+}
+
 /**
  * MenuRoute interface. Defines an internal page/route within this application.
  * Must be known to this angular app. e.g. /security/login
@@ -163,7 +167,7 @@ export interface MenuRoute extends MenuItem {
   route: StrongRoute;
 
   /** A computed tab title callback that should be used to identify the route */
-  title?: (routerState?: RouterStateSnapshot) => string
+  title?: (routerState?: RouterStateSnapshot, titleOptions?: TitleOptionsHash) => string | null;
 
   /** Custom label when shown in the breadcrumb */
   breadcrumbResolve?: (pageInfo: IPageInfo, injector: Injector) => string;


### PR DESCRIPTION
# Bug Fixs: project shown in titles when projects hidden

Since regions still technically have a parent project item, when projects were hidden, the project model name was still emitted in the route title.

This is incorrect as users should not see any project information if projects are hidden

## Changes

* Adds condition in route title builder to use a shallow region route instead of project route if projects are hidden
* Adds test to assert that project names are not emitted when projects are hidden

## Problems

Adds a _TODO_ stating that we may want to refactor the route title builder in the future to use the menu service's `rootToMenuRoute()` method. This method is not currently exposed as public, and causes circular dependencies in the current architecture.

## Issues

Fixes: #2052 

## Visual Changes

From:
![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/09877dcd-f069-4a86-8f2e-0ea29bf15fdb)

To:
![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/12e47352-d6b9-436a-843c-7cfbf2f5ea54)

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
