### PR TITLE
Fix incorrect target for hidden copy component

### DIFF
--- a/src/app/components/shared/hidden-copy/hidden-copy.component.spec.ts
+++ b/src/app/components/shared/hidden-copy/hidden-copy.component.spec.ts
@@ -170,7 +170,7 @@ describe("HiddenCopyComponent", () => {
     });
 
     it("should not copy if disabled and the copy button is clicked", () => {
-      setup({ content: modelData.authToken(), disabled: true });
+      setup({ content: modelData.authToken(), disabled: "true" });
       spec.click(getCopyButton());
       expect(clipboardService.copyFromContent).not.toHaveBeenCalled();
     });

--- a/src/app/components/shared/hidden-copy/hidden-copy.component.spec.ts
+++ b/src/app/components/shared/hidden-copy/hidden-copy.component.spec.ts
@@ -1,19 +1,21 @@
 import { BootstrapColorTypes } from "@helpers/bootstrapTypes";
 import { NgbTooltipModule } from "@ng-bootstrap/ng-bootstrap";
-import { createHostFactory, SpectatorHost } from "@ngneat/spectator";
+import { createHostFactory, SpectatorHost, SpyObject } from "@ngneat/spectator";
 import { IconsModule } from "@shared/icons/icons.module";
 import { modelData } from "@test/helpers/faker";
