### PR TITLE
Bundle dynamically imported web components

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -31,8 +31,8 @@
               "src/manifest.json",
               {
                 "glob": "**/*",
-                "input": "node_modules/@ecoacoustics/web-components/dist",
-                "output": "@ecoacoustics/web-components"
+                "input": "node_modules/@ecoacoustics/web-components/dist/assets",
+                "output": "assets/"
               }
             ],
             "styles": [


### PR DESCRIPTION
# Bundle dynamically imported web components

This fixes a bug where after upgrading web component versions, some web browsers would still look for the old web component import paths that no longer existed.

## Changes

- Bundle web components `components.js` entry point
- Add a defensive programming guard to not re-initialize custom elements if they already exist instead of hard-failing the web client. The underlying bug causing this issue was fixed in this pull request, but I have added it as a defensive programming measure

## Issues

Fixes: #2176

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [x] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
