### PR TITLE
Add website status page & improve error messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,6 @@ RUN sed -i "s|<<VERSION_REPLACED_WHEN_BUILT>>|${WORKBENCH_CLIENT_VERSION}|" ./sr
 
 RUN npm run build:ssr
 
-
-
 FROM node:18-alpine
 
 ARG GIT_COMMIT
@@ -37,7 +35,7 @@ ARG WORKBENCH_CLIENT_VERSION
 
 WORKDIR /home/node/workbench-client
 
-LABEL maintainer="Charles Alleman <alleman@qut.edu.au>" \
+LABEL maintainer="Hudson Newey <neweyh@qut.edu.au>" \
   description="Production environment for workbench client server" \
   version=${WORKBENCH_CLIENT_VERSION} \
   name="Workbench Client" \
@@ -48,8 +46,7 @@ LABEL maintainer="Charles Alleman <alleman@qut.edu.au>" \
   schema-version="1.0"
 
 # Add ability to make https wget requests
-RUN apk upgrade libssl1.1 --update-cache && \
-  apk add wget ca-certificates
+RUN apk add wget ca-certificates
 
 # drop privileges
 USER node

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { ToastrModule } from "ngx-toastr";
 import { environment } from "src/environments/environment";
 import { TitleStrategy } from "@angular/router";
 import { AnnotationsImportModule } from "@components/import-annotations/import-annotations.module";
+import { WebsiteStatusModule } from "@components/website-status/website-status.module";
 import { AppRoutingModule } from "./app-routing.module";
 import { AppComponent, PageTitleStrategy } from "./app.component";
 import { toastrRoot } from "./app.helper";
