### PR TITLE
Add provenance inputs to annotation import

### DIFF
--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
@@ -186,7 +186,7 @@
         </ng-template>
       </ngx-datatable-column>
 
-      <ngx-datatable-column [sortable]="false" prop="event" [width]="80">
+      <ngx-datatable-column [sortable]="false" prop="event" [width]="70">
         <ng-template let-column="column" ngx-datatable-header-template>
           Recording
         </ng-template>
@@ -212,7 +212,7 @@
         </ng-template>
       </ngx-datatable-column>
 
-      <ngx-datatable-column [sortable]="false" prop="event" [width]="80">
+      <ngx-datatable-column [sortable]="false" prop="event" [width]="50">
         <ng-template let-column="column" ngx-datatable-header-template>
           Start Time
         </ng-template>
@@ -226,7 +226,7 @@
         </ng-template>
       </ngx-datatable-column>
 
-      <ngx-datatable-column [sortable]="false" prop="event" [width]="80">
+      <ngx-datatable-column [sortable]="false" prop="event" [width]="50">
         <ng-template let-column="column" ngx-datatable-header-template>
           End Time
         </ng-template>
@@ -240,7 +240,7 @@
         </ng-template>
       </ngx-datatable-column>
 
-      <ngx-datatable-column [sortable]="false" prop="event" [width]="100">
+      <ngx-datatable-column [sortable]="false" prop="event" [width]="70">
         <ng-template let-column="column" ngx-datatable-header-template>
           Low Frequency
         </ng-template>
@@ -254,7 +254,7 @@
         </ng-template>
       </ngx-datatable-column>
 
-      <ngx-datatable-column [sortable]="false" prop="event" [width]="100">
+      <ngx-datatable-column [sortable]="false" prop="event" [width]="70">
         <ng-template let-column="column" ngx-datatable-header-template>
           High Frequency
         </ng-template>
@@ -282,7 +282,7 @@
         </ng-template>
       </ngx-datatable-column>
 
-      <ngx-datatable-column [sortable]="false" prop="event" [width]="80">
+      <ngx-datatable-column [sortable]="false" prop="event" [width]="70">
         <ng-template let-column="column" ngx-datatable-header-template>
           Reference
         </ng-template>
@@ -324,7 +324,7 @@
         </ng-template>
       </ngx-datatable-column>
 
-      <ngx-datatable-column [sortable]="false" prop="event" [width]="100">
+      <ngx-datatable-column [sortable]="false" prop="event" [width]="80">
         <ng-template let-column="column" ngx-datatable-header-template>
           Provenance
         </ng-template>
@@ -342,8 +342,8 @@
 
       <ngx-datatable-column
         [sortable]="false"
-        [minWidth]="240"
-        [width]="240"
+        [minWidth]="230"
+        [width]="230"
         prop="event"
       >
         <ng-template let-column="column" ngx-datatable-header-template>

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
@@ -73,7 +73,6 @@
                       class="file-provenance"
                       inputPlaceholder="Add provenance"
                       [searchCallback]="provenanceApi.typeaheadCallback()"
-                      [resultTemplate]="nameTypeaheadTemplate"
                       [inputDisabled]="isUploading"
                       [multipleInputs]="false"
                       (modelChange)="
@@ -114,7 +113,6 @@
           label="Apply provenance to all files"
           [inputPlaceholder]="'search for provenance by name'"
           [searchCallback]="provenanceApi.typeaheadCallback()"
-          [resultTemplate]="nameTypeaheadTemplate"
           [inputDisabled]="(hasFiles() | async) === false"
           [multipleInputs]="false"
           (modelChange)="
@@ -363,10 +361,6 @@
 
 <ng-template #tagsTypeaheadTemplate let-result="result" let-searchTerm="term">
   <ngb-highlight [result]="result.text" [term]="searchTerm"></ngb-highlight>
