### PR TITLE
Site/point deletion: warn users what will happen with audio recordings upon deletion

### DIFF
--- a/src/app/components/shared/menu/widgets/widget.component.ts
+++ b/src/app/components/shared/menu/widgets/widget.component.ts
@@ -7,4 +7,5 @@ export interface ModalComponent extends WidgetComponent {
   closeModal: (result: any) => void;
   dismissModal?: (reason: any) => void;
   successCallback?: () => void;
+  options?: Record<string, unknown>;
 }

--- a/src/app/components/shared/menu/widgets/widgetItem.ts
+++ b/src/app/components/shared/menu/widgets/widgetItem.ts
@@ -21,7 +21,10 @@ export class WidgetMenuItem {
 export interface MenuModal extends Omit<MenuAction, "kind"> {
   kind: "MenuModal";
   component: Type<ModalComponent>;
+  /** Options to be passed to the bootstrap modal service */
   modalOpts?: NgbModalOptions;
+  /** Options to be passed to the modal component */
+  options?: Record<string, unknown>;
   assignComponentData(component: ModalComponent, modalRef: NgbModalRef): void;
   successCallback?: (componentInstance?: PageComponent) => void;
 }
@@ -47,6 +50,7 @@ export function menuModal<
         dismissModal: (reason: any) => modalRef.dismiss(reason),
         closeModal: (result: any) => modalRef.close(result),
         successCallback: item?.successCallback,
+        ...item.options,
       };
       Object.assign(component, defaultOpts);
     },

--- a/src/app/components/sites/components/delete-site-modal/delete-site-modal.component.spec.ts
+++ b/src/app/components/sites/components/delete-site-modal/delete-site-modal.component.spec.ts
@@ -1,0 +1,111 @@
+import { Spectator, SpyObject, createRoutingFactory } from "@ngneat/spectator";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { ToastrService } from "ngx-toastr";
+import { NgbModalRef } from "@ng-bootstrap/ng-bootstrap";
+import { PageComponent } from "@helpers/page/pageComponent";
+import { SharedActivatedRouteService } from "@services/shared-activated-route/shared-activated-route.service";
+import { DeleteSiteModalComponent } from "./delete-site-modal.component";
+
+describe("DeleteSiteModalComponent", () => {
+  let spectator: Spectator<DeleteSiteModalComponent>;
+  let mockSharedActivatedRoute: SpyObject<SharedActivatedRouteService>;
+  let mockPageComponent: PageComponent;
+
+  const createComponent = createRoutingFactory({
+    component: DeleteSiteModalComponent,
+    imports: [MockBawApiModule],
+    mocks: [ToastrService, NgbModalRef],
+  });
+
+  function setup(): void {
+    mockPageComponent = new PageComponent({});
+
+    spectator = createComponent();
+    spectator.component.closeModal = () => null;
+    spectator.component.dismissModal = () => null;
+    spectator.component.successCallback = () => null;
+
+    mockSharedActivatedRoute = spectator.inject(SharedActivatedRouteService);
+    spyOnProperty(
+      mockSharedActivatedRoute,
+      "pageComponentInstance",
+      "get"
+    ).and.returnValue(mockPageComponent);
+  }
+
+  beforeEach(() => setup());
+
+  function getElementByInnerText<T extends HTMLElement>(text: string): T {
+    return spectator.debugElement.query(
+      (el) => el.nativeElement.innerText === text
+    ).nativeElement as T;
+  }
+
+  const getDeleteButton = (): HTMLAnchorElement =>
+    getElementByInnerText<HTMLAnchorElement>("Delete");
+  const getCancelButton = (): HTMLAnchorElement =>
+    getElementByInnerText<HTMLAnchorElement>("Cancel");
+
+  it("should create", () => {
+    expect(spectator.component).toBeInstanceOf(DeleteSiteModalComponent);
+  });
+
+  // duplicate test from delete-modal.component.spec.ts to ensure no extended functionality is lost
+  it("should invoke the success callback when the delete button is clicked", () => {
+    spyOn(spectator.component, "successCallback").and.stub();
+    getDeleteButton().click();
+    expect(spectator.component.successCallback).toHaveBeenCalledTimes(1);
+  });
+
+  // duplicate test from delete-modal.component.spec.ts to ensure no extended functionality is lost
+  it("should close the modal when the cancel button is clicked", () => {
+    spyOn(spectator.component, "closeModal").and.stub();
+    getCancelButton().click();
+    expect(spectator.component.closeModal).toHaveBeenCalledWith(false);
+  });
+
+  // duplicate test from delete-modal.component.spec.ts to ensure no extended functionality is lost
+  it("should close the modal when the delete button is clicked", () => {
+    spyOn(spectator.component, "closeModal").and.stub();
+    getDeleteButton().click();
+    expect(spectator.component.closeModal).toHaveBeenCalledWith(true);
+  });
+
+  it("should dismiss the modal when the 'Contact Us' link is clicked", () => {
+    const contactUsLinkElement: HTMLAnchorElement =
+      getElementByInnerText<HTMLAnchorElement>("Contact Us");
+    spyOn(spectator.component, "dismissModal").and.stub();
+
+    contactUsLinkElement.click();
+
+    expect(spectator.component.dismissModal).toHaveBeenCalledWith(false);
+  });
+
+  it("should have the correct text for points", () => {
+    spectator.component.isPoint = true;
+    spectator.detectChanges();
+
+    const expectedText = "When this point is deleted it will be made " +
+      "invisible. For data safety: all audio recordings will no longer be " +
+      "accessible but will be recoverable. If you need to recover these " +
+      "recordings after they have been deleted, please Contact Us."
+
+    expect(
+      getElementByInnerText(expectedText)
+    ).toExist();
+  });
+
+  it("should have the correct test for sites", () => {
+    spectator.component.isPoint = false;
+    spectator.detectChanges();
+
+    const expectedText = "When this site is deleted it will be made " +
+      "invisible. For data safety: all audio recordings will no longer be " +
+      "accessible but will be recoverable. If you need to recover these " +
+      "recordings after they have been deleted, please Contact Us."
+
+    expect(
+      getElementByInnerText(expectedText)
+    ).toExist();
+  });
+});

