### PR TITLE
Added creator/updated cards to Harvest pages

### DIFF
--- a/src/app/components/harvest/pages/details/details.component.ts
+++ b/src/app/components/harvest/pages/details/details.component.ts
@@ -13,6 +13,7 @@ import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
 import { Harvest } from "@models/Harvest";
 import { Project } from "@models/Project";
 import { List } from "immutable";
+import { permissionsWidgetMenuItem } from "@menu/widget.menus";
 import { HarvestStagesService } from "../../services/harvest-stages.service";
 import { harvestsMenuItemActions } from "../list/list.component";
 
@@ -53,7 +54,10 @@ DetailsComponent.linkToRoute({
   category: harvestsCategory,
   menus: {
     actions: List([...harvestsMenuItemActions, newSiteMenuItem]),
-    actionWidgets: List([harvestValidationsWidgetMenuItem]),
+    actionWidgets: List([
+      harvestValidationsWidgetMenuItem,
+      permissionsWidgetMenuItem
+    ]),
   },
   pageRoute: harvestMenuItem,
   resolvers: {

--- a/src/app/components/harvest/pages/list/list.component.html
+++ b/src/app/components/harvest/pages/list/list.component.html
@@ -28,6 +28,15 @@
     </ng-template>
   </ngx-datatable-column>
 
+  <ngx-datatable-column prop="">
+    <ng-template let-column="column" ngx-datatable-header-template>
+      Creator
+    </ng-template>
+    <ng-template let-value="value" ngx-datatable-cell-template>
+      <baw-user-link [user]="value.creator"></baw-user-link>
+    </ng-template>
+  </ngx-datatable-column>
+
   <ngx-datatable-column prop="streaming">
     <ng-template let-column="column" ngx-datatable-header-template>
       Upload Type

--- a/src/app/components/harvest/pages/list/list.component.ts
+++ b/src/app/components/harvest/pages/list/list.component.ts
@@ -10,7 +10,6 @@ import {
   newHarvestMenuItem,
 } from "@components/harvest/harvest.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
-import { permissionsWidgetMenuItem } from "@menu/widget.menus";
 import { Harvest } from "@models/Harvest";
 import { Project } from "@models/Project";
 import { List } from "immutable";
@@ -101,7 +100,6 @@ ListComponent.linkToRoute({
   category: harvestsCategory,
   menus: {
     actions: List(harvestsMenuItemActions),
-    actionWidgets: List([permissionsWidgetMenuItem]),
   },
   pageRoute: harvestsMenuItem,
   resolvers: {

--- a/src/app/components/harvest/screens/uploading/batch-uploading.component.html
+++ b/src/app/components/harvest/screens/uploading/batch-uploading.component.html
@@ -58,11 +58,11 @@
           Cyberduck and connect to our cloud.
         </li>
         <li>
-          On your first connection to our cloud, Cyberduck may prompt you with 
-          an "unknown fingerprint" message. Select "Allow".  
+          On your first connection to our cloud, Cyberduck may prompt you with
+          an "unknown fingerprint" message. Select "Allow".
         </li>
         <li>
-          Upload all of your files by dragging them into the cyberduck window and we will check them for you. This  
+          Upload all of your files by dragging them into the cyberduck window and we will check them for you. This
           <a target="_blank" href="https://docs.cyberduck.io/cyberduck/upload/"
             >guide</a
           >
@@ -78,7 +78,7 @@
   <li [ngbNavItem]="3">
     <a ngbNavLink>Linux</a>
     <ng-template ngbNavContent>
-      <p>These instructions use the SCP command program. Alternatively you might prefer <button class="btn btn-link" (click)="activateTab('RClone')">Rclone</button> 
+      <p>These instructions use the SCP command program. Alternatively you might prefer <button class="btn btn-link" (click)="activateTab('RClone')">Rclone</button>
         or a graphical sftp client (if you're in a graphical environment)
       </p>
       <ol>
@@ -87,8 +87,8 @@
           <ul>
             <li>
               <code>
-                scp -r -P {{ harvest.uploadPort }} 
-                "[path to your files]" 
+                scp -r -P {{ harvest.uploadPort }}
+                "[path to your files]"
                 {{ harvest.uploadUser }}@{{ harvest.uploadHost }}:/
               </code>
             </li>
@@ -98,8 +98,8 @@
           When prompted, enter the password <code>{{ harvest.uploadPassword }}</code>
           <ul>
             <li>
-              Note, if you are going to be running  this command multiple times, for example in a script, 
-              you might like to use <a href='https://www.linuxshelltips.com/pass-password-scp-command-linux/'>sshpass</a> 
+              Note, if you are going to be running  this command multiple times, for example in a script,
+              you might like to use <a href='https://www.linuxshelltips.com/pass-password-scp-command-linux/'>sshpass</a>
               to save having to interactively enter the password many times
             </li>
           </ul>
@@ -113,26 +113,26 @@
     <ng-template ngbNavContent>
       <ol>
         <li>
-           Rclone is a <b>command line</b> tool for transferring files, which you can download 
-           and install <a target="_blank" href="https://rclone.org/install/">here</a>. 
+           Rclone is a <b>command line</b> tool for transferring files, which you can download
+           and install <a target="_blank" href="https://rclone.org/install/">here</a>.
         </li>
         <li>
           Paste the following command into your terminal, making sure to replace the <code>[path to your files]</code>
           <ul>
             <li>
               <code>
-                rclone copy -v 
-                --sftp-user {{ harvest.uploadUser }} 
-                --sftp-pass $(rclone obscure {{ harvest.uploadPassword }}) 
-                --sftp-host {{ harvest.uploadHost }} 
-                --sftp-port {{ harvest.uploadPort }} 
+                rclone copy -v
+                --sftp-user {{ harvest.uploadUser }}
+                --sftp-pass $(rclone obscure {{ harvest.uploadPassword }})
+                --sftp-host {{ harvest.uploadHost }}
+                --sftp-port {{ harvest.uploadPort }}
                 "[path to your files]"
                 :sftp:/
-              </code>   
+              </code>
             </li>
             <li>
               Note that rclone will copy the <em>contents</em> of the <code>[path to your files]</code> folder to the destination, not the source folder itself.
-              So if you have a folder for each site, specify their parent folder as the <code>[path to your files]</code> value. 
+              So if you have a folder for each site, specify their parent folder as the <code>[path to your files]</code> value.
             </li>
           </ul>
       </ol>
@@ -154,7 +154,7 @@
         </fa-icon>
 
         Use a wired network connection instead of WiFi. The file transfer will
-        faster and more stable.
+        be faster and more stable.
       </div>
     </div>
   </div>

--- a/src/app/components/shared/menu/widgets/permissions-shield/permissions-shield.component.spec.ts
+++ b/src/app/components/shared/menu/widgets/permissions-shield/permissions-shield.component.spec.ts
@@ -25,6 +25,8 @@ import {
 } from "@test/helpers/general";
 import { MockComponent, MockProvider } from "ng-mocks";
 import { of, Subject } from "rxjs";
+import { Harvest } from "@models/Harvest";
+import { generateHarvest } from "@test/fakes/Harvest";
 import { PermissionsShieldComponent } from "./permissions-shield.component";
 
 const mockUserBadge = MockComponent(UserBadgeComponent);
@@ -33,6 +35,7 @@ describe("PermissionsShieldComponent", () => {
   let defaultProject: Project;
   let defaultRegion: Region;
   let defaultSite: Site;
+  let defaultHarvest: Harvest;
   let defaultModel: MockModel;
   let defaultUser: User;
   let spec: Spectator<PermissionsShieldComponent>;
@@ -71,6 +74,7 @@ describe("PermissionsShieldComponent", () => {
     defaultProject["injector"] = injector;
     defaultRegion["injector"] = injector;
     defaultSite["injector"] = injector;
+    defaultHarvest["injector"] = injector;
     defaultModel["injector"] = injector;
 
     const userSubject = new Subject<User>();
@@ -91,6 +95,7 @@ describe("PermissionsShieldComponent", () => {
     defaultProject = new Project(generateProject());
     defaultRegion = new Region(generateRegion());
     defaultSite = new Site(generateSite());
+    defaultHarvest = new Harvest(generateHarvest());
     defaultModel = new MockModel({});
     defaultUser = new User(generateUser());
   });
@@ -102,7 +107,19 @@ describe("PermissionsShieldComponent", () => {
       expect(spec.component.model).toEqual(defaultModel);
     });
 
-    it("should prioritize site", () => {
+    it("should prioritize harvests", () => {
+      setup([
+        { model: defaultModel },
+        { model: defaultProject },
+        { model: defaultRegion },
+        { model: defaultSite },
+        { model: defaultHarvest },
+      ]);
+      spec.detectChanges();
+      expect(spec.component.model).toEqual(defaultHarvest);
+    });
+
+    it("should prioritize site if there is no harvest", () => {
       setup([
         { model: defaultModel },
         { model: defaultProject },

--- a/src/app/components/shared/menu/widgets/permissions-shield/permissions-shield.component.ts
+++ b/src/app/components/shared/menu/widgets/permissions-shield/permissions-shield.component.ts
@@ -14,6 +14,7 @@ import { Region } from "@models/Region";
 import { Site } from "@models/Site";
 import { SharedActivatedRouteService } from "@services/shared-activated-route/shared-activated-route.service";
 import { map, takeUntil } from "rxjs";
+import { Harvest } from "@models/Harvest";
 import { WidgetComponent } from "../widget.component";
 
 /**
@@ -81,11 +82,13 @@ export class PermissionsShieldComponent
     }
 
     // Grab model in order of priority, site, then region, then project
+    // if the user is looking at a harvest, we should show the harvest information
     const priorityLevels = {
-      site: 0,
-      region: 1,
-      project: 2,
-      anyModel: 3,
+      harvest: 0,
+      site: 1,
+      region: 2,
+      project: 3,
+      anyModel: 4,
     };
 
     let outputModel: AbstractModel;
@@ -105,7 +108,9 @@ export class PermissionsShieldComponent
         this.project = model;
       }
 
-      if (model instanceof Site) {
+      if (model instanceof Harvest) {
+        assignModel(model , priorityLevels.harvest);
+      } else if (model instanceof Site) {
         assignModel(model, priorityLevels.site);
       } else if (priority > priorityLevels.region && model instanceof Region) {
         assignModel(model, priorityLevels.region);


### PR DESCRIPTION
# Add creator/updater cards to harvest pages

**I found a bug in my implementation after I opened this PR. Not ready for review**

The current created by / updated by cards refer to the project. These should instead refer to the harvest.

## Changes

* Adds the "Created by / Updated by" menu cards to the harvest details page
* Adds a "creator" column to Harvest list pages
* Removes the "Created by / Updated by" menu cards from the harvest list page
* Fixes typo in Harvest batch uploading page
* `permissions-shield.component.ts` (menu bar "Created by / Updated by" card now displays Harvest information if available)

## Problems

None

## Issues

#2060 

## Visual Changes

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/b625c845-ac4e-4e02-941b-655dc9ed5b3d)
_Harvest list page with "Creator" column and no "Created by / Updated by" menu cards_

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/dc9aff3d-a13d-4f2d-8362-b5b948881025)
_Harvest details page with "Created by / Updated by" menu card and fixed typo_

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
