### PR TITLE
Support annotation filtering by import file

### DIFF
--- a/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
@@ -61,6 +61,7 @@ describe("annotationSearchParameters", () => {
       inputParams: {
         audioRecordings: "11,12,13",
         tags: "4,5,6",
+        importFiles: "1,12,23",
         recordingDate: ",2020-03-01",
         score: "0.5,0.9",
 
@@ -79,6 +80,7 @@ describe("annotationSearchParameters", () => {
               },
             },
             { "audioRecordings.id": { in: [11, 12, 13] } },
+            { "audioEventImportFileId": { in: [1, 12, 23] } },
             {
               "audioRecordings.siteId": {
                 in: [6, 7, 8, 9],

--- a/src/app/components/annotations/pages/annotationSearchParameters.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.ts
@@ -9,7 +9,7 @@ import {
 } from "@baw-api/ServiceTokens";
 import { MonoTuple } from "@helpers/advancedTypes";
 import { filterEventRecordingDate } from "@helpers/filters/audioEventFilters";
-import { filterAnd, filterModelIds as tagFilters } from "@helpers/filters/filters";
+import { filterAnd, filterModelIds } from "@helpers/filters/filters";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import {
   deserializeParamsToObject,
@@ -38,7 +38,11 @@ import { Site } from "@models/Site";
 import { Tag } from "@models/Tag";
 import { DateTime, Duration } from "luxon";
 
-export type SortingKey = "score-asc" | "score-desc" | "created-asc" | "created-desc";
+export type SortingKey =
+  | "score-asc"
+  | "score-desc"
+  | "created-asc"
+  | "created-desc";
 
 // prettier-ignore
 export const sortingOptions = new Map([
@@ -63,6 +67,7 @@ export const sortingOptions = new Map([
 export interface IAnnotationSearchParameters {
   audioRecordings: CollectionIds;
   tags: CollectionIds;
+  importFiles: CollectionIds;
   onlyUnverified: boolean;
   daylightSavings: boolean;
   recordingDate: MonoTuple<DateTime, 2>;
@@ -102,6 +107,7 @@ const serializationTable: IQueryStringParameterSpec<
 > = {
   audioRecordings: jsNumberArray,
   tags: jsNumberArray,
+  importFiles: jsNumberArray,
   onlyUnverified: jsBoolean,
   daylightSavings: jsBoolean,
   recordingDate: luxonDateArray,
@@ -155,6 +161,7 @@ export class AnnotationSearchParameters
 
   public audioRecordings: CollectionIds;
   public tags: CollectionIds;
+  public importFiles: CollectionIds;
   public onlyUnverified: boolean;
   public daylightSavings: boolean;
   public recordingDate: MonoTuple<DateTime, 2>;
@@ -255,8 +262,9 @@ export class AnnotationSearchParameters
 
   // TODO: fix up this function
   public toFilter(): Filters<AudioEvent> {
-    let filter = tagFilters<Tag>("tags", this.tags);
+    let filter = filterModelIds<Tag>("tags", this.tags);
     filter = this.addRecordingFilters(filter);
+    filter = this.annotationImportFilters(filter);
     filter = this.addRouteFilters(filter);
     filter = this.addEventFilters(filter);
 
@@ -368,13 +376,29 @@ export class AnnotationSearchParameters
     //   this.recordingTimeFinishedBefore
     // );
 
-    const recordingFilter = tagFilters(
+    const recordingFilter = filterModelIds(
       "audioRecordings",
       this.audioRecordings,
       dateFilter,
     );
 
     return recordingFilter;
+  }
+
+  private annotationImportFilters(
+    initialFilter: InnerFilter<AudioEvent>,
+  ): InnerFilter<AudioEvent> {
+    if (!isInstantiated(this.importFiles)) {
+      return initialFilter;
+    }
+
+    const importFileFilters = {
+      audioEventImportFileId: {
+        in: Array.from(this.importFiles),
+      },
+    };
+
+    return filterAnd(importFileFilters, initialFilter);
   }
 
   // TODO: We should add support for event date/time filtering once the api
@@ -397,7 +421,7 @@ export class AnnotationSearchParameters
     let scoreFilters: InnerFilter<AudioEvent> = initialFilter;
     if (isInstantiated(lowerBound)) {
       scoreFilters = filterAnd(scoreFilters, {
-        score: { gteq: lowerBound }
+        score: { gteq: lowerBound },
       });
     }
 

--- a/src/app/components/annotations/pages/annotationSearchParameters.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.ts
@@ -398,7 +398,7 @@ export class AnnotationSearchParameters
       },
     };
 
-    return filterAnd(importFileFilters, initialFilter);
+    return filterAnd(initialFilter, importFileFilters);
   }
 
   // TODO: We should add support for event date/time filtering once the api

--- a/src/app/test/fakes/data/AnnotationSearchParameters.ts
+++ b/src/app/test/fakes/data/AnnotationSearchParameters.ts
@@ -8,6 +8,7 @@ export function generateAnnotationSearchParameters(
   return {
     audioRecordings: modelData.ids(),
     tags: modelData.ids(),
+    importFiles: modelData.ids(),
     onlyUnverified: modelData.bool(),
     daylightSavings: modelData.bool(),
     recordingDate: [modelData.dateTime(), modelData.dateTime()],


### PR DESCRIPTION
# Support annotation filtering by import file

## Changes

- Adds `?importFile=1,2,3,4` qsp that can be used to filter by an annotation import file id

## Issues

Fixes: #2322

## Visual Changes

There are no visual changes

I initially wanted to add an "advanced filters" input so that the user could change this parameter through the UI, but since the audio event file endpoint requires an annotation import file id (there is no shallow route), it makes the logic more complicated than expected.

In the interest of time, I have not added a UI for this filter condition.

## Final Checklist

- [ ] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
