### PR TITLE
Cache Git LFS assets in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,11 @@ jobs:
       cancel-in-progress: true
 
     steps:
+      # We cache LFS assets in CI so that less of the GitHub LFS budget is used
+      # by simple cloning in CI
       - name: Checkout Workbench Client
-        uses: actions/checkout@v4
+        uses: nschloe/action-cached-lfs-checkout@v1
         with:
-          lfs: true
           fetch-depth: 50
 
       # fetch more tag info so git_version.ps1 works properly

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -141,9 +141,7 @@ jobs:
 
     steps:
       - name: Checkout Workbench Client
-        uses: actions/checkout@v4
-        with:
-          lfs: true
+        uses: nschloe/action-cached-lfs-checkout@v1
 
       - name: Checkout LFS objects
         run: git lfs checkout
@@ -163,9 +161,7 @@ jobs:
 
     steps:
       - name: Checkout Workbench Client
-        uses: actions/checkout@v4
-        with:
-          lfs: true
+        uses: nschloe/action-cached-lfs-checkout@v1
 
       - name: Checkout LFS objects
         run: git lfs checkout


### PR DESCRIPTION
# Cache Git LFS assets in CI

This adds nschloe/action-cached-lfs-checkout as a CI dependency in exchange for caching Git LFS assets.

## Changes

- Use [`nschloe/action-cached-lfs-checkout@v1`](https://github.com/nschloe/action-cached-lfs-checkout) when cloning repository with Git LFS assets. This does not replace other workflows `checkout` that do not clone Git LFS assets. (e.g. the `differ.yml` workflow still uses the `checkout@v4` action provided by GitHub)

## Issues

Fixes: #2374

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
