### PR TITLE
Display warning message for "bad" website status

### DIFF
--- a/src/app/components/audio-recordings/pages/details/details.component.ts
+++ b/src/app/components/audio-recordings/pages/details/details.component.ts
@@ -22,6 +22,8 @@ import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
 import { List } from "immutable";
+import { WidgetMenuItem } from "@menu/widgetItem";
+import { WebsiteStatusWarningComponent } from "@menu/website-status-warning/website-status-warning.component";
 import schema from "./audio-recording.schema.json";
 
 const audioRecordingKey = "audioRecording";
@@ -78,7 +80,17 @@ function getPageInfo(
   return {
     pageRoute: audioRecordingMenuItems.details[subRoute],
     category: audioRecordingsCategory,
-    menus: { actions: List([downloadAudioRecordingMenuItem, downloadAudioRecordingAnalysesMenuItem]) },
+    menus: {
+      actions: List([downloadAudioRecordingMenuItem, downloadAudioRecordingAnalysesMenuItem]),
+      actionWidgets: List([
+        new WidgetMenuItem(WebsiteStatusWarningComponent, undefined, {
+          message: `
+            Downloading audio is temporarily unavailable.
+            Please try again later.
+          `,
+        }),
+      ]),
+    },
     resolvers: {
       [audioRecordingKey]: audioRecordingResolvers.show,
       [projectKey]: projectResolvers.showOptional,

--- a/src/app/components/audio-recordings/pages/download/download.component.spec.ts
+++ b/src/app/components/audio-recordings/pages/download/download.component.spec.ts
@@ -30,6 +30,7 @@ import { ToastrService } from "ngx-toastr";
 import { Subject } from "rxjs";
 import { CacheModule } from "@services/cache/cache.module";
 import { DateTimeFilterComponent } from "@shared/date-time-filter/date-time-filter.component";
+import { WebsiteStatusWarningComponent } from "@menu/website-status-warning/website-status-warning.component";
 import { SitesWithoutTimezonesComponent } from "../../components/sites-without-timezones/sites-without-timezones.component";
 import { DownloadTableComponent } from "../../components/download-table/download-table.component";
 import { DownloadAudioRecordingsComponent } from "./download.component";
@@ -47,6 +48,7 @@ describe("DownloadAudioRecordingsComponent", () => {
     declarations: [
       MockComponent(SitesWithoutTimezonesComponent),
       MockComponent(DownloadTableComponent),
+      MockComponent(WebsiteStatusWarningComponent),
       DateTimeFilterComponent,
     ],
     // We are relying on AudioRecordingsService's batchDownloadUrl so we will

--- a/src/app/components/audio-recordings/pages/download/download.component.ts
+++ b/src/app/components/audio-recordings/pages/download/download.component.ts
@@ -9,16 +9,22 @@ import { regionResolvers } from "@baw-api/region/regions.service";
 import { ResolvedModelList, retrieveResolvers } from "@baw-api/resolver-common";
 import { siteResolvers } from "@baw-api/site/sites.service";
 import { contactUsMenuItem } from "@components/about/about.menus";
-import { audioRecordingMenuItems, audioRecordingsCategory } from "@components/audio-recordings/audio-recording.menus";
+import {
+  audioRecordingMenuItems,
+  audioRecordingsCategory,
+} from "@components/audio-recordings/audio-recording.menus";
 import { myAccountMenuItem } from "@components/profile/profile.menus";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { IPageInfo } from "@helpers/page/pageInfo";
 import { StrongRoute } from "@interfaces/strongRoute";
+import { WebsiteStatusWarningComponent } from "@menu/website-status-warning/website-status-warning.component";
+import { WidgetMenuItem } from "@menu/widgetItem";
 import { AudioRecording } from "@models/AudioRecording";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
 import { NgbDate } from "@ng-bootstrap/ng-bootstrap";
+import { List } from "immutable";
 import { BehaviorSubject, takeUntil } from "rxjs";
 import { loginMenuItem } from "src/app/components/security/security.menus";
 
@@ -33,7 +39,8 @@ const siteKey = "site";
 class DownloadAudioRecordingsComponent extends PageComponent implements OnInit {
   @ViewChild(NgForm) public form: NgForm;
 
-  public filters$: BehaviorSubject<Filters<AudioRecording>> = new BehaviorSubject({});
+  public filters$: BehaviorSubject<Filters<AudioRecording>> =
+    new BehaviorSubject({});
 
   public contactUs = contactUsMenuItem;
   public href = "";
@@ -48,7 +55,7 @@ class DownloadAudioRecordingsComponent extends PageComponent implements OnInit {
   public constructor(
     public session: BawSessionService,
     private route: ActivatedRoute,
-    private recordingsApi: AudioRecordingsService,
+    private recordingsApi: AudioRecordingsService
   ) {
     super();
   }
@@ -92,8 +99,18 @@ function getPageInfo(
   subRoute: keyof typeof audioRecordingMenuItems.batch
 ): IPageInfo {
   return {
-    pageRoute: audioRecordingMenuItems.batch[subRoute],
     category: audioRecordingsCategory,
+    pageRoute: audioRecordingMenuItems.batch[subRoute],
+    menus: {
+      actionWidgets: List([
+        new WidgetMenuItem(WebsiteStatusWarningComponent, () => true, {
+          message: `
+            Downloading audio is temporarily unavailable.
+            Please try again later.
+          `,
+        }),
+      ]),
+    },
     resolvers: {
       [projectKey]: projectResolvers.show,
       [regionKey]: regionResolvers.showOptional,

--- a/src/app/components/audio-recordings/pages/list/list.component.spec.ts
+++ b/src/app/components/audio-recordings/pages/list/list.component.spec.ts
@@ -2,6 +2,7 @@ import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { createRoutingFactory, Spectator } from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { assertPageInfo } from "@test/helpers/pageRoute";
+import { WebsiteStatusWarningComponent } from "@menu/website-status-warning/website-status-warning.component";
 import { AudioRecordingsListComponent } from "./list.component";
 
 describe("AudioRecordingsListComponent", () => {
@@ -10,6 +11,7 @@ describe("AudioRecordingsListComponent", () => {
   const createComponent = createRoutingFactory({
     component: AudioRecordingsListComponent,
     imports: [MockBawApiModule, SharedModule],
+    declarations: [WebsiteStatusWarningComponent],
   });
 
   function setup(): void {

--- a/src/app/components/audio-recordings/pages/list/list.component.ts
+++ b/src/app/components/audio-recordings/pages/list/list.component.ts
@@ -14,6 +14,8 @@ import { filterModel } from "@helpers/filters/filters";
 import { IPageInfo } from "@helpers/page/pageInfo";
 import { PagedTableTemplate } from "@helpers/tableTemplate/pagedTableTemplate";
 import { toRelative } from "@interfaces/apiInterfaces";
+import { WebsiteStatusWarningComponent } from "@menu/website-status-warning/website-status-warning.component";
+import { WidgetMenuItem } from "@menu/widgetItem";
 import { AudioRecording } from "@models/AudioRecording";
 import { Project } from "@models/Project";
 import { Region } from "@models/Region";
@@ -176,7 +178,17 @@ function getPageInfo(subRoute: keyof typeof menuItems): IPageInfo {
   return {
     category: audioRecordingsCategory,
     pageRoute: menuItems[subRoute],
-    menus: { actions: List([downloadMenuItems[subRoute], visualizeMenuItem]) },
+    menus: {
+      actions: List([downloadMenuItems[subRoute], visualizeMenuItem]),
+      actionWidgets: List([
+        new WidgetMenuItem(WebsiteStatusWarningComponent, undefined, {
+          message: `
+            Downloading and playing audio is temporarily unavailable.
+            Please try again later.
+          `,
+        }),
+      ]),
+    },
     resolvers: {
       [projectKey]: projectResolvers.showOptional,
       [regionKey]: regionResolvers.showOptional,

--- a/src/app/components/harvest/pages/details/details.component.spec.ts
+++ b/src/app/components/harvest/pages/details/details.component.spec.ts
@@ -18,6 +18,7 @@ import { assertPageInfo } from "@test/helpers/pageRoute";
 import { MockComponents } from "ng-mocks";
 import { ToastrService } from "ngx-toastr";
 import { PageTitleStrategy } from "src/app/app.component";
+import { WebsiteStatusWarningComponent } from "@menu/website-status-warning/website-status-warning.component";
 import { DetailsComponent } from "./details.component";
 
 describe("DetailsComponent", () => {
@@ -33,7 +34,8 @@ describe("DetailsComponent", () => {
       MetadataExtractionComponent,
       ProcessingComponent,
       MetadataReviewComponent,
-      CompleteComponent
+      CompleteComponent,
+      WebsiteStatusWarningComponent,
     ),
     providers: [
       mockProvider(HarvestStagesService),

--- a/src/app/components/harvest/pages/details/details.component.ts
+++ b/src/app/components/harvest/pages/details/details.component.ts
@@ -13,7 +13,11 @@ import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
 import { Harvest } from "@models/Harvest";
 import { Project } from "@models/Project";
 import { List } from "immutable";
-import { permissionsWidgetMenuItem } from "@menu/widget.menus";
+import {
+  permissionsWidgetMenuItem,
+} from "@menu/widget.menus";
+import { WidgetMenuItem } from "@menu/widgetItem";
+import { WebsiteStatusWarningComponent } from "@menu/website-status-warning/website-status-warning.component";
 import { HarvestStagesService } from "../../services/harvest-stages.service";
 import { harvestsMenuItemActions } from "../list/list.component";
 
@@ -56,7 +60,14 @@ DetailsComponent.linkToRoute({
     actions: List([...harvestsMenuItemActions, newSiteMenuItem]),
     actionWidgets: List([
       harvestValidationsWidgetMenuItem,
-      permissionsWidgetMenuItem
+      permissionsWidgetMenuItem,
+      new WidgetMenuItem(WebsiteStatusWarningComponent, undefined, {
+        feature: "isUploadingHealthy",
+        message: `
+         Uploading is temporarily unavailable.
+          Please try again later.
+        `,
+      }),
     ]),
   },
   pageRoute: harvestMenuItem,

--- a/src/app/components/harvest/pages/list/list.component.spec.ts
+++ b/src/app/components/harvest/pages/list/list.component.spec.ts
@@ -23,6 +23,7 @@ import { User } from "@models/User";
 import { generateUser } from "@test/fakes/User";
 import { UserLinkComponent } from "@shared/user-link/user-link/user-link.component";
 import { withDefaultZone } from "@test/helpers/mocks";
+import { WebsiteStatusWarningComponent } from "@menu/website-status-warning/website-status-warning.component";
 import { ListComponent } from "./list.component";
 
 describe("ListComponent", () => {
@@ -34,7 +35,11 @@ describe("ListComponent", () => {
   let modalConfigService: NgbModalConfig;
 
   const createComponent = createRoutingFactory({
-    declarations: [ConfirmationComponent, UserLinkComponent],
+    declarations: [
+      ConfirmationComponent,
+      UserLinkComponent,
+      WebsiteStatusWarningComponent,
+    ],
     component: ListComponent,
     imports: [MockBawApiModule, SharedModule],
     mocks: [ToastrService],
@@ -131,7 +136,6 @@ describe("ListComponent", () => {
     // it doesn't impact future tests by using a stale modal
     modalService?.dismissAll();
   });
-
 
   assertPageInfo(ListComponent, ["Recording Uploads", "All Recording Uploads"]);
 
@@ -237,7 +241,7 @@ describe("ListComponent", () => {
             "status",
           ],
         },
-      }),
+      })
     );
   });
 
@@ -257,7 +261,7 @@ describe("ListComponent", () => {
             eq: defaultProject.id,
           },
         },
-      }),
+      })
     );
   });
 
@@ -284,7 +288,8 @@ describe("ListComponent", () => {
     const expectedProject: Project = defaultHarvest.project;
     const expectedProjectName: string = expectedProject.name;
 
-    const projectNameColumnValue: HTMLTableCellElement = getElementByInnerText(expectedProjectName);
+    const projectNameColumnValue: HTMLTableCellElement =
+      getElementByInnerText(expectedProjectName);
 
     expect(projectNameColumnValue).toExist();
   });

--- a/src/app/components/harvest/pages/list/list.component.ts
+++ b/src/app/components/harvest/pages/list/list.component.ts
@@ -18,6 +18,8 @@ import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { BawApiError } from "@helpers/custom-errors/baw-api-error";
 import { BehaviorSubject, catchError, takeUntil, throwError } from "rxjs";
 import { CLIENT_TIMEOUT } from "@baw-api/api.interceptor.service";
+import { WidgetMenuItem } from "@menu/widgetItem";
+import { WebsiteStatusWarningComponent } from "@menu/website-status-warning/website-status-warning.component";
 
 export const harvestsMenuItemActions = [newHarvestMenuItem];
 const projectKey = "project";
@@ -119,6 +121,15 @@ ListComponent.linkToRoute({
   category: harvestsCategory,
   menus: {
     actions: List(harvestsMenuItemActions),
+    actionWidgets: List([
+      new WidgetMenuItem(WebsiteStatusWarningComponent, undefined, {
+        feature: "isUploadingHealthy",
+        message: `
+          Uploading is temporarily unavailable.
+          Please try again later.
+        `,
+      }),
+    ]),
   },
   pageRoute: harvestsMenuItem,
   resolvers: {

--- a/src/app/components/shared/menu/header/header.component.spec.ts
+++ b/src/app/components/shared/menu/header/header.component.spec.ts
@@ -9,6 +9,7 @@ import { MenuService } from "@services/menu/menu.service";
 import { viewports } from "@test/helpers/general";
 import { MockComponent, MockProvider } from "ng-mocks";
 import { ToastrService } from "ngx-toastr";
+import { WebsiteStatusIndicatorComponent } from "@menu/website-status-indicator/website-status-indicator.component";
 import { HeaderComponent } from "./header.component";
 
 describe("HeaderComponent", () => {
@@ -24,6 +25,7 @@ describe("HeaderComponent", () => {
     declarations: [
       MockComponent(MenuToggleComponent),
       MockComponent(PrimaryMenuComponent),
+      MockComponent(WebsiteStatusIndicatorComponent),
     ],
     imports: [RouterTestingModule, MockBawApiModule, MockDirectivesModule],
   });
@@ -75,6 +77,21 @@ describe("HeaderComponent", () => {
       expect(getPrimaryMenu()).toHaveComputedStyle({
         flexGrow: "1",
       });
+    });
+  });
+
+  describe("status indicator", () => {
+    const statusIndicatorElement = (): HTMLElement =>
+      spec.query("baw-website-status-indicator");
+
+    it("should show when in mobile view", () => {
+      viewport.set(viewports.small);
+      expect(statusIndicatorElement()).toBeVisible();
+    });
+
+    it("should hide when in desktop view", () => {
+      viewport.set(viewports.large);
+      expect(statusIndicatorElement()).toBeHidden();
     });
   });
 });

--- a/src/app/components/shared/menu/header/header.component.ts
+++ b/src/app/components/shared/menu/header/header.component.ts
@@ -28,6 +28,16 @@ import { MenuService } from "@services/menu/menu.service";
 
         <!-- Header Links, only visible on desktop viewports -->
         <baw-primary-menu class="flex-grow-1"></baw-primary-menu>
+
+        <!--
+          Because on desktop we have the website status indicator next to the user login/logout elements.
+          The indicator will be hidden when the primary menu is hidden on mobile views.
+          We therefore add another indicator when in mobile view so that there is always a warning indicator
+          for a bad website status.
+        -->
+        <baw-website-status-indicator
+          class="d-block d-lg-none"
+        ></baw-website-status-indicator>
       </div>
     </nav>
 

--- a/src/app/components/shared/menu/menu.module.ts
+++ b/src/app/components/shared/menu/menu.module.ts
@@ -29,6 +29,7 @@ import { PrimaryMenuComponent } from "./primary-menu/primary-menu.component";
 import { SecondaryMenuComponent } from "./secondary-menu/secondary-menu.component";
 import { SideNavComponent } from "./side-nav/side-nav.component";
 import { UserBadgeComponent } from "./user-badge/user-badge.component";
+import { WebsiteStatusIndicatorComponent } from "./website-status-indicator/website-status-indicator.component";
 
 const privateComponents = [
   MenuButtonComponent,
@@ -36,6 +37,7 @@ const privateComponents = [
   UserBadgeComponent,
   HeaderDropdownComponent,
   HeaderItemComponent,
+  WebsiteStatusIndicatorComponent,
 ];
 
 const publicComponents = [

--- a/src/app/components/shared/menu/menu/menu.component.html
+++ b/src/app/components/shared/menu/menu/menu.component.html
@@ -53,7 +53,7 @@
       </ng-container>
     </li>
 
-    <hr *ngIf="hasWidgets()" class="w-100" />
+    <hr class="w-100" />
 
     <!-- Widgets -->
     <div id="widget">

--- a/src/app/components/shared/menu/menu/menu.component.spec.ts
+++ b/src/app/components/shared/menu/menu/menu.component.spec.ts
@@ -52,6 +52,10 @@ import { MenuComponent } from "./menu.component";
 })
 export class MockWidgetComponent implements WidgetComponent {
   public pageData!: any;
+
+  // you should be able to change this property using the options object
+  // eg. options = { testProperty: "test" }
+  public testProperty?: any;
 }
 
 @Component({
@@ -269,6 +273,18 @@ describe("MenuComponent", () => {
         });
         spec.detectChanges();
         validateNumWidgets(0);
+      });
+
+      it("should set the widget data using the options provided", () => {
+        setup({
+          widgets: OrderedSet([
+            new WidgetMenuItem(MockWidgetComponent, undefined, { testProperty: "test" }),
+          ]),
+        });
+        spec.detectChanges();
+
+        const widget = spec.query(MockWidgetComponent);
+        expect(widget.testProperty).toBe("test");
       });
     });
 

--- a/src/app/components/shared/menu/menu/menu.component.ts
+++ b/src/app/components/shared/menu/menu/menu.component.ts
@@ -160,6 +160,11 @@ export class MenuComponent implements OnChanges, AfterViewInit {
    */
   private insertWidget(widget: WidgetMenuItem): void {
     const temp = this.menuWidget.createComponent(widget.component);
+
+    Object.keys(widget.options ?? {}).forEach((key) => {
+      temp.instance[key] = widget.options[key];
+    });
+
     // This is needed, otherwise widgets sometimes throw
     // ExpressionChangedAfterItHasBeenCheckedError
     temp.changeDetectorRef.detectChanges();

--- a/src/app/components/shared/menu/primary-menu/primary-menu.component.html
+++ b/src/app/components/shared/menu/primary-menu/primary-menu.component.html
@@ -20,6 +20,8 @@
 
   <!-- Right aligned links -->
   <ul class="navbar-nav">
+    <baw-website-status-indicator *ngIf="!isSideNav"></baw-website-status-indicator>
+
     <ng-container
       *ngTemplateOutlet="user ? userTemplate : guestTemplate"
     ></ng-container>

--- a/src/app/components/shared/menu/primary-menu/primary-menu.component.spec.ts
+++ b/src/app/components/shared/menu/primary-menu/primary-menu.component.spec.ts
@@ -37,9 +37,10 @@ import { modelData } from "@test/helpers/faker";
 import { viewports } from "@test/helpers/general";
 import { websiteHttpUrl } from "@test/helpers/url";
 import camelCase from "just-camel-case";
-import { MockProvider } from "ng-mocks";
+import { MockComponent, MockProvider } from "ng-mocks";
 import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject, Subject } from "rxjs";
+import { WebsiteStatusIndicatorComponent } from "@menu/website-status-indicator/website-status-indicator.component";
 import { HeaderDropdownComponent } from "../header-dropdown/header-dropdown.component";
 import { HeaderItemComponent } from "../header-item/header-item.component";
 import { PrimaryMenuComponent } from "./primary-menu.component";
@@ -52,7 +53,11 @@ describe("PrimaryMenuComponent", () => {
   const createComponent = createComponentFactory({
     component: PrimaryMenuComponent,
     providers: [MockProvider(ToastrService)],
-    declarations: [HeaderItemComponent, HeaderDropdownComponent],
+    declarations: [
+      MockComponent(WebsiteStatusIndicatorComponent),
+      HeaderItemComponent,
+      HeaderDropdownComponent,
+    ],
     imports: [
       RouterTestingModule,
       MockBawApiModule,
@@ -393,6 +398,38 @@ describe("PrimaryMenuComponent", () => {
       const link = spec.query<HTMLElement>(getLinkId(loginMenuItem));
       expect(link).toContainText(loginMenuItem.label);
     }));
+  });
+
+  describe("status indicator", () => {
+    const statusIndicatorElement = (): HTMLElement =>
+      spec.query("baw-website-status-indicator");
+
+    // the functionality of the status indicator is tested within the website-status-indicator component
+    // therefore, we only need to assert that the indicator is shown under the correct conditions
+    it("should show the status indicator when not in the sidebar and on desktop", () => {
+      setup({
+        user: null,
+        isFullscreen: false,
+        isSideNav: false,
+      });
+      viewport.set(viewports.large);
+
+      spec.detectChanges();
+
+      expect(statusIndicatorElement()).toExist();
+    });
+
+    it("should hide the status indicator when in the sidebar", () => {
+      setup({
+        user: null,
+        isFullscreen: false,
+        isSideNav: true,
+      });
+
+      spec.detectChanges();
+
+      expect(statusIndicatorElement()).not.toExist();
+    });
   });
 
   describe("display logic", () => {

--- a/src/app/components/shared/menu/website-status-indicator/website-status-indicator.component.spec.ts
+++ b/src/app/components/shared/menu/website-status-indicator/website-status-indicator.component.spec.ts
@@ -1,0 +1,131 @@
+import { WebsiteStatusService } from "@baw-api/website-status/website-status.service";
+import { Spectator, createComponentFactory } from "@ngneat/spectator";
+import { WebsiteStatus } from "@models/WebsiteStatus";
+import { generateWebsiteStatus } from "@test/fakes/WebsiteStatus";
+import { assertTooltip } from "@test/helpers/html";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { SharedModule } from "@shared/shared.module";
+import { ActivatedRoute } from "@angular/router";
+import { mockActivatedRoute } from "@test/helpers/testbed";
+import { MockProvider } from "ng-mocks";
+import { of } from "rxjs";
+import { WebsiteStatusIndicatorComponent } from "./website-status-indicator.component";
+
+describe("WebsiteStatusIndicatorComponent", () => {
+  let spectator: Spectator<WebsiteStatusIndicatorComponent>;
+  let mockApi: jasmine.SpyObj<WebsiteStatusService>;
+
+  const indicatorElement = (): HTMLAnchorElement =>
+    spectator.query<HTMLAnchorElement>("a");
+
+  const createComponent = createComponentFactory({
+    component: WebsiteStatusIndicatorComponent,
+    imports: [MockBawApiModule, SharedModule],
+    providers: [
+      { provide: ActivatedRoute, useValue: mockActivatedRoute() },
+      MockProvider(WebsiteStatusService),
+    ],
+  });
+
+  function setup(
+    websiteStatus: WebsiteStatus = new WebsiteStatus(generateWebsiteStatus())
+  ): void {
+
+    spectator = createComponent({ detectChanges: false });
+
+    mockApi = spectator.inject(WebsiteStatusService);
+    mockApi.status$ = of(websiteStatus);
+
+    jasmine.clock().install();
+
+    spectator.detectChanges();
+  }
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
+  it("should create", () => {
+    setup();
+    expect(spectator.component).toBeInstanceOf(WebsiteStatusIndicatorComponent);
+  });
+
+  it("should update the status if it changes from good to bad", () => {
+    const goodStatus = new WebsiteStatus({
+      ...generateWebsiteStatus(),
+      status: "good",
+    });
+
+    const badStatus = new WebsiteStatus({
+      ...generateWebsiteStatus(),
+      status: "bad",
+    });
+
+    setup(goodStatus);
+
+    expect(indicatorElement()).not.toExist();
+
+    mockApi.status$ = of(badStatus);
+    spectator.detectChanges();
+
+    expect(indicatorElement()).toExist();
+  });
+
+  it("should update the status if it changes from bad to good", () => {
+    const goodStatus = new WebsiteStatus({
+      ...generateWebsiteStatus(),
+      status: "good",
+    });
+
+    const badStatus = new WebsiteStatus({
+      ...generateWebsiteStatus(),
+      status: "bad",
+    });
+
+    setup(badStatus);
+
+    expect(indicatorElement()).toExist();
+
+    mockApi.status$ = of(goodStatus);
+    spectator.detectChanges();
+
+    expect(indicatorElement()).not.toExist();
+  });
+
+  it("should not be visible when website is healthy", () => {
+    const testStatus = new WebsiteStatus({
+      ...generateWebsiteStatus(),
+      status: "good",
+    });
+
+    setup(testStatus);
+
+    expect(indicatorElement()).not.toExist();
+  });
+
+  it("should be visible when website is unhealthy", () => {
+    const testStatus = new WebsiteStatus({
+      ...generateWebsiteStatus(),
+      status: "bad",
+    });
+
+    setup(testStatus);
+
+    expect(indicatorElement()).toExist();
+  });
+
+  it("should have the correct tooltip on hover", () => {
+    const testStatus = new WebsiteStatus({
+      ...generateWebsiteStatus(),
+      status: "bad",
+    });
+
+    const expectedTooltip =
+      "<< brandLong >> is experiencing a temporary loss of services. Some parts " +
+      "of the website may not work.";
+
+    setup(testStatus);
+
+    assertTooltip(indicatorElement(), expectedTooltip);
+  });
+});

--- a/src/app/components/shared/menu/website-status-indicator/website-status-indicator.component.ts
+++ b/src/app/components/shared/menu/website-status-indicator/website-status-indicator.component.ts
@@ -1,0 +1,31 @@
+import { Component } from "@angular/core";
+import { WebsiteStatusService } from "@baw-api/website-status/website-status.service";
+import { websiteStatusMenuItem } from "@components/website-status/website-status.menu";
+import { StrongRoute } from "@interfaces/strongRoute";
+import { ConfigService } from "@services/config/config.service";
+
+@Component({
+  selector: "baw-website-status-indicator",
+  template: `
+    <a
+      *ngIf="!(api.status$ | async)?.isStatusHealthy"
+      class="block nav-link text-danger text-nowrap"
+      [strongRoute]="websiteStatusRoute"
+      [ngbTooltip]="
+        config.settings.brand.long +
+        ' is experiencing a temporary loss of services. ' +
+        'Some parts of the website may not work.'
+      "
+    >
+      <fa-icon [icon]="['fas', 'triangle-exclamation']"></fa-icon>
+    </a>
+  `,
+})
+export class WebsiteStatusIndicatorComponent {
+  public constructor(
+    protected config: ConfigService,
+    protected api: WebsiteStatusService
+  ) {}
+
+  protected websiteStatusRoute: StrongRoute = websiteStatusMenuItem.route;
+}

--- a/src/app/components/shared/menu/widgets/website-status-warning/website-status-warning.component.spec.ts
+++ b/src/app/components/shared/menu/widgets/website-status-warning/website-status-warning.component.spec.ts
@@ -1,0 +1,125 @@
+import { Spectator, createComponentFactory } from "@ngneat/spectator";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { SharedModule } from "@shared/shared.module";
+import { WebsiteStatusService } from "@baw-api/website-status/website-status.service";
+import { MockProvider } from "ng-mocks";
+import { of } from "rxjs";
+import { WebsiteStatus } from "@models/WebsiteStatus";
+import { generateWebsiteStatus } from "@test/fakes/WebsiteStatus";
+import { mockActivatedRoute } from "@test/helpers/testbed";
+import { ActivatedRoute } from "@angular/router";
+import { KeysOfType } from "@helpers/advancedTypes";
+import { WebsiteStatusWarningComponent } from "./website-status-warning.component";
+
+describe("WebsiteCapabilityWarningComponent", () => {
+  let spectator: Spectator<WebsiteStatusWarningComponent>;
+  let mockApi: jasmine.SpyObj<WebsiteStatusService>;
+
+  const createComponent = createComponentFactory({
+    component: WebsiteStatusWarningComponent,
+    imports: [MockBawApiModule, SharedModule],
+    providers: [
+      { provide: ActivatedRoute, useValue: mockActivatedRoute() },
+      MockProvider(WebsiteStatusService),
+    ],
+  });
+
+  const warningMessage = () => spectator.query(".alert", { root: true });
+
+  function setup(
+    mockWebsiteStatus = new WebsiteStatus(generateWebsiteStatus()),
+    feature?: KeysOfType<WebsiteStatus, boolean>,
+    message: string = ""
+  ): void {
+    spectator = createComponent({ detectChanges: false });
+
+    mockApi = spectator.inject(WebsiteStatusService);
+    mockApi.status$ = of(mockWebsiteStatus);
+
+    jasmine.clock().install();
+
+    spectator.component.feature = feature;
+    spectator.component.message = message;
+
+    spectator.detectChanges();
+  }
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
+  it("should create", () => {
+    setup();
+    expect(spectator.component).toBeInstanceOf(WebsiteStatusWarningComponent);
+  });
+
+  it("should update correctly from healthy to unhealthy", () => {
+    const goodWebsiteStatus = new WebsiteStatus(
+      generateWebsiteStatus({
+        upload: "Alive",
+      })
+    );
+
+    const badWebsiteStatus = new WebsiteStatus(
+      generateWebsiteStatus({
+        upload: "Dead",
+      })
+    );
+
+    setup(goodWebsiteStatus, "isUploadingHealthy");
+
+    expect(warningMessage()).not.toExist();
+
+    mockApi.status$ = of(badWebsiteStatus);
+    spectator.detectChanges();
+
+    expect(warningMessage()).toExist();
+  });
+
+  it("should update correctly from unhealthy to healthy", () => {
+    const goodWebsiteStatus = new WebsiteStatus(
+      generateWebsiteStatus({
+        upload: "Alive",
+      })
+    );
+
+    const badWebsiteStatus = new WebsiteStatus(
+      generateWebsiteStatus({
+        upload: "Dead",
+      })
+    );
+
+    setup(badWebsiteStatus, "isUploadingHealthy");
+
+    expect(warningMessage()).toExist();
+
+    mockApi.status$ = of(goodWebsiteStatus);
+    spectator.detectChanges();
+
+    expect(warningMessage()).not.toExist();
+  });
+
+  it("should not display an error message for a healthy feature", () => {
+    const mockWebsiteStatus = new WebsiteStatus(
+      generateWebsiteStatus({
+        upload: "Alive",
+      })
+    );
+
+    setup(mockWebsiteStatus, "isUploadingHealthy", "upload audio");
+
+    expect(warningMessage()).not.toExist();
+  });
+
+  it("should display an error message for an unhealthy feature", () => {
+    const mockWebsiteStatus = new WebsiteStatus(
+      generateWebsiteStatus({
+        storage: "No audio recording storage directories are available.",
+      })
+    );
+
+    setup(mockWebsiteStatus, "isStorageHealthy", "download audio");
+
+    expect(warningMessage()).toExist();
+  });
+});

--- a/src/app/components/shared/menu/widgets/website-status-warning/website-status-warning.component.ts
+++ b/src/app/components/shared/menu/widgets/website-status-warning/website-status-warning.component.ts
@@ -1,0 +1,39 @@
+import { Component } from "@angular/core";
+import { WebsiteStatusService } from "@baw-api/website-status/website-status.service";
+import { websiteStatusMenuItem } from "@components/website-status/website-status.menu";
+import { KeysOfType } from "@helpers/advancedTypes";
+import { WebsiteStatus } from "@models/WebsiteStatus";
+
+@Component({
+  selector: "baw-website-status-warning",
+  template: `
+    <ng-container *ngIf="!(api.status$ | async)?.[feature]">
+      <section>
+        <div class="alert alert-danger">
+          <div>
+            <ng-container *ngIf="message; else contentOutlet">
+              <p>{{ message }}</p>
+            </ng-container>
+
+            <ng-template #contentOutlet>
+              <ng-content></ng-content>
+            </ng-template>
+          </div>
+
+          <div>
+            <small>
+              <a [strongRoute]="websiteStatusRoute">More Information</a>
+            </small>
+          </div>
+        </div>
+      </section>
+    </ng-container>
+  `,
+})
+export class WebsiteStatusWarningComponent {
+  public constructor(protected api: WebsiteStatusService) {}
+
+  public feature: KeysOfType<WebsiteStatus, boolean> = "isStatusHealthy";
+  public message?: string;
+  protected websiteStatusRoute = websiteStatusMenuItem.route;
+}

--- a/src/app/components/shared/menu/widgets/widget.component.ts
+++ b/src/app/components/shared/menu/widgets/widget.component.ts
@@ -1,3 +1,5 @@
+export type WidgetOptions = Record<string, unknown>;
+
 /** Generic widget component */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface WidgetComponent {}
@@ -7,5 +9,4 @@ export interface ModalComponent extends WidgetComponent {
   closeModal: (result: any) => void;
   dismissModal?: (reason: any) => void;
   successCallback?: () => void;
-  options?: Record<string, unknown>;
 }

--- a/src/app/components/shared/menu/widgets/widget.menus.ts
+++ b/src/app/components/shared/menu/widgets/widget.menus.ts
@@ -2,6 +2,7 @@ import { PermissionsShieldComponent } from "@menu/permissions-shield/permissions
 import { isLoggedInPredicate } from "src/app/app.menus";
 import { AllowsOriginalDownloadComponent } from "./allows-original-download/allows-original-download.component";
 import { WidgetMenuItem } from "./widgetItem";
+import { WebsiteStatusWarningComponent } from "./website-status-warning/website-status-warning.component";
 
 export const permissionsWidgetMenuItem = new WidgetMenuItem(
   PermissionsShieldComponent,
@@ -10,4 +11,9 @@ export const permissionsWidgetMenuItem = new WidgetMenuItem(
 
 export const allowsOriginalDownloadWidgetMenuItem = new WidgetMenuItem(
   AllowsOriginalDownloadComponent
+);
+
+/** A website status warning widget that warns if any part of the website is unhealthy */
+export const websiteStatusWarningWidgetMenuItem = new WidgetMenuItem(
+  WebsiteStatusWarningComponent
 );

--- a/src/app/components/shared/menu/widgets/widgetItem.ts
+++ b/src/app/components/shared/menu/widgets/widgetItem.ts
@@ -13,7 +13,9 @@ export class WidgetMenuItem {
     /** Component to display */
     public component: Type<WidgetComponent>,
     /** Whether or not to show this link */
-    public predicate?: UserCallback<boolean>
+    public predicate?: UserCallback<boolean>,
+    /** Options to be passed to the component */
+    public options?: Record<string, unknown>
   ) {}
 }
 

--- a/src/app/components/shared/shared.components.ts
+++ b/src/app/components/shared/shared.components.ts
@@ -22,6 +22,7 @@ import { NgxCaptchaModule } from "ngx-captcha";
 import { ToastrModule } from "ngx-toastr";
 import { DirectivesModule } from "src/app/directives/directives.module";
 import { ConfirmationComponent } from "@components/harvest/components/modal/confirmation.component";
+import { WebsiteStatusWarningComponent } from "@menu/website-status-warning/website-status-warning.component";
 import { AnnotationDownloadComponent } from "./annotation-download/annotation-download.component";
 import { BawClientModule } from "./baw-client/baw-client.module";
 import { BreadcrumbModule } from "./breadcrumb/breadcrumb.module";
@@ -70,6 +71,7 @@ export const sharedComponents = [
   TypeaheadInputComponent,
   ChartComponent,
   InlineListComponent,
+  WebsiteStatusWarningComponent,
 
   // modals
   ConfirmationComponent,

--- a/src/app/components/website-status/website-status.component.ts
+++ b/src/app/components/website-status/website-status.component.ts
@@ -33,13 +33,9 @@ class WebsiteStatusComponent extends PageComponent implements OnInit {
   protected reportProblemRoute = reportProblemMenuItem.route;
 
   public ngOnInit(): void {
-    this.api
-      .show()
+    this.api.status$
       .pipe(takeUntil(this.unsubscribe))
-      .subscribe({
-        next: (model) => (this.model = model),
-        error: () => (this.model = null),
-      });
+      .subscribe((model) => (this.model = model));
   }
 
   protected model: WebsiteStatus;

--- a/src/app/services/baw-api/website-status/website-status.service.spec.ts
+++ b/src/app/services/baw-api/website-status/website-status.service.spec.ts
@@ -1,0 +1,33 @@
+import { SpectatorService, createServiceFactory } from "@ngneat/spectator";
+import {
+  mockServiceImports,
+  mockServiceProviders,
+} from "@test/helpers/api-common";
+import { WebsiteStatusService } from "./website-status.service";
+
+describe("WebsiteStatusService", () => {
+  let spec: SpectatorService<WebsiteStatusService>;
+
+  const createService = createServiceFactory({
+    service: WebsiteStatusService,
+    imports: mockServiceImports,
+    providers: mockServiceProviders,
+  });
+
+  function setup(): void {
+    spec = createService();
+
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date("2020-01-01T00:00:00.000+09:30"));
+  }
+
+  beforeEach(() => setup());
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
+  it("should create", () => {
+    expect(spec.service).toBeInstanceOf(WebsiteStatusService);
+  });
+});

--- a/src/app/services/baw-api/website-status/website-status.service.ts
+++ b/src/app/services/baw-api/website-status/website-status.service.ts
@@ -1,48 +1,61 @@
-import { HttpClient, HttpHeaders } from "@angular/common/http";
-import { Inject, Injectable } from "@angular/core";
-import { ApiShow } from "@baw-api/api-common";
-import { unknownErrorCode } from "@baw-api/baw-api.service";
+import { HttpHeaders } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { BawApiService, unknownErrorCode } from "@baw-api/baw-api.service";
 import {
   BawApiError,
   isBawApiError,
 } from "@helpers/custom-errors/baw-api-error";
-import { WebsiteStatus } from "@models/WebsiteStatus";
-import { API_ROOT } from "@services/config/config.tokens";
-import { Observable, catchError, map, throwError } from "rxjs";
+import { IWebsiteStatus, WebsiteStatus } from "@models/WebsiteStatus";
+import {
+  Observable,
+  catchError,
+  defer,
+  distinct,
+  interval,
+  map,
+  shareReplay,
+  startWith,
+  switchMap,
+  throwError,
+} from "rxjs";
 
 @Injectable()
-export class WebsiteStatusService implements ApiShow<WebsiteStatus> {
-  public constructor(
-    private http: HttpClient,
-    @Inject(API_ROOT) private apiRoot: string
-  ) {}
-
-  // if the server is fully down, we will not receive a response from the API
-  // we can therefore not determine the status of the server and we should return "null"
-  public show(): Observable<WebsiteStatus | null> {
-    const endpoint = `${this.apiRoot}/status`;
-
-    return this.http
-      .get<WebsiteStatus>(endpoint, {
-        headers: WebsiteStatusService.requestHeaders,
-      })
-      .pipe(
-        map((response) => new WebsiteStatus(response)),
-        catchError((err: BawApiError | Error) => {
-          const bawError = isBawApiError(err)
-            ? err
-            : new BawApiError(unknownErrorCode, err.message);
-
-          console.error("Error fetching API /status endpoint:", bawError.message);
-
-          return throwError((): BawApiError => bawError);
-        })
-      );
+export class WebsiteStatusService {
+  public constructor(private api: BawApiService<WebsiteStatus>) {
+    this.status$ = this.tick$.pipe(
+      switchMap(() => this.show()),
+      distinct(),
+      shareReplay(1)
+    );
   }
 
-  // by making this a static field, we don't have to recreate the headers every time we make a request
-  private static readonly requestHeaders = new HttpHeaders({
+  public status$: Observable<WebsiteStatus>;
+  private tick$ = defer(() => interval(30_000).pipe(startWith(-1)));
+
+  // by making this a service level field, we don't have to recreate the headers every time we make a request
+  private readonly requestHeaders = new HttpHeaders({
     // eslint-disable-next-line @typescript-eslint/naming-convention
     Accept: "application/json",
   });
+
+  // if the server is fully down, we will not receive a response from the API
+  // we can therefore not determine the status of the server and we should return "null"
+  private show(): Observable<WebsiteStatus | null> {
+    const endpoint = "/status";
+
+    // we use our custom api.httpGet so that this service using our site wide
+    // caching config (and can be overwritten by the caller in a uniform manner)
+    return (this.api.httpGet(endpoint, this.requestHeaders) as any).pipe(
+      map((response: IWebsiteStatus) => new WebsiteStatus(response)),
+      catchError((err: BawApiError | Error) => {
+        const bawError = isBawApiError(err)
+          ? err
+          : new BawApiError(unknownErrorCode, err.message);
+
+        console.error("Error fetching API /status endpoint:", bawError.message);
+
+        return throwError((): BawApiError => bawError);
+      })
+    );
+  }
 }


### PR DESCRIPTION
# Display warning message for "bad" website status

At the moment, when the server is down / has partial services, the only way users can diagnose the issue as a server side issue is by going to [https://www.ecosounds.org/status](https://www.ecosounds.org/status).

Because this is unintuitive to some users, we should surface the issue sooner as a server issue by adding warnings showing that the service the user is trying to use is non-functional.

**Important note**: I am not displaying an error indicator in the navbar for a timeout error.

This is because:

- We are already displaying a toast message that covers timeout messages
- If the user doesn't have internet, it tells them that they do not have internet and to check their internet / VPN connection
- The warning indicator is supposed portray the message "we are not fully functional right now, and it is not a problem with your internet / client. Try again later". Adding a timeout error case to this icon will change the semantic meaning of this icon to "something failed. It might be you; it might be us."

## Changes

- Add website status indicator to the navigational bar (that only shows when the website status is "bad" / unhealthy)
- Add warning banner to the harvest list & detail pages if the api sftp server is down
- Add warning banner to the audio recording list & download pages if the api storage is down
- Add tests for all the above
- Menu links now always emit a `<hr>` at the base of the menu links container (even when there are no widgets)

## Problems

None

## Issues

Fixes: #2102 

## Visual Changes

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/946dd2ae-b0c1-4da6-8038-474a45f8ca7a)
_API Status indicator icon and tooltip (will only be shown if the server status is `"bad"`)_

---

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/71311420-e81e-4453-9605-4b7c287143d4)
_Warning widget on the harvest list page_

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/7e112251-5248-4dda-b304-d53e1f67920b)
_Warning widget on the harvest page_

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/8eeb3445-ca77-4215-8597-7f506db5c0b1)
_Warning widget on the recording list page_

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/8eeb3445-ca77-4215-8597-7f506db5c0b1)
_Warning widget on the recording list page_

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/8b0f38df-4daa-4aef-a20e-5348ad56468f)
_Warning widget on the batch download page_

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/8aa6c749-224e-4bf6-8408-4d82187030d5)
_Warning widget on the audio recording details page_

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/d8f34664-8ee1-41f0-80d3-5adae96a9a1d)
_New `<hr>` element at the bottom of menu links without widgets_

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