-</ng-template>
-
-<ng-template #nameTypeaheadTemplate let-result="result" let-searchTerm="term">
-  <ngb-highlight [result]="result.name" [term]="searchTerm"></ngb-highlight>
 </ng-template>
 
 <ng-template #emptyTemplate>

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
@@ -24,7 +24,7 @@
             @for (fileModel of importFiles$ | async; track fileModel.file) {
               <li class="file-list-item">
                 <div class="file-list-item-content">
-                  <span class="file-name">
+                  <span>
                     <button
                       class="remove-file-btn btn btn-link text-dark me-1"
                       [ngbTooltip]="'Remove file'"
@@ -170,9 +170,7 @@
         <ng-template let-column="column" ngx-datatable-header-template>
           <span
             class="tooltip-hint"
-            [ngbTooltip]="
-              'File index and the index of the annotation in the file'
-            "
+            [ngbTooltip]="'File index and the index of the annotation in the file'"
             container="body"
           >
             ID

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
@@ -24,7 +24,7 @@
             @for (fileModel of importFiles$ | async; track fileModel.file) {
               <li class="file-list-item">
                 <div class="file-list-item-content">
-                  <span>
+                  <span class="file-actions">
                     <button
                       class="remove-file-btn btn btn-link text-dark me-1"
                       [ngbTooltip]="'Remove file'"
@@ -33,7 +33,7 @@
                       <fa-icon [icon]="['fas', 'xmark']"></fa-icon>
                     </button>
 
-                    <span>{{ fileModel.file.name }}</span>
+                    <span class="file-name">{{ fileModel.file.name }}</span>
                   </span>
 
                   <baw-error-card

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
@@ -320,7 +320,7 @@
         </ng-template>
       </ngx-datatable-column>
 
-      <ngx-datatable-column [sortable]="false" prop="event" [width]="80">
+      <ngx-datatable-column [sortable]="false" prop="event" [width]="100">
         <ng-template let-column="column" ngx-datatable-header-template>
           Provenance
         </ng-template>
@@ -336,8 +336,8 @@
 
       <ngx-datatable-column
         [sortable]="false"
-        [minWidth]="230"
-        [width]="230"
+        [minWidth]="210"
+        [width]="210"
         prop="event"
       >
         <ng-template let-column="column" ngx-datatable-header-template>

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
@@ -67,6 +67,19 @@
                         )
                       "
                     ></baw-typeahead-input>
+
+                    <baw-typeahead-input
+                      #additionalProvenanceInput
+                      class="file-provenance ms-2"
+                      inputPlaceholder="Add provenance"
+                      [searchCallback]="provenanceApi.typeaheadCallback()"
+                      [resultTemplate]="nameTypeaheadTemplate"
+                      [inputDisabled]="isUploading"
+                      [multipleInputs]="false"
+                      (modelChange)="
+                        updateFileProvenance(fileModel, $event?.[0]?.id)
+                      "
+                    ></baw-typeahead-input>
                   </div>
                 </div>
               </li>
@@ -91,6 +104,26 @@
 
         <p class="text-muted">
           Extra tags will be applied to all files in the annotation import.
+        </p>
+      </div>
+
+      <div class="mt-2">
+        <baw-typeahead-input
+          #extraProvenanceInput
+          id="extra-provenance-input"
+          label="Apply provenance to all files"
+          [inputPlaceholder]="'search for provenance by name'"
+          [searchCallback]="provenanceApi.typeaheadCallback()"
+          [resultTemplate]="nameTypeaheadTemplate"
+          [inputDisabled]="(hasFiles() | async) === false"
+          [multipleInputs]="false"
+          (modelChange)="
+            updateExtraProvenances($event[0], extraProvenanceInput)
+          "
+        ></baw-typeahead-input>
+
+        <p class="text-muted">
+          Provenances will be applied to all files in the annotation import.
         </p>
       </div>
     </div>
@@ -139,7 +172,9 @@
         <ng-template let-column="column" ngx-datatable-header-template>
           <span
             class="tooltip-hint"
-            [ngbTooltip]="'File index and the index of the annotation in the file'"
+            [ngbTooltip]="
+              'File index and the index of the annotation in the file'
+            "
             container="body"
           >
             ID
@@ -275,7 +310,7 @@
         </ng-template>
       </ngx-datatable-column>
 
-      <ngx-datatable-column [sortable]="false" prop="event" [width]="120">
+      <ngx-datatable-column [sortable]="false" prop="event" [width]="140">
         <ng-template let-column="column" ngx-datatable-header-template>
           Tags
         </ng-template>
@@ -286,6 +321,21 @@
             [itemKey]="'text'"
             [emptyTemplate]="emptyTemplate"
           ></baw-inline-list>
+        </ng-template>
+      </ngx-datatable-column>
+
+      <ngx-datatable-column [sortable]="false" prop="event" [width]="100">
+        <ng-template let-column="column" ngx-datatable-header-template>
+          Provenance
+        </ng-template>
+
+        <ng-template let-value="value" ngx-datatable-cell-template>
+          @if (value.provenance) {
+            <a [bawUrl]="value.provenance.viewUrl"></a>
+            {{ value.provenance.name }}
+          } @else {
+            <ng-container [ngTemplateOutlet]="emptyTemplate"></ng-container>
+          }
         </ng-template>
       </ngx-datatable-column>
 
@@ -314,6 +364,10 @@
 
 <ng-template #tagsTypeaheadTemplate let-result="result" let-searchTerm="term">
   <ngb-highlight [result]="result.text" [term]="searchTerm"></ngb-highlight>
+</ng-template>
+
+<ng-template #nameTypeaheadTemplate let-result="result" let-searchTerm="term">
+  <ngb-highlight [result]="result.name" [term]="searchTerm"></ngb-highlight>
 </ng-template>
 
 <ng-template #emptyTemplate>

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
@@ -330,8 +330,9 @@
         </ng-template>
 
         <ng-template let-value="value" ngx-datatable-cell-template>
-          @if (value.provenance) {
-            <a [bawUrl]="value.provenance.viewUrl"></a>
+          @if (value.provenance | isUnresolved) {
+            <baw-loading size="sm"></baw-loading>
+          } @else if (value.provenance) {
             {{ value.provenance.name }}
           } @else {
             <ng-container [ngTemplateOutlet]="emptyTemplate"></ng-container>

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
@@ -24,7 +24,7 @@
             @for (fileModel of importFiles$ | async; track fileModel.file) {
               <li class="file-list-item">
                 <div class="file-list-item-content">
-                  <span>
+                  <span class="file-name">
                     <button
                       class="remove-file-btn btn btn-link text-dark me-1"
                       [ngbTooltip]="'Remove file'"
@@ -52,7 +52,7 @@
                     </ng-template>
                   </baw-error-card>
 
-                  <div>
+                  <div class="file-data">
                     <baw-typeahead-input
                       #additionalFileTagInput
                       class="additional-file-tags"
@@ -70,7 +70,7 @@
 
                     <baw-typeahead-input
                       #additionalProvenanceInput
-                      class="file-provenance ms-2"
+                      class="file-provenance"
                       inputPlaceholder="Add provenance"
                       [searchCallback]="provenanceApi.typeaheadCallback()"
                       [resultTemplate]="nameTypeaheadTemplate"

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
@@ -330,10 +330,8 @@
         </ng-template>
 
         <ng-template let-value="value" ngx-datatable-cell-template>
-          @if (value.provenance | isUnresolved) {
-            <baw-loading size="sm"></baw-loading>
-          } @else if (value.provenance) {
-            {{ value.provenance.name }}
+          @if (value.provenance) {
+            {{ value.provenance.toString() }}
           } @else {
             <ng-container [ngTemplateOutlet]="emptyTemplate"></ng-container>
           }

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.scss
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.scss
@@ -5,13 +5,34 @@
 }
 
 .file-list-item-content {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  position: relative;
+
+  display: flex;
+  flex-wrap: wrap;
+
   gap: 1em;
 
   & > * {
     display: flex;
     align-items: center;
+    min-width: 200px;
+
+    width: 25%;
+
+    overflow-wrap: anywhere;
+  }
+}
+
+.file-data {
+  display: flex;
+  flex-wrap: wrap;
+  width: 45% !important;
+
+  gap: 0.5rem;
+
+  & > * {
+    min-width: 0;
+    flex: 1 1 auto;
   }
 }
 
@@ -22,10 +43,6 @@
 
   width: 1.5em;
   height: 1.5em;
-}
-
-.additional-file-tags {
-  width: 100%;
 }
 
 .event-errors {

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.scss
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.scss
@@ -10,39 +10,56 @@
   display: flex;
   flex-wrap: wrap;
 
-  gap: 1em;
+  gap: 1rem;
 
-  & > * {
-    display: flex;
-    align-items: center;
+  .file-actions,
+  .file-error {
+    // Both of the file actions and errors have a fixed with instead of flexing
+    // with their content so that all of the content is vertically aligned.
+    min-width: 200px;
+    width: 25%;
+  }
+
+  .file-data {
     min-width: 200px;
 
-    width: 25%;
-
-    overflow-wrap: anywhere;
-  }
-}
-
-.file-data {
-  display: flex;
-  flex-wrap: wrap;
-  width: 45% !important;
-
-  gap: 0.5rem;
-
-  & > * {
-    min-width: 0;
+    // If there is left over space, we want to allow the "file data" (additional
+    // tags and provenance associated with a file) to fill up this remaining
+    // space.
     flex: 1 1 auto;
+
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+
+    & > * {
+      flex: 1 1;
+    }
   }
 }
 
-.remove-file-btn {
+.file-actions {
   display: flex;
-  justify-content: center;
-  align-items: center;
 
-  width: 1.5em;
-  height: 1.5em;
+  .remove-file-btn {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 1.5em;
+    height: 1.5em;
+  }
+
+  .file-name {
+    // If the user uploads a really long file name, we want the file name to
+    // wrap to the next line.
+    // Because file names sometimes use underscores (or similar) in replacement
+    // of spaces, break-word will not always work.
+    // If the break-word overflow-wrap doesn't work because there are no spaces
+    // in the filename, we fall back to breaking anywhere so that we don't
+    // start overflowing content.
+    overflow-wrap: break-word anywhere;
+  }
 }
 
 .event-errors {

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.spec.ts
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.spec.ts
@@ -573,10 +573,6 @@ describe("AddAnnotationsComponent", () => {
         );
       }));
 
-      it("should perform a dry run with no provenance if the user changes the provenance name to an invalid name", () => {});
-
-      it("should perform a dry run with no provenances if the provenance input is cleared", () => {});
-
       it("should start with no provenance", () => {
         addFiles([modelData.file(), modelData.file()]);
         expect(fileProvenance(0)).toEqual("");

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.spec.ts
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.spec.ts
@@ -8,6 +8,7 @@ import { assertDatatable, assertDatatableRow } from "@test/helpers/datatable";
 import { AudioEventImportFileService } from "@baw-api/audio-event-import-file/audio-event-import-file.service";
 import {
   AUDIO_EVENT_IMPORT_FILE,
+  AUDIO_EVENT_PROVENANCE,
   AUDIO_RECORDING,
   TAG,
 } from "@baw-api/ServiceTokens";
@@ -39,6 +40,9 @@ import { IconsModule } from "@shared/icons/icons.module";
 import { provideMockBawApi } from "@baw-api/provide-baw-ApiMock";
 import { Project } from "@models/Project";
 import { generateProject } from "@test/fakes/Project";
+import { AudioEventProvenanceService } from "@baw-api/AudioEventProvenance/AudioEventProvenance.service";
+import { AudioEventProvenance } from "@models/AudioEventProvenance";
+import { generateAudioEventProvenance } from "@test/fakes/AudioEventProvenance";
 import { AddAnnotationsComponent } from "./add-annotations.component";
 
 describe("AddAnnotationsComponent", () => {
@@ -48,6 +52,7 @@ describe("AddAnnotationsComponent", () => {
   let fileImportSpy: SpyObject<AudioEventImportFileService>;
   let tagServiceSpy: SpyObject<TagsService>;
   let recordingServiceSpy: SpyObject<AudioRecordingsService>;
+  let provenanceServiceSpy: SpyObject<AudioEventProvenanceService>;
 
   let notificationsSpy: SpyObject<ToastService>;
   let routerSpy: SpyObject<Router>;
@@ -56,6 +61,7 @@ describe("AddAnnotationsComponent", () => {
   let routeProject: Project;
   let mockImportResponse: AudioEventImportFile | BawApiError;
   let mockTagsResponse: Tag[];
+  let mockProvenanceResponse: AudioEventProvenance;
   let mockRecordingsResponse: AudioRecording;
 
   const createComponent = createRoutingFactory({
@@ -130,6 +136,7 @@ describe("AddAnnotationsComponent", () => {
 
     fileImportSpy = spec.inject(AUDIO_EVENT_IMPORT_FILE.token);
     tagServiceSpy = spec.inject(TAG.token);
+    provenanceServiceSpy = spec.inject(AUDIO_EVENT_PROVENANCE.token);
     recordingServiceSpy = spec.inject(AUDIO_RECORDING.token);
 
     notificationsSpy = spec.inject(ToastService);
@@ -151,6 +158,10 @@ describe("AddAnnotationsComponent", () => {
       () => new Tag(generateTag(), injectorSpy),
     );
 
+    mockProvenanceResponse = new AudioEventProvenance(
+      generateAudioEventProvenance(),
+    );
+
     mockRecordingsResponse = new AudioRecording(
       generateAudioRecording(),
       injectorSpy,
@@ -161,6 +172,12 @@ describe("AddAnnotationsComponent", () => {
 
     tagServiceSpy.filter.and.callFake(() => of(mockTagsResponse));
     tagServiceSpy.typeaheadCallback.and.returnValue(() => of(mockTagsResponse));
+
+    provenanceServiceSpy.filter.and.callFake(() => of(mockProvenanceResponse));
+    provenanceServiceSpy.show.and.callFake(() => of(mockProvenanceResponse));
+    provenanceServiceSpy.typeaheadCallback.and.returnValue(() =>
+      of([mockProvenanceResponse]),
+    );
 
     recordingServiceSpy.show.and.callFake(() => of(mockRecordingsResponse));
 
@@ -198,6 +215,7 @@ describe("AddAnnotationsComponent", () => {
           file: jasmine.objectContaining({ type: "text/csv" }),
         }),
         audioEventImport,
+        null,
       );
     });
 
@@ -221,6 +239,7 @@ describe("AddAnnotationsComponent", () => {
           file: jasmine.objectContaining({ type: "text/csv" }),
         }),
         audioEventImport,
+        null,
       );
     });
 
@@ -237,6 +256,7 @@ describe("AddAnnotationsComponent", () => {
           file: jasmine.objectContaining({ type: "application/vnd.ms-excel" }),
         }),
         audioEventImport,
+        null,
       );
     });
   });
@@ -333,6 +353,7 @@ describe("AddAnnotationsComponent", () => {
       expect(fileImportSpy.dryCreate).toHaveBeenCalledWith(
         jasmine.any(AudioEventImportFile),
         audioEventImport,
+        null,
       );
     });
 
@@ -347,6 +368,7 @@ describe("AddAnnotationsComponent", () => {
         expect(fileImportSpy.dryCreate).toHaveBeenCalledWith(
           jasmine.objectContaining({ file }),
           audioEventImport,
+          null,
         );
       });
     });
@@ -386,6 +408,7 @@ describe("AddAnnotationsComponent", () => {
           event.isReference ? "Yes" : "No",
           event.score.toLocaleString(),
           expectedTagValue,
+          "Loading...",
           expectedErrorValue,
         ];
 
@@ -445,6 +468,7 @@ describe("AddAnnotationsComponent", () => {
             additionalTagIds: [testedTag.id],
           }),
           audioEventImport,
+          null,
         );
       }));
 
@@ -461,6 +485,7 @@ describe("AddAnnotationsComponent", () => {
             additionalTagIds: [testedTag.id],
           }),
           audioEventImport,
+          null,
         );
       }));
 
