### PR TITLE
Add verification grid/annotation search sorting

### DIFF
--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
@@ -108,7 +108,7 @@
     <select
       id="sort-input"
       class="form-select"
-      placeholder="Upload Date (Ascending)"
+      placeholder="Created Date (Oldest First)"
       [value]="searchParameters.sort ?? 'upload-date-asc'"
       (change)="updateSortBy($event)"
     >

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
@@ -102,6 +102,19 @@
       ></baw-typeahead-input>
     </div>
   </div>
+
+  <div cclass="mt-4 mb-4">
+    <label for="sort-input">Sort by</label>
+    <select
+      id="sort-input"
+      class="form-select"
+      [value]="searchParameters.sortBy"
+      (modelChange)="updateSortBy($event)"
+    >
+      <option value="">Upload date/time</option>
+      <option value="score">Score</option>
+    </select>
+  </div>
 </form>
 
 <ng-template #idTypeaheadTemplate let-result="result" let-searchTerm="term">

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
@@ -103,14 +103,18 @@
     </div>
   </div>
 
-  <div cclass="mt-4 mb-4">
+  <div class="mt-2 mb-2">
     <label for="sort-input">Sort by</label>
     <select
       id="sort-input"
       class="form-select"
+      placeholder="Upload Date (Ascending)"
       [value]="searchParameters.sortBy"
       (change)="updateSortBy($event)"
     >
+      <option value="upload-date-asc">Upload Date (Ascending)</option>
+      <option value="upload-date-desc">Upload Date (Descending)</option>
+
       <option value="score-asc">Score (Ascending)</option>
       <option value="score-desc">Score (Descending)</option>
     </select>

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
@@ -22,7 +22,7 @@
     label="Project(s)"
     [inputPlaceholder]="project ? project.name : 'All'"
     [searchCallback]="
-      createSearchCallback(projectsApi, 'name', searchParameters.modelFilters())
+      createSearchCallback(projectsApi, 'name', this.routeModelFilters())
     "
     [resultTemplate]="nameTypeaheadTemplate"
     [inputDisabled]="!!project"
@@ -36,7 +36,7 @@
       label="Site(s)"
       [inputPlaceholder]="region ? region.name : 'All'"
       [searchCallback]="
-        createSearchCallback(regionsApi, 'name', searchParameters.modelFilters())
+        createSearchCallback(regionsApi, 'name', this.routeModelFilters())
       "
       [resultTemplate]="nameTypeaheadTemplate"
       [inputDisabled]="!!region"
@@ -49,7 +49,7 @@
     [label]="site ? (site?.isPoint ? 'Point(s)' : 'Site(s)') : 'Point(s)'"
     [inputPlaceholder]="site ? site.name : 'All'"
     [searchCallback]="
-      createSearchCallback(sitesApi, 'name', searchParameters.modelFilters())
+      createSearchCallback(sitesApi, 'name', this.routeModelFilters())
     "
     [resultTemplate]="nameTypeaheadTemplate"
     [inputDisabled]="!!site"

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
@@ -112,8 +112,8 @@
       [value]="searchParameters.sort ?? 'upload-date-asc'"
       (change)="updateSortBy($event)"
     >
-      <option value="upload-date-asc">Upload Date (Ascending)</option>
-      <option value="upload-date-desc">Upload Date (Descending)</option>
+      <option value="created-asc">Created Date (Oldest First)</option>
+      <option value="created-desc">Created Date (Newest First)</option>
 
       <option value="score-asc">Score (Ascending)</option>
       <option value="score-desc">Score (Descending)</option>

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
@@ -109,10 +109,10 @@
       id="sort-input"
       class="form-select"
       [value]="searchParameters.sortBy"
-      (modelChange)="updateSortBy($event)"
+      (change)="updateSortBy($event)"
     >
-      <option value="">Upload date/time</option>
-      <option value="score">Score</option>
+      <option value="score-asc">Score (Ascending)</option>
+      <option value="score-desc">Score (Descending)</option>
     </select>
   </div>
 </form>

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
@@ -109,7 +109,7 @@
       id="sort-input"
       class="form-select"
       placeholder="Created Date (Oldest First)"
-      [value]="searchParameters.sort ?? 'upload-date-asc'"
+      [value]="searchParameters.sort ?? 'created-asc'"
       (change)="updateSortBy($event)"
     >
       <option value="created-asc">Created Date (Oldest First)</option>

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
@@ -103,7 +103,7 @@
     </div>
   </div>
 
-  <div class="mt-2 mb-2">
+  <div class="mt-2">
     <label for="sort-input">Sort by</label>
     <select
       id="sort-input"

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
@@ -109,7 +109,7 @@
       id="sort-input"
       class="form-select"
       placeholder="Upload Date (Ascending)"
-      [value]="searchParameters.sortBy"
+      [value]="searchParameters.sort ?? 'upload-date-asc'"
       (change)="updateSortBy($event)"
     >
       <option value="upload-date-asc">Upload Date (Ascending)</option>

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
@@ -190,9 +190,7 @@ export class AnnotationSearchFormComponent implements OnInit {
       return;
     }
 
-    this.searchParameters.sortBy = event.target.value;
+    this.searchParameters.sortBy = event.target.value || null;
     this.searchParametersChange.emit(this.searchParameters);