@@ -75,6 +76,7 @@ export const appImports = [
   SendAudioModule,
   SitesModule,
   StatisticsModule,
+  WebsiteStatusModule,
   VisualizeModule,
   // these last two must be last!
   HomeModule,

--- a/src/app/components/shared/footer/footer.component.spec.ts
+++ b/src/app/components/shared/footer/footer.component.spec.ts
@@ -10,6 +10,7 @@ import { MockDirectivesModule } from "@directives/directives.mock.module";
 import { createComponentFactory, Spectator } from "@ngneat/spectator";
 import { ConfigService } from "@services/config/config.service";
 import { MockConfigModule } from "@services/config/configMock.module";
+import { websiteStatusMenuItem } from "@components/website-status/website-status.menu";
 import { FooterComponent } from "./footer.component";
 
 describe("FooterComponent", () => {
@@ -42,6 +43,7 @@ describe("FooterComponent", () => {
   describe("links", () => {
     [
       statisticsMenuItem,
+      websiteStatusMenuItem,
       disclaimersMenuItem,
       creditsMenuItem,
       ethicsMenuItem,

--- a/src/app/components/shared/footer/footer.component.ts
+++ b/src/app/components/shared/footer/footer.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, OnInit } from "@angular/core";
 import { MenuRoute } from "@interfaces/menusInterfaces";
 import { ConfigService } from "@services/config/config.service";
+import { websiteStatusMenuItem } from "@components/website-status/website-status.menu";
 import {
   contactUsMenuItem,
   creditsMenuItem,
@@ -47,6 +48,7 @@ export class FooterComponent implements OnInit {
   public year = new Date().getFullYear();
   public links: MenuRoute[] = [
     statisticsMenuItem,
+    websiteStatusMenuItem,
     disclaimersMenuItem,
     creditsMenuItem,
     ethicsMenuItem,

--- a/src/app/components/shared/form/form.component.scss
+++ b/src/app/components/shared/form/form.component.scss
@@ -1,6 +1,6 @@
 .login-form {
   a {
-    color: #4aba70;
+    color: var(--baw-highlight);
 
     &:hover {
       text-decoration: underline;

--- a/src/app/components/shared/items/item/item.component.ts
+++ b/src/app/components/shared/items/item/item.component.ts
@@ -20,7 +20,11 @@ import { IconProp } from "@fortawesome/fontawesome-svg-core";
       <span id="name">{{ name }}</span>
 
       <!-- Item value -->
-      <span id="value" class="badge rounded text-bg-secondary float-end">
+      <span
+        id="value"
+        class="badge rounded text-bg-secondary float-end"
+        [ngClass]="color && 'bg-' + color"
+      >
         {{ value ?? "Unknown" }}
       </span>
     </div>
@@ -33,6 +37,7 @@ export class ItemComponent {
   @Input() public name: string;
   @Input() public tooltip: () => string;
   @Input() public value: string | number;
+  @Input() public color: string;
 
   public get tooltipText(): string {
     return this.tooltip?.() ?? undefined;
@@ -44,4 +49,5 @@ export interface IItem {
   name: string;
   tooltip?: () => string;
   value?: string | number;
+  color?: string;
 }

--- a/src/app/components/shared/items/items/items.component.ts
+++ b/src/app/components/shared/items/items/items.component.ts
@@ -24,6 +24,7 @@ import { IItem } from "../item/item.component";
               [name]="stat.name"
               [tooltip]="stat.tooltip"
               [value]="stat.value"
+              [color]="stat.color"
             ></baw-items-item>
           </li>
         </ul>
@@ -36,6 +37,7 @@ import { IItem } from "../item/item.component";
               [name]="stat.name"
               [tooltip]="stat.tooltip"
               [value]="stat.value"
+              [color]="stat.color"
             ></baw-items-item>
           </li>
         </ul>

--- a/src/app/components/website-status/website-status.component.spec.ts
+++ b/src/app/components/website-status/website-status.component.spec.ts
@@ -1,0 +1,173 @@
+import { Spectator, createComponentFactory } from "@ngneat/spectator";
+import { SharedModule } from "@shared/shared.module";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { WebsiteStatus } from "@models/WebsiteStatus";
+import { MockProvider } from "ng-mocks";
+import { WebsiteStatusService } from "@baw-api/website-status/website-status.service";
+import { of } from "rxjs";
+import { ActivatedRoute } from "@angular/router";
+import { mockActivatedRoute } from "@test/helpers/testbed";
+import { WebsiteStatusComponent } from "./website-status.component";
+
+interface GridItem {
+  name: string;
+  value: string;
+}
+
+describe("WebsiteStatusComponent", () => {
+  let spectator: Spectator<WebsiteStatusComponent>;
+  let fakeWebsiteStatus: WebsiteStatus;
+  let userHasInternet: boolean;
+  let mockApi: jasmine.SpyObj<WebsiteStatusService>;
+
+  const createComponent = createComponentFactory({
+    component: WebsiteStatusComponent,
+    imports: [SharedModule, MockBawApiModule],
+    providers: [
+      {
+        provide: ActivatedRoute,
+        useValue: mockActivatedRoute(),
+      },
+      MockProvider(WebsiteStatusService),
+    ],
+  });
+
+  function setup() {
+    spectator = createComponent({ detectChanges: false });
+
+    mockApi = spectator.inject(WebsiteStatusService);
+
+    // we use a callback here so that we can set the "fakeWebsiteStatus" value emitted by the
+    // fake api without us having to re-mock the api
+    mockApi.show = jasmine
+      .createSpy("show")
+      .and.callFake(() => of(fakeWebsiteStatus));
+
+    spyOnProperty(navigator, "onLine", "get").and.callFake(() => userHasInternet);
+
+    spectator.detectChanges();
+  }
+
+  function assertGridItemText(itemName: string, expectedValue: string) {
+    const gridElement = spectator.query(`[ng-reflect-name="${itemName}"]`);
+    const gridElementValue = gridElement.querySelector("#value");
+
+    expect(gridElementValue).toHaveExactTrimmedText(expectedValue);
+  }
+
+  it("should create", () => {
+    setup();
+    expect(spectator.component).toBeInstanceOf(WebsiteStatusComponent);
+  });
+
+  it("should call the api once correctly", () => {
+    setup();
+    // intentionally left the body of "OnceWith" empty because it should be a GET request
+    expect(mockApi.show).toHaveBeenCalledOnceWith();
+  });
+
+  it("should display the correct text for a healthy response", () => {
+    const expectedValues: GridItem[] = [
+      { name: "Overall Server Health", value: "Healthy" },
+      { name: "Server Connection", value: "Healthy" },
+      { name: "Database", value: "Healthy" },
+      { name: "Cache", value: "Healthy" },
+      { name: "Storage", value: "Healthy" },
+      { name: "User Uploads", value: "Healthy" },
+      { name: "User Internet Connection", value: "Healthy" },
+    ];
+
+    userHasInternet = true;
+    fakeWebsiteStatus = new WebsiteStatus({
+      status: "good",
+      database: true,
+      timedOut: false,
+      redis: "PONG",
+      storage: "1 audio recording storage directory available.",
+      upload: "Alive",
+    });
+
+    setup();
+
+    expectedValues.forEach((item) =>
+      assertGridItemText(item.name, item.value.toString())
+    );
+  });
+
+  it("should display the correct text for an unhealthy response", () => {
+    const expectedValues: GridItem[] = [
+      { name: "Overall Server Health", value: "Unhealthy" },
+      { name: "Server Connection", value: "Unhealthy" },
+      { name: "Database", value: "Unhealthy" },
+      { name: "Cache", value: "Unhealthy" },
+      { name: "Storage", value: "Unhealthy" },
+      { name: "User Uploads", value: "Unhealthy" },
+      { name: "User Internet Connection", value: "Healthy" },
+    ];
+
+    userHasInternet = true;
+    fakeWebsiteStatus = new WebsiteStatus({
+      status: "bad",
+      database: false,
+      timedOut: true,
+      redis: "",
+      storage: "No audio recording storage directories are available.",
+      upload: "Dead",
+    });
+
+    setup();
+
+    expectedValues.forEach((item) =>
+      assertGridItemText(item.name, item.value.toString())
+    );
+  });
+
+  it("should display the correct text for a partially healthy response", () => {
+    const expectedValues: GridItem[] = [
+      { name: "Overall Server Health", value: "Unhealthy" },
+      { name: "Server Connection", value: "Healthy" },
+      { name: "Database", value: "Unhealthy" },
+      { name: "Cache", value: "Unhealthy" },
+      { name: "Storage", value: "Healthy" },
+      { name: "User Uploads", value: "Unhealthy" },
+      { name: "User Internet Connection", value: "Healthy" },
+    ];
+
+    userHasInternet = true;
+    fakeWebsiteStatus = new WebsiteStatus({
+      status: "bad",
+      timedOut: false,
+      database: false,
+      redis: "",
+      storage: "1 audio recording storage directory available.",
+      upload: "Dead",
+    });
+
+    setup();
+
+    expectedValues.forEach((item) =>
+      assertGridItemText(item.name, item.value.toString())
+    );
+  });
+
+  it("should display the correct text for a response with no internet connection", () => {
+    const expectedValues: GridItem[] = [
+      { name: "Overall Server Health", value: "Unknown" },
+      { name: "Server Connection", value: "Unknown" },
+      { name: "Database", value: "Unknown" },
+      { name: "Cache", value: "Unknown" },
+      { name: "Storage", value: "Unknown" },
+      { name: "User Uploads", value: "Unknown" },
+      { name: "User Internet Connection", value: "Unhealthy" },
+    ];
+
+    userHasInternet = false;
+    fakeWebsiteStatus = null;
+
+    setup();
+
+    expectedValues.forEach((item) =>
+      assertGridItemText(item.name, item.value.toString())
+    );
+  });
+});

--- a/src/app/components/website-status/website-status.component.ts
+++ b/src/app/components/website-status/website-status.component.ts
@@ -1,0 +1,117 @@
+import { Component, OnInit } from "@angular/core";
+import { WebsiteStatusService } from "@baw-api/website-status/website-status.service";
+import { WebsiteStatus } from "@models/WebsiteStatus";
+import { List } from "immutable";
+import { IItem } from "@shared/items/item/item.component";
+import { takeUntil } from "rxjs/operators";
+import { PageComponent } from "@helpers/page/pageComponent";
+import { reportProblemMenuItem } from "@components/report-problem/report-problem.menus";
+import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
+import {
+  websiteStatusCategory,
+  websiteStatusMenuItem,
+} from "./website-status.menu";
+
+@Component({
+  selector: "baw-website-status",
+  template: `
+    <h2>Website Status</h2>
+    <baw-items [items]="statusItems()"></baw-items>
+
+    <p>
+      If you are experiencing issues with the website, please
+      <a [strongRoute]="reportProblemRoute">Report a Problem</a> so we can
+      investigate.
+    </p>
+  `,
+})
+class WebsiteStatusComponent extends PageComponent implements OnInit {
+  public constructor(private api: WebsiteStatusService) {
+    super();
+  }
+
+  protected reportProblemRoute = reportProblemMenuItem.route;
+
+  public ngOnInit(): void {
+    this.api
+      .show()
+      .pipe(takeUntil(this.unsubscribe))
+      .subscribe({
+        next: (model) => (this.model = model),
+        error: () => (this.model = null),
+      });
+  }
+
+  protected model: WebsiteStatus;
+
+  protected statusItems(): List<IItem> {
+    // if we get no response from the server, the model will be "null"
+    // if we want to see if the server connection is healthy, we want to negate this.model?.timedOut
+    // (so that true) means the server did not time out
+    // however, because "null" is a falsey value, negating "null" will return true (representing that the server connection is healthy)
+    // if we didn't receive a response from the server, we want to keep "null" so that we can display "Unknown" in the template
+    // we therefore need to check if the model is instantiated before we negate it
+    const serverTimeout: boolean = isInstantiated(this.model?.timedOut)
+      ? !this.model.timedOut
+      : null;
+
+    return List<IItem>([
+      {
+        name: "Overall Server Health",
+        icon: ["fas", "heartbeat"],
+        ...this.listItemContent(this.model?.isStatusHealthy),
+      },
+      {
+        name: "Server Connection",
+        icon: ["fas", "network-wired"],
+        ...this.listItemContent(serverTimeout),
+      },
+      {
+        name: "Database",
+        icon: ["fas", "database"],
+        ...this.listItemContent(this.model?.database),
+      },
+      {
+        name: "Cache",
+        icon: ["fas", "memory"],
+        ...this.listItemContent(this.model?.isRedisHealthy),
+      },
+      {
+        name: "Storage",
+        icon: ["fas", "hdd"],
+        ...this.listItemContent(this.model?.isStorageHealthy),
+      },
+      {
+        name: "User Uploads",
+        icon: ["fas", "cloud"],
+        ...this.listItemContent(this.model?.isUploadingHealthy),
+      },
+      {
+        name: "User Internet Connection",
+        icon: ["fas", "wifi"],
+        ...this.listItemContent(navigator.onLine),
+      },
+    ]);
+  }
+
+  private listItemContent(healthy?: boolean): Partial<IItem> {
+    if (!isInstantiated(healthy)) {
+      return {
+        value: "Unknown",
+        color: "secondary",
+      };
+    }
+
+    const value = healthy ? "Healthy" : "Unhealthy";
+    const color = healthy ? "success" : "danger";
+
+    return { value, color };
+  }
+}
+
+WebsiteStatusComponent.linkToRoute({
+  category: websiteStatusCategory,
+  pageRoute: websiteStatusMenuItem,
+});
+
+export { WebsiteStatusComponent };

--- a/src/app/components/website-status/website-status.menu.ts
+++ b/src/app/components/website-status/website-status.menu.ts
@@ -1,0 +1,15 @@
+import { Category, menuRoute } from "@interfaces/menusInterfaces";
+import { websiteStatusRoute } from "./website-status.routes";
+
+export const websiteStatusCategory: Category = {
+  icon: ["fas", "heartbeat"],
+  label: "Website Status",
+  route: websiteStatusRoute,
+};
+
+export const websiteStatusMenuItem = menuRoute({
+  icon: ["fas", "heartbeat"],
+  label: "Website Status",
+  route: websiteStatusRoute,
+  tooltip: () => "Website Status",
+});

--- a/src/app/components/website-status/website-status.module.ts
+++ b/src/app/components/website-status/website-status.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from "@angular/core";
+import { RouterModule } from "@angular/router";
+import { getRouteConfigForPage } from "@helpers/page/pageRouting";
+import { SharedModule } from "@shared/shared.module";
+import { websiteStatusRoute } from "./website-status.routes";
+import { WebsiteStatusComponent } from "./website-status.component";
+
+const components = [
+  WebsiteStatusComponent,
+];
+const routes = websiteStatusRoute.compileRoutes(getRouteConfigForPage);
+
+@NgModule({
+  declarations: components,
+  imports: [SharedModule, RouterModule.forChild(routes)],
+  exports: [RouterModule, ...components],
+})
+export class WebsiteStatusModule {}

--- a/src/app/components/website-status/website-status.routes.ts
+++ b/src/app/components/website-status/website-status.routes.ts
@@ -1,0 +1,3 @@
+import { StrongRoute } from "@interfaces/strongRoute";
+
+export const websiteStatusRoute = StrongRoute.newRoot().add("website_status");

--- a/src/app/helpers/page/defaultMenus.ts
+++ b/src/app/helpers/page/defaultMenus.ts
@@ -17,6 +17,7 @@ import {
 } from "@components/security/security.menus";
 import { sendAudioMenuItem } from "@components/send-audio/send-audio.menus";
 import { statisticsMenuItem } from "@components/statistics/statistics.menus";
+import { websiteStatusMenuItem } from "@components/website-status/website-status.menu";
 import { Category, NavigableMenuItem } from "@interfaces/menusInterfaces";
 import { ConfigService } from "@services/config/config.service";
 import { OrderedSet } from "immutable";
@@ -52,6 +53,7 @@ export class DefaultMenu {
         reportProblemMenuItem,
         statisticsMenuItem,
         annotationsImportMenuItem,
+        websiteStatusMenuItem,
       ]),
       defaultCategory: homeCategory,
     };

--- a/src/app/models/WebsiteStatus.ts
+++ b/src/app/models/WebsiteStatus.ts
@@ -1,0 +1,56 @@
+import { Injector } from "@angular/core";
+import { websiteStatusMenuItem } from "@components/website-status/website-status.menu";
+import { AbstractModelWithoutId } from "./AbstractModel";
+
+export type WebsiteOverallStatus = "good" | "bad";
+export type RedisStatus = "PONG" | "";
+export type UploadStatus = "Alive" | "Dead";
+export type StorageStatus =
+  | "No audio recording storage directories are available."
+  | `${number} audio recording storage directory available.`;
+
+export interface IWebsiteStatus {
+  status: WebsiteOverallStatus;
+  timedOut: boolean;
+  database: boolean;
+  redis: RedisStatus;
+  storage: StorageStatus;
+  upload: UploadStatus;
+}
+
+export class WebsiteStatus
+  extends AbstractModelWithoutId<IWebsiteStatus>
+  implements IWebsiteStatus
+{
+  public constructor(model: IWebsiteStatus, injector?: Injector) {
+    super(model, injector);
+  }
+
+  public readonly kind = "status";
+  public readonly status: WebsiteOverallStatus;
+  public readonly timedOut: boolean;
+  public readonly database: boolean;
+  public readonly redis: RedisStatus;
+  public readonly storage: StorageStatus;
+  public readonly upload: UploadStatus;
+
+  public get isStatusHealthy(): boolean {
+    return this.status === "good";
+  }
+
+  public get isRedisHealthy(): boolean {
+    return this.redis === "PONG";
+  }
+
+  public get isStorageHealthy(): boolean {
+    return this.storage !== "No audio recording storage directories are available.";
+  }
+
+  public get isUploadingHealthy(): boolean {
+    return this.upload === "Alive";
+  }
+
+  public get viewUrl(): string {
+    return websiteStatusMenuItem.route.toRouterLink();
+  }
+}

--- a/src/app/services/baw-api/ServiceProviders.ts
+++ b/src/app/services/baw-api/ServiceProviders.ts
@@ -93,6 +93,7 @@ import { taggingResolvers, TaggingsService } from "./tag/taggings.service";
 import { tagResolvers, TagsService } from "./tag/tags.service";
 import { userResolvers, UserService } from "./user/user.service";
 import { EventSummaryReportService, eventSummaryResolvers } from "./reports/event-report/event-summary-report.service";
+import { WebsiteStatusService } from "./website-status/website-status.service";
 
 const serviceList = [
   {
@@ -284,6 +285,10 @@ const serviceList = [
     serviceToken: Tokens.AUDIO_EVENT_IMPORT,
     service: AudioEventImportService,
     resolvers: audioEventImportResolvers,
+  },
+  {
+    serviceToken: Tokens.WEBSITE_STATUS,
+    service: WebsiteStatusService,
   },
 ];
 

--- a/src/app/services/baw-api/ServiceTokens.ts
+++ b/src/app/services/baw-api/ServiceTokens.ts
@@ -38,6 +38,7 @@ import type { User } from "@models/User";
 import { AudioEventProvenance } from "@models/AudioEventProvenance";
 import { EventSummaryReport } from "@models/EventSummaryReport";
 import { AudioEventImport } from "@models/AudioEventImport";
+import { WebsiteStatus } from "@models/WebsiteStatus";
 import type { AccountsService } from "./account/accounts.service";
 import type { AnalysisJobItemsService } from "./analysis/analysis-job-items.service";
 import type { AnalysisJobsService } from "./analysis/analysis-jobs.service";
@@ -88,6 +89,7 @@ import type { AnalysisJobItemResultsService } from "./analysis/analysis-job-item
 import { AudioEventProvenanceService } from "./AudioEventProvenance/AudioEventProvenance.service";
 import { EventSummaryReportService } from "./reports/event-report/event-summary-report.service";
 import { AudioEventImportService } from "./audio-event-import/audio-event-import.service";
+import { WebsiteStatusService } from "./website-status/website-status.service";
 
 /**
  * Wrapper for InjectionToken class. This is required because of
@@ -208,3 +210,4 @@ export const USER = new ServiceToken<UserService, User>("USER");
 export const AUDIO_EVENT_PROVENANCE = new ServiceToken<AudioEventProvenanceService, AudioEventProvenance>("AUDIO_EVENT_PROVENANCE");
 export const AUDIO_EVENT_SUMMARY_REPORT = new ServiceToken<EventSummaryReportService, EventSummaryReport>("AUDIO_EVENT_SUMMARY_REPORT");
 export const AUDIO_EVENT_IMPORT = new ServiceToken<AudioEventImportService, AudioEventImport>("AUDIO_EVENT_IMPORT");
+export const WEBSITE_STATUS = new ServiceToken<WebsiteStatusService, WebsiteStatus>("WEBSITE_STATUS");

--- a/src/app/services/baw-api/api.interceptor.service.ts
+++ b/src/app/services/baw-api/api.interceptor.service.ts
@@ -127,12 +127,23 @@ export class BawApiInterceptor implements HttpInterceptor {
 
     // Response timed out
     if (response.status === CLIENT_TIMEOUT) {
-      const error = new BawApiError(
-        CLIENT_TIMEOUT,
+      // check if this is the fault of the server or the client
+      const clientHasInternet = navigator.onLine;
+
+      const noClientInternetMessage =
+        "You are not be connected to the internet. " +
+        "Please check your internet (or VPN) connection and try again.";
+      const serverTimeoutMessage =
         "A request took longer than expected to return, " +
-          "this may be an issue with your connection to us, " +
-          "or a temporary issue with our services."
-      );
+        "this may be an issue with your connection to us, " +
+        "or a temporary issue with our services.";
+
+      const errorMessage = clientHasInternet
+        ? serverTimeoutMessage
+        : noClientInternetMessage;
+
+      const error = new BawApiError(CLIENT_TIMEOUT, errorMessage);
+
       return throwError(() => error);
     }
 

--- a/src/app/services/baw-api/website-status/website-status.service.ts
+++ b/src/app/services/baw-api/website-status/website-status.service.ts
@@ -1,0 +1,48 @@
+import { HttpClient, HttpHeaders } from "@angular/common/http";
+import { Inject, Injectable } from "@angular/core";
+import { ApiShow } from "@baw-api/api-common";
+import { unknownErrorCode } from "@baw-api/baw-api.service";
+import {
+  BawApiError,
+  isBawApiError,
+} from "@helpers/custom-errors/baw-api-error";
+import { WebsiteStatus } from "@models/WebsiteStatus";
+import { API_ROOT } from "@services/config/config.tokens";
+import { Observable, catchError, map, throwError } from "rxjs";
+
+@Injectable()
+export class WebsiteStatusService implements ApiShow<WebsiteStatus> {
+  public constructor(
+    private http: HttpClient,
+    @Inject(API_ROOT) private apiRoot: string
+  ) {}
+
+  // if the server is fully down, we will not receive a response from the API
+  // we can therefore not determine the status of the server and we should return "null"
+  public show(): Observable<WebsiteStatus | null> {
+    const endpoint = `${this.apiRoot}/status`;
+
+    return this.http
+      .get<WebsiteStatus>(endpoint, {
+        headers: WebsiteStatusService.requestHeaders,
+      })
+      .pipe(
+        map((response) => new WebsiteStatus(response)),
+        catchError((err: BawApiError | Error) => {
+          const bawError = isBawApiError(err)
+            ? err
+            : new BawApiError(unknownErrorCode, err.message);
+
+          console.error("Error fetching API /status endpoint:", bawError.message);
+
+          return throwError((): BawApiError => bawError);
+        })
+      );
+  }
+
+  // by making this a static field, we don't have to recreate the headers every time we make a request
+  private static readonly requestHeaders = new HttpHeaders({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Accept: "application/json",
+  });
+}

--- a/src/app/styles/bootstrap/components/_index.scss
+++ b/src/app/styles/bootstrap/components/_index.scss
@@ -1,2 +1,3 @@
 @import "buttons";
 @import "pagination";
+@import "links";

--- a/src/app/styles/bootstrap/components/_links.scss
+++ b/src/app/styles/bootstrap/components/_links.scss
@@ -1,0 +1,7 @@
+.nav-link {
+  color: $link-color;
+
+  &:hover {
+    color: $link-hover-color;
+  }
+}

--- a/src/app/test/fakes/WebsiteStatus.ts
+++ b/src/app/test/fakes/WebsiteStatus.ts
@@ -1,0 +1,26 @@
+import { faker } from "@faker-js/faker";
+import {
+  IWebsiteStatus,
+  RedisStatus,
+  StorageStatus,
+  UploadStatus,
+  WebsiteOverallStatus,
+} from "@models/WebsiteStatus";
+import { modelData } from "@test/helpers/faker";
+
+export function generateWebsiteStatus(
+  data?: Partial<IWebsiteStatus>
+): Required<IWebsiteStatus> {
+  return {
+    status: faker.helpers.arrayElement<WebsiteOverallStatus>(["good", "bad"]),
+    timedOut: modelData.datatype.boolean(),
+    database: modelData.datatype.boolean(),
+    redis: faker.helpers.arrayElement<RedisStatus>(["PONG", ""]),
+    storage: faker.helpers.arrayElement<StorageStatus>([
+      `${modelData.datatype.number()} audio recording storage directory available.`,
+      "No audio recording storage directories are available.",
+    ]),
+    upload: faker.helpers.arrayElement<UploadStatus>(["Alive", "Dead"]),
+    ...data,
+  };
+}


### PR DESCRIPTION
# Add website status page & improve error messages

At the moment, it can be unclear why a request failed and the most common user error is a faulty VPN connection / no internet connection.

This pull request hopes to address these issues by improving "timed out" error messages and adding a "Website Status" page (`/website_status`) so that users can easily see if the problem is on their side or server side.

## Changes

* Add "website status" page
* Add models & services for `WebsiteStatus` models & endpoints
* Improve "timed out" error messages to tell the user if they are not connected to the internet
* Update maintainer on Docker image
* Remove deprecated libssl1.1 from Docker image
* Some highlight colours were hard coded and did not use the website theme (eg. links at [https://www.ecosounds.org/about/contact_us](https://www.ecosounds.org/about/contact_us) use the development colours because they are hard coded. These have been changed to use the theme colours
* Add tests for all the above

## Problems

None

## Issues

Fixes: #205 
Fixes: #2095 

## Visual Changes

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/e3f01e31-3293-4116-b6c9-6be42fc2eb6f)
**New "website status" page**

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/f315a2af-4c03-48ec-b627-5b9bbaf0c9d6)
**New toast that displays if the users doesn't have internet connection**

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
