### PR TITLE
Add ability to delete annotation import files

### DIFF
--- a/src/app/components/import-annotations/pages/details/details.component.html
+++ b/src/app/components/import-annotations/pages/details/details.component.html
@@ -67,7 +67,7 @@
 
             <ng-template let-value="value" ngx-datatable-cell-template>
               <a
-                class="btn btn-sm btn-outline-primary"
+                class="btn btn-sm btn-primary"
                 [href]="value.viewUrl"
               >
                 View
@@ -111,18 +111,6 @@
             </ng-template>
 
             <ng-template let-value="value" ngx-datatable-cell-template>
-              <!-- <baw-loading
-                *ngIf="value.additionalTags | isUnresolved; else additionalTagsTemplate"
-                size="sm"
-              ></baw-loading>
-
-              <ng-template #additionalTagsTemplate>
-                <baw-inline-list
-                  [items]="value.additionalTags"
-                  [itemKey]="'text'"
-                  [emptyTemplate]="noAssociatedTagsTemplate"
-                ></baw-inline-list>
-              </ng-template> -->
               <baw-inline-list
                 [items]="value.additionalTags"
                 [itemKey]="'text'"
@@ -144,12 +132,19 @@
                 file viewer for the file type.
               -->
               <a
-                class="btn btn-sm btn-outline-primary"
+                class="btn btn-sm btn-primary"
                 [href]="value.path"
                 target="_blank"
               >
                 Download
               </a>
+
+              <button
+                class="btn btn-sm btn-outline-danger ms-1"
+                (click)="deleteFile(deleteFileModal, value)"
+              >
+                Delete
+              </button>
             </ng-template>
           </ngx-datatable-column>
         </ngx-datatable>
@@ -166,4 +161,18 @@
 
 <ng-template #noAdditionalTagsTemplate>
   <span>No additional tags</span>
+</ng-template>
+
+<ng-template #deleteFileModal let-modal>
+  <baw-harvest-confirmation-modal
+    nextLabel="Delete File"
+    cancelLabel="Return"
+    isDanger="true"
+    [modal]="modal"
+  >
+    <p>
+      Are you sure you want to delete this file? All annotations imported from
+      this file will be removed.
+    </p>
+  </baw-harvest-confirmation-modal>
 </ng-template>

--- a/src/app/components/import-annotations/pages/details/details.component.spec.ts
+++ b/src/app/components/import-annotations/pages/details/details.component.spec.ts
@@ -29,7 +29,7 @@ import { ASSOCIATION_INJECTOR } from "@services/association-injector/association
 import { AudioEventImportFile } from "@models/AudioEventImportFile";
 import { AudioEventImportFileService } from "@baw-api/audio-event-import-file/audio-event-import-file.service";
 import { assertDatatable } from "@test/helpers/datatable";
-import { NgbNavConfig } from "@ng-bootstrap/ng-bootstrap";
+import { NgbModalConfig, NgbNavConfig } from "@ng-bootstrap/ng-bootstrap";
 import { modelData } from "@test/helpers/faker";
 import { generateTag } from "@test/fakes/Tag";
 import { generateAudioEvent } from "@test/fakes/AudioEvent";
@@ -39,6 +39,8 @@ import { AudioRecording } from "@models/AudioRecording";
 import { generateAudioRecording } from "@test/fakes/AudioRecording";
 import { nStepObservable } from "@test/helpers/general";
 import { fakeAsync, flush } from "@angular/core/testing";
