### PR TITLE
Do not log out user before logging in

### DIFF
--- a/src/app/services/baw-api/api.interceptor.service.ts
+++ b/src/app/services/baw-api/api.interceptor.service.ts
@@ -1,5 +1,4 @@
 import {
-  HttpContextToken,
   HttpErrorResponse,
   HttpEvent,
   HttpHandler,
@@ -25,10 +24,6 @@ import { ApiResponse } from "./baw-api.service";
 import { BawSessionService } from "./baw-session.service";
 
 export const CLIENT_TIMEOUT = 0;
-
-// the authentication context token can be used to hide/show the authentication in requests
-// a true value will include the authentication header and cookies
-export const CREDENTIALS_CONTEXT = new HttpContextToken<boolean>(() => true);
 
 /**
  * BAW API Interceptor.
@@ -58,10 +53,8 @@ export class BawApiInterceptor implements HttpInterceptor {
       return next.handle(request);
     }
 
-    const shouldSendCredentials = request.context.get(CREDENTIALS_CONTEXT);
-
     // If logged in, add authorization token
-    if (this.session.isLoggedIn && shouldSendCredentials) {
+    if (this.session.isLoggedIn && request.withCredentials) {
       request = request.clone({
         setHeaders: {
           // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -70,10 +63,8 @@ export class BawApiInterceptor implements HttpInterceptor {
       });
     }
 
-    // Convert outgoing data
-    // if withCredentials is false, the request will not include cookies (such as the _baw_session cookie)
+    // Convert outgoing data to snake_case
     request = request.clone({
-      withCredentials: shouldSendCredentials,
       body: toSnakeCase(request.body),
     });
 

--- a/src/app/services/baw-api/baw-api.service.ts
+++ b/src/app/services/baw-api/baw-api.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpContext, HttpHeaders } from "@angular/common/http";
+import { HttpClient, HttpHeaders } from "@angular/common/http";
 import { Inject, Injectable, Optional } from "@angular/core";
 import { KeysOfType, Writeable, XOR } from "@helpers/advancedTypes";
 import { toSnakeCase } from "@helpers/case-converter/case-converter";
@@ -29,7 +29,6 @@ import {
 import { defaultCachingConfig } from "@services/cache/ngHttpCachingConfig";
 import { withCacheLogging } from "@services/cache/cache-logging.service";
 import { BawSessionService } from "./baw-session.service";
-import { CREDENTIALS_CONTEXT } from "./api.interceptor.service";
 import { BAW_SERVICE_OPTIONS } from "./api-common";
 
 export const defaultApiPageSize = 25;
@@ -165,11 +164,8 @@ export class BawApiService<
 
   // the "context" headers are passed to the interceptor to determine if the request should be cached and if
   // the Authentication token and cookies should be sent in requests
-  private withCredentialsHttpContext(
-    options: Required<BawServiceOptions>,
-    baseContext: HttpContext = new HttpContext()
-  ): HttpContext {
-    return baseContext.set(CREDENTIALS_CONTEXT, options.withCredentials);
+  private httpClientOptions(options: Required<BawServiceOptions>): Parameters<HttpClient["get"]>[1] {
+    return { withCredentials: options.withCredentials };
   }
 
   // because users can input a partial options object, it is possible for the disableNotification property to be undefined
@@ -651,7 +647,8 @@ export class BawApiService<
    * @param headers Request headers
    *
    * @param options Options to modify the request
-   * eg. `{ withCredentials: false }` will not include the users authentication token and cookies in the request
+   * e.g. `{ withCredentials: false }` will not include the users authentication
+   * token or cookies in the request.
    */
   public httpGet(
     path: string,
@@ -666,12 +663,11 @@ export class BawApiService<
       withCacheLogging()
     );
 
-    const context = this.withCredentialsHttpContext(fullOptions, cacheContext);
-
     return this.http.get<ApiResponse<Model>>(this.getPath(path), {
       responseType: "json",
+      context: cacheContext,
       headers,
-      context,
+      ...this.httpClientOptions(fullOptions),
     });
   }
 
@@ -684,7 +680,8 @@ export class BawApiService<
    * @param headers Request headers
    *
    * @param options Options to modify the request
-   * eg. `{ withCredentials: false }` will not include the users authentication token and cookies in the request
+   * e.g. `{ withCredentials: false }` will not include the users authentication
+   * token or cookies in the request.
    */
   public httpDelete(
     path: string,
@@ -693,12 +690,10 @@ export class BawApiService<
   ): Observable<ApiResponse<Model | void>> {
     const fullOptions = this.buildServiceOptions(options);
 
-    const context = this.withCredentialsHttpContext(fullOptions);
-
     return this.http.delete<ApiResponse<null>>(this.getPath(path), {
       responseType: "json",
       headers,
-      context,
+      ...this.httpClientOptions(fullOptions),
     });
   }
 
@@ -712,7 +707,8 @@ export class BawApiService<
    * @param headers Request headers
    *
    * @param options Options to modify the request
