### PR TITLE
Add support for downloading region annotations

### DIFF
--- a/src/app/components/regions/pages/details/details.component.ts
+++ b/src/app/components/regions/pages/details/details.component.ts
@@ -16,7 +16,7 @@ import {
   regionMenuItem,
   regionsCategory,
 } from "@components/regions/regions.menus";
-import { deleteRegionModal } from "@components/regions/regions.modals";
+import { deleteRegionModal, regionAnnotationsModal } from "@components/regions/regions.modals";
 import { shallowRegionsRoute } from "@components/regions/regions.routes";
 import { newPointMenuItem } from "@components/sites/points.menus";
 import { reportMenuItems } from "@components/reports/reports.menu";
@@ -48,6 +48,7 @@ export const regionMenuItemActions = [
   audioRecordingMenuItems.batch.region,
   reportMenuItems.new.region,
   annotationMenuItems.search.region,
+  regionAnnotationsModal,
 ];
 
 const projectKey = "project";

--- a/src/app/components/regions/regions.menus.ts
+++ b/src/app/components/regions/regions.menus.ts
@@ -1,9 +1,10 @@
 import { retrieveResolvedModel } from "@baw-api/resolver-common";
 import { RouterStateSnapshot } from "@angular/router";
 import { projectMenuItem } from "@components/projects/projects.menus";
