### PR TITLE
Admin Uploads View

### DIFF
--- a/src/app/components/admin/admin.menus.ts
+++ b/src/app/components/admin/admin.menus.ts
@@ -59,4 +59,14 @@ export const adminThemeMenuItem = menuRoute({
   route: adminRoute.add("theme"),
   tooltip: () => "View and experiment with website theme",
   parent: adminDashboardMenuItem,
+  predicate: isAdminPredicate,
+});
+
+export const adminUploadsMenuItem = menuRoute({
+  icon: ["fas", "cloud"],
+  label: "All Recording Uploads",
+  route: adminRoute.add("all_uploads"),
+  tooltip: () => "View all uploads",
+  parent: adminDashboardMenuItem,
+  predicate: isAdminPredicate,
 });

--- a/src/app/components/admin/admin.module.ts
+++ b/src/app/components/admin/admin.module.ts
@@ -12,6 +12,7 @@ import { TagGroupsModule } from "./tag-group/tag-groups.module";
 import { TagsModule } from "./tags/tags.module";
 import { AdminThemeTemplateComponent } from "./theme-template/theme-template.component";
 import { AdminUserListComponent } from "./users/user.component";
+import { AllUploadsComponent } from "./all-uploads/all-uploads.component";
 
 const modules = [
   AnalysisJobsModule,
@@ -25,6 +26,7 @@ const components = [
   AdminDashboardComponent,
   AdminUserListComponent,
   AdminThemeTemplateComponent,
+  AllUploadsComponent,
 ];
 const routes = adminRoute.compileRoutes(getRouteConfigForPage);
 

--- a/src/app/components/admin/all-uploads/all-uploads.component.spec.ts
+++ b/src/app/components/admin/all-uploads/all-uploads.component.spec.ts
@@ -1,0 +1,112 @@
+import { assertPageInfo } from "@test/helpers/pageRoute";
+import { Spectator, SpyObject, createRoutingFactory } from "@ngneat/spectator";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { SharedModule } from "@shared/shared.module";
+import { ToastrService } from "ngx-toastr";
+import { ConfirmationComponent } from "@components/harvest/components/modal/confirmation.component";
+import { LoadingComponent } from "@shared/loading/loading.component";
+import { UserLinkComponent } from "@shared/user-link/user-link/user-link.component";
+import { Injector } from "@angular/core";
+import { SHALLOW_HARVEST } from "@baw-api/ServiceTokens";
+import { Harvest } from "@models/Harvest";
+import { Project } from "@models/Project";
+import { generateProject } from "@test/fakes/Project";
+import { of } from "rxjs";
+import { User } from "@models/User";
+import { generateUser } from "@test/fakes/User";
+import { ShallowHarvestsService } from "@baw-api/harvest/harvest.service";
+import { generateHarvest } from "@test/fakes/Harvest";
+import { AllUploadsComponent } from "./all-uploads.component";
+
+// the functionality that the project names are shown in the harvest list
+// and the correct api calls are made is asserted in the harvest list component
+// these tests assert that the harvest list component is extended correctly
+describe("AllUploadsComponent", () => {
+  let spectator: Spectator<AllUploadsComponent>;
+  let fakeHarvest: Harvest;
+  let fakeHarvestApi: SpyObject<ShallowHarvestsService>;
+
+  const createComponent = createRoutingFactory({
+    declarations: [LoadingComponent, ConfirmationComponent, UserLinkComponent],
+    component: AllUploadsComponent,
+    imports: [MockBawApiModule, SharedModule],
+    mocks: [ToastrService],
+  });
+
+  function setup(): void {
+    fakeHarvest = new Harvest(generateHarvest({ status: "uploading" }));
+
+    spectator = createComponent({ detectChanges: false });
+
+    const injector = spectator.inject(Injector);
+    fakeHarvest["injector"] = injector;
+
+    fakeHarvestApi = spectator.inject(SHALLOW_HARVEST.token);
+    fakeHarvest.addMetadata({
+      paging: { items: 1, page: 0, total: 1, maxPage: 5 },
+    });
+
+    // since the harvest creator is a resolved model, we need to mock the creator property
+    const fakeUser: User = new User(generateUser());
+    spyOnProperty(fakeHarvest, "creator").and.callFake(() => fakeUser);
+
+    const mockHarvestProject: Project = new Project(generateProject());
+    spyOnProperty(fakeHarvest, "project").and.callFake(
+      () => mockHarvestProject
+    );
+
+    // mock the harvest service filter API to populate the
+    // list component ngx-datatable
+    const mockResponse = of([fakeHarvest]);
+    fakeHarvestApi.filter.and.callFake(() => mockResponse);
+    fakeHarvestApi.transitionStatus.and.callFake(() => of(fakeHarvest));
+
+    spectator.detectChanges();
+  }
+
+  beforeEach(() => setup());
+
+  assertPageInfo(AllUploadsComponent, ["Recording Uploads", "All Recording Uploads"]);
+
+  it("should create", () => {
+    expect(spectator.component).toBeInstanceOf(AllUploadsComponent);
+  });
+
+  it("should return 'null' for the project", () => {
+    expect(spectator.component.project).toBeNull();
+  });
+
+  it("should have the harvest list table", () => {
+    const datatableElement: HTMLElement =
+      spectator.query<HTMLElement>("ngx-datatable");
+    expect(datatableElement).toExist();
+  });
+
+  it("should make the correct api calls", () => {
+    expect(fakeHarvestApi.transitionStatus).not.toHaveBeenCalled();
+
+    // test that the filter object that the filter service was called with did not contain a filter key
+    expect(fakeHarvestApi.filter).not.toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        filter: jasmine.any(Object),
+      })
+    );
+
+    // assert that projection conditions were still applied to the request body
+    expect(fakeHarvestApi.filter).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        projection: {
+          include: [
+            "id",
+            "projectId",
+            "name",
+            "createdAt",
+            "creatorId",
+            "streaming",
+            "status",
+          ],
+        },
+      }),
+    );
+  });
+});

