### PR TITLE
Move status route `/website_status` to `/status`

### DIFF
--- a/src/app/components/website-status/website-status.routes.ts
+++ b/src/app/components/website-status/website-status.routes.ts
@@ -1,3 +1,3 @@
 import { StrongRoute } from "@interfaces/strongRoute";
 
-export const websiteStatusRoute = StrongRoute.newRoot().add("website_status");
+export const websiteStatusRoute = StrongRoute.newRoot().add("status");


### PR DESCRIPTION
# Move status route /website_status to /status

This does not effect other naming conventions throughout the client such as the page title fragment which will remain as `<<BrandName>> | Website Status`. This is because seeing `<<BrandName>> | Status` in your history is ambiguous in my opinion.

## Changes

- Moves the `/website_status` route to `/status`

## Problems

None

## Issues

None

## Visual Changes

None

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