+import { getElementByInnerText } from "@test/helpers/html";
+import { Sorting } from "@baw-api/baw-api.service";
 import { AnnotationImportDetailsComponent } from "./details.component";
 
 describe("AnnotationsDetailsComponent", () => {
@@ -91,6 +93,18 @@ describe("AnnotationsDetailsComponent", () => {
     spec.detectChanges();
   }
 
+  function deleteFirstFile() {
+    const deleteButton = getElementByInnerText(spec, "Delete");
+    spec.click(deleteButton);
+
+    const confirmationButton = spec.query<HTMLButtonElement>(
+      "baw-harvest-confirmation-modal #next-btn",
+      { root: true },
+    );
+    spec.click(confirmationButton);
+    flush();
+  }
+
   async function setup(): Promise<void> {
     spec = createComponent({
       detectChanges: false,
@@ -117,27 +131,27 @@ describe("AnnotationsDetailsComponent", () => {
     mockAudioEvents = modelData.randomArray(
       1,
       10,
-      () => new AudioEvent(generateAudioEvent(), injector)
+      () => new AudioEvent(generateAudioEvent(), injector),
     );
     mockAudioEvents.forEach((event) =>
       event.addMetadata(
         modelData.model.generatePagingMetadata({
           items: mockAudioEvents.length,
-        })
-      )
+        }),
+      ),
     );
 
     mockAudioEventImportFiles = modelData.randomArray(
       1,
       10,
-      () => new AudioEventImportFile(generateAudioEventImportFile(), injector)
+      () => new AudioEventImportFile(generateAudioEventImportFile(), injector),
     );
     mockAudioEventImportFiles.forEach((file) =>
       file.addMetadata(
         modelData.model.generatePagingMetadata({
           items: mockAudioEventImportFiles.length,
-        })
-      )
+        }),
+      ),
     );
 
     mockRecordingsService = spec.inject(AUDIO_RECORDING.token);
@@ -145,15 +159,16 @@ describe("AnnotationsDetailsComponent", () => {
 
     mockAudioEventFileService = spec.inject(AUDIO_EVENT_IMPORT_FILE.token);
     mockAudioEventFileService.list.and.callFake(() =>
-      of(mockAudioEventImportFiles)
+      of(mockAudioEventImportFiles),
     );
     mockAudioEventFileService.filter.and.callFake(() =>
-      of(mockAudioEventImportFiles)
+      of(mockAudioEventImportFiles),
     );
+    mockAudioEventFileService.destroy.andReturn(of());
 
     mockAudioEventImportService = spec.inject(AUDIO_EVENT_IMPORT.token);
     mockAudioEventImportService.show.and.callFake(() =>
-      of(mockAudioEventImport)
+      of(mockAudioEventImport),
     );
 
     const audioEventSubject = new Subject<AudioEventImport>();
@@ -169,6 +184,13 @@ describe("AnnotationsDetailsComponent", () => {
 
     mockTagsService = spec.inject(TAG.token);
     mockTagsService.show.and.callFake(() => tagsSubject);
+
+    // When deleting a file, we use a modal to confirm that the user wants to
+    // delete the file.
+    // By disabling the modal animation, we don't have to (fake) async await for
+    // the modal to open during testing.
+    const modalConfigService = spec.inject(NgbModalConfig);
+    modalConfigService.animation = false;
 
     // without mocking the timezone, tests that assert time will fail in CI
     // and other timezones that are not the same as the developers local timezone (UTC+8)
@@ -198,10 +220,10 @@ describe("AnnotationsDetailsComponent", () => {
     {
       audioEventImport: {
         model: new AudioEventImport(
-          generateAudioEventImport({ name: "test name" })
+          generateAudioEventImport({ name: "test name" }),
         ),
       },
-    }
+    },
   );
 
   it("should create", () => {
@@ -217,7 +239,7 @@ describe("AnnotationsDetailsComponent", () => {
       jasmine.objectContaining({
         paging: { page: 1 },
       }),
-      mockAudioEventImport
+      mockAudioEventImport,
     );
   }));
 
@@ -232,7 +254,7 @@ describe("AnnotationsDetailsComponent", () => {
       expect(mockEventsService.filter).toHaveBeenCalledOnceWith(
         jasmine.objectContaining({
           paging: { page: 1 },
-        })
+        }),
       );
     });
   });
@@ -259,6 +281,39 @@ describe("AnnotationsDetailsComponent", () => {
       ],
       rows: () => expectedFilesTable,
       root: () => activeTabContent(),
+    }));
+
+    it("should make the correct api requests to delete a file", fakeAsync(() => {
+      deleteFirstFile();
+      expect(mockAudioEventFileService.destroy).toHaveBeenCalledTimes(1);
+    }));
+
+    it("should refresh the files table after deleting a file", fakeAsync(() => {
+      // We first sort the files table by "File Name" column, to ensure that
+      // the re-fetch request maintains the same sorting conditions.
+      const fileNameColumn = spec.query(".datatable-header-cell-template-wrap");
+      const sortingHandle = fileNameColumn.querySelector(".sort-btn");
+      spec.click(sortingHandle);
+
+      const expectedSortingFilters: Sorting<keyof AudioEventImportFile> = {
+        direction: "asc",
+        orderBy: "name",
+      };
+      expect(mockAudioEventFileService.filter).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          sorting: expectedSortingFilters,
+        }),
+        jasmine.any(AudioEventImport),
+      );
+
+      deleteFirstFile();
+
+      expect(mockAudioEventFileService.filter).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          sorting: expectedSortingFilters,
+        }),
+        jasmine.any(AudioEventImport),
+      );
     }));
   });
 });


### PR DESCRIPTION
# Add ability to delete annotation import files

## Changes

- Add "delete" button to annotation import "files" tab
- Change "View" and "Download" buttons to primary buttons instead of `btn-outline-primary` to better unify the design of the website.

## Issues

Fixes: #2298

## Visual Changes

![image](https://github.com/user-attachments/assets/2f93abce-8b06-4fa2-bd5c-e8bf7fdecce0)

_"files" tab with new "Delete" `btn-outline-danger` button_

---

![image](https://github.com/user-attachments/assets/edec4211-e439-46da-bc3e-c6b324676eb0)

_"Events" tab with changed "View" button that is now solid (instead of outline)_

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