--- a/src/app/components/admin/all-uploads/all-uploads.component.ts
+++ b/src/app/components/admin/all-uploads/all-uploads.component.ts
@@ -1,0 +1,34 @@
+import { Component } from "@angular/core";
+import { List } from "immutable";
+import { ListComponent } from "@components/harvest/pages/list/list.component";
+import { ActivatedRoute } from "@angular/router";
+import { ShallowHarvestsService } from "@baw-api/harvest/harvest.service";
+import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
+import { adminCategory, adminUploadsMenuItem } from "../admin.menus";
+import { adminMenuItemActions } from "../dashboard/dashboard.component";
+
+@Component({
+  selector: "baw-all-uploads",
+  templateUrl: "../../harvest/pages/list/list.component.html",
+})
+class AllUploadsComponent extends ListComponent {
+  public constructor(
+    private modal: NgbModal,
+    private api: ShallowHarvestsService,
+    private activatedRoute: ActivatedRoute
+  ) {
+    super(modal, api, activatedRoute);
+  }
+
+  public override get project() {
+    return null;
+  }
+}
+
+AllUploadsComponent.linkToRoute({
+  category: adminCategory,
+  pageRoute: adminUploadsMenuItem,
+  menus: { actions: List(adminMenuItemActions) },
+});
+
+export { AllUploadsComponent };

--- a/src/app/components/admin/dashboard/dashboard.component.ts
+++ b/src/app/components/admin/dashboard/dashboard.component.ts
@@ -8,6 +8,7 @@ import {
   adminDashboardMenuItem,
   adminJobStatusMenuItem,
   adminThemeMenuItem,
+  adminUploadsMenuItem,
   adminUserListMenuItem,
 } from "../admin.menus";
 import { adminOrphansMenuItem } from "../orphan/orphans.menus";