-
-    console.debug(this.searchParameters.sortBy);
   }
 }

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
@@ -214,6 +214,9 @@ export class AnnotationSearchFormComponent implements OnInit {
       return;
     }
 
+    // So that we can minimize the number of query string parameters, we use
+    // upload-date-asc as the default if there is no "sort" query string
+    // parameter.
     const newValue = event.target.value;
     if (newValue === "upload-date-asc") {
       this.searchParameters.sort = null;

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
@@ -28,6 +28,8 @@ import { TypeaheadInputComponent } from "@shared/typeahead-input/typeahead-input
 import { DateTime } from "luxon";
 import { FormsModule } from "@angular/forms";
 import { WIPComponent } from "@shared/wip/wip.component";
+import { filterModel } from "@helpers/filters/filters";
+import { InnerFilter } from "@baw-api/baw-api.service";
 
 @Component({
   selector: "baw-annotation-search-form",
@@ -113,6 +115,28 @@ export class AnnotationSearchFormComponent implements OnInit {
         dateFinishedBefore,
       };
     }
+  }
+
+  /**
+    * Creates a filter condition to fetch models scoped to the current route
+    * models.
+    * This can be used in the typeaheads where you need to provide search
+    * results for site, regions, etc... under a parent model (e.g. project).
+    */
+  protected routeModelFilters(): InnerFilter<Project | Region | Site> {
+    if (this.site) {
+      return filterModel("sites", this.site);
+    } else if (this.region) {
+      return filterModel("regions", this.region);
+    } else if (this.project){
+      return filterModel("projects", this.project);
+    }
+
+    // We should never get to this condition because each annotation search
+    // should at least be scoped under a project.
+    // However, I have included this condition so that if we ever get into this
+    // unexpected state, the client doesn't completely crash and can recover.
+    return {};
   }
 
   protected toggleAdvancedFilters(): void {

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
@@ -190,7 +190,13 @@ export class AnnotationSearchFormComponent implements OnInit {
       return;
     }
 
-    this.searchParameters.sortBy = event.target.value || null;
+    const newValue = event.target.value;
+    if (newValue === "upload-date-asc") {
+      this.searchParameters.sort = null;
+    } else {
+      this.searchParameters.sort = newValue;
+    }
+
     this.searchParametersChange.emit(this.searchParameters);
   }
 }

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
@@ -183,4 +183,16 @@ export class AnnotationSearchFormComponent implements OnInit {
     this.searchParameters.onlyUnverified = value;
     this.searchParametersChange.emit(this.searchParameters);
   }
+
+  public updateSortBy(event: Event): void {
+    if (!(event.target instanceof HTMLSelectElement)) {
+      console.warn("Attempted to update sort key through non-select element");
+      return;
+    }
+
+    this.searchParameters.sortBy = event.target.value;
+    this.searchParametersChange.emit(this.searchParameters);
+
+    console.debug(this.searchParameters.sortBy);
+  }
 }

--- a/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
@@ -72,6 +72,7 @@ describe("annotationSearchParameters", () => {
                 lessThan: DateTime.fromISO("2020-03-01T00:00:00.000Z", { zone: "utc" })
               }
             },
