### PR TITLE
Add data-sharing-policy cms page

### DIFF
--- a/src/app/components/about/about.menus.ts
+++ b/src/app/components/about/about.menus.ts
@@ -36,3 +36,10 @@ export const ethicsMenuItem = menuRoute({
   route: aboutRoute.add("ethics"),
   tooltip: () => "Ethics",
 });
+
+export const dataSharingPolicyMenuItem = menuRoute({
+  icon: ["fas", "right-left"],
+  label: "Data Sharing",
+  route: aboutRoute.add("data_sharing_policy"),
+  tooltip: () => "Data Sharing Policy",
+});

--- a/src/app/components/about/about.menus.ts
+++ b/src/app/components/about/about.menus.ts
@@ -38,7 +38,7 @@ export const ethicsMenuItem = menuRoute({
 });
 
 export const dataSharingPolicyMenuItem = menuRoute({
-  icon: ["fas", "right-left"],
+  icon: ["fas", "file-shield"],
   label: "Data Sharing",
   route: aboutRoute.add("data_sharing_policy"),
   tooltip: () => "Data Sharing Policy",

--- a/src/app/components/about/about.module.ts
+++ b/src/app/components/about/about.module.ts
@@ -7,12 +7,14 @@ import { ContactUsComponent } from "./pages/contact-us/contact-us.component";
 import { CreditsComponent } from "./pages/credits/credits.component";
 import { DisclaimersComponent } from "./pages/disclaimers/disclaimers.component";
 import { EthicsComponent } from "./pages/ethics/ethics.component";
+import { DataSharingPolicyComponent } from "./pages/data-sharing-policy/data-sharing-policy.component";
 
 const components = [
   ContactUsComponent,
   CreditsComponent,
   DisclaimersComponent,
   EthicsComponent,
+  DataSharingPolicyComponent,
 ];
 
 const routes = aboutRoute.compileRoutes(getRouteConfigForPage);

--- a/src/app/components/about/pages/data-sharing-policy/data-sharing-policy.component.spec.ts
+++ b/src/app/components/about/pages/data-sharing-policy/data-sharing-policy.component.spec.ts
@@ -1,0 +1,19 @@
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { MockBawApiModule } from "@baw-api/baw-apiMock.module";
+import { CMS } from "@baw-api/cms/cms.service";
+import { createComponentFactory, Spectator } from "@ngneat/spectator";
+import { SharedModule } from "@shared/shared.module";
+import { assertCms } from "@test/helpers/api-common";
+import { DataSharingPolicyComponent } from "./data-sharing-policy.component";
+
+describe("DataSharingPolicyComponent", () => {
+  let spectator: Spectator<DataSharingPolicyComponent>;
+  const createComponent = createComponentFactory({
+    component: DataSharingPolicyComponent,
+    imports: [SharedModule, HttpClientTestingModule, MockBawApiModule],
+  });
+
+  beforeEach(() => (spectator = createComponent({ detectChanges: false })));
+
+  assertCms<DataSharingPolicyComponent>(() => spectator, CMS.dataSharingPolicy);
+});

--- a/src/app/components/about/pages/data-sharing-policy/data-sharing-policy.component.ts
+++ b/src/app/components/about/pages/data-sharing-policy/data-sharing-policy.component.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component } from "@angular/core";
+import { CMS } from "@baw-api/cms/cms.service";
+import { aboutCategory, dataSharingPolicyMenuItem } from "@components/about/about.menus";
+import { PageComponent } from "@helpers/page/pageComponent";
+
+@Component({
+  selector: "baw-about-data-sharing-policy",
+  template: "<baw-cms [page]='page'></baw-cms>",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class DataSharingPolicyComponent extends PageComponent {
+  public page = CMS.dataSharingPolicy;
+}
+
+DataSharingPolicyComponent.linkToRoute({
+  category: aboutCategory,
+  pageRoute: dataSharingPolicyMenuItem,
+});
+
+export { DataSharingPolicyComponent };

--- a/src/app/components/shared/footer/footer.component.spec.ts
+++ b/src/app/components/shared/footer/footer.component.spec.ts
@@ -2,6 +2,7 @@ import { RouterTestingModule } from "@angular/router/testing";
 import {
   contactUsMenuItem,
   creditsMenuItem,
+  dataSharingPolicyMenuItem,
   disclaimersMenuItem,
   ethicsMenuItem,
 } from "@components/about/about.menus";
@@ -47,6 +48,7 @@ describe("FooterComponent", () => {
       disclaimersMenuItem,
       creditsMenuItem,
       ethicsMenuItem,
+      dataSharingPolicyMenuItem,
       contactUsMenuItem,
     ].forEach((link, index) => {
       function getId() {

--- a/src/app/components/shared/footer/footer.component.ts
+++ b/src/app/components/shared/footer/footer.component.ts
@@ -5,6 +5,7 @@ import { websiteStatusMenuItem } from "@components/website-status/website-status
 import {
   contactUsMenuItem,
   creditsMenuItem,
+  dataSharingPolicyMenuItem,
   disclaimersMenuItem,
   ethicsMenuItem,
 } from "../../about/about.menus";
@@ -52,6 +53,7 @@ export class FooterComponent implements OnInit {
     disclaimersMenuItem,
     creditsMenuItem,
     ethicsMenuItem,
+    dataSharingPolicyMenuItem,
     contactUsMenuItem,
   ];
 

--- a/src/app/services/baw-api/cms/cms.service.ts
+++ b/src/app/services/baw-api/cms/cms.service.ts
@@ -17,6 +17,7 @@ export enum CMS {
   home = "",
   credits = "credits",
   dataUpload = "data_upload",
+  dataSharingPolicy = "data_sharing_policy",
   ethics = "ethics",
   privacy = "privacy",
 }


### PR DESCRIPTION
# Add data-sharing-policy cms page

## Changes

- Add `dataSharingPolicy` to registered CMS pages
- Adds `/about/data_sharing_policy` route & pages. Notice the icon used in the breadcrumbs; I welcome feedback on this choice (full list of available icons can be found [here](https://fontawesome.com/))
- Adds "Data Sharing" menu item in footer ("policy" word excluded to conserve space)

## Problems

- The CMS page does not exist and cannot (easily) exist until a server bug is fixed (see: https://github.com/QutEcoacoustics/baw-server/issues/719)

## Issues

Fixes: #2217

## Visual Changes

![image](https://github.com/user-attachments/assets/e764f5e7-fd0d-4e3d-9b14-5a76f887714f)

_Failure message if CMS page does not exist_

![image](https://github.com/user-attachments/assets/ef9f8a7d-0201-4a07-a726-51a09140d82e)

_Data sharing page with "ethics" cms page as an example_

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
