### PR TITLE
Add base `/annotation` search/verification page

### DIFF
--- a/src/app/components/annotations/annotation.menu.ts
+++ b/src/app/components/annotations/annotation.menu.ts
@@ -52,6 +52,8 @@ function makeAnnotationSearchMenuItem(
 }
 
 const annotationSearchMenuitem: AnnotationMenuRoutes = {
+  /** /annotations */
+  base: makeAnnotationSearchMenuItem("base"),
   /** /project/:projectId/site/:siteId/annotations */
   site: makeAnnotationSearchMenuItem("site", siteMenuItem),
   /** /project/:projectId/region/:regionId/site/:siteId/annotations */
@@ -63,6 +65,8 @@ const annotationSearchMenuitem: AnnotationMenuRoutes = {
 };
 
 const verificationMenuItem: AnnotationMenuRoutes = {
+  /** /annotations/verify */
+  base: makeVerificationMenuItem("base"),
   /** /project/:projectId/site/:siteId/annotations/verify */
   site: makeVerificationMenuItem("site", annotationSearchMenuitem.site),
   /** /project/:projectId/region/:regionId/site/:siteId/annotations/verify */
@@ -72,7 +76,6 @@ const verificationMenuItem: AnnotationMenuRoutes = {
   /** /project/:projectId/annotations/verify */
   project: makeVerificationMenuItem("project", annotationSearchMenuitem.project),
 };
-
 
 const verificationCategory = {
   site: makeVerificationCategory("site"),

--- a/src/app/components/annotations/annotation.routes.ts
+++ b/src/app/components/annotations/annotation.routes.ts
@@ -26,10 +26,17 @@ const annotationSearchRouteQueryParamResolver = (
       }
     : {};
 
-export type AnnotationRoute = "project" | "region" | "site" | "siteAndRegion";
+export type AnnotationRoute =
+  | "base"
+  | "project"
+  | "region"
+  | "site"
+  | "siteAndRegion";
 export type AnnotationStrongRoute = Record<AnnotationRoute, StrongRoute>;
 
 export const annotationSearchRoute: AnnotationStrongRoute = {
+  /** /annotations */
+  base: StrongRoute.newRoot().add(annotationsRouteName),
   /** /project/:projectId/site/:siteId/annotations */
   site: siteRoute.add(
     annotationsRouteName,
@@ -55,6 +62,12 @@ export const annotationSearchRoute: AnnotationStrongRoute = {
 const verificationRouteGuards = [isLoggedInGuard];
 
 export const verificationRoute: AnnotationStrongRoute = {
+  /** /annotations/verify */
+  base: annotationSearchRoute.base.add(
+    verificationRouteName,
+    annotationSearchRouteQueryParamResolver,
+    { canActivate: verificationRouteGuards },
+  ),
   /** /project/:projectId/site/:siteId/annotations/verify */
   site: annotationSearchRoute.site.add(
     verificationRouteName,

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
@@ -17,17 +17,19 @@
     (modelChange)="updateSubModel('tags', $event)"
   ></baw-typeahead-input>
 
-  <baw-typeahead-input
-    id="projects-input"
-    label="Project(s)"
-    [inputPlaceholder]="project ? project.name : 'All'"
-    [searchCallback]="
-      createSearchCallback(projectsApi, 'name', this.routeModelFilters())
-    "
-    [resultTemplate]="nameTypeaheadTemplate"
-    [inputDisabled]="!!project"
-    (modelChange)="updateSubModel('projects', $event)"
-  ></baw-typeahead-input>
+  @if (!hideProjectsInput) {
+    <baw-typeahead-input
+      id="projects-input"
+      label="Project(s)"
+      [inputPlaceholder]="project ? project.name : 'All'"
+      [searchCallback]="
+        createSearchCallback(projectsApi, 'name', this.routeModelFilters())
+      "
+      [resultTemplate]="nameTypeaheadTemplate"
+      [inputDisabled]="!!project"
+      (modelChange)="updateSubModel('projects', $event)"
+    ></baw-typeahead-input>
+  }
 
   <!-- We disable the input and use a placeholder value if the form is immutably scoped to a region/site -->
   @if (!site || site?.isPoint) {

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.spec.ts
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.spec.ts
@@ -39,6 +39,8 @@ import {
 } from "@test/helpers/general";
 import { IconsModule } from "@shared/icons/icons.module";
 import { defaultDebounceTime } from "src/app/app.helper";
+import { ConfigService } from "@services/config/config.service";
+import { testApiConfig } from "@services/config/configMock.service";
 import { AnnotationSearchFormComponent } from "./annotation-search-form.component";
 
 describe("AnnotationSearchFormComponent", () => {
@@ -89,8 +91,14 @@ describe("AnnotationSearchFormComponent", () => {
 
   const sortingDropdown = () => spec.query("#sort-input");
 
-  function setup(params: Params = {}): Promise<any> {
+  function setup(params: Params = {}, hideProjects = false): Promise<any> {
     spec = createComponent({ detectChanges: false });
+
+    const mockSettings = testApiConfig.settings;
+    mockSettings.hideProjects = hideProjects;
+
+    const mockConfigService = spec.inject(ConfigService);
+    spyOnProperty(mockConfigService, "settings").and.returnValue(mockSettings);
 
     injector = spec.inject(ASSOCIATION_INJECTOR);
     tagsApiSpy = spec.inject(TAG.token);
@@ -178,6 +186,11 @@ describe("AnnotationSearchFormComponent", () => {
     expect(recordingsTypeahead()).toBeHidden();
     toggleDropdown(spec, advancedFiltersToggle());
     expect(recordingsTypeahead()).toBeVisible();
+  }));
+
+  it("should not show the projects input if projects are hidden", fakeAsync(() => {
+    setup({}, true);
+    expect(projectsTypeahead()).not.toExist();
   }));
 
   describe("pre-population from first load", () => {

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
@@ -41,6 +41,7 @@ import { InnerFilter } from "@baw-api/baw-api.service";
 import { Writeable } from "@helpers/advancedTypes";
 import { DebouncedInputDirective } from "@directives/debouncedInput/debounced-input.directive";
 import { toNumber } from "@helpers/typing/toNumber";
+import { ConfigService } from "@services/config/config.service";
 
 enum ScoreRangeBounds {
   Lower,
@@ -71,7 +72,10 @@ export class AnnotationSearchFormComponent implements OnInit {
     protected regionsApi: ShallowRegionsService,
     protected sitesApi: ShallowSitesService,
     protected tagsApi: TagsService,
-  ) {}
+    private config: ConfigService,
+  ) {
+    this.hideProjectsInput = this.config.settings.hideProjects;
+  }
 
   @Input({ required: true })
   public searchParameters: AnnotationSearchParameters;
@@ -86,6 +90,7 @@ export class AnnotationSearchFormComponent implements OnInit {
   protected createSearchCallback = createSearchCallback;
   protected createIdSearchCallback = createIdSearchCallback;
   protected hideAdvancedFilters = true;
+  protected hideProjectsInput = false;
   protected scoreRangeBounds = ScoreRangeBounds;
 
   protected get project(): Project {

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
@@ -73,9 +73,7 @@ export class AnnotationSearchFormComponent implements OnInit {
     protected sitesApi: ShallowSitesService,
     protected tagsApi: TagsService,
     private config: ConfigService,
-  ) {
-    this.hideProjectsInput = this.config.settings.hideProjects;
-  }
+  ) {}
 
   @Input({ required: true })
   public searchParameters: AnnotationSearchParameters;
@@ -112,6 +110,8 @@ export class AnnotationSearchFormComponent implements OnInit {
     const advancedFilterKeys: (keyof AnnotationSearchParameters)[] = [
       "audioRecordings",
     ];
+
+    this.hideProjectsInput = this.config.settings.hideProjects;
 
     for (const key of advancedFilterKeys) {
       const value = this.searchParameters[key];

--- a/src/app/components/annotations/pages/annotationSearchParameters.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.ts
@@ -293,7 +293,14 @@ export class AnnotationSearchParameters
     // however, the api doesn't currently support this functionality
     // therefore, we do a virtual join by filtering on the project/region site
     // ids on the client.
+    //
+    // The siteIds() method will return "null" if we don't want to scope to
+    // any site ids.
+    // In this case, we return an empty inner filter.
     const modelSiteIds = this.siteIds();
+    if (modelSiteIds === null) {
+      return {};
+    }
 
     return {
       "audioRecordings.siteId": {
@@ -313,7 +320,7 @@ export class AnnotationSearchParameters
   // TODO: remove this method once the API supports filtering audio events by
   // projects, and regions.
   // see: https://github.com/QutEcoacoustics/baw-server/issues/687
-  private siteIds(): Id[] {
+  private siteIds(): Id[] | null {
     const qspSites = this.sites ? Array.from(this.sites) : [];
 
     // We use a !== null condition here instead of a truthy assertion so that
@@ -342,11 +349,7 @@ export class AnnotationSearchParameters
       return qspProjects;
     }
 
-    // This condition should never hit in regular use.
-    // We return an empty array here instead of throwing an error in the hope
-    // that the application can recover instead of crashing all work.
-    console.error("Failed to find any scoped route or qsps models");
-    return [];
+    return null;
   }
 
   private addRouteFilters(

--- a/src/app/components/annotations/pages/annotationSearchParameters.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.ts
@@ -271,6 +271,18 @@ export class AnnotationSearchParameters
     // If the "sort" query string parameter is not set, this.sortingFilters()
     // will return undefined.
     const sorting = this.sortingFilters();
+
+    // If there are no filter conditions, we want to return the sorting
+    // conditions, but if there are even no sorting conditions, we just want to
+    // return an empty filter body.
+    if (Object.keys(filter).length === 0) {
+      if (sorting !== undefined) {
+        return { sorting };
+      }
+
+      return {};
+    }
+
     if (sorting === undefined) {
       return { filter };
     }
@@ -297,6 +309,7 @@ export class AnnotationSearchParameters
     // The siteIds() method will return "null" if we don't want to scope to
     // any site ids.
     // In this case, we return an empty inner filter.
+    //
     const modelSiteIds = this.siteIds();
     if (modelSiteIds === null) {
       return {};

--- a/src/app/components/annotations/pages/search/search.component.ts
+++ b/src/app/components/annotations/pages/search/search.component.ts
@@ -37,6 +37,7 @@ import { AssociationInjector } from "@models/ImplementsInjector";
 import { IfLoggedInComponent } from "@shared/can/can.component";
 import { AnnotationEventCardComponent } from "@shared/audio-event-card/annotation-event-card.component";
 import { ErrorHandlerComponent } from "@shared/error-handler/error-handler.component";
+import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { AnnotationSearchFormComponent } from "../../components/annotation-search-form/annotation-search-form.component";
 import { AnnotationSearchParameters } from "../annotationSearchParameters";
 
@@ -200,15 +201,19 @@ class AnnotationSearchComponent
   }
 
   protected verifyAnnotationsRoute(): StrongRoute {
-    if (this.searchParameters.routeSiteId) {
+    // I use isInstantiated() here instead of a falsy assertion so that ids of
+    // zero will pass as a valid project route id.
+    if (isInstantiated(this.searchParameters.routeSiteId)) {
       return this.searchParameters.routeSiteModel.isPoint
         ? annotationMenuItems.verify.siteAndRegion.route
         : annotationMenuItems.verify.site.route;
-    } else if (this.searchParameters.routeRegionId) {
+    } else if (isInstantiated(this.searchParameters.routeRegionId)) {
       return annotationMenuItems.verify.region.route;
+    } else if (isInstantiated(this.searchParameters.routeProjectId)) {
+      return annotationMenuItems.verify.project.route;
     }
 
-    return annotationMenuItems.verify.project.route;
+    return annotationMenuItems.verify.base.route;
   }
 }
 

--- a/src/app/components/annotations/pages/search/search.component.ts
+++ b/src/app/components/annotations/pages/search/search.component.ts
@@ -227,7 +227,8 @@ function getPageInfo(
   };
 }
 
-AnnotationSearchComponent.linkToRoute(getPageInfo("project"))
+AnnotationSearchComponent.linkToRoute(getPageInfo("base"))
+  .linkToRoute(getPageInfo("project"))
   .linkToRoute(getPageInfo("region"))
   .linkToRoute(getPageInfo("site"))
   .linkToRoute(getPageInfo("siteAndRegion"));

--- a/src/app/components/annotations/pages/verification/verification.component.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.ts
@@ -336,7 +336,8 @@ function getPageInfo(
   };
 }
 
-VerificationComponent.linkToRoute(getPageInfo("project"))
+VerificationComponent.linkToRoute(getPageInfo("base"))
+  .linkToRoute(getPageInfo("project"))
   .linkToRoute(getPageInfo("region"))
   .linkToRoute(getPageInfo("site"))
   .linkToRoute(getPageInfo("siteAndRegion"));

--- a/src/app/components/annotations/pages/verification/verification.component.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.ts
@@ -22,7 +22,6 @@ import { firstValueFrom } from "rxjs";
 import { annotationMenuItems } from "@components/annotations/annotation.menu";
 import { Filters, Paging } from "@baw-api/baw-api.service";
 import { VerificationGridComponent } from "@ecoacoustics/web-components/@types/components/verification-grid/verification-grid";
-import { StrongRoute } from "@interfaces/strongRoute";
 import { ProgressWarningComponent } from "@components/annotations/components/modals/progress-warning/progress-warning.component";
 import { NgbModal, NgbTooltip } from "@ng-bootstrap/ng-bootstrap";
 import { SearchFiltersModalComponent } from "@components/annotations/components/modals/search-filters/search-filters.component";
@@ -231,18 +230,6 @@ class VerificationComponent
         this.openSearchFiltersModal();
       }
     });
-  }
-
-  protected verifyAnnotationsRoute(): StrongRoute {
-    if (this.site) {
-      return this.site.isPoint
-        ? annotationMenuItems.verify.siteAndRegion.route
-        : annotationMenuItems.verify.site.route;
-    } else if (this.region) {
-      return annotationMenuItems.verify.region.route;
-    }
-
-    return annotationMenuItems.verify.project.route;
   }
 
   protected getPageCallback(): any {

--- a/src/app/components/regions/pages/list/list.component.ts
+++ b/src/app/components/regions/pages/list/list.component.ts
@@ -14,11 +14,13 @@ import { List } from "immutable";
 import { CardsComponent } from "@shared/model-cards/cards/cards.component";
 import { ErrorHandlerComponent } from "@shared/error-handler/error-handler.component";
 import { DebouncedInputDirective } from "@directives/debouncedInput/debounced-input.directive";
+import { annotationMenuItems } from "@components/annotations/annotation.menu";
 
 export const regionsMenuItemActions = [
   shallowNewRegionMenuItem,
   audioRecordingMenuItems.list.base,
   audioRecordingMenuItems.batch.base,
+  annotationMenuItems.search.base,
 ];
 
 @Component({


### PR DESCRIPTION
# Add base `/annotation` search/verification page

## Changes

- Adds a base `/annotation` page that can be used to search annotation across the entire website. I have only exposed this route on the region list page so that clients with `projectsHidden` (E.g. A2O) can verify annotations across the entire project.
- Hides the "Projects" input in the annotation search form if `hideProjects` is set

I do not expect users to use this route for sites with > 1 project.

## Issues

Fixes: #2296

## Visual Changes

![image](https://github.com/user-attachments/assets/bb055e7f-4688-4c63-8ffe-aa8ab4f9a7b3)

_Annotation search form without the "projects" input because `hideProjects` was set in the environment.json_

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