@@ -27,6 +28,7 @@ export const adminMenuItemActions = [
   adminTagsMenuItem,
   adminThemeMenuItem,
   adminUserListMenuItem,
+  adminUploadsMenuItem,
 ];
 
 @Component({

--- a/src/app/components/harvest/harvest.module.ts
+++ b/src/app/components/harvest/harvest.module.ts
@@ -8,7 +8,6 @@ import { FileRowComponent } from "./components/metadata-review/file-row.componen
 import { FolderRowComponent } from "./components/metadata-review/folder-row.component";
 import { LoadMoreComponent } from "./components/metadata-review/load-more.component";
 import { WhitespaceComponent } from "./components/metadata-review/whitespace.component";
-import { ConfirmationComponent } from "./components/modal/confirmation.component";
 import { CanCloseDialogComponent } from "./components/shared/can-close-dialog.component";
 import { EtaComponent } from "./components/shared/eta.component";
 import { StatisticGroupComponent } from "./components/shared/statistics/group.component";
@@ -49,9 +48,6 @@ const internalComponents = [
   StatisticsComponent,
   TitleComponent,
   UploadUrlComponent,
-
-  // Modals
-  ConfirmationComponent,
 
   // Widgets
   ValidationsWidgetComponent,

--- a/src/app/components/harvest/pages/list/list.component.html
+++ b/src/app/components/harvest/pages/list/list.component.html
@@ -1,6 +1,18 @@
-<h1>Upload History</h1>
+<h1>
+  <ng-container *ngIf="project === null; else showProject">
+    All Uploads
+  </ng-container>
 
-<p *ngIf="!canCreateHarvestCapability" class="alert alert-info">
+  <ng-template #showProject>
+    Upload History
+  </ng-template>
+</h1>
+
+<!--
+  If canCreateHarvestCapability is false, the project does not allow uploading audio
+  However, if there is no project, the canCreateHarvestCapability will be undefined
+-->
+<p *ngIf="canCreateHarvestCapability === false" class="alert alert-info">
   This project does not allow uploading audio,
   <a [strongRoute]="contactUs.route">{{ contactUs.label }}</a> to request
   permission to upload audio.
@@ -37,6 +49,28 @@
     </ng-template>
   </ngx-datatable-column>
 
+  <!-- If the list is not scoped to a project, list all projects with names -->
+  <ngx-datatable-column *ngIf="project === null" prop="">
+    <ng-template let-column="column" ngx-datatable-header-template>
+      Project
+    </ng-template>
+    <ng-template let-value="value" ngx-datatable-cell-template>
+      <!-- Show loading animation while project is unresolved -->
+      <!-- Without this, ngx-datatable will not trigger change detection when the model is resolved -->
+      <baw-loading
+        *ngIf="value.project | isUnresolved; else showProject"
+        size="sm"
+      ></baw-loading>
+
+      <!-- Create project link when site is loaded-->
+      <ng-template #showProject>
+        <a [bawUrl]="value.project.viewUrl">
+          {{ value.project.name }}
+        </a>
+      </ng-template>
+    </ng-template>
+  </ngx-datatable-column>
+
   <ngx-datatable-column prop="streaming">
     <ng-template let-column="column" ngx-datatable-header-template>
       Upload Type
@@ -52,18 +86,18 @@
     </ng-template>
   </ngx-datatable-column>
 
-  <ngx-datatable-column prop="action">
+  <ngx-datatable-column prop="action" [sortable]="false">
     <ng-template let-column="column" ngx-datatable-header-template>
       Action
     </ng-template>
     <ng-template let-row="row" let-value="value" ngx-datatable-cell-template>
-      <a class="btn btn-sm btn-primary" [bawUrl]="row.viewUrl">
+      <a class="btn btn-sm btn-primary me-1" [bawUrl]="row.viewUrl">
         {{ asHarvest(row).status !== "complete" ? "Continue" : "View" }}
       </a>
       <a
         name="list-abort-button"
         *ngIf="asHarvest(row).isAbortable()"
-        class="btn btn-sm btn-outline-danger ms-1"
+        class="btn btn-sm btn-outline-danger"
         (click)="abortUpload(abortUploadModal, asHarvest(row))"
       >
         Abort

--- a/src/app/components/shared/shared.components.ts
+++ b/src/app/components/shared/shared.components.ts
@@ -21,6 +21,7 @@ import { DateValueAccessorModule } from "angular-date-value-accessor";
 import { NgxCaptchaModule } from "ngx-captcha";
 import { ToastrModule } from "ngx-toastr";
 import { DirectivesModule } from "src/app/directives/directives.module";
+import { ConfirmationComponent } from "@components/harvest/components/modal/confirmation.component";
 import { AnnotationDownloadComponent } from "./annotation-download/annotation-download.component";
 import { BawClientModule } from "./baw-client/baw-client.module";
 import { BreadcrumbModule } from "./breadcrumb/breadcrumb.module";
@@ -65,6 +66,9 @@ export const sharedComponents = [
   TypeaheadInputComponent,
   ChartComponent,
   InlineListComponent,
+
+  // modals
+  ConfirmationComponent,
 ];
 
 export const internalComponents = [];

--- a/src/app/pipes/date/date.pipe.ts
+++ b/src/app/pipes/date/date.pipe.ts
@@ -1,4 +1,3 @@
-import { DatePipe } from "@angular/common";
 import { Pipe, PipeTransform } from "@angular/core";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { DateTime } from "luxon";
@@ -9,19 +8,21 @@ import { DateTime } from "luxon";
 // having to cast to a JavaScript Date object in each component
 // using this pipe also allows us to standardise the date format throughout the client
 @Pipe({
-  name: "dateTime"
+  name: "dateTime",
 })
 export class DateTimePipe implements PipeTransform {
-  public constructor(
-    private angularDatePipe: DatePipe
-  ) {}
+  public constructor() {}
 
-  public transform(value?: DateTime): string {
+  public transform(value?: DateTime, includeTime = false, localTime = false): string {
     if (!isInstantiated(value)) {
       return "";
     }
 
     const dateFormat = "yyyy-MM-dd";
-    return this.angularDatePipe.transform(value.toJSDate(), dateFormat);
+    const dateTimeFormat = "yyyy-MM-dd HH:mm:ss";
+
+    const localizedDate = localTime ? value.toLocal() : value;
+
+    return localizedDate.toFormat(includeTime ? dateTimeFormat : dateFormat);
   }
 }


### PR DESCRIPTION
# Admin Uploads View

Adds a way for admins to see all harvests (regardless of project) from the admin dashboard.

From this page, admins can abort, and view harvests.

## Changes

- Added "All Uploads" page to "Admin Dashboard"
- Added tests for "All Uploads" page
- Added the ability for our (relatively new) custom date pipe to take relative dates
- Added the ability for `pageComponent`'s to extend other page components through `setToRoute`
- Changed the harvest list component to be able to scope to projects or no projects
- Fixed bug where users could sort harvest data table by action (this caused an error)
- Fixed bug where non-admin users could access the themes devtools route
- Fixed bug where "Abort" button on small screens would no be aligned with the "Continue" button

## Problems

None

## Issues

Fixes: #2051 

## Visual Changes

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/e8eb51d9-dbd0-453c-aa49-cf5e9e6ec9a7)
**New "all uploads" page on the admin dashboard showing uploads from the "aaaaaaa" and "2022 Symposium Example" projects**

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
