### PR TITLE
Add tests for persistent attribute case conversion

### DIFF
--- a/src/app/components/harvest/components/shared/title.component.spec.ts
+++ b/src/app/components/harvest/components/shared/title.component.spec.ts
@@ -4,7 +4,11 @@ import { By } from "@angular/platform-browser";
 import { ShallowHarvestsService } from "@baw-api/harvest/harvest.service";
 import { Harvest } from "@models/Harvest";
 import { Project } from "@models/Project";
-import { SpectatorHost, createHostFactory, SpyObject } from "@ngneat/spectator";
+import {
+  SpyObject,
+  createComponentFactory,
+  Spectator,
+} from "@ngneat/spectator";
 import { generateHarvest } from "@test/fakes/Harvest";
 import { generateProject } from "@test/fakes/Project";
 import { MockProvider } from "ng-mocks";
@@ -12,33 +16,28 @@ import { ToastrService } from "ngx-toastr";
 import { TitleComponent } from "./title.component";
 
 describe("titleComponent", () => {
-  let spectator: SpectatorHost<TitleComponent>;
+  let spectator: Spectator<TitleComponent>;
   let mockHarvest: Harvest;
   let mockProject: Project;
 
-  const createHost = createHostFactory({
+  const createComponent = createComponentFactory({
     component: TitleComponent,
     imports: [FormsModule],
     mocks: [ToastrService],
   });
 
   function setup(): SpyObject<ShallowHarvestsService> {
-    spectator = createHost(
-      `
-      <baw-harvest-title></baw-harvest-title>
-      `,
-      {
-        props: {
-          project: mockProject,
-          harvest: mockHarvest
-        },
-        providers: [
-          MockProvider(ShallowHarvestsService, {}),
-        ],
-      }
-    );
+    spectator = createComponent({
+      props: {
+        project: mockProject,
+        harvest: mockHarvest,
+      },
+      providers: [MockProvider(ShallowHarvestsService, {})],
+    });
 
-    const mockHarvestApi = spectator.inject<SpyObject<ShallowHarvestsService>>( ShallowHarvestsService as any );
+    const mockHarvestApi = spectator.inject<SpyObject<ShallowHarvestsService>>(
+      ShallowHarvestsService as any
+    );
     mockHarvestApi.updateName = jasmine.createSpy("updateName") as any;
 
     spectator.detectChanges();
@@ -72,7 +71,7 @@ describe("titleComponent", () => {
     expect(getHarvestTitle().innerText).toEqual(expectedTitle);
   });
 
-  it("should not attempt to load the harvest name when a Harvest model is not initialized" , () => {
+  it("should not attempt to load the harvest name when a Harvest model is not initialized", () => {
     mockHarvest = undefined;
     setup();
 

--- a/src/app/components/harvest/pages/details/details.component.spec.ts
+++ b/src/app/components/harvest/pages/details/details.component.spec.ts
@@ -9,25 +9,32 @@ import { StreamUploadingComponent } from "@components/harvest/screens/uploading/
 import { HarvestStagesService } from "@components/harvest/services/harvest-stages.service";
 import { Harvest, HarvestStatus } from "@models/Harvest";
 import { Project } from "@models/Project";
-import { createRoutingFactory, mockProvider, SpectatorRouting } from "@ngneat/spectator";
+import {
+  createRoutingFactory,
+  mockProvider,
+  SpectatorRouting,
+} from "@ngneat/spectator";
 import { SharedModule } from "@shared/shared.module";
 import { StepperComponent } from "@shared/stepper/stepper.component";
 import { generateHarvest } from "@test/fakes/Harvest";
 import { generateProject } from "@test/fakes/Project";
 import { assertPageInfo } from "@test/helpers/pageRoute";
-import { MockComponents } from "ng-mocks";
 import { ToastrService } from "ngx-toastr";
 import { PageTitleStrategy } from "src/app/app.component";
 import { WebsiteStatusWarningComponent } from "@menu/website-status-warning/website-status-warning.component";
+import { TitleComponent } from "@components/harvest/components/shared/title.component";
+import { getElementByInnerText } from "@test/helpers/html";
+import { Type } from "@angular/core";
 import { DetailsComponent } from "./details.component";
 
 describe("DetailsComponent", () => {
   let spec: SpectatorRouting<DetailsComponent>;
   let defaultProject: Project;
+  let defaultHarvest: Harvest;
 
   const createComponent = createRoutingFactory({
     component: DetailsComponent,
-    declarations: MockComponents(
+    declarations: [
       ScanningComponent,
       StreamUploadingComponent,
       BatchUploadingComponent,
@@ -36,31 +43,31 @@ describe("DetailsComponent", () => {
       MetadataReviewComponent,
       CompleteComponent,
       WebsiteStatusWarningComponent,
-    ),
-    providers: [
-      mockProvider(HarvestStagesService),
-      PageTitleStrategy,
+      TitleComponent,
     ],
+    providers: [mockProvider(HarvestStagesService), PageTitleStrategy],
     imports: [MockBawApiModule, SharedModule],
     mocks: [ToastrService],
   });
 
   assertPageInfo<Harvest>(DetailsComponent, "test name", {
     harvest: {
-      model: new Harvest(generateHarvest({ name: "test name" }))
+      model: new Harvest(generateHarvest({ name: "test name" })),
     },
   });
 
   beforeEach(() => {
     defaultProject = new Project(generateProject());
+    defaultHarvest = new Harvest(generateHarvest());
   });
 
-  function setup(project: Project = defaultProject) {
+  function setup(): void {
     spec = createComponent({
-      detectChanges: false,
-      data: { project: { model: project } },
+      data: {
+        project: { model: defaultProject },
+        harvest: { model: defaultHarvest },
+      },
     });
-    spec.detectChanges();
   }
 
   it("should create", () => {
@@ -68,10 +75,22 @@ describe("DetailsComponent", () => {
     expect(spec.component).toBeInstanceOf(DetailsComponent);
   });
 
-  xit("should show project name", () => {
+  it("should show project name", () => {
     setup();
-    spec.detectChanges();
-    expect(spec.query("h1")).toHaveText(defaultProject.name);
+
+    const expectedTitle = `Project: ${defaultProject.name}`;
+    const titleElement = getElementByInnerText(spec, expectedTitle);
+
+    expect(titleElement).toExist();
+  });
+
+  it("should show the harvest name", () => {
+    setup();
+
+    const expectedTitle = `Upload Recordings: ${defaultHarvest.name}`;
+    const titleElement = getElementByInnerText(spec, expectedTitle);
+
+    expect(titleElement).toExist();
   });
 
   // TODO: Re-implement tests
@@ -83,7 +102,7 @@ describe("DetailsComponent", () => {
       spec.detectChanges();
     }
 
-    function assertStage(stage: number, component: any) {
+    function assertStage(stage: number, component: any): void {
       expect(spec.query(component)).toBeInstanceOf(component);
       expect(spec.query(StepperComponent).activeStep).toBe(stage);
     }

--- a/src/app/components/harvest/pages/details/details.component.spec.ts
+++ b/src/app/components/harvest/pages/details/details.component.spec.ts
@@ -24,7 +24,6 @@ import { PageTitleStrategy } from "src/app/app.component";
 import { WebsiteStatusWarningComponent } from "@menu/website-status-warning/website-status-warning.component";
 import { TitleComponent } from "@components/harvest/components/shared/title.component";
 import { getElementByInnerText } from "@test/helpers/html";
-import { Type } from "@angular/core";
 import { DetailsComponent } from "./details.component";
 
 describe("DetailsComponent", () => {
@@ -102,7 +101,7 @@ describe("DetailsComponent", () => {
       spec.detectChanges();
     }
 
-    function assertStage(stage: number, component: any): void {
+    function assertStage(stage: number, component: any) {
       expect(spec.query(component)).toBeInstanceOf(component);
       expect(spec.query(StepperComponent).activeStep).toBe(stage);
     }

--- a/src/app/components/harvest/services/harvest-stages.service.ts
+++ b/src/app/components/harvest/services/harvest-stages.service.ts
@@ -77,9 +77,11 @@ export class HarvestStagesService implements OnDestroy {
     { label: "Processing", icon: ["fas", "arrows-spin"] },
     { label: "Complete", icon: ["fas", "flag-checkered"] },
   ];
+
   private _streamingStages: Step[] = [0, 1, 6].map(
     (step): Step => this._stages[step]
   );
+
   public get stages(): Step[] {
     return this.harvest?.streaming ? this._streamingStages : this._stages;
   }
@@ -89,7 +91,7 @@ export class HarvestStagesService implements OnDestroy {
   }
 
   public get currentStage(): number {
-    const temp: Record<HarvestStatus, number> = {
+    const temp = {
       newHarvest: 0,
       uploading: 1,
       scanning: 2,
@@ -97,7 +99,7 @@ export class HarvestStagesService implements OnDestroy {
       metadataReview: 4,
       processing: 5,
       complete: this.harvest?.streaming ? 2 : 6,
-    };
+    } as const satisfies Record<HarvestStatus, number>;
     return temp[this.stage];
   }
 

--- a/src/app/models/AbstractModel.spec.ts
+++ b/src/app/models/AbstractModel.spec.ts
@@ -535,9 +535,7 @@ describe("AbstractModel", () => {
       expect(model.userDescription).toEqual("this should be left untouched");
     });
 
-    it("should add new persistent attributes correctly", () => {});
-
-    it("should correctly modify an existing attribute when becoming persistent", () => {
+    it("should correctly add persistent attributes", () => {
       const addedAttribute = {
         key: "userDescription",
         create: true,

--- a/src/app/models/AbstractModel.ts
+++ b/src/app/models/AbstractModel.ts
@@ -21,7 +21,7 @@ export type AbstractModelConstructor<Model> = new (
  * BAW Server Abstract Model
  */
 export abstract class AbstractModelWithoutId<Model = Record<string, any>> {
-  public constructor(raw: Model, protected injector?: AssociationInjector) {
+  public constructor(raw: Readonly<Model>, protected injector?: AssociationInjector) {
     const transformedRaw = this.getPersistentAttributes()
       .filter((attr) => attr.convertCase)
       .reduce((acc, attr) => {


### PR DESCRIPTION
# Add tests for persistent attribute case conversion

## Changes

- Adds tests for hotfix 2b61e14. Ensuring that abstract model values are case-converted correctly
- Re-enables some previously disabled `harvest/details.component` tests
- Corrects typing for AbstractModelWithoutId constructor making the `raw` object passed in the constructor a `ReadOnly` argument (does not effect typing of object going in, just the usage within the constructor)

## Final Checklist

- [ ] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [ ] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