-import { ClipboardModule } from "ngx-clipboard";
+import { ClipboardModule, ClipboardService } from "ngx-clipboard";
 import { HiddenCopyComponent } from "./hidden-copy.component";
 
 describe("HiddenCopyComponent", () => {
   let spec: SpectatorHost<HiddenCopyComponent>;
+  let clipboardService: SpyObject<ClipboardService>;
+
   const createHost = createHostFactory({
     component: HiddenCopyComponent,
     imports: [IconsModule, NgbTooltipModule, ClipboardModule],
   });
 
-  function setup(props: Partial<HiddenCopyComponent>) {
+  function setup(props: Partial<HiddenCopyComponent> = {}) {
     props.value ??= "value";
     props.content ??= "content";
     props.tooltip ??= "tooltip";
@@ -21,6 +23,9 @@ describe("HiddenCopyComponent", () => {
     spec = createHost("<baw-hidden-copy></baw-hidden-copy>", {
       props,
     });
+
+    clipboardService = spec.inject(ClipboardService);
+    clipboardService.copyFromContent = jasmine.createSpy("copyFromContent") as any;
   }
 
   function getVisibilityButton() {
@@ -29,6 +34,14 @@ describe("HiddenCopyComponent", () => {
 
   function getCopyButton() {
     return spec.query<HTMLButtonElement>("#copy-btn");
+  }
+
+  function getCopyIcon() {
+    return spec.query("#copy-icon");
+  }
+
+  function getCopiedTooltip() {
+    return spec.query<HTMLSpanElement>("[ngbTooltip='Coped!']");
   }
 
   it("should create", () => {
@@ -45,7 +58,7 @@ describe("HiddenCopyComponent", () => {
     it("should have tooltip", () => {
       const tooltip = modelData.random.words();
       setup({ tooltip });
-      // Container is body so that we dont have issues with the tooltip
+      // Container is body so that we don't have issues with the tooltip
       // breaking css and clipping
       expect(getVisibilityButton()).toHaveTooltip(tooltip, {
         container: "body",
@@ -75,18 +88,38 @@ describe("HiddenCopyComponent", () => {
     it("should have tooltip", () => {
       const tooltip = modelData.random.words();
       setup({ tooltip });
-      // Container is body so that we dont have issues with the tooltip
+      // Container is body so that we don't have issues with the tooltip
       // breaking css and clipping
+
+      // if we hover over the "Copied!" tooltip element, it should not show
+      spec.focus(getCopyButton());
+
       // Tooltip should only show on click
-      expect(getCopyButton()).toHaveTooltip("Copied!", {
-        triggers: "manual",
-        container: "body",
-      });
+      expect(getCopiedTooltip()).not.toBeVisible();
+
+      // after the button is clicked, we expect that the tooltip will be visible
+      spec.click(getCopyButton());
+      expect(getCopiedTooltip()).not.toBeVisible();
     });
 
     it("should not be disabled", () => {
       setup({ disabled: undefined });
       expect(getCopyButton()).not.toHaveAttribute("disabled");
+    });
+
+    // these tests were not always present which resulted in bugs such as the
+    // copy button not copying the text
+    // see: https://github.com/QutEcoacoustics/workbench-client/issues/2146
+    it("should copy if the copy icon is clicked", () => {
+      setup({ content: modelData.authToken() });
+      spec.click(getCopyIcon());
+      expect(clipboardService.copyFromContent).toHaveBeenCalledTimes(1);
+    });
+
+    it("should copy if the copy button is clicked", () => {
+      setup({ content: modelData.authToken() });
+      spec.click(getCopyButton());
+      expect(clipboardService.copyFromContent).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -134,6 +167,12 @@ describe("HiddenCopyComponent", () => {
       const disabled = modelData.random.words();
       setup({ disabled });
       expect(getCopyButton()).toHaveAttribute("disabled");
+    });
+
+    it("should not copy if disabled and the copy button is clicked", () => {
+      setup({ content: modelData.authToken(), disabled: true });
+      spec.click(getCopyButton());
+      expect(clipboardService.copyFromContent).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/components/shared/hidden-copy/hidden-copy.component.ts
+++ b/src/app/components/shared/hidden-copy/hidden-copy.component.ts
@@ -1,9 +1,6 @@
 import { Component, Input } from "@angular/core";
 import { BootstrapColorTypes } from "@helpers/bootstrapTypes";
 
-/**
- * Loading Animation
- */
 @Component({
   selector: "baw-hidden-copy",
   template: `
@@ -22,29 +19,36 @@ import { BootstrapColorTypes } from "@helpers/bootstrapTypes";
         <fa-icon [icon]="['fas', 'eye']"></fa-icon>
       </button>
 
-      <pre
-        class="text-center form-control">{{ visible ? content : "..." }}<ng-content *ngIf="visible"></ng-content></pre>
+      <pre class="text-center form-control">{{ visible ? content : "..." }}<ng-content *ngIf="visible"></ng-content></pre>
 
-      <button
+      <!--
+        We use a manual trigger for the "Copied!" tooltip so that so that it is
+        only triggered by the cbOnSuccess event.
+
+        We also add the container="body" so that the tooltip can go above this
+        components top level container.
+
+        We can't add the ngbTooltip with the ngxClipboard directive otherwise
+        the content fails to copy.
+      -->
+      <span
         #copyTooltip="ngbTooltip"
-        id="copy-btn"
-        type="button"
-        class="btn"
+        ngbTooltip="Copied!"
         triggers="manual"
         container="body"
-        ngbTooltip="Copied!"
-        [ngClass]="'btn-outline-' + color"
-        [disabled]="disabled"
       >
-        <!-- ! Be careful changing how the clipboard works. It is not tested -->
-        <span
+        <button
+          id="copy-btn"
+          class="btn"
+          [ngClass]="'btn-outline-' + color"
+          [disabled]="disabled"
           ngxClipboard
           [cbContent]="value"
           (cbOnSuccess)="copyTooltip.open()"
         >
-          <fa-icon [icon]="['fas', 'copy']"></fa-icon>
-        </span>
-      </button>
+          <fa-icon id="copy-icon" [icon]="['fas', 'copy']"></fa-icon>
+        </button>
+      </span>
     </div>
   `,
   styles: [
@@ -53,13 +57,28 @@ import { BootstrapColorTypes } from "@helpers/bootstrapTypes";
         margin: 0;
         white-space: pre-wrap;
       }
+
+      /*
+        In bootstrap, any element that is inside the same form-control has
+        its edge border radius set to 0 so that all inner form-control
+        elements are flush.
+        However, because we have wrapped the copy-btn inside a tooltip <span>,
+        bootstrap attempts to flatten the span's border radius (which is not
+        visible) instead of the copy buttons.
+        to keep consistent with the bootstrap styling, I manually flatten the
+        left edges of the copy button.
+      */
+      #copy-btn {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+      }
     `,
   ],
 })
 export class HiddenCopyComponent {
   @Input() public color: BootstrapColorTypes = "secondary";
   @Input() public tooltip: string;
-  @Input() public disabled: string | undefined;
+  @Input() public disabled: string | boolean | undefined;
   @Input() public value: string;
   @Input() public content: string;
   public visible: boolean;

--- a/src/app/components/shared/hidden-copy/hidden-copy.component.ts
+++ b/src/app/components/shared/hidden-copy/hidden-copy.component.ts
@@ -78,7 +78,7 @@ import { BootstrapColorTypes } from "@helpers/bootstrapTypes";
 export class HiddenCopyComponent {
   @Input() public color: BootstrapColorTypes = "secondary";
   @Input() public tooltip: string;
-  @Input() public disabled: string | boolean | undefined;
+  @Input() public disabled: string | undefined;
   @Input() public value: string;
   @Input() public content: string;
   public visible: boolean;


### PR DESCRIPTION
# Fix incorrect target for hidden copy component

There was previously a bug where the touch target for the `HiddenCopyComponent` was the copy icon, not the copy button.

This is was exacerbated by the fact that there were no unit tests to assert that this component would copy text correctly.

## Changes

- Changes the `HiddenCopyCompont`'s copy touch target to the copy button instead of the copy icon
- Adds unit tests to assert that the copy button works correctly

## Issues

Fixes: #2146

## Visual Changes

![image](https://github.com/user-attachments/assets/4f30db98-f8c6-46cc-bfe9-3904b3e3711e)

_Should be unchanged, let me know if you see any discrepancies_

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
