### PR TITLE
Fix project list layout shift

### DIFF
--- a/src/app/components/shared/formly/license-input/license-input.component.html
+++ b/src/app/components/shared/formly/license-input/license-input.component.html
@@ -8,7 +8,7 @@
   <div class="input-controls form-control input-group p-0">
     <baw-typeahead-input
       #licenseTypeahead
-      class="license-input"
+      class="license-input mb-0"
       [inputPlaceholder]="'No License'"
       [searchCallback]="searchCallback()"
       [multipleInputs]="false"

--- a/src/app/components/shared/model-cards/card/card.component.scss
+++ b/src/app/components/shared/model-cards/card/card.component.scss
@@ -16,7 +16,7 @@
     border-bottom: var(--card-border);
 
     a {
-      display: inline-block;
+      display: block;
       width: auto;
       height: auto;
     }

--- a/src/app/components/shared/model-cards/card/card.component.scss
+++ b/src/app/components/shared/model-cards/card/card.component.scss
@@ -16,6 +16,11 @@
     border-bottom: var(--card-border);
 
     a {
+      // We use "disable: block" so the images box model is pre-allocated to
+      // reduce layout shift.
+      // Additionally, we do this at the link level so that the touch target
+      // is a fixed size / location and doesn't move when images are loaded or
+      // changed.
       display: block;
       width: auto;
       height: auto;

--- a/src/app/components/shared/typeahead-input/typeahead-input.component.html
+++ b/src/app/components/shared/typeahead-input/typeahead-input.component.html
@@ -3,7 +3,7 @@
     @if (label) {
       {{ label }}
     }
-    <div class="typeahead-input-container form-control">
+    <div class="typeahead-input-container mb-0 form-control">
       @if (multipleInputs) {
         @for (item of value; track item; let i = $index) {
           <span

--- a/src/app/components/shared/typeahead-input/typeahead-input.component.html
+++ b/src/app/components/shared/typeahead-input/typeahead-input.component.html
@@ -3,7 +3,7 @@
     @if (label) {
       {{ label }}
     }
-    <div class="typeahead-input-container mb-0 form-control">
+    <div class="typeahead-input-container form-control">
       @if (multipleInputs) {
         @for (item of value; track item; let i = $index) {
           <span

--- a/src/app/components/shared/typeahead-input/typeahead-input.component.html
+++ b/src/app/components/shared/typeahead-input/typeahead-input.component.html
@@ -1,5 +1,5 @@
 <div>
-  <label class="form-label w-100">
+  <label class="typeahead-label form-label w-100">
     @if (label) {
       {{ label }}
     }

--- a/src/app/components/shared/typeahead-input/typeahead-input.component.scss
+++ b/src/app/components/shared/typeahead-input/typeahead-input.component.scss
@@ -6,6 +6,7 @@
 // overwritten by consumers simply through a style selector.
 // e.g. <baw-typeahead-input style="margin: 2rem"></baw-typeahead-input>
 :host {
+  display: block;
   margin-bottom: 0.5rem;
 }
 
@@ -20,6 +21,9 @@
   display: flex;
   flex-wrap: wrap;
   padding: 0;
+}
+
+.typeahead-label {
   margin: 0;
 }
 

--- a/src/app/components/shared/typeahead-input/typeahead-input.component.scss
+++ b/src/app/components/shared/typeahead-input/typeahead-input.component.scss
@@ -1,3 +1,14 @@
+// Because the typeahead includes a <label> element, it naturally has a
+// margin-bottom provided by bootstrap.
+// However, because the label is inside of this component, it's not possible to
+// override the margin.
+// Therefore, I expose the margin on the host element so that it can be
+// overwritten by consumers simply through a style selector.
+// e.g. <baw-typeahead-input style="margin: 2rem"></baw-typeahead-input>
+:host {
+  margin-bottom: 0.5rem;
+}
+
 #typeahead-input {
   width: max-content;
   min-width: 10rem;

--- a/src/app/components/shared/typeahead-input/typeahead-input.component.scss
+++ b/src/app/components/shared/typeahead-input/typeahead-input.component.scss
@@ -20,6 +20,7 @@
   display: flex;
   flex-wrap: wrap;
   padding: 0;
+  margin: 0;
 }
 
 .item-pill {


### PR DESCRIPTION
# Fix project list layout shift

## Changes

- Fixes images on the project list page not having space allocated before the image is rendered, causing layout shift
- Fixes typeahead input using an internal margin instead of being overrideable by the host

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
