### PR TITLE
Annotation search tweaks

### DIFF
--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
@@ -156,7 +156,7 @@
   </div>
 
   <div class="mt-2">
-    <label class="form-label w-100">Show annotations</label>
+    <label class="form-label w-100">Show annotations that</label>
     <baw-selectable-items
       [options]="verifiedStatusOptions"
       [selection]="searchParameters.verificationStatus ?? defaultVerificationStatus"

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
@@ -98,9 +98,9 @@ export class AnnotationSearchFormComponent implements OnInit {
   protected hideAdvancedFilters = true;
   protected scoreRangeBounds = ScoreRangeBounds;
   protected verifiedStatusOptions: ISelectableItem<VerificationStatusKey>[] = [
-    { label: "I have not verified", value: "unverified-for-me", disabled: true },
-    { label: "no one has verified", value: "unverified" },
-    { label: "even if they have been verified", value: "any" },
+    { label: "have not been verified by me", value: "unverified-for-me", disabled: true },
+    { label: "have not been verified by anyone", value: "unverified" },
+    { label: "are verified or unverified", value: "any" },
   ];
 
   protected get project(): Project {

--- a/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
@@ -167,7 +167,12 @@ describe("annotationSearchParameters", () => {
             { "audioRecordings.siteId": { in: [6, 7, 8, 9] } },
             { score: { gteq: 0.5 } },
             { score: { lteq: 0.9 } },
-            { "verifications.id": { eq: null } },
+            {
+              or: [
+                { "verifications.confirmed": { eq: null } },
+                { "verifications.confirmed": { eq: "skip" } },
+              ],
+            },
           ],
         },
         sorting: {
@@ -217,7 +222,7 @@ describe("annotationSearchParameters", () => {
       }),
     },
     {
-      name: "should have the correct filters for only a selection filter",
+      name: "should have the correct filters for only a verification status filter",
       inputParams: {
         verificationStatus: "unverified",
       },
@@ -229,7 +234,12 @@ describe("annotationSearchParameters", () => {
                 in: Array.from(routeProject.siteIds),
               },
             },
-            { "verifications.id": { eq: null } },
+            {
+              or: [
+                { "verifications.confirmed": { eq: null } },
+                { "verifications.confirmed": { eq: "skip" } },
+              ],
+            },
           ],
         },
         sorting: defaultSorting,

--- a/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
@@ -73,6 +73,12 @@ describe("annotationSearchParameters", () => {
     or: [
       { "verifications.creatorId": { notEq: 42 } },
       { "verifications.id": { eq: null } },
+      {
+        and: [
+          { "verifications.creatorId": { eq: 42 } },
+          { "verifications.confirmed": { eq: "skip" } },
+        ],
+      },
     ],
   };
 

--- a/src/app/components/annotations/pages/annotationSearchParameters.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.ts
@@ -300,7 +300,12 @@ export class AnnotationSearchParameters
           },
         ],
       }],
-      ["unverified", { "verifications.id": { eq: null } }],
+      ["unverified", {
+        or: [
+          { "verifications.confirmed": { eq: null } },
+          { "verifications.confirmed": { eq: "skip" } },
+        ],
+      }],
       ["any", null],
     ]) satisfies Map<VerificationStatusKey, InnerFilter<AudioEvent>>;
   }

--- a/src/app/components/annotations/pages/search/search.component.spec.ts
+++ b/src/app/components/annotations/pages/search/search.component.spec.ts
@@ -194,6 +194,12 @@ describe("AnnotationSearchComponent", () => {
               or: [
                 { "verifications.creatorId": { notEq: mockUser.id} },
                 { "verifications.id": { eq: null } },
+                {
+                  and: [
+                    { "verifications.creatorId": { eq: mockUser.id} },
+                    { "verifications.confirmed": { eq: "skip" } },
+                  ],
+                },
               ],
             }
           ],

--- a/src/app/components/shared/items/selectable-items/selectable-items.component.html
+++ b/src/app/components/shared/items/selectable-items/selectable-items.component.html
@@ -11,7 +11,7 @@
     @let selected = option.value === selection();
 
     <button
-      class="btn btn-sm btn-default me-1"
+      class="inline-button btn btn-sm btn-default"
       (click)="changeSelection(option.value)"
       [disabled]="option.disabled || disabled()"
       [attr.readonly]="selected"

--- a/src/app/components/shared/items/selectable-items/selectable-items.component.scss
+++ b/src/app/components/shared/items/selectable-items/selectable-items.component.scss
@@ -5,3 +5,19 @@ button {
     cursor: not-allowed;
   }
 }
+
+.inline-button {
+  &:not(:first-of-type) {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  &:not(:last-of-type) {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+
+    // We remove the right border so that when the two buttons are positioned
+    // against each other, there is not a double border.
+    border-right: none;
+  }
+}


### PR DESCRIPTION
# Annotation search tweaks

## Changes

- Changes the "that I have not verified" filter to include events you added a "skip" decision to
- Changes copy text of "verification status" filters
- `baw-selectable-items` with `[inline=true]` now has no margin between elements

## Issues

Fixes: #2364

## Visual Changes

<img width="1765" height="874" alt="image" src="https://github.com/user-attachments/assets/b3d2fa94-2507-4f60-b3ed-22abf93d0dff" />

_Annotation search form with new inline selectable styles + copy text_

---

<img width="1344" height="351" alt="image" src="https://github.com/user-attachments/assets/009823b3-596b-4bfd-9819-52669c08cd7e" />

_Project permissions page with new inline selectable styles_

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
