### PR TITLE
Bug fix: allow setting location on sites/points to null

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ This website can be customised through the environment file located at `./src/as
 | `settings.links`         | This is a list of external links used throughout the website. Check the template for the list of modifiable links                          |
 | `settings.customMenu`    | This is a list of custom menu items which changes the contents of the header with instance specific links. Check the template for examples |
 
+To use the embedded Google Maps in both development and production, it is required that the `keys.googleMaps` property is set.
+If you have not set this value the embedded maps will not work, and an error will be thrown in the console with the message "Google Maps JavaScript API error: InvalidKeyMapError".
+
 ### Testing
 
 #### Unit tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@angular/compiler": "16.2.9",
         "@angular/core": "16.2.9",
         "@angular/forms": "16.2.9",
-        "@angular/google-maps": "16.2.8",
+        "@angular/google-maps": "16.2.12",
         "@angular/localize": "16.2.9",
         "@angular/platform-browser": "16.2.9",
         "@angular/platform-browser-dynamic": "16.2.9",
@@ -631,9 +631,9 @@
       }
     },
     "node_modules/@angular/google-maps": {
-      "version": "16.2.8",
-      "resolved": "https://registry.npmjs.org/@angular/google-maps/-/google-maps-16.2.8.tgz",
-      "integrity": "sha512-idDU0dPr/npn6GPsIQEQapJrL6EB53qZa++djElkxXeq3La5N2We29taaG9tUMHBGMkdtfgh8p9rdG8ThpvaHA==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@angular/google-maps/-/google-maps-16.2.12.tgz",
+      "integrity": "sha512-Ift6PbHYUhmM7fU6EVKt0IEFI5Pw7PHwh+V4buygwpCUcY4wvQkpIoKRierE0M6e+hNTLAUdyuxBET8qlZh7tA==",
       "dependencies": {
         "@types/google.maps": "^3.52.4",
         "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@angular/compiler": "16.2.9",
     "@angular/core": "16.2.9",
     "@angular/forms": "16.2.9",
-    "@angular/google-maps": "16.2.8",
+    "@angular/google-maps": "16.2.12",
     "@angular/localize": "16.2.9",
     "@angular/platform-browser": "16.2.9",
     "@angular/platform-browser-dynamic": "16.2.9",

--- a/src/app/components/shared/formly/location-input.component.ts
+++ b/src/app/components/shared/formly/location-input.component.ts
@@ -105,8 +105,12 @@ export class LocationInputComponent extends FieldType implements OnInit {
       latitude: this.latitude,
       longitude: this.longitude,
     });
+
     this.model["latitude"] = this.latitude;
     this.model["longitude"] = this.longitude;
+    this.model["customLatitude"] = this.latitude;
+    this.model["customLongitude"] = this.longitude;
+
     this.setMarker(this.latitude, this.longitude);
   }
 


### PR DESCRIPTION
# Bug fix: allow setting location on sites/points to null

Currently, it is impossible to remove the location of a site/point.

This PR adds the ability for users to completely remove site locations by setting both the "longitude" and "latitude" inputs to empty values on the site/point edit page.

## Changes

- Changed the `location-input.component.ts` so that it also updates the models `customLongitude` and `customLatitude`
- Add tests to the `location-input.component.spec.ts` to test that the correct error messages are shown when only a longitude or only a latitude is input
- Add tests to the `location-input.component.spec.ts` to test that location is emitted as null when both the inputs are empty
- Add tests to assert that the site/point edit component constructs the a model with longitude and latitude set to null when location inputs are empty
- Add documentation to [README.md](README.md) to show that a Google Maps API key is now required to run in both development and production environments
- Upgrades @angular/google-maps from 16.2.8 -> 16.2.12 (the latest version for Angular 16)

## Problems

None

## Issues

#2040 

## Visual Changes

None

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
