### PR TITLE
Hide WIP for non-admins

### DIFF
--- a/src/app/components/shared/wip/wip.component.spec.ts
+++ b/src/app/components/shared/wip/wip.component.spec.ts
@@ -2,10 +2,14 @@ import { BawSessionService } from "@baw-api/baw-session.service";
 import { createComponentFactory, Spectator } from "@ngneat/spectator";
 import { provideMockConfig } from "@services/config/provide-configMock";
 import { IconsModule } from "@shared/icons/icons.module";
+import { User } from "@models/User";
+import { generateUser } from "@test/fakes/User";
 import { WIPComponent } from "./wip.component";
 
 describe("WIPComponent", () => {
   let spec: Spectator<WIPComponent>;
+
+  const wipContent = () => spec.query(".wip-content");
 
   const createComponent = createComponentFactory({
     component: WIPComponent,
@@ -13,11 +17,40 @@ describe("WIPComponent", () => {
     providers: [BawSessionService, provideMockConfig()],
   });
 
+  function setup(userModel?: User) {
+    spec = createComponent({ detectChanges: false});
+
+    const sessionService = spec.inject(BawSessionService);
+    spyOnProperty(sessionService, "loggedInUser").and.returnValue(userModel);
+
+    spec.detectChanges();
+  }
+
   beforeEach(() => {
     spec = createComponent();
   });
 
   it("should create", () => {
-    expect(spec.component).toBeTruthy();
+    setup();
+    expect(spec.component).toBeInstanceOf(WIPComponent);
   });
+
+  it("should be hidden for guest users", () => {
+    setup();
+    expect(wipContent()).not.toExist();
+  });
+
+  it("should be hidden for non-admin logged in users", () => {
+    const user = new User(generateUser({}, false));
+    setup(user);
+
+    expect(wipContent()).not.toExist();
+  });
+
+  it("should be visible for admin users", () => {
+    const user = new User(generateUser({}, true));
+    setup(user);
+
+    expect(wipContent()).toExist();
+  })
 });

--- a/src/app/components/shared/wip/wip.component.ts
+++ b/src/app/components/shared/wip/wip.component.ts
@@ -1,13 +1,11 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  OnInit,
+  inject,
   ViewEncapsulation,
 } from "@angular/core";
 import { BawSessionService } from "@baw-api/baw-session.service";
-import { ConfigService } from "@services/config/config.service";
 import { NgbTooltip } from "@ng-bootstrap/ng-bootstrap";
-import { NgTemplateOutlet } from "@angular/common";
 import { FaIconComponent } from "@fortawesome/angular-fontawesome";
 
 /**
@@ -18,49 +16,27 @@ import { FaIconComponent } from "@fortawesome/angular-fontawesome";
   template: `
     @if (showWipContent) {
       <div class="wip-wrapper" [ngbTooltip]="'This feature is a work in progress'">
-        <ng-container *ngTemplateOutlet="icon"></ng-container>
+        <div class="wip-icon">
+          <fa-icon size="lg" [icon]="['fas', 'person-digging']"></fa-icon>
+        </div>
 
         <div class="wip-content">
           <ng-content></ng-content>
         </div>
       </div>
-    } @else {
-      <div
-        class="wip-placeholder"
-        [ngbTooltip]="'This feature is a work in progress'"
-      >
-        <ng-container *ngTemplateOutlet="icon"></ng-container>
-        <p class="wip-text">
-          This section is a work in progress. Expect new things here soon!
-        </p>
-      </div>
     }
-
-    <ng-template #icon>
-      <div class="wip-icon">
-        <fa-icon size="lg" [icon]="['fas', 'person-digging']"></fa-icon>
-      </div>
-    </ng-template>
   `,
-  styleUrl: "wip.component.scss",
+  styleUrl: "./wip.component.scss",
   // eslint-disable-next-line @angular-eslint/use-component-view-encapsulation
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgbTooltip, NgTemplateOutlet, FaIconComponent]
+  imports: [NgbTooltip, FaIconComponent]
 })
-export class WIPComponent implements OnInit {
+export class WIPComponent {
   public production: boolean;
-
-  public constructor(
-    private session: BawSessionService,
-    private config: ConfigService
-  ) {}
-
-  public ngOnInit(): void {
-    this.production = this.config.environment.production;
-  }
+  private session = inject(BawSessionService);
 
   public get showWipContent(): boolean {
-    return !this.production || this.session.loggedInUser?.isAdmin;
+    return this.session.loggedInUser?.isAdmin;
   }
 }


### PR DESCRIPTION
# Hide WIP for non-admins

## Changes

- WIP component no longer shows "this is a work in progress" message if the user is not logged in
- WIP content now only shows for administrator users. This means that the content is no longer visible to non-admin users in non-production environments (e.g. staging)

## Issues

Fixes: #2335

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
