### PR TITLE
Fix "skip" decisions not working across users

### DIFF
--- a/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
@@ -72,13 +72,8 @@ describe("annotationSearchParameters", () => {
   const myUnverifiedFilters = {
     or: [
       { "verifications.creatorId": { notEq: 42 } },
-      { "verifications.id": { eq: null } },
-      {
-        and: [
-          { "verifications.creatorId": { eq: 42 } },
-          { "verifications.confirmed": { eq: "skip" } },
-        ],
-      },
+      { "verifications.confirmed": { eq: null } },
+      { "verifications.confirmed": { eq: "skip" } },
     ],
   };
 

--- a/src/app/components/annotations/pages/annotationSearchParameters.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.ts
@@ -291,13 +291,8 @@ export class AnnotationSearchParameters
       ["unverified-for-me", {
         or: [
           { "verifications.creatorId": { notEq: this.user?.id ?? null } },
-          { "verifications.id": { eq: null } },
-          {
-            and: [
-              { "verifications.creatorId": { eq: this.user?.id ?? null } },
-              { "verifications.confirmed": { eq: "skip" } },
-            ],
-          },
+          { "verifications.confirmed": { eq: null } },
+          { "verifications.confirmed": { eq: "skip" } },
         ],
       }],
       ["unverified", {

--- a/src/app/components/annotations/pages/search/search.component.spec.ts
+++ b/src/app/components/annotations/pages/search/search.component.spec.ts
@@ -193,13 +193,8 @@ describe("AnnotationSearchComponent", () => {
             {
               or: [
                 { "verifications.creatorId": { notEq: mockUser.id} },
-                { "verifications.id": { eq: null } },
-                {
-                  and: [
-                    { "verifications.creatorId": { eq: mockUser.id} },
-                    { "verifications.confirmed": { eq: "skip" } },
-                  ],
-                },
+                { "verifications.confirmed": { eq: null } },
+                { "verifications.confirmed": { eq: "skip" } },
               ],
             }
           ],


### PR DESCRIPTION
# Fix "skip" decisions not working across users

This PR changes it so that `skip` decisions will **always** be shown.

Please check my logic. Do we want users to re-see their `skip` decisions? (This change will make it so that users will re-see their `skip` decisions if they reload the page).

## Changes

- Fixes `skip` decisions not working across users

## Issues

NA

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
