### PR TITLE
Add analysis job status to website status page

### DIFF
--- a/src/app/components/website-status/website-status.component.spec.ts
+++ b/src/app/components/website-status/website-status.component.spec.ts
@@ -70,6 +70,7 @@ describe("WebsiteStatusComponent", () => {
       { name: "Cache", value: "Healthy" },
       { name: "Storage", value: "Healthy" },
       { name: "User Uploads", value: "Healthy" },
+      { name: "Batch Analysis", value: "Healthy" },
       { name: "User Internet Connection", value: "Healthy" },
     ];
 
@@ -81,6 +82,7 @@ describe("WebsiteStatusComponent", () => {
       redis: "PONG",
       storage: "1 audio recording storage directory available.",
       upload: "Alive",
+      batchAnalysis: "Connected",
     });
 
     setup(fakeWebsiteStatus);
@@ -98,6 +100,7 @@ describe("WebsiteStatusComponent", () => {
       { name: "Cache", value: "Unhealthy" },
       { name: "Storage", value: "Unhealthy" },
       { name: "User Uploads", value: "Unhealthy" },
+      { name: "Batch Analysis", value: "Unhealthy" },
       { name: "User Internet Connection", value: "Healthy" },
     ];
 
@@ -109,6 +112,7 @@ describe("WebsiteStatusComponent", () => {
       redis: "",
       storage: "No audio recording storage directories are available.",
       upload: "Dead",
+      batchAnalysis: "Failed to connect",
     });
 
     setup(fakeWebsiteStatus);
@@ -126,6 +130,7 @@ describe("WebsiteStatusComponent", () => {
       { name: "Cache", value: "Unhealthy" },
       { name: "Storage", value: "Healthy" },
       { name: "User Uploads", value: "Unhealthy" },
+      { name: "Batch Analysis", value: "Healthy" },
       { name: "User Internet Connection", value: "Healthy" },
     ];
 
@@ -137,6 +142,7 @@ describe("WebsiteStatusComponent", () => {
       redis: "",
       storage: "1 audio recording storage directory available.",
       upload: "Dead",
+      batchAnalysis: "Connected",
     });
 
     setup(fakeWebsiteStatus);
@@ -154,6 +160,7 @@ describe("WebsiteStatusComponent", () => {
       { name: "Cache", value: "Unknown" },
       { name: "Storage", value: "Unknown" },
       { name: "User Uploads", value: "Unknown" },
+      { name: "Batch Analysis", value: "Unknown" },
       { name: "User Internet Connection", value: "Healthy" },
     ];
 
@@ -175,6 +182,7 @@ describe("WebsiteStatusComponent", () => {
       { name: "Cache", value: "Unknown" },
       { name: "Storage", value: "Unknown" },
       { name: "User Uploads", value: "Unknown" },
+      { name: "Batch Analysis", value: "Unknown" },
       { name: "User Internet Connection", value: "Unhealthy" },
     ];
 

--- a/src/app/components/website-status/website-status.component.ts
+++ b/src/app/components/website-status/website-status.component.ts
@@ -80,6 +80,11 @@ class WebsiteStatusComponent extends PageComponent implements OnInit {
         ...this.listItemContent(this.model?.isUploadingHealthy),
       },
       {
+        name: "Batch Analysis",
+        icon: ["fas", "server"],
+        ...this.listItemContent(this.model?.isBatchAnalysisHealthy),
+      },
+      {
         name: "User Internet Connection",
         icon: ["fas", "wifi"],
         ...this.listItemContent(this.model?.onLine),

--- a/src/app/models/WebsiteStatus.ts
+++ b/src/app/models/WebsiteStatus.ts
@@ -9,6 +9,7 @@ export type UploadStatus = "Alive" | "Dead";
 export type StorageStatus =
   | "No audio recording storage directories are available."
   | `${number} audio recording storage directory available.`;
+export type BatchAnalysisStatus = "Connected" | "Failed to connect";
 
 export interface IWebsiteStatus {
   status: WebsiteOverallStatus | undefined;
@@ -17,6 +18,7 @@ export interface IWebsiteStatus {
   redis: RedisStatus | undefined;
   storage: StorageStatus | undefined;
   upload: UploadStatus | undefined;
+  batchAnalysis: BatchAnalysisStatus | undefined;
 }
 
 export class WebsiteStatus
@@ -34,6 +36,7 @@ export class WebsiteStatus
   public readonly redis: RedisStatus | undefined;
   public readonly storage: StorageStatus | undefined;
   public readonly upload: UploadStatus | undefined;
+  public readonly batchAnalysis: BatchAnalysisStatus | undefined;
 
   public get isStatusHealthy(): boolean | null {
     return isInstantiated(this.status) ? this.status === "good" : null;
@@ -59,6 +62,10 @@ export class WebsiteStatus
 
   public get isUploadingHealthy(): boolean | null {
     return isInstantiated(this.upload) ? this.upload === "Alive" : null;
+  }
+
+  public get isBatchAnalysisHealthy(): boolean | null {
+    return isInstantiated(this.batchAnalysis) ? this.batchAnalysis === "Connected" : null;
   }
 
   public get onLine(): boolean {

--- a/src/app/test/fakes/WebsiteStatus.ts
+++ b/src/app/test/fakes/WebsiteStatus.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import {
+  BatchAnalysisStatus,
   IWebsiteStatus,
   RedisStatus,
   StorageStatus,
@@ -21,6 +22,7 @@ export function generateWebsiteStatus(
       "No audio recording storage directories are available.",
     ]),
     upload: faker.helpers.arrayElement<UploadStatus>(["Alive", "Dead"]),
+    batchAnalysis: faker.helpers.arrayElement<BatchAnalysisStatus>(["Connected", "Failed to connect"]),
     ...data,
   };
 }


### PR DESCRIPTION
# Add analysis job status to website status page

I still need to add shield icons to the analysis jobs view, but I mocked up this quick branch while I was waiting for my database backed verifications PR to pass CI.

## Changes

- Adds analysis job status to website `/status` page

## Issues

Fixes: #2223

## Visual Changes

![image](https://github.com/user-attachments/assets/359afcec-0dcd-49f8-81c6-a6fc66d87620)

_New website status page_

TODO: Shield widgets for analysis job view page

## Final Checklist

- [ ] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
