### PR TITLE
Add menu item to download a projects annotations

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -81,8 +81,11 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macOS-latest
           - windows-latest
+          # TODO: Re-enable. This is currently disabled because the CI can't find the FIREFOX_BIN environment variable
+          # this might be a bug with the macOS image provided by GitHub or the karma-firefox-launcher that we use
+          # (which is deprecated)
+          # - macOS-latest
         browsers:
           - ChromeHeadless
           - FirefoxHeadless

--- a/src/app/components/projects/pages/details/details.component.ts
+++ b/src/app/components/projects/pages/details/details.component.ts
@@ -18,7 +18,7 @@ import {
   projectMenuItem,
   projectsMenuItem,
 } from "@components/projects/projects.menus";
-import { deleteProjectModal } from "@components/projects/projects.modals";
+import { deleteProjectModal, projectAnnotationsModal } from "@components/projects/projects.modals";
 import { newSiteMenuItem } from "@components/sites/sites.menus";
 import { reportMenuItems } from "@components/reports/reports.menu";
 import { visualizeMenuItem } from "@components/visualize/visualize.menus";
@@ -44,6 +44,7 @@ export const projectMenuItemActions = [
   deleteProjectModal,
   newSiteMenuItem,
   assignSiteMenuItem,
+  projectAnnotationsModal,
   audioRecordingMenuItems.list.project,
   audioRecordingMenuItems.batch.project,
   harvestsMenuItem,

--- a/src/app/components/projects/projects.modals.ts
+++ b/src/app/components/projects/projects.modals.ts
@@ -1,8 +1,17 @@
 import { menuModal } from "@menu/widgetItem";
 import { DeleteModalComponent } from "@shared/delete-modal/delete-modal.component";
-import { defaultDeleteIcon, isProjectEditorPredicate } from "src/app/app.menus";
+import { defaultAnnotationDownloadIcon, defaultDeleteIcon, isProjectEditorPredicate } from "src/app/app.menus";
+import { AnnotationDownloadComponent } from "@shared/annotation-download/annotation-download.component";
 import { projectMenuItem } from "./projects.menus";
 import { DetailsComponent } from "./pages/details/details.component";
+
+export const projectAnnotationsModal = menuModal({
+  icon: defaultAnnotationDownloadIcon,
+  label: "Download Annotations",
+  tooltip: () => "Download annotations for this project",
+  component: AnnotationDownloadComponent,
+  modalOpts: {},
+});
 
 export const deleteProjectModal = menuModal({
   icon: defaultDeleteIcon,

--- a/src/app/components/shared/annotation-download/annotation-download.component.ts
+++ b/src/app/components/shared/annotation-download/annotation-download.component.ts
@@ -15,6 +15,7 @@ import { Site } from "@models/Site";
 import { FormlyFieldConfig } from "@ngx-formly/core";
 import { SharedActivatedRouteService } from "@services/shared-activated-route/shared-activated-route.service";
 import { takeUntil } from "rxjs";
+import { ProjectsService } from "@baw-api/project/projects.service";
 import schema from "./annotations-download.schema.json";
 
 interface TimezoneModel {
@@ -40,19 +41,21 @@ interface TimezoneModel {
         <span id="subTitle">
           <p>
             The annotations in the CSV will have all their dates and times set
-            to a time zone of your choice. The default time zone is the local
-            time for the
-            {{ region ? "point" : "site" }} where the audio was recorded.
+            to a time zone of your choice.
+            <ng-container *ngIf="site">
+              The default time zone is the local time for the
+              {{ region ? "point" : "site" }} where the audio was recorded.
+            </ng-container>
           </p>
-          <p>
+          <p *ngIf="site">
             For example, annotations created for audio from Brisbane will have
-            dates and times set to AEST (+10).
+            dates and times set to AEST (+10:00).
           </p>
           <p>
-            However, if you have recordings from Brisbane and Perth, which time
+            If you have recordings from Brisbane and Perth, which time
             zone do we choose for all downloaded events?
           </p>
-          <p>AEST (+10) or AWST (+8) or UTC (+0)?</p>
+          <p>AEST (+10:00) or AWST (+08:00) or UTC (+00:00)?</p>
           <p>
             It depends on how you want to work with your data, so the choice is
             yours. Please select the time zone you wish to use:
@@ -85,12 +88,13 @@ export class AnnotationDownloadComponent
   public fields: FormlyFieldConfig[] = schema.fields;
   public form = new FormGroup({});
   public model: TimezoneModel = { timezone: "UTC" };
-  public project?: Project;
+  public project: Project;
   public region?: Region;
   public site?: Site;
 
   public constructor(
     private siteApi: SitesService,
+    private projectApi: ProjectsService,
     private sharedRoute: SharedActivatedRouteService
   ) {
     super();
@@ -111,10 +115,11 @@ export class AnnotationDownloadComponent
         this.project = retrieveResolvedModel(pageInfo, Project);
         this.region = retrieveResolvedModel(pageInfo, Region);
         this.site = retrieveResolvedModel(pageInfo, Site);
-        this.model.timezone = this.site.tzinfoTz ?? this.model.timezone;
+        this.model.timezone = this.site?.tzinfoTz ?? this.model.timezone;
       });
   }
 
+  // TODO: add support for region scoped annotation downloads
   public getAnnotationsPath(): string {
     // if the timezone is UTC, vvo/tzdb will return Etc/UTC
     // because the API expects UTC timezones to have the value "UTC", we change "Etc/UTC" to "UTC" when we send the
@@ -122,10 +127,14 @@ export class AnnotationDownloadComponent
     const timezone =
       this.model.timezone === "Etc/UTC" ? "UTC" : this.model.timezone;
 
-    return this.siteApi.downloadAnnotations(
-      this.site,
-      this.region?.projectId ?? this.project,
-      timezone
-    );
+    if (this.site) {
+      return this.siteApi.downloadAnnotations(
+        this.site,
+        this.region?.projectId ?? this.project,
+        timezone
+      );
+    }
+
+    return this.projectApi.downloadAnnotations(this.project, timezone);
   }
 }

--- a/src/app/services/baw-api/project/projects.service.ts
+++ b/src/app/services/baw-api/project/projects.service.ts
@@ -10,6 +10,7 @@ import {
   IdOr,
   IdParamOptional,
   option,
+  param,
   StandardApi,
 } from "../api-common";
 import { BawApiService, Filters } from "../baw-api.service";
@@ -18,6 +19,7 @@ import { ShowDefaultResolver } from "../ShowDefaultResolver";
 
 const projectId: IdParamOptional<Project> = id;
 const endpoint = stringTemplate`/projects/${projectId}${option}`;
+const annotationsEndpoint = stringTemplate`/projects/${projectId}/audio_events/download?${param}`;
 
 /**
  * Projects Service.
@@ -64,6 +66,17 @@ export class ProjectsService implements StandardApi<Project> {
     return this.filter(
       this.api.filterThroughAssociation(filters, "creatorId", user)
     );
+  }
+
+  public downloadAnnotations(
+    model: IdOr<Project>,
+    selectedTimezone: string
+  ): string {
+    const url = new URL(
+      this.api.getPath(annotationsEndpoint(model, emptyParam))
+    );
+    url.searchParams.set("selected_timezone_name", selectedTimezone);
+    return url.toString();
   }
 }
 


### PR DESCRIPTION
# Add menu item to download a projects annotations

There is the need to download annotations at the project level.

This PR adds a "Download Annotations" menu item that allows users to download annotations at the project level.

## Changes

- Add the annotations-download modal to the projects menu
- Add unit tests for project level annotation downloads
- The text in the annotation download modal doesn't state that The default time zone is the local time for the site where the audio was recorded." if downloading from a project. This was done because downloading without a `selected_timezone_name` qsp still converts all the dates/times to UTC [example](https://api.staging.ecosounds.org/projects/1135/audio_events/download). Meaning that it's not possible to replicate this behavior for project level annotation downloads.

## Problems

Because this PR does not add support for downloading annotations from regions, this PR does not fulfill the requirements needed to fully resolve #2080

## Issues

Related to: #2080 

## Visual Changes

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/a967d857-9c2f-44b7-8c05-d05f6381c14d)

_The new dialog to download annotations at the project level_

![image](https://github.com/QutEcoacoustics/workbench-client/assets/33742269/15ef54aa-be5e-4c1f-b99a-237cf37c7e6f)

_The new project menu items_

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
