### PR TITLE
Don't send auth token when calling /status

### DIFF
--- a/src/app/services/baw-api/api.interceptor.service.spec.ts
+++ b/src/app/services/baw-api/api.interceptor.service.spec.ts
@@ -1,276 +1,343 @@
-// /* eslint-disable @typescript-eslint/naming-convention */
-// import { HttpClient, HttpClientModule, HttpParams } from "@angular/common/http";
-// import { TestRequest } from "@angular/common/http/testing";
-// import { ApiErrorDetails } from "@baw-api/api.interceptor.service";
-// import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
-// import { SecurityService } from "@baw-api/security/security.service";
-// import { API_ROOT } from "@helpers/app-initializer/app-initializer";
-// import { Session } from "@models/User";
-// import {
-//   createHttpFactory,
-//   HttpMethod,
-//   SpectatorHttp,
-// } from "@ngneat/spectator";
-// import { generateApiErrorResponse } from "@test/fakes/ApiErrorDetails";
-// import { generateSessionUser } from "@test/fakes/User";
-// import { noop } from "rxjs";
-// import { ApiResponse } from "./baw-api.service";
-// import { shouldNotFail, shouldNotSucceed } from "./baw-api.service.spec";
+import {
+  HttpClient,
+  HttpClientModule,
+  HttpContext,
+  HttpParams,
+} from "@angular/common/http";
+import { TestRequest } from "@angular/common/http/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { User } from "@models/User";
+import {
+  createHttpFactory,
+  HttpMethod,
+  SpectatorHttp,
+} from "@ngneat/spectator";
+import { noop } from "rxjs";
+import { generateUser } from "@test/fakes/User";
+import { API_ROOT } from "@services/config/config.tokens";
+import {
+  ApiErrorDetails,
+  BawApiError,
+} from "@helpers/custom-errors/baw-api-error";
+import { generateBawApiError } from "@test/fakes/BawApiError";
+import { NOT_FOUND, UNPROCESSABLE_ENTITY } from "http-status";
+import { BawSessionService } from "./baw-session.service";
+import { shouldNotFail, shouldNotSucceed } from "./baw-api.service.spec";
+import { CREDENTIALS_CONTEXT } from "./api.interceptor.service";
 