-import { Category, menuRoute } from "@interfaces/menusInterfaces";
+import { Category, menuItem, menuRoute } from "@interfaces/menusInterfaces";
 import { Region } from "@models/Region";
 import {
+  defaultAnnotationDownloadIcon,
   defaultEditIcon,
   defaultNewIcon,
   isProjectEditorPredicate,
@@ -70,4 +71,11 @@ export const editRegionMenuItem = menuRoute({
   route: regionMenuItem.route.add("edit"),
   tooltip: () => "Change the details for this site",
   title: () => CommonRouteTitles.routeEditTitle,
+});
+
+export const regionAnnotationsMenuItem = menuItem({
+  icon: defaultAnnotationDownloadIcon,
+  label: "Download Annotations",
+  parent: regionMenuItem,
+  tooltip: () => "Download annotations for this site",
 });

--- a/src/app/components/regions/regions.modals.ts
+++ b/src/app/components/regions/regions.modals.ts
@@ -1,6 +1,7 @@
 import { menuModal } from "@menu/widgetItem";
 import { DeleteModalComponent } from "@shared/delete-modal/delete-modal.component";
-import { defaultDeleteIcon, isProjectEditorPredicate } from "src/app/app.menus";
+import { defaultAnnotationDownloadIcon, defaultDeleteIcon, isProjectEditorPredicate } from "src/app/app.menus";
+import { AnnotationDownloadComponent } from "@shared/annotation-download/annotation-download.component";
 import { regionMenuItem } from "./regions.menus";
 import { RegionDetailsComponent } from "./pages/details/details.component";
 
@@ -12,4 +13,12 @@ export const deleteRegionModal = menuModal({
   predicate: isProjectEditorPredicate,
   component: DeleteModalComponent,
   successCallback: (pageComponentInstance?: RegionDetailsComponent) => pageComponentInstance.deleteModel(),
+});
+
+export const regionAnnotationsModal = menuModal({
+  icon: defaultAnnotationDownloadIcon,
+  label: "Download Annotations",
+  tooltip: () => "Download annotations for this site",
+  component: AnnotationDownloadComponent,
+  modalOpts: {},
 });

--- a/src/app/components/shared/annotation-download/annotation-download.component.ts
+++ b/src/app/components/shared/annotation-download/annotation-download.component.ts
@@ -130,15 +130,17 @@ export class AnnotationDownloadComponent
     const timezone =
       this.model.timezone === "Etc/UTC" ? "UTC" : this.model.timezone;
 
-    if (this.region) {
-      return this.regionApi.downloadAnnotations(
-        this.region,
+    // we pick the most specific model available in the route, meaning that
+    // the order of these if conditions is important
+    if (this.site) {
+      return this.siteApi.downloadAnnotations(
+        this.site,
         this.region?.projectId ?? this.project,
         timezone
       );
-    } else if (this.site) {
-      return this.siteApi.downloadAnnotations(
-        this.site,
+    } else if (this.region) {
+      return this.regionApi.downloadAnnotations(
+        this.region,
         this.region?.projectId ?? this.project,
         timezone
       );

--- a/src/app/components/shared/annotation-download/annotation-download.component.ts
+++ b/src/app/components/shared/annotation-download/annotation-download.component.ts
@@ -18,6 +18,7 @@ import { takeUntil } from "rxjs";
 import { ProjectsService } from "@baw-api/project/projects.service";
 import { FormComponent } from "../form/form.component";
 import schema from "./annotations-download.schema.json";
+import { RegionsService } from "@baw-api/region/regions.service";
 
 interface TimezoneModel {
   timezone?: string;

--- a/src/app/components/shared/annotation-download/annotation-download.component.ts
+++ b/src/app/components/shared/annotation-download/annotation-download.component.ts
@@ -16,9 +16,9 @@ import { FormlyFieldConfig } from "@ngx-formly/core";
 import { SharedActivatedRouteService } from "@services/shared-activated-route/shared-activated-route.service";
 import { takeUntil } from "rxjs";
 import { ProjectsService } from "@baw-api/project/projects.service";
+import { RegionsService } from "@baw-api/region/regions.service";
 import { FormComponent } from "../form/form.component";
 import schema from "./annotations-download.schema.json";
-import { RegionsService } from "@baw-api/region/regions.service";
 
 interface TimezoneModel {
   timezone?: string;

--- a/src/app/components/shared/annotation-download/annotation-download.component.ts
+++ b/src/app/components/shared/annotation-download/annotation-download.component.ts
@@ -96,6 +96,7 @@ export class AnnotationDownloadComponent
 
   public constructor(
     private siteApi: SitesService,
+    private regionApi: RegionsService,
     private projectApi: ProjectsService,
     private sharedRoute: SharedActivatedRouteService
   ) {
@@ -129,7 +130,13 @@ export class AnnotationDownloadComponent
     const timezone =
       this.model.timezone === "Etc/UTC" ? "UTC" : this.model.timezone;
 
-    if (this.site) {
+    if (this.region) {
+      return this.regionApi.downloadAnnotations(
+        this.region,
+        this.region?.projectId ?? this.project,
+        timezone
+      );
+    } else if (this.site) {
       return this.siteApi.downloadAnnotations(
         this.site,
         this.region?.projectId ?? this.project,

--- a/src/app/services/baw-api/region/regions.service.spec.ts
+++ b/src/app/services/baw-api/region/regions.service.spec.ts
@@ -7,6 +7,9 @@ import {
   mockServiceProviders,
   validateStandardApi,
 } from "@test/helpers/api-common";
+import { API_ROOT } from "@services/config/config.tokens";
+import { generateProject } from "@test/fakes/Project";
+import { modelData } from "@test/helpers/faker";
 import { RegionsService } from "./regions.service";
 
 type Model = Region;
@@ -14,9 +17,14 @@ type Params = [IdOr<Project>];
 type Service = RegionsService;
 
 describe("RegionsService", (): void => {
-  const createModel = () => new Region(generateRegion({ id: 10 }));
-  const baseUrl = "/projects/5/regions/";
-  const updateUrl = baseUrl + "10";
+  const mockRegionId = modelData.id();
+  const mockProjectId = modelData.id();
+  const createModel = () => new Region(generateRegion({ id: mockRegionId }));
+
+  const baseUrl = `/projects/${mockProjectId}/regions/`;
+  const updateUrl: string = baseUrl + mockRegionId;
+  let apiRoot: string;
+
   let spec: SpectatorService<RegionsService>;
 
   const createService = createServiceFactory({
@@ -26,6 +34,7 @@ describe("RegionsService", (): void => {
 
   beforeEach((): void => {
     spec = createService();
+    apiRoot = spec.inject(API_ROOT);
   });
 
   validateStandardApi<Model, Params, Service>(
@@ -35,7 +44,48 @@ describe("RegionsService", (): void => {
     baseUrl + "filter",
     updateUrl,
     createModel,
-    10,
-    5
+    mockRegionId,
+    mockProjectId,
   );
+
+  describe("downloadAnnotations", () => {
+    const defaultTimezone = "UTC";
+
+    function getUrl(timezone = defaultTimezone) {
+      const url = new URL(
+        `${apiRoot}/projects/${mockProjectId}/regions/${mockRegionId}/audio_events/download?selected_timezone_name=${timezone}`
+      );
+      return url.toString();
+    }
+
+    it("should return url using model ids", () => {
+      const expectedUrl = getUrl();
+      const realizedUrl = spec.service.downloadAnnotations(
+        mockRegionId,
+        mockProjectId,
+        defaultTimezone
+      );
+
+      expect(realizedUrl).toEqual(expectedUrl);
+    });
+
+    it("should return url using model objects", () => {
+      const expectedUrl = getUrl();
+      const realizedUrl = spec.service.downloadAnnotations(
+        new Region(generateRegion({ id: mockRegionId })),
+        new Project(generateProject({ id: mockProjectId })),
+        defaultTimezone
+      )
+
+      expect(realizedUrl).toBe(expectedUrl);
+    });
+
+    it("should return url with timezone", () => {
+      const expectedUrl = getUrl("Brisbane");
+      const realizedUrl = spec.service.downloadAnnotations(mockRegionId, mockProjectId, "Brisbane");
+
+      expect(realizedUrl).toEqual(expectedUrl);
+    });
+
+  });
 });

--- a/src/app/services/baw-api/region/regions.service.ts
+++ b/src/app/services/baw-api/region/regions.service.ts
@@ -11,6 +11,7 @@ import {
   IdParam,
   IdParamOptional,
   option,
+  param,
   StandardApi,
 } from "../api-common";
 import { BawApiService, Filters } from "../baw-api.service";
@@ -20,6 +21,7 @@ const projectId: IdParam<Project> = id;
 const regionId: IdParamOptional<Region> = id;
 const endpoint = stringTemplate`/projects/${projectId}/regions/${regionId}${option}`;
 const endpointShallow = stringTemplate`/regions/${regionId}${option}`;
+const annotationsEndpoint = stringTemplate`/projects/${projectId}/regions/${regionId}/audio_events/download?${param}`;
 
 /**
  * Regions Service.
@@ -66,6 +68,18 @@ export class RegionsService implements StandardApi<Region, [IdOr<Project>]> {
     project: IdOr<Project>
   ): Observable<Region | void> {
     return this.api.destroy(endpoint(project, model, emptyParam));
+  }
+
+  public downloadAnnotations(
+    model: IdOr<Region>,
+    project: IdOr<Project>,
+    selectedTimezone: string
+  ): string {
+    const url = new URL(
+      this.api.getPath(annotationsEndpoint(project, model, emptyParam))
+    );
+    url.searchParams.set("selected_timezone_name", selectedTimezone ?? "UTC");
+    return url.toString();
   }
 }
 

--- a/src/app/services/baw-api/site/sites.service.spec.ts
+++ b/src/app/services/baw-api/site/sites.service.spec.ts
@@ -21,7 +21,6 @@ describe("SitesService", (): void => {
   const createModel = () => new Site(generateSite({ id: 10 }));
   const listUrl = "/projects/5/sites/";
   const showUrl = listUrl + "10";
-  let service: SitesService;
   let apiRoot: string;
   let spec: SpectatorService<SitesService>;
 
@@ -32,7 +31,6 @@ describe("SitesService", (): void => {
 
   beforeEach((): void => {
     spec = createService();
-    service = spec.inject(SitesService);
     apiRoot = spec.inject(API_ROOT);
   });
 
@@ -69,14 +67,14 @@ describe("SitesService", (): void => {
     }
 
     it("should return url using model ids", () => {
-      expect(service.downloadAnnotations(10, 5, defaultTimezone)).toBe(
+      expect(spec.service.downloadAnnotations(10, 5, defaultTimezone)).toBe(
         getUrl()
       );
     });
 
     it("should return url using model objects", () => {
       expect(
-        service.downloadAnnotations(
+        spec.service.downloadAnnotations(
           new Site(generateSite({ id: 10 })),
           new Project(generateProject({ id: 5 })),
           defaultTimezone
@@ -85,7 +83,7 @@ describe("SitesService", (): void => {
     });
 
     it("should return url with timezone", () => {
-      expect(service.downloadAnnotations(10, 5, "Brisbane")).toBe(
+      expect(spec.service.downloadAnnotations(10, 5, "Brisbane")).toBe(
         getUrl("Brisbane")
       );
     });


### PR DESCRIPTION
# Add support for downloading region annotations

## Changes

- Adds an annotations download menu item and associated modal for the region details page
- Adds a `downloadAnnotations` method to the regions service to create a url that points to the url endpoint where annotations can be downloaded

## Issues

Fixes: #2237

## Final Checklist

## Visual Changes

![image](https://github.com/user-attachments/assets/9180c566-5061-40a5-b465-97d5999ecda6)

_New menu item on the region details page to download annotations (same icon as project and site detail pages)_

---

![image](https://github.com/user-attachments/assets/b78e14ea-3f13-46cc-991f-781c6b6da4b2)

_Modal to download annotations (same modal used in project and site annotation downloads)_

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
