### PR TITLE
Hotfix: fix applying persistant case-converted properties

### DIFF
--- a/src/app/models/AbstractModel.ts
+++ b/src/app/models/AbstractModel.ts
@@ -30,7 +30,7 @@ export abstract class AbstractModelWithoutId<Model = Record<string, any>> {
         return acc;
       }, {});
 
-    Object.assign(this, transformedRaw, raw);
+    Object.assign(this, raw, transformedRaw);
   }
 
   /** Keys for accessing hidden data associated with a model */


### PR DESCRIPTION
# Fix applying persistant case-converted properties

This pull request fixes the `@bawPersistedAttribute({ caseConvert: true });` that is used in the Harvest Metadata review page.

This was previously not working and caused the metadata review page to not load.

## Issues

Fixes: #2177

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