-// describe("BawApiInterceptor", () => {
-//   let apiRoot: string;
-//   let http: HttpClient;
-//   let spec: SpectatorHttp<SecurityService>;
-//   const createService = createHttpFactory({
-//     service: SecurityService,
-//     imports: [HttpClientModule, MockBawApiModule],
-//   });
+describe("BawApiInterceptor", () => {
+  let apiRoot: string;
+  let http: HttpClient;
+  let spec: SpectatorHttp<BawSessionService>;
+  const createService = createHttpFactory({
+    service: BawSessionService,
+    imports: [HttpClientModule, MockBawApiModule],
+  });
 
-//   function getPath(path: string) {
-//     return apiRoot + path;
-//   }
+  function getPath(path: string) {
+    return apiRoot + path;
+  }
 
-//   function setLoggedOut() {
-//     spyOn(spec.service, "isLoggedIn").and.callFake(() => false);
-//     spyOn(spec.service, "getLocalUser").and.callFake(() => undefined);
-//   }
+  function setLoggedOut() {
+    spyOnProperty(spec.service, "isLoggedIn", "get").and.returnValue(false);
+    spyOnProperty(spec.service, "loggedInUser", "get").and.returnValue(
+      undefined
+    );
+  }
 
-//   function setLoggedIn(authToken?: string) {
-//     spyOn(spec.service, "isLoggedIn").and.callFake(() => true);
-//     spyOn(spec.service, "getLocalUser").and.callFake(() =>
-//       authToken
-//         ? new Session(generateSessionUser({ authToken }))
-//         : new Session(generateSessionUser())
-//     );
-//   }
+  function setLoggedIn(authToken?: string) {
+    spyOnProperty(spec.service, "isLoggedIn", "get").and.returnValue(true);
+    spyOnProperty(spec.service, "authToken", "get").and.returnValue(authToken);
+    spyOnProperty(spec.service, "loggedInUser", "get").and.returnValue(
+      new User(generateUser())
+    );
+  }
 
-//   beforeEach(() => {
-//     spec = createService();
-//     http = spec.inject(HttpClient);
-//     apiRoot = spec.inject(API_ROOT);
-//   });
+  beforeEach(() => {
+    spec = createService();
+    http = spec.inject(HttpClient);
+    apiRoot = spec.inject(API_ROOT);
+  });
 
-//   describe("error handling", () => {
-//     function convertErrorResponseToDetails(
-//       response: ApiResponse<null>
-//     ): ApiErrorDetails {
-//       return {
-//         status: response.meta.status,
-//         message: response.meta.error.details,
-//         info: response.meta.error.info,
-//       };
-//     }
+  describe("error handling", () => {
+    function convertErrorResponseToDetails(
+      response: BawApiError
+    ): ApiErrorDetails {
+      return {
+        status: response.status,
+        message: response.message,
+        info: response.info as any,
+      };
+    }
 
-//     beforeEach(() => setLoggedOut());
+    beforeEach(() => setLoggedOut());
 
-//     it("should handle api error response", () => {
-//       const error = generateApiErrorResponse("Unauthorized", {
-//         message: "Incorrect user name",
-//       });
+    it("should handle api error response", () => {
+      const error = generateBawApiError(
+        NOT_FOUND,
+        "The following action does not exist, if you believe this is an error please report a problem."
+      );
 
-//       http
-//         .get(getPath("/brokenapiroute"))
-//         .subscribe(shouldNotSucceed, (err) => {
-//           expect(err).toEqual(convertErrorResponseToDetails(error));
-//         });
+      http.get(getPath("/brokenapiroute")).subscribe({
+        next: shouldNotSucceed,
+        error: (err) => {
+          expect(err).toEqual(error);
+        },
+      });
 
-//       spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET).flush(error, {
-//         status: error.meta.status,
-//         statusText: error.meta.message,
-//       });
-//     });
+      spec
+        .expectOne(getPath("/brokenapiroute"), HttpMethod.GET)
+        .flush({}, { status: 404, statusText: "" });
+    });
 
-//     it("should handle api error response with info", () => {
-//       const error = generateApiErrorResponse("Unprocessable Entity", {
-//         info: { name: ["has already been taken"] },
-//       });
+    xit("should handle api error response with info", () => {
+      const error = generateBawApiError(UNPROCESSABLE_ENTITY, "", {
+        name: ["has already been taken"],
+      }) as any;
 
-//       http
-//         .get(getPath("/brokenapiroute"))
-//         .subscribe(shouldNotSucceed, (err) => {
-//           expect(err).toEqual(convertErrorResponseToDetails(error));
-//         });
+      http.get(getPath("/brokenapiroute")).subscribe({
+        next: shouldNotSucceed,
+        error: (err) => {
+          expect(err).toEqual(convertErrorResponseToDetails(error));
+        },
+      });
 
-//       spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET).flush(error, {
-//         status: error.meta.status,
-//         statusText: error.meta.message,
-//       });
-//     });
+      spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET).flush(error, {
+        status: error.meta.status,
+        statusText: error.meta.message,
+      });
+    });
 
-//     it("should handle http error response", () => {
-//       http
-//         .get(getPath("/brokenapiroute"))
-//         .subscribe(shouldNotSucceed, (err) => {
-//           expect(err).toEqual({
-//             status: 404,
-//             message: `Http failure response for ${apiRoot}/brokenapiroute: 404 Page Not Found`,
-//           });
-//         });
+    xit("should handle http error response", () => {
+      http.get(getPath("/brokenapiroute")).subscribe({
+        next: shouldNotSucceed,
+        error: (err) => {
+          expect(err).toEqual({
+            status: 404,
+            message: `Http failure response for ${apiRoot}/brokenapiroute: 404 Page Not Found`,
+          });
+        },
+      });
 
-//       spec
-//         .expectOne(getPath("/brokenapiroute"), HttpMethod.GET)
-//         .flush({}, { status: 404, statusText: "Page Not Found" });
-//     });
-//   });
+      spec
+        .expectOne(getPath("/brokenapiroute"), HttpMethod.GET)
+        .flush({}, { status: 404, statusText: "Page Not Found" });
+    });
+  });
 
-//   describe("non baw api traffic", () => {
-//     describe("outgoing data", () => {
-//       function makeRequest() {
-//         http.get("https://brokenlink").subscribe(noop, noop);
-//         return spec.expectOne("https://brokenlink", HttpMethod.GET);
-//       }
+  describe("non baw api traffic", () => {
+    describe("outgoing data", () => {
+      function makeRequest() {
+        http.get("https://brokenlink").subscribe(noop);
+        return spec.expectOne("https://brokenlink", HttpMethod.GET);
+      }
 
-//       it("should not set Authorization header when not logged in", () => {
-//         setLoggedOut();
-//         const req = makeRequest();
-//         expect(req.request.headers.has("Authorization")).toBeFalsy();
-//       });
+      it("should not set Authorization header when not logged in", () => {
+        setLoggedOut();
+        const req = makeRequest();
+        expect(req.request.headers.has("Authorization")).toBeFalsy();
+      });
 
-//       it("should not set Authorization header when logged in", () => {
-//         setLoggedIn();
-//         const req = makeRequest();
-//         expect(req.request.headers.has("Authorization")).toBeFalsy();
-//       });
+      it("should not set Authorization header when logged in", () => {
+        setLoggedIn();
+        const req = makeRequest();
+        expect(req.request.headers.has("Authorization")).toBeFalsy();
+      });
 
-//       it("should not convert into snake case for GET requests", () => {
-//         setLoggedOut();
-//         http
-//           .get("https://brokenlink/brokenapiroute", {
-//             params: new HttpParams().set("shouldNotConvert", "true"),
-//           })
-//           .subscribe(noop, noop);
-//         expect(
-//           spec.expectOne(
-//             "https://brokenlink/brokenapiroute?shouldNotConvert=true",
-//             HttpMethod.GET
-//           )
-//         ).toBeInstanceOf(TestRequest);
-//       });
+      it("should not convert into snake case for GET requests", () => {
+        setLoggedOut();
+        http
+          .get("https://brokenlink/brokenapiroute", {
+            params: new HttpParams().set("shouldNotConvert", "true"),
+          })
+          .subscribe(noop);
+        expect(
+          spec.expectOne(
+            "https://brokenlink/brokenapiroute?shouldNotConvert=true",
+            HttpMethod.GET
+          )
+        ).toBeInstanceOf(TestRequest);
+      });
 
-//       it("should not convert into snake case for POST requests", () => {
-//         setLoggedOut();
-//         http
-//           .post("https://brokenlink/brokenapiroute", {
-//             shouldNotConvert: true,
-//           })
-//           .subscribe(noop, noop);
+      it("should not convert into snake case for POST requests", () => {
+        setLoggedOut();
+        http
+          .post("https://brokenlink/brokenapiroute", {
+            shouldNotConvert: true,
+          })
+          .subscribe(noop);
 
-//         const req = spec.expectOne(
-//           "https://brokenlink/brokenapiroute",
-//           HttpMethod.POST
-//         );
-//         expect(req.request.body).toEqual({ shouldNotConvert: true });
-//       });
-//     });
+        const req = spec.expectOne(
+          "https://brokenlink/brokenapiroute",
+          HttpMethod.POST
+        );
+        expect(req.request.body).toEqual({ shouldNotConvert: true });
+      });
+    });
 
-//     describe("incoming data", () => {
-//       beforeEach(() => setLoggedOut());
+    describe("incoming data", () => {
+      beforeEach(() => setLoggedOut());
 
-//       it("should not convert into camel case for GET requests", () => {
-//         http
-//           .get("https://brokenlink/brokenapiroute")
-//           .subscribe(
-//             (response) => expect(response).toEqual({ dummy_response: true }),
-//             shouldNotFail
-//           );
-//         spec
-//           .expectOne("https://brokenlink/brokenapiroute", HttpMethod.GET)
-//           .flush({ dummy_response: true });
-//       });
+      it("should not convert into camel case for GET requests", () => {
+        http.get("https://brokenlink/brokenapiroute").subscribe({
+          next: (response) =>
+            expect(response).toEqual({ dummy_response: true }),
+          error: shouldNotFail,
+        });
+        spec
+          .expectOne("https://brokenlink/brokenapiroute", HttpMethod.GET)
+          .flush({ dummy_response: true });
+      });
 
-//       it("should not convert into camel case for POST requests", () => {
-//         http
-//           .post("https://brokenlink/brokenapiroute", {})
-//           .subscribe(
-//             (response) => expect(response).toEqual({ dummy_response: true }),
-//             shouldNotFail
-//           );
-//         spec
-//           .expectOne("https://brokenlink/brokenapiroute", HttpMethod.POST)
-//           .flush({ dummy_response: true });
-//       });
-//     });
-//   });
+      it("should not convert into camel case for POST requests", () => {
+        http.post("https://brokenlink/brokenapiroute", {}).subscribe({
+          next: (response) =>
+            expect(response).toEqual({ dummy_response: true }),
+          error: shouldNotFail,
+        });
+        spec
+          .expectOne("https://brokenlink/brokenapiroute", HttpMethod.POST)
+          .flush({ dummy_response: true });
+      });
+    });
+  });
 
-//   describe("baw api traffic", () => {
-//     describe("outgoing data", () => {
-//       it("should set cookies", () => {
-//         setLoggedOut();
-//         http.get(getPath("/brokenapiroute")).subscribe(noop, noop);
-//         const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
-//         expect(req.request.withCredentials).toBeTrue();
-//       });
+  describe("baw api traffic", () => {
+    describe("outgoing data", () => {
+      it("should set cookies", () => {
+        setLoggedOut();
+        http.get(getPath("/brokenapiroute")).subscribe(noop);
+        const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
+        expect(req.request.withCredentials).toBeTrue();
+      });
 
-//       it("should convert into snake case for GET requests", () => {
-//         setLoggedOut();
-//         http
-//           .get(getPath("/brokenapiroute"), {
-//             params: new HttpParams().set("shouldConvert", "true"),
-//           })
-//           .subscribe(noop, noop);
+      it("should convert into snake case for GET requests", () => {
+        setLoggedOut();
+        http
+          .get(getPath("/brokenapiroute"), {
+            params: new HttpParams().set("shouldConvert", "true"),
+          })
+          .subscribe(noop);
 
-//         expect(
-//           spec.expectOne(
-//             getPath("/brokenapiroute?should_convert=true"),
-//             HttpMethod.GET
-//           )
-//         ).toBeInstanceOf(TestRequest);
-//       });
+        expect(
+          spec.expectOne(
+            getPath("/brokenapiroute?should_convert=true"),
+            HttpMethod.GET
+          )
+        ).toBeInstanceOf(TestRequest);
+      });
 
-//       it("should convert into snake case for POST requests", () => {
-//         setLoggedOut();
-//         http
-//           .post(getPath("/brokenapiroute"), { shouldConvert: true })
-//           .subscribe(noop, noop);
-//         const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.POST);
-//         expect(req.request.body).toEqual({ should_convert: true });
-//       });
+      it("should convert into snake case for POST requests", () => {
+        setLoggedOut();
+        http
+          .post(getPath("/brokenapiroute"), { shouldConvert: true })
+          .subscribe(noop);
+        const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.POST);
+        expect(req.request.body).toEqual({ should_convert: true });
+      });
 
-//       it("should not attach Authorization when unauthenticated", () => {
-//         setLoggedOut();
-//         http.get(getPath("/brokenapiroute")).subscribe(noop, noop);
-//         const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
-//         expect(req.request.headers.has("Authorization")).toBeFalsy();
-//       });
+      it("should not attach Authorization when unauthenticated", () => {
+        setLoggedOut();
+        http.get(getPath("/brokenapiroute")).subscribe(noop);
+        const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
+        expect(req.request.headers.has("Authorization")).toBeFalsy();
+      });
 
-//       it("should attach Authorization when authenticated", () => {
-//         setLoggedIn("xxxxxxxxxxxxxxxxxxxx");
-//         http.get(getPath("/brokenapiroute")).subscribe(noop, noop);
-//         const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
-//         expect(req.request.headers.get("Authorization")).toBe(
-//           'Token token="xxxxxxxxxxxxxxxxxxxx"'
-//         );
-//       });
-//     });
+      it("should not attach Authorization when unauthenticated and the credentials context is explicitly set", () => {
+        const mockContext = new HttpContext().set(CREDENTIALS_CONTEXT, true);
+        setLoggedOut();
 
-//     describe("incoming data", () => {
-//       beforeEach(() => setLoggedOut());
+        http
+          .get(getPath("/brokenapiroute"), {
+            context: mockContext,
+          })
+          .subscribe(noop);
 
-//       it("should convert into camel case for GET requests", () => {
-//         http
-//           .get(getPath("/brokenapiroute"))
-//           .subscribe(
-//             (response) => expect(response).toEqual({ dummyResponse: true }),
-//             shouldNotFail
-//           );
+        const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
 
-//         spec
-//           .expectOne(getPath("/brokenapiroute"), HttpMethod.GET)
-//           .flush({ dummy_response: true });
-//       });
+        expect(req.request.headers.has("Authorization")).toBeFalsy();
+      });
 
-//       it("should convert incoming data from baw api into camel case for POST requests", () => {
-//         http
-//           .post(getPath("/brokenapiroute"), {})
-//           .subscribe(
-//             (response) => expect(response).toEqual({ dummyResponse: true }),
-//             shouldNotFail
-//           );
+      it("should attach Authorization when authenticated and the credentials context is not set", () => {
+        setLoggedIn("xxxxxxxxxxxxxxxxxxxx");
+        http.get(getPath("/brokenapiroute")).subscribe(noop);
+        const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
+        expect(req.request.headers.get("Authorization")).toBe(
+          'Token token="xxxxxxxxxxxxxxxxxxxx"'
+        );
+      });
 
-//         spec
-//           .expectOne(getPath("/brokenapiroute"), HttpMethod.POST)
-//           .flush({ dummy_response: true });
-//       });
-//     });
-//   });
-// });
+      it("should not attach Authorization when the credentials context has set to false", () => {
+        const mockContext = new HttpContext().set(CREDENTIALS_CONTEXT, false);
+
+        setLoggedIn("xxxxxxxxxxxxxxxxxxxx");
+
+        http
+          .get(getPath("/brokenapiroute"), {
+            context: mockContext,
+          })
+          .subscribe(noop);
+
+        const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
+
+        expect(req.request.headers.has("Authorization")).toBeFalse();
+      });
+
+      it("should attach Authorization when the credentials context is explicitly set to true", () => {
+        const mockContext = new HttpContext().set(CREDENTIALS_CONTEXT, true);
+
+        setLoggedIn("xxxxxxxxxxxxxxxxxxxx");
+
+        http
+          .get(getPath("/brokenapiroute"), {
+            context: mockContext,
+          })
+          .subscribe(noop);
+
+        const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
+
+        expect(req.request.headers.get("Authorization")).toBe(
+          'Token token="xxxxxxxxxxxxxxxxxxxx"'
+        );
+      });
+
+      it("should default to attaching Authorization when the credentials context is not set", () => {
+        setLoggedIn("xxxxxxxxxxxxxxxxxxxx");
+
+        http.get(getPath("/brokenapiroute")).subscribe(noop);
+
+        const req = spec.expectOne(getPath("/brokenapiroute"), HttpMethod.GET);
+
+        expect(req.request.headers.get("Authorization")).toBe(
+          'Token token="xxxxxxxxxxxxxxxxxxxx"'
+        );
+      });
+    });
+
+    describe("incoming data", () => {
+      beforeEach(() => setLoggedOut());
+
+      it("should convert into camel case for GET requests", () => {
+        http.get(getPath("/brokenapiroute")).subscribe({
+          next: (response) => expect(response).toEqual({ dummyResponse: true }),
+          error: shouldNotFail,
+        });
+
+        spec
+          .expectOne(getPath("/brokenapiroute"), HttpMethod.GET)
+          .flush({ dummy_response: true });
+      });
+
+      it("should convert incoming data from baw api into camel case for POST requests", () => {
+        http.post(getPath("/brokenapiroute"), {}).subscribe({
+          next: (response) => expect(response).toEqual({ dummyResponse: true }),
+          error: shouldNotFail,
+        });
+
+        spec
+          .expectOne(getPath("/brokenapiroute"), HttpMethod.POST)
+          .flush({ dummy_response: true });
+      });
+    });
+  });
+});

