### PR TITLE
Increase browser timeout to 20 seconds

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,7 +5,7 @@ export const environment = {
   /** Timeout for web requests in server side renderer */
   ssrTimeout: 1_000,
   /** Timeout for web requests in browser */
-  browserTimeout: 10_000,
+  browserTimeout: 20_000,
   /**
    * Current build version of this code. This is set by the docker container
    * and should not be modified without care


### PR DESCRIPTION
# Increase browser timeout to 20 seconds

Very large harvests were failing due some requests taking more than 10 seconds to complete.

This commit extends the browser timeout to 20 seconds so that very large harvests can load.

## Changes

- Increases browser timeout to 20 seconds

## Issues

Fixes: #2226

## Visual Changes

N.A

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