-   * eg. `{ withCredentials: false }` will not include the users authentication token and cookies in the request
+   * e.g. `{ withCredentials: false }` will not include the users authentication
+   * token or cookies in the request.
    */
   public httpPost(
     path: string,
@@ -727,15 +723,13 @@ export class BawApiService<
     // const cachingOptions = this.buildCachingOptions(options);
     // const cacheContext = withNgHttpCachingContext(cachingOptions);
 
-    const context = this.withCredentialsHttpContext(fullOptions);
-
     return this.http.post<ApiResponse<Model | Model[]>>(
       this.getPath(path),
       body,
       {
         responseType: "json",
         headers,
-        context,
+        ...this.httpClientOptions(fullOptions),
       }
     );
   }
@@ -750,7 +744,8 @@ export class BawApiService<
    * @param headers Request headers
    *
    * @param options Options to modify the request
-   * eg. `{ withCredentials: false }` will not include the users authentication token and cookies in the request
+   * e.g. `{ withCredentials: false }` will not include the users authentication
+   * token or cookies in the request.
    */
   public httpPut(
     path: string,
@@ -760,12 +755,10 @@ export class BawApiService<
   ): Observable<ApiResponse<Model>> {
     const fullOptions = this.buildServiceOptions(options);
 
-    const context = this.withCredentialsHttpContext(fullOptions);
-
     return this.http.put<ApiResponse<Model>>(this.getPath(path), body, {
       responseType: "json",
       headers,
-      context,
+      ...this.httpClientOptions(fullOptions),
     });
   }
 
@@ -779,7 +772,8 @@ export class BawApiService<
    * @param headers Request headers
    *
    * @param options Options to modify the request
-   * eg. `{ withCredentials: false }` will not include the users authentication token and cookies in the request
+   * e.g. `{ withCredentials: false }` will not include the users authentication
+   * token or cookies in the request.
    */
   public httpPatch(
     path: string,
@@ -789,12 +783,10 @@ export class BawApiService<
   ): Observable<ApiResponse<Model>> {
     const fullOptions = this.buildServiceOptions(options);
 
-    const context = this.withCredentialsHttpContext(fullOptions);
-
     return this.http.patch<ApiResponse<Model>>(this.getPath(path), body, {
       responseType: "json",
       headers,
-      context,
+      ...this.httpClientOptions(fullOptions),
     });
   }
 

--- a/src/app/services/baw-api/baw-form-api.service.ts
+++ b/src/app/services/baw-api/baw-form-api.service.ts
@@ -59,14 +59,14 @@ export class BawFormApiService<Model extends AbstractModelWithoutId> {
           throw new BawApiError(
             BAD_REQUEST,
             "Unable to retrieve authenticity token for form request.",
-            {}
+            {},
           );
         }
         return token;
       }),
       // Mimic a traditional form-based request
       mergeMap((token: string) =>
-        this.formRequest(submissionEndpoint, body(token), options)
+        this.formRequest(submissionEndpoint, body(token), options),
       ),
       tap((response: string) => {
         // Check for recaptcha error message in page body
@@ -75,14 +75,14 @@ export class BawFormApiService<Model extends AbstractModelWithoutId> {
           throw new BawApiError(
             BAD_REQUEST,
             "Captcha response was not correct.",
-            {}
+            {},
           );
         }
       }),
       // Complete observable
       first(),
       // Handle custom errors
-      catchError(this.handleError)
+      catchError(this.handleError),
     );
   }
 

--- a/src/app/services/baw-api/security/security.service.spec.ts
+++ b/src/app/services/baw-api/security/security.service.spec.ts
@@ -213,18 +213,15 @@ describe("SecurityService", () => {
         );
       }
 
-      it("should call signOut", async () => {
+      // If the user is logged out before logging in, the authentication token
+      // will be rotated.
+      // We used to do this before we started rotating authentication tokens,
+      // so this test protects against regressions.
+      it("should not sign the user out", async () => {
         const promise = interceptSignOut(true);
         spec.service.signIn(defaults.loginDetails);
         await promise;
-        expect(spec.service.signOut).toHaveBeenCalled();
-      });
-
-      it("should handle signOut failure", async () => {
-        const promise = interceptSignOut(false);
-        spec.service.signIn(defaults.loginDetails);
-        await promise;
-        expect(spec.service.signOut).toHaveBeenCalled();
+        expect(spec.service.signOut).not.toHaveBeenCalled();
       });
 
       it("should call handleAuth", async () => {

--- a/src/app/services/baw-api/security/security.service.ts
+++ b/src/app/services/baw-api/security/security.service.ts
@@ -143,12 +143,7 @@ export class SecurityService {
       }
     );
 
-    // Logout first to ensure token and cookie are synchronized
-    return this.signOut().pipe(
-      mergeMap(() => handleAuth),
-      // Ignore any sign out errors, and continue with authentication
-      catchError(() => handleAuth)
-    );
+    return handleAuth;
   }
 
   /**


### PR DESCRIPTION
# Do not log out user before logging in

## Changes

- Do not call `signOut` before logging user in
- Do not send authentication information (e.g. `Cookies` or `Authentication` headers) with login requests
- Refactor out `HTTP_AUTHENTICATION_CONTEXT` and replace with native `withCredentials` Request option

## Issues

Fixes: #2381

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