--- a/src/app/services/baw-api/harvest/harvest.service.ts
+++ b/src/app/services/baw-api/harvest/harvest.service.ts
@@ -61,7 +61,7 @@ export class HarvestsService implements StandardApi<Harvest, [IdOr<Project>]> {
     project: IdOr<Project>
   ): Observable<Harvest> {
     return this.api.show(Harvest, endpoint(project, model, emptyParam), {
-      disableCache: true,
+      cacheOptions: { cache: false },
     });
   }
 

--- a/src/app/services/baw-api/website-status/website-status.service.spec.ts
+++ b/src/app/services/baw-api/website-status/website-status.service.spec.ts
@@ -1,12 +1,20 @@
-import { SpectatorService, createServiceFactory } from "@ngneat/spectator";
+import {
+  SpectatorService,
+  SpyObject,
+  createServiceFactory,
+} from "@ngneat/spectator";
 import {
   mockServiceImports,
   mockServiceProviders,
 } from "@test/helpers/api-common";
+import { BawApiService } from "@baw-api/baw-api.service";
+import { WebsiteStatus } from "@models/WebsiteStatus";
+import { of } from "rxjs";
 import { WebsiteStatusService } from "./website-status.service";
 
 describe("WebsiteStatusService", () => {
   let spec: SpectatorService<WebsiteStatusService>;
+  let mockApi: SpyObject<BawApiService<WebsiteStatus>>;
 
   const createService = createServiceFactory({
     service: WebsiteStatusService,
@@ -15,7 +23,11 @@ describe("WebsiteStatusService", () => {
   });
 
   function setup(): void {
-    spec = createService();
+    spec = createService({});
+
+    mockApi = spec.inject(BawApiService<WebsiteStatus>);
+    mockApi.httpGet = jasmine.createSpy("httpGet") as any;
+    mockApi.httpGet.and.returnValue(of());
 
     jasmine.clock().install();
     jasmine.clock().mockDate(new Date("2020-01-01T00:00:00.000+09:30"));
@@ -29,5 +41,21 @@ describe("WebsiteStatusService", () => {
 
   it("should create", () => {
     expect(spec.service).toBeInstanceOf(WebsiteStatusService);
+  });
+
+  it("should call httpGet with the correct options", () => {
+    const expectedHeaders = spec.service["requestHeaders"];
+    const expectedOptions = {
+      cacheOptions: { cache: false },
+      withCredentials: false,
+    };
+
+    spec.service["show"]().subscribe();
+
+    expect(mockApi.httpGet).toHaveBeenCalledWith(
+      "/status",
+      expectedHeaders,
+      expectedOptions
+    );
   });
 });

--- a/src/app/services/baw-api/website-status/website-status.service.ts
+++ b/src/app/services/baw-api/website-status/website-status.service.ts
@@ -61,9 +61,12 @@ export class WebsiteStatusService {
   private show(): Observable<WebsiteStatus | null> {
     const endpoint = "/status";
 
-    // we use our custom api.httpGet so that this service using our site wide
-    // caching config (and can be overwritten by the caller in a uniform manner)
-    return (this.api.httpGet(endpoint, this.requestHeaders) as any).pipe(
+    return (
+      this.api.httpGet(endpoint, this.requestHeaders, {
+        cacheOptions: { cache: false },
+        withCredentials: false,
+      }) as any
+    ).pipe(
       map((response: IWebsiteStatus) => new WebsiteStatus(response)),
       catchError((err: BawApiError | Error) => {
         const bawError = isBawApiError(err)


### PR DESCRIPTION
# Don't send auth token when calling `/status`

At the moment, the website status service contacts the `/status` endpoint with a Bearer token in the `Authentication` request headers.

This can cause the request to fail and incorrectly report an "Unhealthy" status when the website is actually healthy.

**_This PR modifies some very critical code that impacts a vast majority of the website_**

## Changes

- Adds `AUTHENTICATION_CONTEXT` token to `api.interceptor.service.ts`. This allows us to conditionally append the `Authentication` token in the interceptor (defaults to sending the auth token)
- Adds `withCredentials` to `baw-api.service.ts` `httpGet`, `httpPost`, `httpPut`, and `httpDelete`. This option takes a property `{ withCredentials: boolean }` that can be used to conditionally add the auth token to requests
- Combines all the options for baw api services into one interface called `BawServiceOptions`
- Refactors all services that use the old options config style to the new config style
- Explicitly sets caching strategy in the `website-status.service.ts` (to prevent regressions in the future where we could change the caching strategy without considering this service)
- Adds tests for the above
- Renames `options` in `baw-api.service.ts` http functions to `headers` (because they are always used in the headers, and it can now cause confusion as these methods can take option objects)
- Re-enables a majority of api interceptor tests (these are currently commented out, outdated, and non-functional)

## Problems

None

## Issues

Fixes: #2124 

## Visual Changes

None

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [x] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