--- a/src/app/components/sites/components/delete-site-modal/delete-site-modal.component.ts
+++ b/src/app/components/sites/components/delete-site-modal/delete-site-modal.component.ts
@@ -1,0 +1,49 @@
+import { Component } from "@angular/core";
+import { contactUsMenuItem } from "@components/about/about.menus";
+import { StrongRoute } from "@interfaces/strongRoute";
+import { DeleteModalComponent } from "@shared/delete-modal/delete-modal.component";
+
+@Component({
+  selector: "baw-delete-site-modal",
+  template: `
+    <div class="modal-header">
+      <h4 class="modal-title">Delete {{ isPoint ? "Point" : "Site" }}</h4>
+      <button
+        type="button"
+        class="btn-close"
+        aria-label="Close"
+        (click)="dismissModal(false)"
+      ></button>
+    </div>
+
+    <div class="modal-body">
+      <span id="subTitle">
+        <p>
+          Are you certain you wish to delete this
+          {{ isPoint ? "point" : "site" }}?
+        </p>
+      </span>
+
+      <p class="alert alert-warning">
+        When this {{ isPoint ? "point" : "site" }} is deleted it will be made
+        invisible. For data safety: all audio recordings will no longer be
+        accessible but will be recoverable. If you need to recover these
+        recordings after they have been deleted, please
+        <a [strongRoute]="contactUsRoute" (click)="dismissModal(false)">Contact Us</a>.
+      </p>
+    </div>
+
+    <div class="modal-footer">
+      <a class="btn btn-outline-primary" (click)="closeModal(false)">Cancel</a>
+      <a class="btn btn-danger text-white" (click)="deleteModel()">Delete</a>
+    </div>
+  `,
+})
+export class DeleteSiteModalComponent extends DeleteModalComponent {
+  public constructor() {
+    super();
+  }
+
+  public isPoint: boolean;
+  protected contactUsRoute: StrongRoute = contactUsMenuItem.route;
+}

