### PR TITLE
Add Open Ecoacoustic Sponsor Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,12 @@ $ docker run -p 4000:4000 -v "$(pwd)/environment.json:/environment.json" -e DEBU
 ## Licence
 
 Apache License, Version 2.0
+
+## Acknowledgements
+
+This work has been supported through several grants.
+
+The most recent of which is the ARDC Platforms project. This project is currently sponsored by the Open Ecoacoustics
+ARDC Platforms project. See [doi.org/10.47486/PL050](https://doi.org/10.47486/PL050) for more details.
+
+[![The Open Ecoacoustics Logo](./src/assets/images/logos/OpenEcoAcoustics_horizontal_rgb.jpg)](https://openecoacoustics.org/)

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -31,7 +31,7 @@
 <section id="about_us" class="overflow-auto pb-5 pt-5">
   <div class="container">
     <h2>Who Are We?</h2>
-    <p>
+    <p class="info-text">
       Welcome! {{ brand.long }} is a repository of environmental audio
       recordings. This website facilitates the management, access,
       visualization, and analysis of environmental acoustic data. It uses the
@@ -148,5 +148,27 @@
         </a>
       </baw-model-cards>
     </ng-container>
+  </div>
+</section>
+
+<section id="sponsors" class="bg-black text-white pb-5 pt-5 m-atuo">
+  <div class="container">
+    <h2>Sponsors</h2>
+    <p class="mb-5 info-text">
+      This work has been supported through several grants. The most recent of
+      which is the ARDC Platforms project.
+      <a href="https://openecoacoustics.org/">Open Ecoacoustics</a> currently
+      sponsors development of the workbench thanks to the ARDC Platforms
+      project. See
+      <a href="https://doi.org/10.47486/PL050">doi.org/10.47486/PL050</a> for
+      more details.
+    </p>
+
+    <a href="https://openecoacoustics.org/">
+      <img
+        class="container"
+        src="assets/images/logos/OpenEcoAcoustics_horizontal_rgb.svg"
+      />
+    </a>
   </div>
 </section>

--- a/src/app/components/home/home.component.scss
+++ b/src/app/components/home/home.component.scss
@@ -69,3 +69,21 @@ p {
     }
   }
 }
+
+// use this style class for paragraphs
+.info-text {
+  color: var(--baw-highlight-contrast);
+
+  p {
+    font-size: 1.25rem;
+  }
+
+  a {
+    color: var(--baw-highlight-contrast);
+
+    &:hover,
+    &:focus {
+      filter: brightness(70%);
+    }
+  }
+}

--- a/src/assets/images/logos/OpenEcoAcoustics_horizontal_rgb.jpg
+++ b/src/assets/images/logos/OpenEcoAcoustics_horizontal_rgb.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b81bec6138e447798070a5a1dc40422adcc89667bcd1ad48526d036f5b218170
+size 143973

--- a/src/assets/images/logos/OpenEcoAcoustics_horizontal_rgb.svg
+++ b/src/assets/images/logos/OpenEcoAcoustics_horizontal_rgb.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92f2bdafed5c2065646b9a3255504b454caf2dc2d6d5e2df5aef01ef8ac0a95d
+size 7608


### PR DESCRIPTION
# Add Open Ecoacoustic Sponsor Information

We should disclose that this project is sponsored by [Open Ecoacoustics](https://openecoacoustics.org/)

## Changes

- Added Open Ecoacoustics branding to README.md
- Added Open Ecoacoustics sponsor information to the home page
- Refactored out how links work on the home screen (there was previously one inline link. This caused it to have it's own specific styling. I've refactored it out to a common class)
- Uploaded PNG and SVG of open ecoacoustic logo

## Problems

None

## Issues

Fixes: #2087 

## Visual Changes

![276834316-0427cd39-39cc-4a58-9737-7bd263887edd](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/3464820a-3d6f-4023-abe7-ffff643cffad)
**Open Ecoacoustic branding on home page**

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/88fae06d-8b0b-47d2-b6c2-23b49160f2d2)
**Open Ecoacoustic branding on README**

For additional mock-ups see #2087 

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
