### PR TITLE
Fix downloading verification grid results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/platform-server": "17.1.2",
         "@angular/router": "17.1.2",
         "@angular/ssr": "^17.1.2",
-        "@ecoacoustics/web-components": "1.2.0",
+        "@ecoacoustics/web-components": "^1.2.2",
         "@fortawesome/angular-fontawesome": "^0.14.1",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
@@ -2837,9 +2837,9 @@
       }
     },
     "node_modules/@ecoacoustics/web-components": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ecoacoustics/web-components/-/web-components-1.2.0.tgz",
-      "integrity": "sha512-OWeJE8E4kd+bhcW6zuPKEv4yCKGnxlYrE6ATou4Pit0OR0HbnwcmnZ65OiyXdxEsZxlhbN9J/UqYAxAXEbwI6w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@ecoacoustics/web-components/-/web-components-1.2.2.tgz",
+      "integrity": "sha512-HGtrZ3fxLiNmj2LG4oEgpCauAKI9wdXqglhYPmAULx9UCUXPOUBo3g7npJavBM7q+OXU7z6GmMh+91J6YaIP2Q==",
       "dependencies": {
         "@json2csv/plainjs": "^7.0.6",
         "@lit-labs/preact-signals": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@angular/platform-server": "17.1.2",
     "@angular/router": "17.1.2",
     "@angular/ssr": "^17.1.2",
-    "@ecoacoustics/web-components": "1.2.0",
+    "@ecoacoustics/web-components": "^1.2.2",
     "@fortawesome/angular-fontawesome": "^0.14.1",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",

--- a/src/app/components/annotations/pages/search/search.component.spec.ts
+++ b/src/app/components/annotations/pages/search/search.component.spec.ts
@@ -3,7 +3,11 @@ import { Params } from "@angular/router";
 import { of } from "rxjs";
 import { CUSTOM_ELEMENTS_SCHEMA, INJECTOR, Injector } from "@angular/core";
 import { modelData } from "@test/helpers/faker";
-import { MEDIA, SHALLOW_AUDIO_EVENT, SHALLOW_SITE } from "@baw-api/ServiceTokens";
+import {
+  MEDIA,
+  SHALLOW_AUDIO_EVENT,
+  SHALLOW_SITE,
+} from "@baw-api/ServiceTokens";
 import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
 import { SharedModule } from "@shared/shared.module";
 import { RouterTestingModule } from "@angular/router/testing";
@@ -113,7 +117,7 @@ describe("AnnotationSearchComponent", () => {
       generateAnnotation({
         audioRecording: mockAudioRecording,
       }),
-      mediaServiceSpy
+      injector
     );
 
     audioEventsApiSpy = spectator.inject(SHALLOW_AUDIO_EVENT.token);
@@ -194,7 +198,7 @@ describe("AnnotationSearchComponent", () => {
 
     const element = getElementByInnerText(spectator, expectedText);
     expect(element).not.toExist();
-  })
+  });
 
   it("should display a page of search results", () => {
     spectator.detectChanges();

--- a/src/app/components/shared/audio-event-card/annotation-event-card.component.spec.ts
+++ b/src/app/components/shared/audio-event-card/annotation-event-card.component.spec.ts
@@ -74,7 +74,7 @@ describe("AudioEventCardComponent", () => {
         endTimeSeconds: 5,
         tags: [mockTag],
       }),
-      mediaServiceSpy
+      injectorSpy
     );
 
     audioRecordingApiSpy = spectator.inject(AUDIO_RECORDING.token);

--- a/src/app/components/web-components/grid-tile-content/grid-tile-content.component.spec.ts
+++ b/src/app/components/web-components/grid-tile-content/grid-tile-content.component.spec.ts
@@ -9,20 +9,19 @@ import { getElementByInnerText } from "@test/helpers/html";
 import { SpectrogramComponent } from "@ecoacoustics/web-components/@types/components/spectrogram/spectrogram";
 import { Annotation } from "@models/data/Annotation";
 import { generateAnnotation } from "@test/fakes/data/Annotation";
-import { MediaService } from "@services/media/media.service";
-import { MEDIA } from "@baw-api/ServiceTokens";
 import { AnnotationService } from "@services/models/annotation.service";
 import { AudioRecording } from "@models/AudioRecording";
 import { generateAudioRecording } from "@test/fakes/AudioRecording";
 import { patchSharedArrayBuffer } from "src/patches/tests/testPatches";
 import { detectChanges } from "@test/helpers/changes";
 import { testAsset } from "@test/helpers/karma";
+import { INJECTOR, Injector } from "@angular/core";
 import { GridTileContentComponent } from "./grid-tile-content.component";
 
 describe("GridTileContentComponent", () => {
   let spectator: Spectator<GridTileContentComponent>;
 
-  let mediaServiceSpy: SpyObject<MediaService>;
+  let injectorSpy: SpyObject<Injector>;
   let contextRequestSpy: jasmine.Spy;
 
   let mockAnnotation: Annotation;
@@ -44,15 +43,14 @@ describe("GridTileContentComponent", () => {
       ],
     });
 
-    mediaServiceSpy = spectator.inject(MEDIA.token);
+    injectorSpy = spectator.inject(INJECTOR);
 
     // I hard code the audio recording duration and event start/end times so
     // that I know the audio event will neatly fit within the audio recording
     // when context is added
     mockAudioRecording = new AudioRecording(
-      generateAudioRecording({
-        durationSeconds: 600,
-      })
+      generateAudioRecording({ durationSeconds: 600 }),
+      injectorSpy
     );
 
     mockAudioRecording.getMediaUrl = jasmine
@@ -66,7 +64,7 @@ describe("GridTileContentComponent", () => {
         audioRecording: mockAudioRecording,
         audioRecordingId: mockAudioRecording.id,
       }),
-      mediaServiceSpy
+      injectorSpy
     );
 
     updateContext(mockAnnotation);
@@ -112,10 +110,7 @@ describe("GridTileContentComponent", () => {
     });
 
     it("should have the correct audio link if a new subject is provided", () => {
-      const newTestSubject = new Annotation(
-        generateAnnotation(),
-        mediaServiceSpy
-      );
+      const newTestSubject = new Annotation(generateAnnotation(), injectorSpy);
       updateContext(newTestSubject);
 
       const expectedHref = newTestSubject.viewUrl;

--- a/src/app/models/data/Annotation.ts
+++ b/src/app/models/data/Annotation.ts
@@ -1,3 +1,4 @@
+import { MEDIA } from "@baw-api/ServiceTokens";
 import { annotationMenuItem } from "@components/library/library.menus";
 import { listenRecordingMenuItem } from "@components/listen/listen.menus";
 import { DateTimeTimezone } from "@interfaces/apiInterfaces";
@@ -19,11 +20,6 @@ export interface IAnnotation extends Required<IAudioEvent> {
 //
 // this model is created from the AnnotationService and MediaService's
 export class Annotation extends AbstractModelWithoutId implements IAnnotation {
-  public constructor(data: IAnnotation, mediaService: MediaService) {
-    super(data);
-    this.mediaService = mediaService;
-  }
-
   public id: number;
   public audioRecordingId: number;
   public startTimeSeconds: number;
@@ -42,7 +38,9 @@ export class Annotation extends AbstractModelWithoutId implements IAnnotation {
   public tags: ITag[];
   public audioRecording: AudioRecording;
 
-  private mediaService: MediaService;
+  public get mediaService(): MediaService {
+    return this.injector.get(MEDIA.token);
+  }
 
   public get viewUrl(): string {
     return annotationMenuItem.route.format({

--- a/src/app/services/models/annotation.service.ts
+++ b/src/app/services/models/annotation.service.ts
@@ -15,15 +15,13 @@ import { AudioEvent } from "@models/AudioEvent";
 import { AudioRecording } from "@models/AudioRecording";
 import { Annotation } from "@models/data/Annotation";
 import { Tag } from "@models/Tag";
-import { MediaService } from "@services/media/media.service";
 import { firstValueFrom, Observable, of } from "rxjs";
 
 @Injectable()
 export class AnnotationService {
   public constructor(
     private tagsApi: TagsService,
-    private audioRecordingsApi: AudioRecordingsService,
-    private mediaService: MediaService
+    private audioRecordingsApi: AudioRecordingsService
   ) {}
 
   public async show(audioEvent: AudioEvent): Promise<Annotation> {
@@ -40,7 +38,7 @@ export class AnnotationService {
       audioRecording,
     };
 
-    return new Annotation(data as any, this.mediaService);
+    return new Annotation(data);
   }
 
   private async showTags(audioEvent: AudioEvent): Promise<Tag[]> {

--- a/src/app/test/helpers/changes.ts
+++ b/src/app/test/helpers/changes.ts
@@ -11,9 +11,7 @@ import { Spectator } from "@ngneat/spectator";
  *
  * @param spectator The spectator instance to detect changes on
  */
-export async function detectChanges<T>(
-  spectator: Spectator<T>
-) {
+export async function detectChanges<T>(spectator: Spectator<T>) {
   do {
     // Detect changes in Angular components
     spectator.detectChanges();
@@ -37,6 +35,7 @@ export async function detectChanges<T>(
       "oe-indicator",
       "oe-axes",
       "oe-verification-grid",
+      "oe-data-source",
     ];
 
     const webComponents: any[] = [];

--- a/src/app/test/helpers/html.ts
+++ b/src/app/test/helpers/html.ts
@@ -131,3 +131,21 @@ export function assertTooltip(element: HTMLElement, content: string) {
 
   element.dispatchEvent(new MouseEvent("mouseleave"));
 }
+
+export async function waitUntil(
+  condition: () => boolean,
+  timeout = 5_000,
+  interval = 100
+): Promise<void> {
+  const endTime = Date.now() + timeout;
+
+  while (Date.now() < endTime) {
+    if (condition()) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+
+  throw new Error("Timeout exceeded while waiting for condition");
+}


### PR DESCRIPTION
# Fix downloading verification grid results

Downloading verification grid results was previously broken due to injected services being included in the `toJSON` output

## Changes

- Uses the injector to get the `mediaService` instance in the `Annotation` model. Allowing for advanced DI and improves consistancy with how other services are injected in other models (e.g. for association services)
- Bumps web components version for selection highlight box fixes (also enables automatic minor version bumps through the `^` prefix)

## Issues

Fixes: #2157

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
