### PR TITLE
Improved performance of harvest list page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,9 @@
   "typescript.tsdk": "node_modules\\typescript\\lib",
   "cSpell.words": [
     "Datatable",
+    "datatable",
+    "luxon",
+    "toastr",
     "typeahead",
     "Ecoacoustics"
   ]

--- a/src/app/components/harvest/pages/list/list.component.ts
+++ b/src/app/components/harvest/pages/list/list.component.ts
@@ -48,12 +48,25 @@ class ListComponent extends PageComponent implements OnInit {
   public ngOnInit(): void {
     this.project = this.route.snapshot.data[projectKey].model;
     this.canCreateHarvestCapability = this.project.can("createHarvest").can;
-    // A BehaviorSubject is need on fitlers$ to update the ngx-datatable harvest list & models
+    // A BehaviorSubject is need on filters$ to update the ngx-datatable harvest list & models
     // The this.filters$ is triggered in abortUpload()
     this.filters$ = new BehaviorSubject({
       sorting: {
         direction: "desc",
         orderBy: "createdAt",
+      },
+      // projection allows us only to emit the fields that we want
+      // this improves performance and reduces the amount of data sent
+      projection: {
+        include: [
+          "id",
+          "projectId",
+          "name",
+          "createdAt",
+          "creatorId",
+          "streaming",
+          "status",
+        ]
       }
     });
   }

--- a/src/app/directives/datatable/pagination.directive.spec.ts
+++ b/src/app/directives/datatable/pagination.directive.spec.ts
@@ -202,6 +202,17 @@ describe("DatatablePaginationDirective", () => {
       flushGetModels();
       assertLoading(false);
     }));
+
+    it("should only emit one api request when loaded", fakeAsync(() => {
+      const mockGetModels = jasmine.createSpy("getModels").and.callFake(() => of(defaultModels));
+
+      generateModels();
+      setup({ filters: {}, getModels: mockGetModels });
+
+      flushGetModels();
+
+      expect(mockGetModels).toHaveBeenCalledTimes(1);
+    }));
   });
 
   describe("total", () => {

--- a/src/app/directives/datatable/pagination.directive.ts
+++ b/src/app/directives/datatable/pagination.directive.ts
@@ -123,10 +123,6 @@ export class DatatablePaginationDirective<Model extends AbstractModel>
    * retrieved from the api request
    */
   private rows$: Observable<any[]>;
-  /**
-   * Observable tracking the total number of models for the current base filter
-   */
-  private total$: Observable<number>;
   /** Observable tracking when the table is loading new data */
   private loading$ = new BehaviorSubject<boolean>(false);
   /**
@@ -182,12 +178,6 @@ export class DatatablePaginationDirective<Model extends AbstractModel>
       tap((): void => this.loading$.next(false))
     );
 
-    this.total$ = this.rows$.pipe(
-      // Get the total number of models for the current filter from the
-      // responses metadata
-      map((models): number => models[0]?.getMetadata().paging.total ?? 0)
-    );
-
     this.subscribeToTableOutputs();
     this.setTableInputs();
   }
@@ -234,9 +224,10 @@ export class DatatablePaginationDirective<Model extends AbstractModel>
 
   /** Sets table inputs with latest values from observables */
   private setTableInputs(): void {
-    // Set table rows on change
+    // Set table rows and the total number of rows on change
     this.rows$.pipe(takeUntil(this.unsubscribe)).subscribe((rows): void => {
       this.datatable.rows = rows;
+      this.datatable.count = rows[0]?.getMetadata().paging.total ?? 0;
     });
 
     // Set loading state on change
@@ -245,11 +236,6 @@ export class DatatablePaginationDirective<Model extends AbstractModel>
       .subscribe((isLoading): void => {
         this.datatable.loadingIndicator = isLoading;
       });
-
-    // Set count on change
-    this.total$.pipe(takeUntil(this.unsubscribe)).subscribe((total): void => {
-      this.datatable.count = total;
-    });
 
     // Set page number on change
     this.pageAndSort$


### PR DESCRIPTION
# Improve performance of harvest list page

The harvest list page sends two requests and requests a lot of redundant information

## Changes

* The Harvest list page now only requests the subset of harvest properties it needs
* our custom `pagination.directive.ts` now only makes one request (this fixes double requests on any page that uses this directive)
* Adds tests for all changes
* Fixes typos

## Problems

Na

## Issues

Fixes: #2045

## Visual Changes

Na

## TODO

Measure the performance increase (expecting >200%)

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