+            { "audioRecordings.id": { in: [11, 12, 13] } },
             {
               "audioRecordings.siteId": {
                 in: [6, 7, 8, 9],
@@ -97,30 +98,6 @@ describe("annotationSearchParameters", () => {
 
         sort: "score-asc",
       },
-      /*
-      expectedFitlers: () => ({
-        filter: {
-          and: [
-            { "audioRecordings.id": { in: [11, 12, 13] } },
-            { "tags.id": { in: [4, 5, 6] } },
-            {
-              recordedDate: {
-                lessThan: {
-                  expressions: ["local_offset", "time_of_day"],
-                  value: "22:15",
-                },
-              },
-            },
-            { "regions.id": { in: [2, 3, 4, 5] } },
-            { "sites.id": { in: [6, 7, 8, 9] } }
-          ],
-        },
-        sorting: {
-          orderBy: "score",
-          direction: "asc",
-        },
-      } as Filters<AudioEvent>),
-      */
       expectedFitlers: () => ({
         filter: {
           and: [
@@ -130,6 +107,7 @@ describe("annotationSearchParameters", () => {
                 lessThan: jasmine.any(DateTime),
               },
             },
+            { "audioRecordings.id": { in: [11, 12, 13] } },
             { "audioRecordings.siteId": { in: [6, 7, 8, 9] } },
           ],
         },
@@ -138,7 +116,6 @@ describe("annotationSearchParameters", () => {
           direction: "asc",
         },
       }),
-      //expectedFitlers: () => ({}),
     },
   ];
 

--- a/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
@@ -74,7 +74,7 @@ describe("annotationSearchParameters", () => {
             },
             {
               "audioRecordings.siteId": {
-                in: Array.from(routeProject.siteIds),
+                in: [6, 7, 8, 9],
               },
             },
           ],
@@ -97,6 +97,7 @@ describe("annotationSearchParameters", () => {
 
         sort: "score-asc",
       },
+      /*
       expectedFitlers: () => ({
         filter: {
           and: [
@@ -119,6 +120,25 @@ describe("annotationSearchParameters", () => {
           direction: "asc",
         },
       } as Filters<AudioEvent>),
+      */
+      expectedFitlers: () => ({
+        filter: {
+          and: [
+            { "tags.id": { in: [4, 5, 6] } },
+            {
+              "audioRecordings.recordedDate": {
+                lessThan: jasmine.any(DateTime),
+              },
+            },
+            { "audioRecordings.siteId": { in: [6, 7, 8, 9] } },
+          ],
+        },
+        sorting: {
+          orderBy: "score",
+          direction: "asc",
+        },
+      }),
+      //expectedFitlers: () => ({}),
     },
   ];
 

--- a/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
@@ -41,7 +41,7 @@ describe("annotationSearchParameters", () => {
     expect(dataModel.toFilter()).toEqual(expectedFilters);
   });
 
-  fit("should create correct filter condition when filters is set", () => {
+  it("should create correct filter condition when filters is set", () => {
     const mockQueryParameters: Params = {
       audioRecordings: "11,12,13",
       tags: "4,5,6",

--- a/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
@@ -1,8 +1,127 @@
+import { modelData } from "@test/helpers/faker";
+import { Project } from "@models/Project";
+import { Filters } from "@baw-api/baw-api.service";
+import { AudioEvent } from "@models/AudioEvent";
+import { Params } from "@angular/router";
+import { DateTime } from "luxon";
 import { AnnotationSearchParameters } from "./annotationSearchParameters";
+
+function addRouteModels(
+  dataModel: AnnotationSearchParameters,
+): AnnotationSearchParameters {
+  const mockProjectId = modelData.id();
+  dataModel.routeProjectId = modelData.id();
+
+  const mockSiteIds = modelData.ids();
+  dataModel.routeProjectModel = new Project({
+    id: mockProjectId,
+    siteIds: mockSiteIds,
+  });
+
+  return dataModel;
+}
 
 describe("annotationSearchParameters", () => {
   it("should create", () => {
     const dataModel = new AnnotationSearchParameters();
     expect(dataModel).toBeInstanceOf(AnnotationSearchParameters);
+  });
+
+  it("should create correct default filters", () => {
+    const dataModel = addRouteModels(new AnnotationSearchParameters());
+
+    const expectedFilters = {
+      filter: {
+        "audioRecordings.siteId": {
+          in: Array.from(dataModel.routeProjectModel.siteIds),
+        },
+      },
+    } as Filters<AudioEvent>;
+
+    expect(dataModel.toFilter()).toEqual(expectedFilters);
+  });
+
+  fit("should create correct filter condition when filters is set", () => {
+    const mockQueryParameters: Params = {
+      audioRecordings: "11,12,13",
+      tags: "4,5,6",
+      recordingDate: ",2020-03-01",
+
+      regions: "2,3,4,5",
+      sites: "6,7,8,9",
+    };
+
+    const dataModel = addRouteModels(
+      new AnnotationSearchParameters(mockQueryParameters),
+    );
+
+    // Note that there are no sorting parameters in this expected filter.
+    // If there are sorting parameters (even empty objects) in your resulting
+    // filters, something has gone wrong.
+    const expectedFilters = {
+      filter: {
+        and: [
+          { "tags.id": { in: [4, 5, 6] } },
+          {
+            "audioRecordings.recordedDate": {
+              lessThan: DateTime.fromISO("2020-03-01T00:00:00.000Z", { zone: "utc" })
+            }
+          },
+          {
+            "audioRecordings.siteId": {
+              in: Array.from(dataModel.routeProjectModel.siteIds),
+            },
+          },
+        ],
+      },
+    } as Filters<AudioEvent>;
+
+    expect(dataModel.toFilter()).toEqual(expectedFilters);
+  });
+
+  it("should create correct filter condition when both filters and sorting is set", () => {
+    const mockQueryParameters: Params = {
+      audioRecordings: "11,12,13",
+      tags: "4,5,6",
+      recordingDate: ",2020-03-01",
+
+      regions: "2,3,4,5",
+      sites: "6,7,8,9",
+
+      sortBy: "score-asc",
+    };
+
+    const expectedFilters = {
+      filter: {
+        "audioRecordings.id": {
+          in: [11, 12, 13],
+        },
+        "tags.id": {
+          in: [4, 5, 6],
+        },
+        recordedDate: {
+          lessThan: {
+            expressions: ["local_offset", "time_of_day"],
+            value: "22:15",
+          },
+        },
+        "regions.id": {
+          in: [2, 3, 4, 5],
+        },
+        "sites.id": {
+          in: [6, 7, 8, 9],
+        },
+      },
+      sorting: {
+        orderBy: "score",
+        direction: "asc",
+      },
+    } as Filters<AudioEvent>;
+
+    const dataModel = addRouteModels(
+      new AnnotationSearchParameters(mockQueryParameters),
+    );
+
+    expect(dataModel.toFilter()).toEqual(expectedFilters);
   });
 });

--- a/src/app/components/annotations/pages/annotationSearchParameters.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.ts
@@ -36,7 +36,7 @@ import { DateTime, Duration } from "luxon";
 
 export type SortingKey = string;
 
-export const sortByOptions = {
+export const sortingOptions = {
   "score-asc": {
     orderBy: "score",
     direction: "asc",
@@ -86,7 +86,7 @@ export interface IAnnotationSearchParameters {
   eventDate: MonoTuple<DateTime, 2>;
   eventTime: MonoTuple<Duration, 2>;
 
-  sortBy: SortingKey;
+  sort: SortingKey;
 }
 
 // we exclude project, region, and site from the serialization table because
@@ -107,7 +107,7 @@ const serializationTable: IQueryStringParameterSpec<
   regions: jsNumberArray,
   sites: jsNumberArray,
 
-  sortBy: jsString,
+  sort: jsString,
 };
 
 const deserializationTable: IQueryStringParameterSpec<
@@ -167,7 +167,7 @@ export class AnnotationSearchParameters
   public eventDate: MonoTuple<DateTime, 2>;
   public eventTime: MonoTuple<Duration, 2>;
 
-  public sortBy: SortingKey;
+  public sort: SortingKey;
 
   @hasMany<AnnotationSearchParameters, AudioRecording>(
     AUDIO_RECORDING,
@@ -303,10 +303,10 @@ export class AnnotationSearchParameters
 
   private sortingFilters(): Sorting<keyof AudioEvent> {
     const defaultSortKey = "upload-date-asc";
-    const sortKey = this.sortBy in sortByOptions
-      ? this.sortBy
+    const sortingKey = this.sort in sortingOptions
+      ? this.sort
       : defaultSortKey;
 
-    return sortByOptions[sortKey];
+    return sortingOptions[sortingKey];
   }
 }

--- a/src/app/components/annotations/pages/annotationSearchParameters.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.ts
@@ -10,6 +10,7 @@ import {
 import { MonoTuple } from "@helpers/advancedTypes";
 import { filterEventRecordingDate } from "@helpers/filters/audioEventFilters";
 import { filterAnd, filterModelIds } from "@helpers/filters/filters";
+import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import {
   deserializeParamsToObject,
   IQueryStringParameterSpec,
@@ -288,7 +289,7 @@ export class AnnotationSearchParameters
 
     // We use a !== null condition here instead of a truthy assertion so that
     // a route site if of 0 also passes this condition.
-    if (this.routeSiteId !== null) {
+    if (isInstantiated(this.routeSiteId)) {
       return [this.routeSiteId];
     } else if (qspSites.length > 0) {
       return qspSites;
@@ -298,7 +299,7 @@ export class AnnotationSearchParameters
     // is the region level.
     const qspRegions = this.regions ? Array.from(this.regions) : [];
 
-    if (this.routeRegionId !== null) {
+    if (isInstantiated(this.routeRegionId)) {
       return Array.from(this.routeRegionModel.siteIds);
     } else if (qspRegions.length > 0) {
       return qspRegions;
@@ -306,7 +307,7 @@ export class AnnotationSearchParameters
 
     const qspProjects = this.projects ? Array.from(this.projects) : [];
 
-    if (this.routeProjectId !== null) {
+    if (isInstantiated(this.routeProjectId)) {
       return Array.from(this.routeProjectModel.siteIds);
     } else if (qspProjects.length > 0) {
       return qspProjects;

--- a/src/app/components/annotations/pages/annotationSearchParameters.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.ts
@@ -45,6 +45,14 @@ export const sortByOptions = {
     orderBy: "score",
     direction: "desc",
   },
+  "upload-date-asc": {
+    orderBy: "createdAt",
+    direction: "asc",
+  },
+  "upload-date-desc": {
+    orderBy: "createdAt",
+    direction: "desc",
+  },
 } as const satisfies Record<string, Sorting<keyof AudioEvent>>;
 
 export interface IAnnotationSearchParameters {
@@ -207,14 +215,11 @@ export class AnnotationSearchParameters
     const siteFilters = filterAnd(dateTimeFilters, this.routeFilters());
     const filter = this.eventDateTimeFilters(siteFilters);
 
-    const sorting = sortByOptions[this.sortBy];
+    const sorting = this.sortingFilters();
     if (sorting === undefined) {
-      return {
-        filter
-      };
+      return { filter };
     }
 
-    console.debug("sorting", sorting);
     return { filter, sorting };
   }
 
@@ -235,7 +240,7 @@ export class AnnotationSearchParameters
     }
   }
 
-  public routeFilters(): InnerFilter<AudioEvent> {
+  private routeFilters(): InnerFilter<AudioEvent> {
     let siteIds: number[] = [];
 
     // because this filter is constructed for audio events, but the project
@@ -260,7 +265,7 @@ export class AnnotationSearchParameters
       "audioRecordings.siteId": {
         in: siteIds,
       },
-    } as any;
+    } as InnerFilter<AudioEvent>;
   }
 
   private recordingDateTimeFilters(
@@ -294,5 +299,14 @@ export class AnnotationSearchParameters
     initialFilter: InnerFilter<AudioEvent>
   ): InnerFilter<AudioEvent> {
     return initialFilter;
+  }
+
+  private sortingFilters(): Sorting<keyof AudioEvent> {
+    const defaultSortKey = "upload-date-asc";
+    const sortKey = this.sortBy in sortByOptions
+      ? this.sortBy
+      : defaultSortKey;
+
+    return sortByOptions[sortKey];
   }
 }

--- a/src/app/components/annotations/pages/annotationSearchParameters.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.ts
@@ -235,7 +235,7 @@ export class AnnotationSearchParameters
   // TODO: fix up this function
   public toFilter(): Filters<AudioEvent> {
     const tagFilters = filterModelIds<Tag>("tags", this.tags);
-    const dateTimeFilters = this.recordingDateTimeFilters(tagFilters);
+    const dateTimeFilters = this.recordingFilters(tagFilters);
     const siteFilters = filterAnd(dateTimeFilters, this.routeFilters());
     const filter = this.eventDateTimeFilters(siteFilters);
 
@@ -320,7 +320,7 @@ export class AnnotationSearchParameters
     return [];
   }
 
-  private recordingDateTimeFilters(
+  private recordingFilters(
     initialFilter: InnerFilter<AudioEvent>,
   ): InnerFilter<AudioEvent> {
     const dateFilter = filterEventRecordingDate(
@@ -341,7 +341,13 @@ export class AnnotationSearchParameters
     //   this.recordingTimeFinishedBefore
     // );
 
-    return dateFilter;
+    const recordingFilter = filterModelIds(
+      "audioRecordings",
+      this.audioRecordings,
+      dateFilter,
+    );
+
+    return recordingFilter;
   }
 
   // TODO: this function is a placeholder for future implementation once the api

--- a/src/app/components/annotations/pages/annotationSearchParameters.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.ts
@@ -264,9 +264,9 @@ export class AnnotationSearchParameters
   private siteIds(): Id[] {
     const qspSites = this.sites ? Array.from(this.sites) : [];
 
-    // We use a !== undefined condition here instead of a truthy assertion so
-    // that a route site if of 0 also passes this condition.
-    if (this.routeSiteId || this.routeSiteId === 0) {
+    // We use a !== null condition here instead of a truthy assertion so that
+    // a route site if of 0 also passes this condition.
+    if (this.routeSiteId !== null) {
       return [this.routeSiteId];
     } else if (qspSites.length > 0) {
       return qspSites;
@@ -276,7 +276,7 @@ export class AnnotationSearchParameters
     // is the region level.
     const qspRegions = this.regions ? Array.from(this.regions) : [];
 
-    if (this.routeRegionId || this.routeRegionId === 0) {
+    if (this.routeRegionId !== null) {
       return Array.from(this.routeRegionModel.siteIds);
     } else if (qspRegions.length > 0) {
       return qspRegions;
@@ -284,7 +284,7 @@ export class AnnotationSearchParameters
 
     const qspProjects = this.projects ? Array.from(this.projects) : [];
 
-    if (this.routeProjectId || this.routeProjectId === 0) {
+    if (this.routeProjectId !== null) {
       return Array.from(this.routeProjectModel.siteIds);
     } else if (qspProjects.length > 0) {
       return qspProjects;

--- a/src/app/components/annotations/pages/search/search.component.spec.ts
+++ b/src/app/components/annotations/pages/search/search.component.spec.ts
@@ -165,7 +165,7 @@ describe("AnnotationSearchComponent", () => {
     expect(spec.component).toBeInstanceOf(AnnotationSearchComponent);
   });
 
-  fit("should make the correct api call", () => {
+  it("should make the correct api call", () => {
     const expectedBody: Filters<AudioEvent> = {
       paging: {
         page: 1,

--- a/src/app/components/annotations/pages/search/search.component.spec.ts
+++ b/src/app/components/annotations/pages/search/search.component.spec.ts
@@ -165,7 +165,7 @@ describe("AnnotationSearchComponent", () => {
     expect(spec.component).toBeInstanceOf(AnnotationSearchComponent);
   });
 
-  it("should make the correct api call", () => {
+  fit("should make the correct api call", () => {
     const expectedBody: Filters<AudioEvent> = {
       paging: {
         page: 1,
@@ -180,10 +180,14 @@ describe("AnnotationSearchComponent", () => {
           },
           {
             "audioRecordings.siteId": {
-              in: Array.from(routeProject.siteIds),
+              in: Array.from(mockSearchParameters.sites),
             },
           },
         ],
+      },
+      sorting: {
+        orderBy: "createdAt",
+        direction: "asc",
       },
     };
 

--- a/src/app/components/annotations/pages/search/search.component.ts
+++ b/src/app/components/annotations/pages/search/search.component.ts
@@ -169,7 +169,7 @@ class AnnotationSearchComponent
 
       const response = await firstValueFrom(request);
 
-      const itemWarningThreshold = 1_000 as const;
+      const itemWarningThreshold = 1_000;
       const responseMetadata = response[0].getMetadata();
       const numberOfItems = responseMetadata.paging.total;
 

--- a/src/app/components/annotations/pages/search/search.component.ts
+++ b/src/app/components/annotations/pages/search/search.component.ts
@@ -89,7 +89,8 @@ class AnnotationSearchComponent
         }
         this.loading = false;
       },
-      () => this.searchParameters.toFilter().filter
+      () => this.searchParameters.toFilter().filter,
+      () => this.searchParameters.toFilter().sorting,
     );
 
     // we make the page size an even number so that the page of results is more

--- a/src/app/components/annotations/pages/verification/verification.component.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.ts
@@ -300,12 +300,8 @@ class VerificationComponent
 
   private filterConditions(page: number): Filters<AudioEvent> {
     const paging: Paging = { page };
-    const routeFilters: InnerFilter<AudioEvent> =
-      this.searchParameters.toFilter().filter;
+    const routeFilters = this.searchParameters.toFilter();
 
-    // Note that the route filters are expanded after the paging filters so that
-    // if in the future we want to route filters to override the verification
-    // grid paging, it can.
     return {
       paging,
       ...routeFilters,

--- a/src/app/components/annotations/pages/verification/verification.component.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.ts
@@ -20,7 +20,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { Location } from "@angular/common";
 import { firstValueFrom } from "rxjs";
 import { annotationMenuItems } from "@components/annotations/annotation.menu";
-import { Filters, InnerFilter, Paging } from "@baw-api/baw-api.service";
+import { Filters, Paging } from "@baw-api/baw-api.service";
 import { VerificationGridComponent } from "@ecoacoustics/web-components/@types/components/verification-grid/verification-grid";
 import { StrongRoute } from "@interfaces/strongRoute";
 import { ProgressWarningComponent } from "@components/annotations/components/modals/progress-warning/progress-warning.component";

--- a/src/app/components/annotations/pages/verification/verification.component.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.ts
@@ -300,10 +300,16 @@ class VerificationComponent
 
   private filterConditions(page: number): Filters<AudioEvent> {
     const paging: Paging = { page };
-    const filter: InnerFilter<AudioEvent> =
+    const routeFilters: InnerFilter<AudioEvent> =
       this.searchParameters.toFilter().filter;
 
-    return { filter, paging };
+    // Note that the route filters are expanded after the paging filters so that
+    // if in the future we want to route filters to override the verification
+    // grid paging, it can.
+    return {
+      paging,
+      ...routeFilters,
+    };
   }
 
   private updateUrlParameters(): void {

--- a/src/app/components/shared/audio-event-card/annotation-event-card.component.html
+++ b/src/app/components/shared/audio-event-card/annotation-event-card.component.html
@@ -29,21 +29,19 @@
       @for (text of annotation().tags; track text; let isLast = $last) {
         <span>
           <a [href]="text.viewUrl">{{ text.text }}</a>
-          @if (!isLast) {
-            ,
-          }
+          @if (!isLast) {, }
         </span>
       }
     </span>
 
     <span class="info-line">
       @if (annotation().audioRecording.site | isUnresolved) {
-        <baw-loading size="sm"></baw-loading>
+        <baw-loading
+          size="sm"
+        ></baw-loading>
       } @else {
         <fa-icon class="me-2" [icon]="['fas', 'location-dot']"></fa-icon>
-        <a [href]="annotation().audioRecording.site.viewUrl">{{
-          annotation().audioRecording.site.name
-        }}</a>
+        <a [href]="annotation().audioRecording.site.viewUrl">{{ annotation().audioRecording.site.name }}</a>
       }
     </span>
 
@@ -59,9 +57,7 @@
 
     <span class="info-line">
       <fa-icon class="me-2" [icon]="['fas', 'circle-info']"></fa-icon>
-      <a class="more-information-link" [href]="annotation().viewUrl"
-        >More information</a
-      >
+      <a class="more-information-link" [href]="annotation().viewUrl">More information</a>
     </span>
   </div>
 </div>

--- a/src/app/components/shared/audio-event-card/annotation-event-card.component.html
+++ b/src/app/components/shared/audio-event-card/annotation-event-card.component.html
@@ -9,7 +9,7 @@
       <oe-indicator>
         <oe-spectrogram
           [id]="spectrogramId"
-          [src]="annotation.audioLink"
+          [src]="annotation().audioLink"
           scaling="stretch"
           color-map="grayscale"
           window-size="512"
@@ -26,38 +26,42 @@
   <div class="card-body">
     <span class="info-line tag-information">
       <fa-icon class="me-2" [icon]="['fas', 'tags']"></fa-icon>
-      @for (text of annotation.tags; track text; let isLast = $last) {
+      @for (text of annotation().tags; track text; let isLast = $last) {
         <span>
           <a [href]="text.viewUrl">{{ text.text }}</a>
-          @if (!isLast) {, }
+          @if (!isLast) {
+            ,
+          }
         </span>
       }
     </span>
 
     <span class="info-line">
-      @if (annotation.audioRecording.site | isUnresolved) {
-        <baw-loading
-          size="sm"
-        ></baw-loading>
+      @if (annotation().audioRecording.site | isUnresolved) {
+        <baw-loading size="sm"></baw-loading>
       } @else {
         <fa-icon class="me-2" [icon]="['fas', 'location-dot']"></fa-icon>
-        <a [href]="annotation.audioRecording.site.viewUrl">{{ annotation.audioRecording.site.name }}</a>
+        <a [href]="annotation().audioRecording.site.viewUrl">{{
+          annotation().audioRecording.site.name
+        }}</a>
       }
     </span>
 
     <span class="info-line">
       <fa-icon class="me-2" [icon]="['fas', 'record-vinyl']"></fa-icon>
-      <a [href]="annotation.listenViewUrl">
+      <a [href]="annotation().listenViewUrl">
         <baw-zoned-datetime
-          [value]="annotation.audioRecording.recordedDate"
-          [timezone]="annotation.audioRecording.recordedDateTimezone"
+          [value]="annotation().audioRecording.recordedDate"
+          [timezone]="annotation().audioRecording.recordedDateTimezone"
         ></baw-zoned-datetime>
       </a>
     </span>
 
     <span class="info-line">
       <fa-icon class="me-2" [icon]="['fas', 'circle-info']"></fa-icon>
-      <a class="more-information-link" [href]="annotation.viewUrl">More information</a>
+      <a class="more-information-link" [href]="annotation().viewUrl"
+        >More information</a
+      >
     </span>
   </div>
 </div>

--- a/src/app/components/shared/audio-event-card/annotation-event-card.component.ts
+++ b/src/app/components/shared/audio-event-card/annotation-event-card.component.ts
@@ -3,7 +3,7 @@ import {
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
   ElementRef,
-  Input,
+  input,
   OnInit,
   ViewChild,
 } from "@angular/core";
@@ -21,16 +21,15 @@ import { IsUnresolvedPipe } from "../../../pipes/is-unresolved/is-unresolved.pip
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class AnnotationEventCardComponent implements OnInit, AfterViewInit {
-  @Input({ required: true })
-  public annotation: Annotation;
+  public annotation = input.required<Annotation>();
 
   protected spectrogramId: string;
 
-  @ViewChild("mediaControls")
+  @ViewChild("mediaControls", { static: true })
   private mediaControls: ElementRef<MediaControlsComponent>;
 
   public ngOnInit(): void {
-    this.spectrogramId = `spectrogram-${this.annotation.id}`;
+    this.spectrogramId = `spectrogram-${this.annotation().id}`;
   }
 
   public ngAfterViewInit(): void {

--- a/src/app/helpers/paginationTemplate/paginationTemplate.ts
+++ b/src/app/helpers/paginationTemplate/paginationTemplate.ts
@@ -5,6 +5,7 @@ import {
   defaultApiPageSize,
   Filters,
   InnerFilter,
+  Sorting,
 } from "@baw-api/baw-api.service";
 import { BawApiError } from "@helpers/custom-errors/baw-api-error";
 import { PageComponent } from "@helpers/page/pageComponent";
@@ -89,7 +90,8 @@ export abstract class PaginationTemplate<M extends AbstractModel>
      * Default inner filter values
      */
     protected defaultInnerFilter: () => InnerFilter<M> = () =>
-      ({} as InnerFilter<M>)
+      ({} as InnerFilter<M>),
+    protected defaultSortingFilter?: () => Sorting<keyof M>,
   ) {
     super();
   }
@@ -193,11 +195,11 @@ export abstract class PaginationTemplate<M extends AbstractModel>
   protected generateFilter(): Filters<M> {
     // if the template has an explicit page size set, we should add the number
     // of items to the request body
-    // if the user has not set an explit page size, we want to use the default
+    // if the user has not set an explicit page size, we want to use the default
     // returned by the api
     const pageItemFilters = this.pageSize ? { items: this.pageSize } : {};
 
-    return {
+    const filters: Filters<M> = {
       paging: {
         page: this.page,
         ...pageItemFilters,
@@ -209,5 +211,11 @@ export abstract class PaginationTemplate<M extends AbstractModel>
           } as InnerFilter<M>)
         : this.defaultInnerFilter(),
     };
+
+    if (this.defaultSortingFilter) {
+      filters.sorting = this.defaultSortingFilter();
+    }
+
+    return filters;
   }
 }

--- a/src/app/helpers/query-string-parameters/queryStringParameters.spec.ts
+++ b/src/app/helpers/query-string-parameters/queryStringParameters.spec.ts
@@ -218,8 +218,21 @@ describe("queryStringParameters", () => {
 
       const result = deserializeParamsToObject(testInput, testSpec);
 
-      expect(result["time"][0]).toEqual(null);
+      expect(result["time"][0]).toBeNull();
       expect(result["time"][1].toFormat("hh:mm")).toEqual("12:12");
+    });
+
+    it("should emit null values if a number param is not a number", () => {
+      const testSpec: IQueryStringParameterSpec = {
+        badId: jsNumber,
+      };
+
+      const testInput: Params = {
+        badId: "this is not a number",
+      };
+
+      const result = deserializeParamsToObject(testInput, testSpec);
+      expect(result["badId"]).toBeNull();
     });
   });
 });

--- a/src/app/helpers/query-string-parameters/queryStringParameters.ts
+++ b/src/app/helpers/query-string-parameters/queryStringParameters.ts
@@ -132,7 +132,6 @@ function queryStringNumber(value: string): number | null {
   // the condition is not applied, rather than returning incorrect results that would be returned with parseInt()
   const parsedNumber = Number(value);
   if (isNaN(parsedNumber)) {
-    console.warn(`Expected "number" type query string parameter. Received "${value}".`);
     return null;
   }
 

--- a/src/app/helpers/query-string-parameters/queryStringParameters.ts
+++ b/src/app/helpers/query-string-parameters/queryStringParameters.ts
@@ -124,17 +124,22 @@ function queryStringBoolean(value: string): boolean {
   return value === "true";
 }
 
-function queryStringNumber(value: string): number {
+function queryStringNumber(value: string): number | null {
   // we want to use number here so that if the user inputs a malformed number into the query string parameters
   // the condition is not applied, rather than returning incorrect results that would be returned with parseInt()
-  return Number(value);
+  const parsedNumber = Number(value);
+  if (isNaN(parsedNumber)) {
+    return null;
+  }
+
+  return parsedNumber;
 }
 
 function queryStringArray(value: string): string[] {
   return value.split(",");
 }
 
-function queryStringToNumberArray(value: string): number[] {
+function queryStringToNumberArray(value: string): (number | null)[] {
   return queryStringArray(value).map(queryStringNumber);
 }
 
@@ -142,11 +147,11 @@ function queryStringToBooleanArray(value: string): boolean[] {
   return queryStringArray(value).map(queryStringBoolean);
 }
 
-function queryStringDateArray(value: string): DateTime[] {
+function queryStringDateArray(value: string): (DateTime | null)[] {
   return queryStringArray(value).map(queryStringDate);
 }
 
-function queryStringDate(value: string): DateTime {
+function queryStringDate(value: string): DateTime | null {
   // if a null or undefined value is passed into luxon's DateTime.fromISO, it will return the current time
   // this can be confusing and lead to lots of bugs. We therefore return the null value here
   if (value === "") {

--- a/src/app/helpers/query-string-parameters/queryStringParameters.ts
+++ b/src/app/helpers/query-string-parameters/queryStringParameters.ts
@@ -129,6 +129,7 @@ function queryStringNumber(value: string): number | null {
   // the condition is not applied, rather than returning incorrect results that would be returned with parseInt()
   const parsedNumber = Number(value);
   if (isNaN(parsedNumber)) {
+    console.warn(`Expected "number" type query string parameter. Received "${value}".`);
     return null;
   }
 

--- a/src/app/test/fakes/data/AnnotationSearchParameters.ts
+++ b/src/app/test/fakes/data/AnnotationSearchParameters.ts
@@ -1,5 +1,5 @@
 import { Params } from "@angular/router";
-import { IAnnotationSearchParameters, sortByOptions } from "@components/annotations/pages/annotationSearchParameters";
+import { IAnnotationSearchParameters, sortingOptions } from "@components/annotations/pages/annotationSearchParameters";
 import { modelData } from "@test/helpers/faker";
 
 export function generateAnnotationSearchParameters(
@@ -22,8 +22,8 @@ export function generateAnnotationSearchParameters(
     eventDate: [modelData.dateTime(), modelData.dateTime()],
     eventTime: [modelData.time(), modelData.time()],
     daylightSavings: modelData.bool(),
-    sortBy: modelData.helpers.arrayElement(
-      Object.keys(sortByOptions) as any,
+    sort: modelData.helpers.arrayElement(
+      Object.keys(sortingOptions) as any,
     ),
     ...data,
   };

--- a/src/app/test/fakes/data/AnnotationSearchParameters.ts
+++ b/src/app/test/fakes/data/AnnotationSearchParameters.ts
@@ -1,5 +1,5 @@
 import { Params } from "@angular/router";
-import { IAnnotationSearchParameters } from "@components/annotations/pages/annotationSearchParameters";
+import { IAnnotationSearchParameters, sortByOptions } from "@components/annotations/pages/annotationSearchParameters";
 import { modelData } from "@test/helpers/faker";
 
 export function generateAnnotationSearchParameters(
@@ -22,6 +22,9 @@ export function generateAnnotationSearchParameters(
     eventDate: [modelData.dateTime(), modelData.dateTime()],
     eventTime: [modelData.time(), modelData.time()],
     daylightSavings: modelData.bool(),
+    sortBy: modelData.helpers.arrayElement(
+      Object.keys(sortByOptions) as any,
+    ),
     ...data,
   };
 }

--- a/src/app/test/fakes/data/AnnotationSearchParameters.ts
+++ b/src/app/test/fakes/data/AnnotationSearchParameters.ts
@@ -1,5 +1,5 @@
 import { Params } from "@angular/router";
-import { IAnnotationSearchParameters, sortingOptions } from "@components/annotations/pages/annotationSearchParameters";
+import { IAnnotationSearchParameters, SortingKey, sortingOptions } from "@components/annotations/pages/annotationSearchParameters";
 import { modelData } from "@test/helpers/faker";
 
 export function generateAnnotationSearchParameters(
@@ -23,7 +23,10 @@ export function generateAnnotationSearchParameters(
     eventTime: [modelData.time(), modelData.time()],
     daylightSavings: modelData.bool(),
     sort: modelData.helpers.arrayElement(
-      Object.keys(sortingOptions) as any,
+      // We need to type cast Object.keys here because lib.d's implementation of
+      // Object.keys does not maintain object structural typing, and will return
+      // string[], which incorrectly broadens the type.
+      Object.keys(sortingOptions) as SortingKey[],
     ),
     ...data,
   };


### PR DESCRIPTION
# Add verification grid/annotation search sorting

## Changes

- Adds options to sort by
	- Created date (Ascending)
	- Created date (Descending)
	- Score (Ascending)
	- Score (Descending)
- Fixes annotation search form site and point filters
- Adds tests for annotation search parameters
- Paged table template now takes an optional callback that can be used to create sorting conditions for a filter request
- Annotation model in `annotation-event-card.component` now uses a signal
- Media controls `ViewChild` selector in `annotation-event-card.component` is now a static selector
- Fix bug in number qsp serializer where non-numbers would be serialized as `NaN`. Incorrect numbers in qsps are now omitted and log a warning.
- Remove focused test that somehow got onto the main branch (looking for eslint rule now)

## Issues

Fixes: #2309

## Visual Changes

![image](https://github.com/user-attachments/assets/232c4e88-c623-4f6d-a5cd-c8ab09ec2534)

_New annotation search with "Sort By" dropdown_

---

![image](https://github.com/user-attachments/assets/e3ceefc4-c223-4983-a2cd-cbcc3ff9a53f)

_Expanded "sort by" dropdown_

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