@@ -522,6 +547,7 @@ describe("AddAnnotationsComponent", () => {
         expect(fileImportSpy.create).toHaveBeenCalledWith(
           jasmine.objectContaining({ file }),
           audioEventImport,
+          null,
         );
       });
     });

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.spec.ts
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.spec.ts
@@ -646,6 +646,7 @@ describe("AddAnnotationsComponent", () => {
         "Reference",
         "Score",
         "Tags",
+        "Provenance",
         "Errors",
       ],
       rows: () => [],

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.spec.ts
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.spec.ts
@@ -93,7 +93,8 @@ describe("AddAnnotationsComponent", () => {
   const removeFileButtons = () =>
     spec.queryAll<HTMLButtonElement>(".remove-file-btn");
 
-  const additionalFileTagInputs = () => spec.queryAll(".additional-file-tags");
+  const additionalFileTagInputs = (): (TypeaheadInputComponent &
+    HTMLElement)[] => spec.queryAll(".additional-file-tags");
   const extraTagsTypeahead = (): TypeaheadInputComponent & HTMLElement =>
     spec.query("#extra-tags-input");
 
@@ -140,8 +141,9 @@ describe("AddAnnotationsComponent", () => {
   }
 
   function fileProvenance(index: number): string {
-    const tagInput = additionalFileTagInputs()[index];
-    return tagInput.textContent.trim();
+    const provenanceInput = provenanceFileInputs()[index];
+    const inputElement = provenanceInput.querySelector("input");
+    return inputElement.value;
   }
 
   function setup(): void {

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.ts
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.ts
@@ -400,6 +400,7 @@ class AddAnnotationsComponent
     const provenanceFileInputs = this.provenanceFileInputs;
     for (const input of provenanceFileInputs) {
       input.value = [extraProvenance];
+      input.inputModel = extraProvenance.toString();
     }
 
     for (const file of this.importFiles$.value) {
@@ -408,7 +409,8 @@ class AddAnnotationsComponent
 
     this.performDryRun();
 
-    host.value = null;
+    host.value = [];
+    host.inputModel = null;
   }
 
   protected updateFileProvenance(model: QueuedFile, provenanceId: Id): void {

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.ts
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.ts
@@ -392,7 +392,7 @@ class AddAnnotationsComponent
     extraProvenance: AudioEventProvenance,
     host: TypeaheadInputComponent<AudioEventProvenance>,
   ): void {
-    // when the user applies "extra tags" we want to immediately set the import
+    // when the user applies "provenances" we want to immediately set the import
     // state to "UPLOADING" so that the UI elements get locked while the extra
     // tags are applied
     this.importState = ImportState.UPLOADING;

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.ts
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.ts
@@ -106,8 +106,8 @@ interface QueuedFile {
   additionalTagIds: Id[];
 
   /**
-   * Describes what machine learning recogniser generated the events in the
-   * file.
+   * Describes how the events in the file were created/generated.
+   * E.g. What machine learning recogniser was used.
    */
   provenanceId: Id;
 }

--- a/src/app/components/import-annotations/pages/details/details.component.html
+++ b/src/app/components/import-annotations/pages/details/details.component.html
@@ -54,8 +54,24 @@
                 <baw-inline-list
                   [items]="value.tags"
                   [itemKey]="'text'"
-                  [emptyTemplate]="noAssociatedTagsTemplate"
+                  [emptyTemplate]="noTagsTemplate"
                 ></baw-inline-list>
+              }
+            </ng-template>
+          </ngx-datatable-column>
+
+          <ngx-datatable-column prop="">
+            <ng-template let-column="column" ngx-datatable-header-template>
+              Provenance
+            </ng-template>
+
+            <ng-template let-value="value" ngx-datatable-cell-template>
+              @if (value.provenance | isUnresolved) {
+                <baw-loading size="sm"></baw-loading>
+              } @else if (value.provenance) {
+                {{ value.provenance }}
+              } @else {
+                <ng-container [ngTemplateOutlet]="noProvenanceTemplate"></ng-container>
               }
             </ng-template>
           </ngx-datatable-column>
@@ -114,7 +130,7 @@
               <baw-inline-list
                 [items]="value.additionalTags"
                 [itemKey]="'text'"
-                [emptyTemplate]="noAssociatedTagsTemplate"
+                [emptyTemplate]="noTagsTemplate"
               ></baw-inline-list>
             </ng-template>
           </ngx-datatable-column>
@@ -155,12 +171,12 @@
 
 <div [ngbNavOutlet]="nav" class="mt-2"></div>
 
-<ng-template #noAssociatedTagsTemplate>
+<ng-template #noTagsTemplate>
   <span>No associated tags</span>
 </ng-template>
 
-<ng-template #noAdditionalTagsTemplate>
-  <span>No additional tags</span>
+<ng-template #noProvenanceTemplate>
+  <span>No provenance</span>
 </ng-template>
 
 <ng-template #deleteFileModal let-modal>

--- a/src/app/components/import-annotations/pages/details/details.component.spec.ts
+++ b/src/app/components/import-annotations/pages/details/details.component.spec.ts
@@ -16,6 +16,7 @@ import { AudioEvent } from "@models/AudioEvent";
 import {
   AUDIO_EVENT_IMPORT,
   AUDIO_EVENT_IMPORT_FILE,
+  AUDIO_EVENT_PROVENANCE,
   AUDIO_RECORDING,
   SHALLOW_AUDIO_EVENT,
   TAG,
@@ -41,6 +42,9 @@ import { nStepObservable } from "@test/helpers/general";
 import { fakeAsync, flush } from "@angular/core/testing";
 import { getElementByInnerText } from "@test/helpers/html";
 import { Sorting } from "@baw-api/baw-api.service";
+import { AudioEventProvenance } from "@models/AudioEventProvenance";
+import { AudioEventProvenanceService } from "@baw-api/AudioEventProvenance/AudioEventProvenance.service";
+import { generateAudioEventProvenance } from "@test/fakes/AudioEventProvenance";
 import { AnnotationImportDetailsComponent } from "./details.component";
 
 describe("AnnotationsDetailsComponent", () => {
@@ -53,10 +57,12 @@ describe("AnnotationsDetailsComponent", () => {
   let mockAudioEventImportService: SpyObject<AudioEventImportService>;
   let mockAudioEventFileService: SpyObject<AudioEventImportFileService>;
   let mockRecordingsService: SpyObject<AudioRecordingsService>;
+  let mockProvenanceService: SpyObject<AudioEventProvenanceService>;
 
   let mockAudioEventImport: AudioEventImport;
   let mockTagModel: Tag;
   let mockAudioEvents: AudioEvent[];
+  let mockProvenance: AudioEventProvenance;
   let mockAudioEventImportFiles: AudioEventImportFile[];
   let mockAudioRecording: AudioRecording;
 
@@ -141,6 +147,11 @@ describe("AnnotationsDetailsComponent", () => {
       ),
     );
 
+    mockProvenance = new AudioEventProvenance(
+      generateAudioEventProvenance(),
+      injector,
+    );
+
     mockAudioEventImportFiles = modelData.randomArray(
       1,
       10,
@@ -173,10 +184,12 @@ describe("AnnotationsDetailsComponent", () => {
 
     const audioEventSubject = new Subject<AudioEventImport>();
     const tagsSubject = new Subject<Tag[]>();
+    const provenanceSubject = new Subject<AudioEventProvenance>();
 
     const promise = Promise.all([
       nStepObservable(audioEventSubject, () => mockAudioEvents as any),
       nStepObservable(tagsSubject, () => mockTagModel as any),
+      nStepObservable(provenanceSubject, () => mockProvenance as any),
     ]);
 
     mockEventsService = spec.inject(SHALLOW_AUDIO_EVENT.token);
@@ -184,6 +197,9 @@ describe("AnnotationsDetailsComponent", () => {
 
     mockTagsService = spec.inject(TAG.token);
     mockTagsService.show.and.callFake(() => tagsSubject);
+
+    mockProvenanceService = spec.inject(AUDIO_EVENT_PROVENANCE.token);
+    mockProvenanceService.show.and.callFake(() => provenanceSubject);
 
     // When deleting a file, we use a modal to confirm that the user wants to
     // delete the file.

--- a/src/app/components/import-annotations/pages/details/details.component.spec.ts
+++ b/src/app/components/import-annotations/pages/details/details.component.spec.ts
@@ -221,6 +221,7 @@ describe("AnnotationsDetailsComponent", () => {
       "Audio Recording": event.audioRecording?.id.toString(),
       "Created At": event.createdAt?.toFormat("yyyy-MM-dd HH:mm:ss"),
       Tags: mockTagModel.text,
+      Provenance: mockProvenance.name,
       Actions: "",
     }));
   }
@@ -261,7 +262,13 @@ describe("AnnotationsDetailsComponent", () => {
 
   describe("audio event table", () => {
     assertDatatable(() => ({
-      columns: () => ["Audio Recording", "Created At", "Tags", "Actions"],
+      columns: () => [
+        "Audio Recording",
+        "Created At",
+        "Tags",
+        "Provenance",
+        "Actions",
+      ],
       rows: () => expectedAudioEventTable,
       root: () => activeTabContent(),
     }));

--- a/src/app/components/import-annotations/pages/details/details.component.ts
+++ b/src/app/components/import-annotations/pages/details/details.component.ts
@@ -41,6 +41,7 @@ import { hasResolvedSuccessfully, ResolvedModelList, retrieveResolvers } from "@
 import { Project } from "@models/Project";
 import { ConfirmationComponent } from "@components/harvest/components/modal/confirmation.component";
 import { BawApiError } from "@helpers/custom-errors/baw-api-error";
+import { NgTemplateOutlet } from "@angular/common";
 import {
   annotationsImportMenuItem,
   editAnnotationImportMenuItem,
@@ -79,6 +80,7 @@ interface ImportGroup {
   selector: "baw-annotation-import",
   templateUrl: "./details.component.html",
   imports: [
+    NgTemplateOutlet,
     NgbNav,
     NgbNavItem,
     NgbNavItemRole,

--- a/src/app/components/scripts/edit/edit.component.spec.ts
+++ b/src/app/components/scripts/edit/edit.component.spec.ts
@@ -13,15 +13,18 @@ import { assertErrorHandler } from "@test/helpers/html";
 import { assertPageInfo } from "@test/helpers/pageRoute";
 import { mockActivatedRoute } from "@test/helpers/testbed";
 import { ToastService } from "@services/toasts/toasts.service";
-import { Subject } from "rxjs";
+import { of, Subject } from "rxjs";
 import { AssociationInjector } from "@models/ImplementsInjector";
 import { ASSOCIATION_INJECTOR } from "@services/association-injector/association-injector.tokens";
 import { appLibraryImports } from "src/app/app.config";
 import { provideMockBawApi } from "@baw-api/provide-baw-ApiMock";
+import { AudioEventProvenanceService } from "@baw-api/AudioEventProvenance/AudioEventProvenance.service";
 import { AdminScriptsEditComponent } from "./edit.component";
 
 describe("AdminScriptsEditComponent", () => {
   let api: SpyObject<ScriptsService>;
+  let provenanceApi: SpyObject<AudioEventProvenanceService>;
+
   let component: AdminScriptsEditComponent;
   let defaultModel: Script;
   let fixture: ComponentFixture<AdminScriptsEditComponent>;
@@ -38,16 +41,20 @@ describe("AdminScriptsEditComponent", () => {
           provide: ActivatedRoute,
           useValue: mockActivatedRoute(
             { script: scriptResolvers.show },
-            { script: { model, error } }
+            { script: { model, error } },
           ),
         },
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AdminScriptsEditComponent);
-    api = TestBed.inject(ScriptsService) as SpyObject<ScriptsService>;
     router = TestBed.inject(Router);
     notifications = TestBed.inject(ToastService);
+
+    api = TestBed.inject(ScriptsService) as SpyObject<ScriptsService>;
+    provenanceApi = TestBed.inject(
+      AudioEventProvenanceService,
+    ) as SpyObject<AudioEventProvenanceService>;
 
     injector = TestBed.inject(ASSOCIATION_INJECTOR);
     if (model) {
@@ -59,6 +66,8 @@ describe("AdminScriptsEditComponent", () => {
     spyOn(notifications, "success").and.stub();
     spyOn(notifications, "error").and.stub();
     spyOn(router, "navigateByUrl").and.stub();
+
+    provenanceApi.show.and.returnValue(of());
 
     fixture.detectChanges();
   }

--- a/src/app/components/shared/inline-list/inline-list.component.ts
+++ b/src/app/components/shared/inline-list/inline-list.component.ts
@@ -1,6 +1,5 @@
 import { NgIfContext, NgTemplateOutlet } from "@angular/common";
 import { Component, Input, TemplateRef } from "@angular/core";
-import { UrlDirective } from "@directives/url/url.directive";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { AbstractModel } from "@models/AbstractModel";
 
@@ -10,7 +9,7 @@ import { AbstractModel } from "@models/AbstractModel";
     @if (!!items && items.length > 0) {
       @for (item of items; track item; let isLast = $last) {
         <span>
-          <a [bawUrl]="item.viewUrl">{{ itemText(item) }}</a>
+          <a [href]="item.viewUrl">{{ itemText(item) }}</a>
           @if (!isLast) {, }
         </span>
       }
@@ -18,7 +17,7 @@ import { AbstractModel } from "@models/AbstractModel";
       <ng-template [ngTemplateOutlet]="emptyTemplate"></ng-template>
     }
   `,
-  imports: [NgTemplateOutlet, UrlDirective]
+  imports: [NgTemplateOutlet]
 })
 export class InlineListComponent {
   @Input() public items: AbstractModel[];

--- a/src/app/components/shared/inline-list/inline-list.component.ts
+++ b/src/app/components/shared/inline-list/inline-list.component.ts
@@ -1,5 +1,6 @@
 import { NgIfContext, NgTemplateOutlet } from "@angular/common";
 import { Component, Input, TemplateRef } from "@angular/core";
+import { UrlDirective } from "@directives/url/url.directive";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { AbstractModel } from "@models/AbstractModel";
 
@@ -9,7 +10,7 @@ import { AbstractModel } from "@models/AbstractModel";
     @if (!!items && items.length > 0) {
       @for (item of items; track item; let isLast = $last) {
         <span>
-          <a [href]="item.viewUrl">{{ itemText(item) }}</a>
+          <a [bawUrl]="item.viewUrl">{{ itemText(item) }}</a>
           @if (!isLast) {, }
         </span>
       }
@@ -17,7 +18,7 @@ import { AbstractModel } from "@models/AbstractModel";
       <ng-template [ngTemplateOutlet]="emptyTemplate"></ng-template>
     }
   `,
-  imports: [NgTemplateOutlet]
+  imports: [NgTemplateOutlet, UrlDirective]
 })
 export class InlineListComponent {
   @Input() public items: AbstractModel[];

--- a/src/app/components/shared/typeahead-input/typeahead-input.component.html
+++ b/src/app/components/shared/typeahead-input/typeahead-input.component.html
@@ -46,6 +46,7 @@
         (focus)="focus$.next($any($event).target.value)"
         (selectItem)="onItemSelected($event)"
         (keydown.backspace)="removeLastItem()"
+        (input)="handleInput()"
         [disabled]="inputDisabled"
       />
     </div>

--- a/src/app/components/shared/typeahead-input/typeahead-input.component.spec.ts
+++ b/src/app/components/shared/typeahead-input/typeahead-input.component.spec.ts
@@ -180,8 +180,6 @@ describe("TypeaheadInputComponent", () => {
     tick(defaultDebounceTime);
     selectedDropdownOption().click();
 
-    // assert that the component only emitted the second site, and that the first site was removed
-    expect(spec.component.value).toHaveLength(0);
     expect(spec.component.modelChange.emit).toHaveBeenCalledWith([
       siteToSelect,
     ]);
@@ -264,6 +262,36 @@ describe("TypeaheadInputComponent", () => {
     const dropdownItems = dropdownOptions();
     expect(dropdownItems).toHaveLength(0);
   }));
+
+  describe("single input mode", () => {
+    beforeEach(() => {
+      spec.component.multipleInputs = false;
+    });
+
+    it("should emit an empty value if the user inputs an invalid value in single input mode", fakeAsync(() => {
+      spec.component.modelChange.emit = jasmine.createSpy("modelChange");
+
+      typeInInput("this is not a valid site name");
+      tick(defaultDebounceTime);
+
+      expect(spec.component.value).toEqual([]);
+      expect(spec.component.modelChange.emit).not.toHaveBeenCalled();
+    }));
+
+    it("should emit an empty value if the user clears the input in single input mode", fakeAsync(() => {
+      const testInput = defaultFakeSites[0].name;
+      typeInInput(testInput);
+      tick(defaultDebounceTime);
+      selectedDropdownOption().click();
+
+      spec.component.modelChange.emit = jasmine.createSpy("modelChange");
+      typeInInput("");
+      tick(defaultDebounceTime);
+
+      expect(spec.component.value).toEqual([]);
+      expect(spec.component.modelChange.emit).toHaveBeenCalledOnceWith([]);
+    }));
+  });
 
   describe("default query", () => {
     it("should show a list of default options when focused and the defaultQuery is true", fakeAsync(() => {

--- a/src/app/components/shared/typeahead-input/typeahead-input.component.ts
+++ b/src/app/components/shared/typeahead-input/typeahead-input.component.ts
@@ -31,8 +31,8 @@ export type TypeaheadSearchCallback<T> = (
 
 @Component({
   selector: "baw-typeahead-input",
-  templateUrl: "typeahead-input.component.html",
-  styleUrl: "typeahead-input.component.scss",
+  templateUrl: "./typeahead-input.component.html",
+  styleUrl: "./typeahead-input.component.scss",
   imports: [FaIconComponent, NgTemplateOutlet, NgbTypeahead, FormsModule],
 })
 export class TypeaheadInputComponent<T = unknown> {

--- a/src/app/components/shared/typeahead-input/typeahead-input.component.ts
+++ b/src/app/components/shared/typeahead-input/typeahead-input.component.ts
@@ -26,7 +26,7 @@ import { FormsModule } from "@angular/forms";
 
 export type TypeaheadSearchCallback<T> = (
   text: string,
-  activeItems: T[]
+  activeItems: T[],
 ) => Observable<T[]>;
 
 @Component({
@@ -70,7 +70,7 @@ export class TypeaheadInputComponent<T = unknown> {
   public inputModel: string | null;
   protected focus$ = new Subject<T[]>();
 
-  public findOptions = (text$: Observable<string>): Observable<T[]> => {
+  protected findOptions = (text$: Observable<string>): Observable<T[]> => {
     const maximumResults = 10;
 
     return merge(this.focus$, text$).pipe(
@@ -91,15 +91,15 @@ export class TypeaheadInputComponent<T = unknown> {
 
         return this.searchCallback(term, this.value);
       }),
-      map((items: T[]) => items.slice(0, maximumResults))
+      map((items: T[]) => items.slice(0, maximumResults)),
     );
   };
 
-  public templateFormatter = (item: T): string => item.toString();
+  protected templateFormatter = (item: T): string => item.toString();
 
-  public onItemSelected($event: NgbTypeaheadSelectItemEvent<T>): void {
-    $event.preventDefault();
-    const selectedItem = $event.item;
+  protected onItemSelected(event: NgbTypeaheadSelectItemEvent<T>): void {
+    event.preventDefault();
+    const selectedItem = event.item;
 
     if (this.multipleInputs) {
       this.value.push(selectedItem);
@@ -107,19 +107,21 @@ export class TypeaheadInputComponent<T = unknown> {
 
       this.inputModel = null;
     } else {
-      this.inputModel = selectedItem.toString();
+      this.value = [selectedItem];
       this.modelChange.emit([selectedItem]);
+
+      this.inputModel = selectedItem.toString();
     }
   }
 
-  public removeLastItem(): void {
+  protected removeLastItem(): void {
     if (this.multipleInputs && this.value.length > 0 && !this.inputModel) {
       this.value.pop();
       this.modelChange.emit(this.value);
     }
   }
 
-  public removeItem(indexToRemove: number): void {
+  protected removeItem(indexToRemove: number): void {
     // if the "value" array has a length of 1, the splice function doesn't return an empty array
     // therefore, we use length === 1 as an edge case
     if (this.value.length === 1) {
@@ -127,6 +129,24 @@ export class TypeaheadInputComponent<T = unknown> {
     } else {
       this.value.splice(indexToRemove, 1);
       this.modelChange.emit(this.value);
+    }
+  }
+
+  protected handleInput(): void {
+    // When in single input mode, the typeahead acts as autocomplete where items
+    // wil be suggested as the user searches, and the input's value will be used
+    // as output.
+    // Therefore, if the user selects an item, then starts changing the value,
+    // we want to undo that selection.
+    // To prevent emitting a lot of events, we only emit a change event if there
+    // is a value currently selected.
+    //
+    // TODO: we should add "lose matching" support so that if the user types in
+    // the exact value as a search result it should be automatically selected,
+    // meaning that the user doesn't have to click on the search result item.
+    if (!this.multipleInputs && this.value.length > 0) {
+      this.value = [];
+      this.modelChange.emit([]);
     }
   }
 }

--- a/src/app/models/AudioEvent.ts
+++ b/src/app/models/AudioEvent.ts
@@ -86,10 +86,7 @@ export class AudioEvent
   public deleter?: User;
   @hasOne<AudioEvent, AudioRecording>(AUDIO_RECORDING, "audioRecordingId")
   public audioRecording?: AudioRecording;
-  @hasOne<AudioEvent, AudioEventProvenance>(
-    AUDIO_EVENT_PROVENANCE,
-    "provenanceId",
-  )
+  @hasOne<AudioEvent, AudioEventProvenance>(AUDIO_EVENT_PROVENANCE, "provenanceId")
   public provenance?: AudioEventProvenance;
   @hasMany<AudioEvent, Tag>(TAG, "tagIds")
   public tags?: Tag[];

--- a/src/app/models/AudioEvent.ts
+++ b/src/app/models/AudioEvent.ts
@@ -88,7 +88,7 @@ export class AudioEvent
   public audioRecording?: AudioRecording;
   @hasOne<AudioEvent, AudioEventProvenance>(
     AUDIO_EVENT_PROVENANCE,
-    "provenanceId"
+    "provenanceId",
   )
   public provenance?: AudioEventProvenance;
   @hasMany<AudioEvent, Tag>(TAG, "tagIds")
@@ -97,7 +97,7 @@ export class AudioEvent
   public constructor(audioEvent: IAudioEvent, injector?: AssociationInjector) {
     super(audioEvent, injector);
     this.taggings = ((audioEvent.taggings ?? []) as ITagging[]).map(
-      (tagging) => new Tagging(tagging, injector)
+      (tagging) => new Tagging(tagging, injector),
     );
   }
 
@@ -115,7 +115,7 @@ export class AudioEvent
   public get listenViewUrl(): string {
     return listenRecordingMenuItem.route.format(
       { audioRecordingId: this.audioRecordingId },
-      { start: this.startTimeSeconds, padding: 10 }
+      { start: this.startTimeSeconds, padding: 10 },
     );
   }
 

--- a/src/app/models/AudioEventImport/ImportedAudioEvent.ts
+++ b/src/app/models/AudioEventImport/ImportedAudioEvent.ts
@@ -1,10 +1,11 @@
-import { AUDIO_EVENT_IMPORT, AUDIO_RECORDING } from "@baw-api/ServiceTokens";
+import { AUDIO_EVENT_IMPORT, AUDIO_EVENT_PROVENANCE, AUDIO_RECORDING } from "@baw-api/ServiceTokens";
 import { Id } from "@interfaces/apiInterfaces";
 import { AbstractModel } from "@models/AbstractModel";
 import { hasOne } from "@models/AssociationDecorators";
 import { bawPersistAttr, bawSubModelCollection } from "@models/AttributeDecorators";
 import { IAudioEvent } from "@models/AudioEvent";
 import { AudioEventImport } from "@models/AudioEventImport";
+import { AudioEventProvenance } from "@models/AudioEventProvenance";
 import { AudioRecording } from "@models/AudioRecording";
 import { ITag, Tag } from "@models/Tag";
 
@@ -46,12 +47,15 @@ export class ImportedAudioEvent
   public readonly errors?: EventImportError[];
   @bawSubModelCollection<ImportedAudioEvent, Tag>(Tag)
   public readonly tags?: Tag[];
+  public readonly provenanceId?: Id;
 
   // Associations
   @hasOne<ImportedAudioEvent, AudioRecording>(AUDIO_RECORDING, "audioRecordingId")
   public audioRecording?: AudioRecording;
   @hasOne<ImportedAudioEvent, AudioEventImport>(AUDIO_EVENT_IMPORT, "audioEventImportId")
   public audioEventImport?: AudioEventImport;
+  @hasOne<ImportedAudioEvent, AudioEventProvenance>(AUDIO_EVENT_PROVENANCE, "provenanceId")
+  public provenance?: AudioEventProvenance;
 
   public get viewUrl(): string {
     throw new Error("Method not implemented.");

--- a/src/app/models/AudioEventImportFile.ts
+++ b/src/app/models/AudioEventImportFile.ts
@@ -1,16 +1,28 @@
-import { CollectionIds, DateTimeTimezone, FilePath, Id } from "@interfaces/apiInterfaces";
+import {
+  CollectionIds,
+  DateTimeTimezone,
+  FilePath,
+  Id,
+} from "@interfaces/apiInterfaces";
 import {
   ANALYSIS_JOB_ITEM,
   AUDIO_EVENT_IMPORT,
   TAG,
 } from "@baw-api/ServiceTokens";
-import { bawDateTime, bawPersistAttr, bawSubModelCollection } from "./AttributeDecorators";
+import {
+  bawDateTime,
+  bawPersistAttr,
+  bawSubModelCollection,
+} from "./AttributeDecorators";
 import { AbstractModel } from "./AbstractModel";
 import { hasMany, hasOne } from "./AssociationDecorators";
 import { AnalysisJobItem } from "./AnalysisJobItem";
 import { Tag } from "./Tag";
 import { AudioEventImport } from "./AudioEventImport";
-import { IImportedAudioEvent, ImportedAudioEvent } from "./AudioEventImport/ImportedAudioEvent";
+import {
+  IImportedAudioEvent,
+  ImportedAudioEvent,
+} from "./AudioEventImport/ImportedAudioEvent";
 
 export interface IAudioEventImportFile {
   id?: Id;

--- a/src/app/models/AudioEventProvenance.ts
+++ b/src/app/models/AudioEventProvenance.ts
@@ -38,6 +38,6 @@ export class AudioEventProvenance
   }
 
   public override toString(): string {
-    return `${this.name} (version ${this.version})`;
+    return `${this.name} (v.${this.version})`;
   }
 }

--- a/src/app/models/AudioEventProvenance.ts
+++ b/src/app/models/AudioEventProvenance.ts
@@ -27,7 +27,6 @@ export class AudioEventProvenance
 
   /**
    * Navigates to the details page of an AudioEventProvenance
-   * WARNING: THIS IS NOT CURRENTLY FUNCTIONAL, BUT WE DO USE THIS IN THE CODEBASE AS A STAGING PLACEHOLDER
    */
   public get viewUrl(): string {
     console.warn("AudioEventProvenance.viewUrl is not implemented");

--- a/src/app/models/AudioEventProvenance.ts
+++ b/src/app/models/AudioEventProvenance.ts
@@ -1,13 +1,15 @@
-import { Id } from "../interfaces/apiInterfaces";
+import { HasAllUsers, HasDescription, Id } from "../interfaces/apiInterfaces";
 import { AbstractModel } from "./AbstractModel";
 import { bawPersistAttr } from "./AttributeDecorators";
 
-export interface IAudioEventProvenance {
+export interface IAudioEventProvenance extends HasAllUsers, HasDescription {
   id: Id;
   name: string;
   version: string;
   description: string;
-  score: number;
+
+  scoreMinimum: number;
+  scoreMaximum: number;
 }
 
 export class AudioEventProvenance
@@ -23,7 +25,9 @@ export class AudioEventProvenance
   @bawPersistAttr()
   public readonly description: string;
   @bawPersistAttr()
-  public readonly score: number;
+  public readonly scoreMinimum: number;
+  @bawPersistAttr()
+  public readonly scoreMaximum: number;
 
   /**
    * Navigates to the details page of an AudioEventProvenance

--- a/src/app/services/baw-api/AudioEventProvenance/AudioEventProvenance.service.ts
+++ b/src/app/services/baw-api/AudioEventProvenance/AudioEventProvenance.service.ts
@@ -5,26 +5,19 @@ import {
   id,
   option,
   IdParamOptional,
+  emptyParam,
+  filterParam,
 } from "@baw-api/api-common";
 import { BawApiService, Filters } from "@baw-api/baw-api.service";
 import { stringTemplate } from "@helpers/stringTemplate/stringTemplate";
 import { AudioEventProvenance } from "@models/AudioEventProvenance";
-import { Observable, of } from "rxjs";
+import { Observable } from "rxjs";
 import { Resolvers } from "@baw-api/resolver-common";
+import { TypeaheadSearchCallback } from "@shared/typeahead-input/typeahead-input.component";
+import { createSearchCallback } from "@helpers/typeahead/typeaheadCallbacks";
 
 const audioEventProvenanceId: IdParamOptional<AudioEventProvenance> = id;
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const endpoint = stringTemplate`/provenance/${audioEventProvenanceId}${option}`;
-
-const mockAudioEventProvenance: AudioEventProvenance = new AudioEventProvenance(
-  {
-    id: 1,
-    name: "Fake Audio Event Provenance",
-    version: "1.0",
-    description: "Mock Description",
-    score: 0.5,
-  }
-);
+const endpoint = stringTemplate`/provenances/${audioEventProvenanceId}${option}`;
 
 // the baw-api functionality of this model is not currently complete, therefore we are returning mock data
 // TODO: remove mock data once the api is complete
@@ -32,60 +25,56 @@ const mockAudioEventProvenance: AudioEventProvenance = new AudioEventProvenance(
 export class AudioEventProvenanceService
   implements StandardApi<AudioEventProvenance>
 {
-  public constructor(protected _api: BawApiService<AudioEventProvenance>) {}
+  public constructor(protected api: BawApiService<AudioEventProvenance>) {}
 
   public list(): Observable<AudioEventProvenance[]> {
-    return of([mockAudioEventProvenance]);
-    // return this.api.list(AudioEventProvenance, endpoint(emptyParam, emptyParam));
+    return this.api.list(
+      AudioEventProvenance,
+      endpoint(emptyParam, emptyParam),
+    );
   }
 
   public filter(
-    _filters: Filters<AudioEventProvenance>
+    filters: Filters<AudioEventProvenance>,
   ): Observable<AudioEventProvenance[]> {
-    return of([mockAudioEventProvenance]);
-    // return this.api.filter(
-    //    AudioEventProvenance,
-    //    endpoint(emptyParam, filterParam),
-    //    filters
-    // );
+    return this.api.filter(
+      AudioEventProvenance,
+      endpoint(emptyParam, filterParam),
+      filters,
+    );
   }
 
-  // since the API for this service isn't currently functional, we return a fake model
   public show(
-    _model: IdOr<AudioEventProvenance>
+    model: IdOr<AudioEventProvenance>,
   ): Observable<AudioEventProvenance> {
-    return of(mockAudioEventProvenance);
-    // return this.api.show(AudioEventProvenance, endpoint(model, emptyParam));
+    return this.api.show(AudioEventProvenance, endpoint(model, emptyParam));
   }
 
-  public create(
-    _model: AudioEventProvenance
-  ): Observable<AudioEventProvenance> {
-    return of(mockAudioEventProvenance);
-    // return this.api.create(
-    //    AudioEventProvenance,
-    //    endpoint(emptyParam, emptyParam),
-    //    (audioEventProvenance) => endpoint(audioEventProvenance, emptyParam),
-    //    model
-    // );
+  public create(model: AudioEventProvenance): Observable<AudioEventProvenance> {
+    return this.api.create(
+      AudioEventProvenance,
+      endpoint(emptyParam, emptyParam),
+      (audioEventProvenance) => endpoint(audioEventProvenance, emptyParam),
+      model,
+    );
   }
 
-  public update(
-    _model: AudioEventProvenance
-  ): Observable<AudioEventProvenance> {
-    return of(mockAudioEventProvenance);
-    // return this.api.update(
-    //    AudioEventProvenance,
-    //    endpoint(model, emptyParam),
-    //    model
-    // );
+  public update(model: AudioEventProvenance): Observable<AudioEventProvenance> {
+    return this.api.update(
+      AudioEventProvenance,
+      endpoint(model, emptyParam),
+      model,
+    );
   }
 
   public destroy(
-    _model: IdOr<AudioEventProvenance>
+    model: IdOr<AudioEventProvenance>,
   ): Observable<void | AudioEventProvenance> {
-    return of();
-    // return this.api.destroy(endpoint(model, emptyParam));
+    return this.api.destroy(endpoint(model, emptyParam));
+  }
+
+  public typeaheadCallback(): TypeaheadSearchCallback<AudioEventProvenance> {
+    return createSearchCallback(this, "name");
   }
 }
 
@@ -93,5 +82,5 @@ export const audioEventProvenanceResolvers = new Resolvers<
   AudioEventProvenance,
   [IdOr<AudioEventProvenance>]
 >([AudioEventProvenanceService], "audioEventProvenanceId").create(
-  "AUDIO_EVENT_PROVENANCE"
+  "AUDIO_EVENT_PROVENANCE",
 );

--- a/src/app/services/baw-api/AudioEventProvenance/AudioEventProvenance.service.ts
+++ b/src/app/services/baw-api/AudioEventProvenance/AudioEventProvenance.service.ts
@@ -19,8 +19,6 @@ import { createSearchCallback } from "@helpers/typeahead/typeaheadCallbacks";
 const audioEventProvenanceId: IdParamOptional<AudioEventProvenance> = id;
 const endpoint = stringTemplate`/provenances/${audioEventProvenanceId}${option}`;
 
-// the baw-api functionality of this model is not currently complete, therefore we are returning mock data
-// TODO: remove mock data once the api is complete
 @Injectable()
 export class AudioEventProvenanceService
   implements StandardApi<AudioEventProvenance>

--- a/src/app/services/baw-api/audio-event-import-file/audio-event-import-file.service.spec.ts
+++ b/src/app/services/baw-api/audio-event-import-file/audio-event-import-file.service.spec.ts
@@ -8,7 +8,7 @@ import { IdOr } from "@baw-api/api-common";
 import { AudioEventImportFileService } from "./audio-event-import-file.service";
 
 type Model = AudioEventImportFile;
-type Params = [IdOr<AudioEventImport>];
+type Params = [IdOr<AudioEventImport>, ...args: any];
 type Service = AudioEventImportFileService;
 
 describe("AudioEventImportFIleService", () => {

--- a/src/app/services/baw-api/provide-baw-ApiMock.ts
+++ b/src/app/services/baw-api/provide-baw-ApiMock.ts
@@ -59,6 +59,7 @@ import { UserService } from "./user/user.service";
 import { WebsiteStatusService } from "./website-status/website-status.service";
 import { AudioEventImportService } from "./audio-event-import/audio-event-import.service";
 import { AudioEventImportFileService } from "./audio-event-import-file/audio-event-import-file.service";
+import { AudioEventProvenanceService } from "./AudioEventProvenance/AudioEventProvenance.service";
 
 // If you get the following error while trying to stub a service:
 //
@@ -103,6 +104,7 @@ export const mockProviders: Provider[] = [
   mockProvider(WebsiteStatusService),
   mockProvider(AudioEventImportService),
   mockProvider(AudioEventImportFileService),
+  mockProvider(AudioEventProvenanceService),
 ];
 
 export function provideMockBawApi(): (EnvironmentProviders | Provider)[] {

--- a/src/app/services/baw-api/tag/tags.service.ts
+++ b/src/app/services/baw-api/tag/tags.service.ts
@@ -77,7 +77,7 @@ export class TagsService implements StandardApi<Tag> {
   }
 
   public typeaheadCallback(): TypeaheadSearchCallback<Tag> {
-    return createSearchCallback<Tag>(this, "text");
+    return createSearchCallback(this, "text");
   }
 
   /**

--- a/src/app/styles/_ngx-datatable.scss
+++ b/src/app/styles/_ngx-datatable.scss
@@ -63,6 +63,10 @@ ngx-datatable {
       height: 100%;
     }
   }
+
+  datatable-header-cell {
+    white-space: wrap !important;
+  }
 }
 
 @keyframes query {

--- a/src/app/test/fakes/AudioEventProvenance.ts
+++ b/src/app/test/fakes/AudioEventProvenance.ts
@@ -6,8 +6,8 @@ export function generateAudioEventProvenance(
 ): Required<IAudioEventProvenance> {
   return {
     id: modelData.id(),
-    name: modelData.param(),
-    version: modelData.param(),
+    name: modelData.name.jobTitle(),
+    version: modelData.version(),
     description: modelData.description(),
     scoreMinimum: modelData.datatype.number(),
     scoreMaximum: modelData.datatype.number(),

--- a/src/app/test/fakes/AudioEventProvenance.ts
+++ b/src/app/test/fakes/AudioEventProvenance.ts
@@ -9,7 +9,10 @@ export function generateAudioEventProvenance(
     name: modelData.param(),
     version: modelData.param(),
     description: modelData.description(),
-    score: modelData.percentage(),
+    scoreMinimum: modelData.datatype.number(),
+    scoreMaximum: modelData.datatype.number(),
+    ...modelData.model.generateDescription(),
+    ...modelData.model.generateAllUsers(),
     ...data,
   };
 }

--- a/src/app/test/helpers/faker.ts
+++ b/src/app/test/helpers/faker.ts
@@ -50,12 +50,10 @@ export const modelData = {
   ids: () => randomArray(1, 5, () => faker.datatype.number(100)),
   imageUrl: () => faker.image.imageUrl(),
   imageUrls,
-  licenseName: () => modelData.helpers.arrayElement(
-    Object.keys(spdxLicenseListFull),
-  ),
-  license: () => modelData.helpers.arrayElement(
-    Object.values(spdxLicenseListFull),
-  ),
+  licenseName: () =>
+    modelData.helpers.arrayElement(Object.keys(spdxLicenseListFull)),
+  license: () =>
+    modelData.helpers.arrayElement(Object.values(spdxLicenseListFull)),
   icon: (): IconProp => [
     "fas",
     faker.helpers.arrayElement<IconName>([
@@ -78,6 +76,8 @@ export const modelData = {
     ":" +
     faker.helpers.arrayElement(["00", "30"]),
   param: () => faker.name.jobTitle().replace(specialCharRegex, ""),
+  version: () =>
+    `${modelData.datatype.number()}.${modelData.datatype.number()}`,
   seconds: () => faker.datatype.number(86400 - 30) + 30,
   startEndSeconds: () => {
     const min = faker.datatype.number(86400 - 30) + 30;
@@ -281,7 +281,7 @@ function hexaDecimal(count: number = 1): string {
 function randomArray<T>(
   min: number,
   max: number,
-  callback: (index: number) => T
+  callback: (index: number) => T,
 ): T[] {
   const len = faker.datatype.number({ min, max });
   const array = [];
@@ -317,7 +317,7 @@ function randomFile(
     type: string;
     name: string;
     contents: BlobPart[];
-  }> = {}
+  }> = {},
 ) {
   return new File(data.contents ?? [], data?.name ?? faker.system.fileName(), {
     type: data.type ?? "text/plain",


### PR DESCRIPTION
# Add provenance inputs to annotation import

## Changes

- Add "provenance" inputs to annotation import page
- Add "provenance" column to annotation preview table
- Add "provenance" column to annotation import "events" tab
- Update the `provenance` model to reflect API model
- Make the `provenance.service` functional (instead of using mocks)
- "script" crud pages now show correct "provenance" information instead of mock data
- Headings for "compact" ngx-datatable's can now text wrap
- Single input typeahead elements now clear their selected value if the user modifies the free form text with an item selected
- Improved mobile compatibility of annotation import page
	- The "file" list now wraps correctly on smaller screen widths

## Issues

Fixes: #2234

## Visual Changes

![image](https://github.com/user-attachments/assets/2d5cb871-dfe3-4136-8d28-f9ccf4cd47ae)

_New Annotation import tag with long error message_

---

![image](https://github.com/user-attachments/assets/801d332e-7f67-4d21-b469-527497242423)

_Annotation import "Events" tab showing new "Provenance" column_

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
