### PR TITLE
Fix tests on chrome due to hsl being floats

### DIFF
--- a/src/app/services/theme/theme.service.spec.ts
+++ b/src/app/services/theme/theme.service.spec.ts
@@ -1,6 +1,5 @@
 import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
 import { hsl } from "d3-color";
-import { DeviceDetectorService } from "ngx-device-detector";
 import { ThemeColor, ThemeService } from "./theme.service";
 
 const themeColors: ThemeColor[] = [
@@ -16,7 +15,6 @@ const themeColors: ThemeColor[] = [
 ];
 
 describe("ThemeService", () => {
-  let isFirefox: boolean;
   let spec: SpectatorService<ThemeService>;
   const createService = createServiceFactory(ThemeService);
   const defaultColorName: ThemeColor = "highlight";
@@ -45,7 +43,7 @@ describe("ThemeService", () => {
     const lightness = `${prefix}-lightness`;
 
     function readHslValue(value: number) {
-      return isFirefox ? value.toFixed(2) : value;
+      return value.toFixed(2);
     }
 
     const style = document.documentElement.style;
@@ -61,7 +59,6 @@ describe("ThemeService", () => {
 
     // Styles are not reset between tests, so we reset here
     spec.service.resetTheme();
-    isFirefox = spec.inject(DeviceDetectorService).browser === "Firefox";
   });
 
   afterAll(() => spec.service.resetTheme());


### PR DESCRIPTION
# Bug fix - tests failing on Chrome due to hsl now being floats

CI and tests are failing because the latest version of chrome now uses floats for hsl, rather than whole numbers. This brings it in to line with firefox, and we can therefore remove the conditional validation case for browsers in the `theme.service.spec.ts` tests.

## Changes

* Changes non-firefox browsers to expect floats for HSL values in theme service tests

## Problems

None

## Issues

#2063 

## Visual Changes

None

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
