### PR TITLE
Bump web components (4.2.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/platform-server": "19.2.5",
         "@angular/router": "19.2.5",
         "@angular/ssr": "19.2.6",
-        "@ecoacoustics/web-components": "^4.0.0",
+        "@ecoacoustics/web-components": "^4.2.0",
         "@fortawesome/angular-fontawesome": "^1.0.0",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
@@ -3571,9 +3571,9 @@
       }
     },
     "node_modules/@ecoacoustics/web-components": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@ecoacoustics/web-components/-/web-components-4.0.0.tgz",
-      "integrity": "sha512-JlpXq2yyA2NTvjPyFENHjbHePMvddOVwczMcX/FaxmsYNLefaWua5nKF1/IS+WDpP9xafWP8oH98R/HIHR3DXA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@ecoacoustics/web-components/-/web-components-4.2.0.tgz",
+      "integrity": "sha512-2KLxdujEqYmImj8L4WJ2coUiSY4D8OMmIVyHsiB4hd9mv2JK2qKm5/H+ACesn6Svngb/U3FbIg1YsTQopunYYQ==",
       "dependencies": {
         "@json2csv/plainjs": "7.0.6",
         "@lit-labs/preact-signals": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@angular/platform-server": "19.2.5",
     "@angular/router": "19.2.5",
     "@angular/ssr": "19.2.6",
-    "@ecoacoustics/web-components": "^4.0.0",
+    "@ecoacoustics/web-components": "^4.2.0",
     "@fortawesome/angular-fontawesome": "^1.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",


### PR DESCRIPTION
# Bump web components to version 4.2.0

## Changes

- Bumps web components to version 4.2.0

### Web Component Features

- Add placeholders for empty tiles
- Adds empty-subject-message property to verification grid for customizing the empty tile message
vsync's the selection highlight box (use RAF)
- Moves the completion text from the top left to the center of the verification grid
- Adds slight box-shadow to grid tiles
- Uses css contain for verification grid tiles
- Adds max-grid-size to oe-verification-grid-settings component
- Refactor selection logic into common method
- Bifurcate selectionHead into selectionHead & focusHead
- Focus outline is now consistent across browsers
- Change paging shortcuts to pageUp & pageDown
- Add support for selecting with arrow keys
- Add support for selecting with home & end keys
- Add support for shortcut modifiers with highlight selection
- Add auto-advancing head on decisions
- Add autofocus attribute
	- override oe-verification-grid and oe-verification-grid-tile focus() methods

### Web Component Bug Fixes

- Fixes a bug where if the dataset was smaller than the grid size, completion progress could go over 100%
- Fixes bug where bootstrap SVG text would not use the theme's font color
- Fixes bug where menu items would have slight unstyled panel color at top & bottom of menu
- Fixes a bug where pressing escape to dismiss the bootstrap modal before verification grid had loaded would cause navigation bailout, and spectrogram/verification grid load failure
- Fixes bug where downsizing the verification grid during load would result in disabled decision buttons
- Fixes a bug where the box-shadow on the verification buttons would have gaps when squashed together
- Fix bug where pressing alt + number shortcuts could switch tabs

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
