### PR TITLE
fix: verification grid result downloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/platform-server": "17.1.2",
         "@angular/router": "17.1.2",
         "@angular/ssr": "^17.1.2",
-        "@ecoacoustics/web-components": "^1.2.2",
+        "@ecoacoustics/web-components": "^1.2.5",
         "@fortawesome/angular-fontawesome": "^0.14.1",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
@@ -2837,9 +2837,9 @@
       }
     },
     "node_modules/@ecoacoustics/web-components": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@ecoacoustics/web-components/-/web-components-1.2.2.tgz",
-      "integrity": "sha512-HGtrZ3fxLiNmj2LG4oEgpCauAKI9wdXqglhYPmAULx9UCUXPOUBo3g7npJavBM7q+OXU7z6GmMh+91J6YaIP2Q==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@ecoacoustics/web-components/-/web-components-1.2.5.tgz",
+      "integrity": "sha512-OmshN95yJAzSQf+CPBsFujRDRw5A3353Yi4EXJAO8MgG+/ZG83BrC6dsyuzJEFpA9Sz89UwIlceyKvC7TLvmXw==",
       "dependencies": {
         "@json2csv/plainjs": "^7.0.6",
         "@lit-labs/preact-signals": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@angular/platform-server": "17.1.2",
     "@angular/router": "17.1.2",
     "@angular/ssr": "^17.1.2",
-    "@ecoacoustics/web-components": "^1.2.2",
+    "@ecoacoustics/web-components": "^1.2.5",
     "@fortawesome/angular-fontawesome": "^0.14.1",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",

--- a/src/app/services/models/annotation.service.ts
+++ b/src/app/services/models/annotation.service.ts
@@ -25,16 +25,12 @@ export class AnnotationService {
   ) {}
 
   public async show(audioEvent: AudioEvent): Promise<Annotation> {
-    const tags = await this.showTags(audioEvent);
+    const audioEventTags = await this.showTags(audioEvent);
     const audioRecording = await this.showAudioRecording(audioEvent);
-
-    // TODO: this is a tempoary patch for ecoacoustics/web-components#213
-    // until it is fixed upstream
-    const tagDescriptor = tags.map((tag) => tag.text).join(", ");
 
     const data = {
       ...audioEvent,
-      tags: tagDescriptor,
+      tags: audioEventTags,
       audioRecording,
     };
 


### PR DESCRIPTION
# fix: verification grid result downloads

## Changes

- Bumps web component version to fix the download format of paginated result downloads
- Removes tag model stringification hack previously implemented because the web components didn't support tag arrays

## Issues

Fixes: #2168

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
