### PR TITLE
Fix new site form not submitting with project_ids

### DIFF
--- a/src/app/components/sites/pages/new/new.component.spec.ts
+++ b/src/app/components/sites/pages/new/new.component.spec.ts
@@ -117,7 +117,6 @@ describe("SiteNewComponent", () => {
           expect(spec.component).toBeTruthy();
         });
 
-        // TODO Validate region id is set in api call
         it("should call api", () => {
           setup(defaultProject, defaultRegion);
           api.create.and.callFake(() => new Subject());
@@ -128,6 +127,27 @@ describe("SiteNewComponent", () => {
           spec.component.submit({ ...site });
           expect(api.create).toHaveBeenCalledWith(
             new Site({ ...site }),
+            defaultProject
+          );
+        });
+
+        it("should contain the region and project id in the api calls site model", () => {
+          setup(defaultProject, defaultRegion);
+          api.create.and.callFake(() => new Subject());
+          const site = new Site(
+            generateSite(withRegion ? { regionId: defaultRegion.id } : {})
+          );
+
+          spec.component.submit({ ...site });
+
+          const expectedSiteModel = new Site({
+            ...site,
+            projectIds: [defaultProject.id],
+            regionId: withRegion ? defaultRegion.id : undefined,
+          });
+
+          expect(api.create).toHaveBeenCalledWith(
+            expectedSiteModel,
             defaultProject
           );
         });

--- a/src/app/components/sites/pages/new/new.component.ts
+++ b/src/app/components/sites/pages/new/new.component.ts
@@ -40,7 +40,23 @@ class SiteNewComponent extends FormTemplate<Site> implements OnInit {
       successMsg: (model) => defaultSuccessMsg("created", model.name),
       redirectUser: (model) =>
         this.router.navigateByUrl(model.getViewUrl(this.project)),
-      getModel: () => (this.region ? { regionId: this.region.id } : {}),
+      getModel: () => {
+        // TODO: for some reason if we use a set here, the project ids don't get
+        // serialized correctly when sending the model body
+        // to get around this, I've used an array and cast to any
+        // we should figure out why we need this type casing and fix it in the
+        // correct way
+        const projectIds = [this.project.id] as any;
+
+        if (this.region) {
+          return {
+            regionId: this.region.id,
+            projectIds,
+          };
+        }
+
+        return { projectIds };
+      },
     });
   }
 


### PR DESCRIPTION
# Fix new site form not submitting with project_ids

Following a change to the baw-server which required an array of project_ids to be sent while site creation, the new site form started throwing errors which stopped users from creating new sites.

This commit now sends project_ids when creating a new site, fixing the bug which stopped users from creating new sites.

## Changes

- The base site model used for the new site form to include the currently scoped project in the `projectIds` base model property
- Add tests to assert that both `regionId` and `projectIds` are sent with the correct data

## Problems

N.A.

## Issues

Fixes: #2143

## Visual Changes

N.A.

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
