### PR TITLE
Remove `eslint-prefer-arrow` as a dependency

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -139,7 +139,6 @@
         "no-multiple-empty-lines": "error",
         "no-shadow": "off",
         "no-underscore-dangle": "off",
-        "prefer-arrow/prefer-arrow-functions": "off",
         "quotes": [
           "error",
           "double",

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,6 @@
         "eslint": "^8.57.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jsdoc": "^48.0.2",
-        "eslint-plugin-prefer-arrow": "1.2.3",
         "eslint-plugin-rxjs": "^5.0.3",
         "eslint-plugin-rxjs-angular": "^2.0.1",
         "jasmine-core": "^5.4.0",
@@ -11597,16 +11596,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-prefer-arrow": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz",
-      "integrity": "sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "eslint": ">=2.0.0"
       }
     },
     "node_modules/eslint-plugin-rxjs": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "eslint": "^8.57.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsdoc": "^48.0.2",
-    "eslint-plugin-prefer-arrow": "1.2.3",
     "eslint-plugin-rxjs": "^5.0.3",
     "eslint-plugin-rxjs-angular": "^2.0.1",
     "jasmine-core": "^5.4.0",


### PR DESCRIPTION
# Remove `eslint-prefer-arrow` as a dependency

We added this package as a dev dependency, but then explcitly disabled
it in the eslintrc, meaning that is was not used, and can be safely
removed.

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [ ] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
