### PR TITLE
Increase prod timeout to match dev timeout

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,7 +2,7 @@ export const environment = {
   testing: false,
   production: true,
   ssrTimeout: 100,
-  browserTimeout: 10_000,
+  browserTimeout: 20_000,
   // Version is set by the docker container, edit with care
   version: "<<VERSION_REPLACED_WHEN_BUILT>>",
 };


### PR DESCRIPTION
# Increase prod timeout to match dev timeout

In the last commit I increased the browser timeout to 10 seconds.

I tested that the new timeout was successful, but forgot to change the `environment.prod` file

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
