### PR TITLE
Fix: FOUC before environment.json is loaded

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -58,7 +58,6 @@
             "ssr": {
               "entry": "src/server.ts"
             },
-            "prerender": false,
             "outputMode": "server"
           },
           "configurations": {

--- a/angular.json
+++ b/angular.json
@@ -58,6 +58,7 @@
             "ssr": {
               "entry": "src/server.ts"
             },
+            "prerender": false,
             "outputMode": "server"
           },
           "configurations": {

--- a/src/app/app.config.server.ts
+++ b/src/app/app.config.server.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { mergeApplicationConfig, ApplicationConfig, InjectionToken } from "@angular/core";
+import { mergeApplicationConfig, ApplicationConfig } from "@angular/core";
 import { provideServerRendering } from "@angular/platform-server";
 import {
   NgHttpCachingConfig,
@@ -12,10 +12,10 @@ import { UniversalDeviceDetectorService } from "@services/universal-device-detec
 import { providerTimeoutInterceptor } from "@services/timeout/provide-timeout";
 import { environment } from "src/environments/environment";
 import { provideServerRouting } from "@angular/ssr";
+import { API_CONFIG } from "@services/config/config.tokens";
+import { Configuration } from "@helpers/app-initializer/app-initializer";
 import { appConfig } from "./app.config";
 import { serverRoutes } from "./app.routes";
-
-const ENVIRONMENT = new InjectionToken("ENVIRONMENT");
 
 function readConfig() {
   const environmentPath = environment.production
@@ -24,10 +24,10 @@ function readConfig() {
 
   if (existsSync(environmentPath)) {
     const rawConfig = readFileSync(environmentPath, "utf-8").toString();
-    return JSON.parse(rawConfig);
+    const config = JSON.parse(rawConfig);
+    return new Configuration(config);
   }
 }
-global.config = readConfig();
 
 // we disable caching on the server to prevent potentially serving stale data
 // and data that requires authorization to unauthenticated users
@@ -40,6 +40,8 @@ const serverConfig: ApplicationConfig = {
   providers: [
     provideServerRendering(),
     provideServerRouting(serverRoutes),
+
+    { provide: API_CONFIG, useFactory: readConfig },
 
     {
       provide: DeviceDetectorService,

--- a/src/app/app.config.server.ts
+++ b/src/app/app.config.server.ts
@@ -1,4 +1,5 @@
-import { mergeApplicationConfig, ApplicationConfig } from "@angular/core";
+import { existsSync, readFileSync } from "node:fs";
+import { mergeApplicationConfig, ApplicationConfig, InjectionToken } from "@angular/core";
 import { provideServerRendering } from "@angular/platform-server";
 import {
   NgHttpCachingConfig,
@@ -13,6 +14,20 @@ import { environment } from "src/environments/environment";
 import { provideServerRouting } from "@angular/ssr";
 import { appConfig } from "./app.config";
 import { serverRoutes } from "./app.routes";
+
+const ENVIRONMENT = new InjectionToken("ENVIRONMENT");
+
+function readConfig() {
+  const environmentPath = environment.production
+    ? "/environment.json"
+    : "./src/assets/environment.json";
+
+  if (existsSync(environmentPath)) {
+    const rawConfig = readFileSync(environmentPath, "utf-8").toString();
+    return JSON.parse(rawConfig);
+  }
+}
+global.config = readConfig();
 
 // we disable caching on the server to prevent potentially serving stale data
 // and data that requires authorization to unauthenticated users

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -20,7 +20,6 @@ import { LoadingComponent } from "@shared/loading/loading.component";
 import { CardsComponent } from "@shared/model-cards/cards/cards.component";
 import { StrongRouteDirective } from "@directives/strongRoute/strong-route.directive";
 import { AuthenticatedImageDirective } from "@directives/image/image.directive";
-import { RenderMode } from "@angular/ssr";
 import { WithLoadingPipe } from "../../pipes/with-loading/with-loading.pipe";
 import { homeCategory, homeMenuItem } from "./home.menus";
 
@@ -142,7 +141,6 @@ HomeComponent.linkToRoute({
   category: homeCategory,
   pageRoute: homeMenuItem,
   fullscreen: true,
-  renderMode: RenderMode.Prerender,
 });
 
 export { HomeComponent };

--- a/src/app/guards/security/is-logged-in/is-logged-in.guard.spec.ts
+++ b/src/app/guards/security/is-logged-in/is-logged-in.guard.spec.ts
@@ -56,7 +56,7 @@ describe("isLoggedInGuard", () => {
     expect(result).toBeTrue();
   });
 
-  fit("should navigate to the login page if the user is not logged in", async () => {
+  it("should navigate to the login page if the user is not logged in", async () => {
     setLoggedIn(false);
     const expectedRouterLocation = router.createUrlTree([loginRoute.toRouterLink()], {
       queryParams: {

--- a/src/app/services/config/config.service.ts
+++ b/src/app/services/config/config.service.ts
@@ -31,7 +31,7 @@ export class ConfigService {
     private notification: ToastService,
     private theme: ThemeService,
     handler: HttpBackend,
-    @Inject(IS_SERVER_PLATFORM) private isServer: boolean
+    @Inject(IS_SERVER_PLATFORM) private isServer: boolean,
   ) {
     // This is to bypass the interceptor and prevent circular dependencies
     // (interceptor requires API_ROOT)
@@ -55,8 +55,8 @@ export class ConfigService {
 
     // if we are in ssr, we can read the file directly from the file system
     // instead of using the http client
-    if (this.isServer) {
-      const config = await import("../../../assets/environment.json");
+    if (this.isServer && global.config !== undefined) {
+      const config = global.config;
       this.setConfig(new Configuration(config));
       return;
     }

--- a/src/app/services/config/config.service.ts
+++ b/src/app/services/config/config.service.ts
@@ -53,14 +53,6 @@ export class ConfigService {
       return;
     }
 
-    // if we are in ssr, we can read the file directly from the file system
-    // instead of using the http client
-    if (this.isServer && global.config !== undefined) {
-      const config = global.config;
-      this.setConfig(new Configuration(config));
-      return;
-    }
-
     return firstValueFrom(
       this.http.get("assets/environment.json").pipe(
         retry({ count: 5, delay: 250 }),

--- a/src/app/services/config/config.tokens.ts
+++ b/src/app/services/config/config.tokens.ts
@@ -1,4 +1,10 @@
 import { InjectionToken } from "@angular/core";
 
+/**
+ * Object data from an environment.json that can be used to construct a
+ * Configuration model.
+ * This DI token exists so that different environments (e.g. browser, ssr, and
+ * test) can use their own methods to create an API_CONFIG.
+ */
 export const API_CONFIG = new InjectionToken<Promise<any>>("baw.api.config");
 export const API_ROOT = new InjectionToken<string>("baw.api.root");


### PR DESCRIPTION
# Fix: FOUC before environment.json is loaded

The problem is that when reading the environment.json in ssr, we're reading from `assets/environment.json` which is always the dev environmen.json.

Once the client side takes over, it requests the correct `environment.json`

## Changes

- Provides `API_CONFIG` DI token to SSR environments. This was previously only provided in testing environments, but has been expanded to include SSR.
- During SSR, the `/environment.json` file is read ONCE using NodeJS
- Improves performance of SSR by not reading the environment.json before every request
- Disables pre-rendering on home page

## Related Issues

Fixes: #2313

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [x] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