--- a/src/app/components/sites/points.modals.ts
+++ b/src/app/components/sites/points.modals.ts
@@ -1,9 +1,9 @@
 import { menuModal } from "@menu/widgetItem";
 import { AnnotationDownloadComponent } from "@shared/annotation-download/annotation-download.component";
-import { DeleteModalComponent } from "@shared/delete-modal/delete-modal.component";
 import { defaultAnnotationDownloadIcon } from "src/app/app.menus";
 import { pointMenuItem } from "./points.menus";
 import { deleteSiteModal } from "./sites.modals";
+import { DeleteSiteModalComponent } from "./components/delete-site-modal/delete-site-modal.component";
 
 export const pointAnnotationsModal = menuModal({
   icon: defaultAnnotationDownloadIcon,
@@ -18,5 +18,8 @@ export const deletePointModal = menuModal({
   label: "Delete point",
   parent: pointMenuItem,
   tooltip: () => "Delete this point",
-  component: DeleteModalComponent,
+  component: DeleteSiteModalComponent,
+  options: {
+    isPoint: true,
+  },
 });

--- a/src/app/components/sites/sites.modals.ts
+++ b/src/app/components/sites/sites.modals.ts
@@ -1,9 +1,9 @@
 import { menuModal } from "@menu/widgetItem";
 import { AnnotationDownloadComponent } from "@shared/annotation-download/annotation-download.component";
-import { DeleteModalComponent } from "@shared/delete-modal/delete-modal.component";
 import { defaultAnnotationDownloadIcon, defaultDeleteIcon, isProjectEditorPredicate } from "src/app/app.menus";
 import { siteMenuItem } from "./sites.menus";
 import { SiteDetailsComponent } from "./pages/details/details.component";
+import { DeleteSiteModalComponent } from "./components/delete-site-modal/delete-site-modal.component";
 
 export const siteAnnotationsModal = menuModal({
   icon: defaultAnnotationDownloadIcon,
@@ -19,6 +19,9 @@ export const deleteSiteModal = menuModal({
   parent: siteMenuItem,
   tooltip: () => "Delete this site",
   predicate: isProjectEditorPredicate,
-  component: DeleteModalComponent,
+  component: DeleteSiteModalComponent,
   successCallback: (pageComponentInstance?: SiteDetailsComponent) => pageComponentInstance.deleteModel(),
+  options: {
+    isPoint: false,
+  },
 });

--- a/src/app/components/sites/sites.module.ts
+++ b/src/app/components/sites/sites.module.ts
@@ -12,6 +12,7 @@ import { SiteNewComponent } from "./pages/new/new.component";
 import { WizardComponent } from "./pages/wizard/wizard.component";
 import { pointsRoute } from "./points.routes";
 import { sitesRoute } from "./sites.routes";
+import { DeleteSiteModalComponent } from "./components/delete-site-modal/delete-site-modal.component";
 
 const components = [
   SiteComponent,
@@ -20,6 +21,7 @@ const components = [
   SiteNewComponent,
   WizardComponent,
   RecentAnnotationsComponent,
+  DeleteSiteModalComponent,
 ];
 
 const siteRoutes = sitesRoute.compileRoutes(getRouteConfigForPage);


### PR DESCRIPTION
# Site/point deletion: warn users what will happen with audio recordings upon deletion

As users are now uploading audio recordings via the Harvest webpages, they sometimes run into issues when uploading duplicate audio recordings.

Currently when a point/site is deleted, the audio recordings are disassociated from the site/point, but they still exist (they are hidden). So if a user uploads an audio recording -> deletes a site -> creates a new site -> uploads the same audio recording, it will be blocked from Harvest as a duplicate upload.

We should explain this behavior to users in "user friendly" language when the site is deleted via a warning in the deletion modal window.

## Changes

* Adds a specialised delete modal for sites/points
* Adds the ability to pass component options to modals
* Adds tests for new sites/points delete modal

## Problems

None

## Issues

Fixes: #2067

## Visual Changes

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/4b1b811d-b847-45f2-b1f9-95acc86a5b59)
**New deletion modal with warning text**

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
