### PR TITLE
Verification Compound Tasks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/platform-server": "19.2.5",
         "@angular/router": "19.2.5",
         "@angular/ssr": "19.2.6",
-        "@ecoacoustics/web-components": "^4.2.0",
+        "@ecoacoustics/web-components": "^5.0.0",
         "@fortawesome/angular-fontawesome": "^1.0.0",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
@@ -3571,9 +3571,9 @@
       }
     },
     "node_modules/@ecoacoustics/web-components": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@ecoacoustics/web-components/-/web-components-4.2.0.tgz",
-      "integrity": "sha512-2KLxdujEqYmImj8L4WJ2coUiSY4D8OMmIVyHsiB4hd9mv2JK2qKm5/H+ACesn6Svngb/U3FbIg1YsTQopunYYQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@ecoacoustics/web-components/-/web-components-5.0.0.tgz",
+      "integrity": "sha512-bwEbBOhpClOelnDa5A+ALssITqctKeC1Q+zl3qrHOjsTznjHQPiilTMo6WVASufQ6FqQAMujvJw4dg41U/vuxw==",
       "dependencies": {
         "@json2csv/plainjs": "7.0.6",
         "@lit-labs/preact-signals": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/platform-server": "19.2.5",
         "@angular/router": "19.2.5",
         "@angular/ssr": "19.2.6",
-        "@ecoacoustics/web-components": "^5.0.0",
+        "@ecoacoustics/web-components": "^5.1.0",
         "@fortawesome/angular-fontawesome": "^1.0.0",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
@@ -3571,9 +3571,9 @@
       }
     },
     "node_modules/@ecoacoustics/web-components": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@ecoacoustics/web-components/-/web-components-5.0.0.tgz",
-      "integrity": "sha512-bwEbBOhpClOelnDa5A+ALssITqctKeC1Q+zl3qrHOjsTznjHQPiilTMo6WVASufQ6FqQAMujvJw4dg41U/vuxw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ecoacoustics/web-components/-/web-components-5.1.0.tgz",
+      "integrity": "sha512-jA8YFL+8JPYNBiq11UxJJiLuZqX2Gac/CkMnKBkFpVqaLgyzyrQfU5Ue7U5NOCcKGYe1GSPJgmD0iLZ5dlPgkw==",
       "dependencies": {
         "@json2csv/plainjs": "7.0.6",
         "@lit-labs/preact-signals": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@angular/platform-server": "19.2.5",
     "@angular/router": "19.2.5",
     "@angular/ssr": "19.2.6",
-    "@ecoacoustics/web-components": "^5.0.0",
+    "@ecoacoustics/web-components": "^5.1.0",
     "@fortawesome/angular-fontawesome": "^1.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@angular/platform-server": "19.2.5",
     "@angular/router": "19.2.5",
     "@angular/ssr": "19.2.6",
-    "@ecoacoustics/web-components": "^4.2.0",
+    "@ecoacoustics/web-components": "^5.0.0",
     "@fortawesome/angular-fontawesome": "^1.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
@@ -166,7 +166,7 @@
   </div>
 
   <div class="mt-2">
-    <label class="form-label w-100">Verification Task</label>
+    <label class="form-label w-100">Task Behavior</label>
     <baw-selectable-items
       [options]="taskBehaviorOptions"
       [selection]="searchParameters.taskBehavior ?? 'verify'"

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
@@ -166,7 +166,7 @@
   </div>
 
   <div class="mt-2">
-    <label class="form-label w-100">Task behavior</label>
+    <label class="form-label w-100">Verification Task</label>
     <baw-selectable-items
       [options]="taskBehaviorOptions"
       [selection]="searchParameters.taskBehavior ?? 'verify'"

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
@@ -165,6 +165,16 @@
     ></baw-selectable-items>
   </div>
 
+  <div class="mt-2">
+    <label class="form-label w-100">Task behavior</label>
+    <baw-selectable-items
+      [options]="taskBehaviorOptions"
+      [selection]="searchParameters.taskBehavior ?? 'verify'"
+      [inline]="true"
+      (selectionChange)="updateDiscreteOptions('taskBehavior', $event)"
+    ></baw-selectable-items>
+  </div>
+
   <label class="form-label mt-2 w-100">
     Sort by
     <select

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
@@ -14,6 +14,7 @@ import { ShallowSitesService } from "@baw-api/site/sites.service";
 import { TagsService } from "@baw-api/tag/tags.service";
 import {
   AnnotationSearchParameters,
+  TaskBehaviorKey,
   VerificationStatusKey,
 } from "@components/annotations/pages/annotationSearchParameters";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
@@ -101,6 +102,10 @@ export class AnnotationSearchFormComponent implements OnInit {
     { label: "have not been verified by me", value: "unverified-for-me", disabled: true },
     { label: "have not been verified by anyone", value: "unverified" },
     { label: "are verified or unverified", value: "any" },
+  ];
+  protected taskBehaviorOptions: ISelectableItem<TaskBehaviorKey>[] = [
+    { label: "verify", value: "verify" },
+    { label: "verify and correct", value: "verify-and-correct" },
   ];
 
   protected get project(): Project {

--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
@@ -105,7 +105,7 @@ export class AnnotationSearchFormComponent implements OnInit {
   ];
   protected taskBehaviorOptions: ISelectableItem<TaskBehaviorKey>[] = [
     { label: "verify", value: "verify" },
-    { label: "verify and correct", value: "verify-and-correct" },
+    { label: "verify and correct tag", value: "verify-and-correct-tag" },
   ];
 
   protected get project(): Project {

--- a/src/app/components/annotations/pages/annotationSearchParameters.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.ts
@@ -71,7 +71,7 @@ export const sortingOptions = new Map([
 // session state.
 export type VerificationStatusKey = "unverified-for-me" | "unverified" | "any";
 
-export type TaskBehaviorKey = "verify-and-correct" | "verify";
+export type TaskBehaviorKey = "verify-and-correct-tag" | "verify";
 
 export interface IAnnotationSearchParameters {
   audioRecordings: CollectionIds;
@@ -550,7 +550,7 @@ export class AnnotationSearchParameters
   }
 
   private isTaskBehaviorKey(key: string): key is TaskBehaviorKey {
-    const validOptions: TaskBehaviorKey[] = ["verify-and-correct", "verify"];
+    const validOptions: TaskBehaviorKey[] = ["verify-and-correct-tag", "verify"];
     return validOptions.some((option) => option === key);
   }
 }

--- a/src/app/components/annotations/pages/annotationSearchParameters.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.ts
@@ -251,7 +251,8 @@ export class AnnotationSearchParameters
   public set taskBehavior(value: string) {
     if (this.isTaskBehaviorKey(value) || !isInstantiated(value)) {
       // So that we can minimize the number of query string parameters, we use
-      // "unverified-for-me" as the default if there is no "sort" query string parameter.
+      // "unverified-for-me" as the default if there is no "taskBehavior" query
+      // string parameter.
       if (value === "verify") {
         this._taskBehavior = null;
       } else {

--- a/src/app/components/annotations/pages/annotationSearchParameters.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.ts
@@ -71,6 +71,8 @@ export const sortingOptions = new Map([
 // session state.
 export type VerificationStatusKey = "unverified-for-me" | "unverified" | "any";
 
+export type TaskBehaviorKey = "verify-and-correct" | "verify";
+
 export interface IAnnotationSearchParameters {
   audioRecordings: CollectionIds;
   tags: CollectionIds;
@@ -105,6 +107,7 @@ export interface IAnnotationSearchParameters {
 
   sort: SortingKey;
   verificationStatus: VerificationStatusKey;
+  taskBehavior: TaskBehaviorKey;
 }
 
 // we exclude project, region, and site from the serialization table because
@@ -128,6 +131,7 @@ const serializationTable: IQueryStringParameterSpec<
 
   sort: jsString,
   verificationStatus: jsString,
+  taskBehavior: jsString,
 };
 
 const deserializationTable: IQueryStringParameterSpec<
@@ -194,6 +198,7 @@ export class AnnotationSearchParameters
 
   private _sort: SortingKey;
   private _verificationStatus: VerificationStatusKey;
+  private _taskBehavior: TaskBehaviorKey;
 
   public get sort(): SortingKey {
     return this._sort;
@@ -233,6 +238,24 @@ export class AnnotationSearchParameters
         this._verificationStatus = null;
       } else {
         this._verificationStatus = value;
+      }
+    } else {
+      console.error(`Invalid select key: "${value}"`);
+    }
+  }
+
+  public get taskBehavior(): TaskBehaviorKey {
+    return this._taskBehavior;
+  }
+
+  public set taskBehavior(value: string) {
+    if (this.isTaskBehaviorKey(value) || !isInstantiated(value)) {
+      // So that we can minimize the number of query string parameters, we use
+      // "unverified-for-me" as the default if there is no "sort" query string parameter.
+      if (value === "verify") {
+        this._taskBehavior = null;
+      } else {
+        this._taskBehavior = value;
       }
     } else {
       console.error(`Invalid select key: "${value}"`);
@@ -524,5 +547,10 @@ export class AnnotationSearchParameters
 
   private isVerificationStatusKey(key: string): key is VerificationStatusKey {
     return this.verificationStatusOptions.has(key as any);
+  }
+
+  private isTaskBehaviorKey(key: string): key is TaskBehaviorKey {
+    const validOptions: TaskBehaviorKey[] = ["verify-and-correct", "verify"];
+    return validOptions.some((option) => option === key);
   }
 }

--- a/src/app/components/annotations/pages/verification/verification.component.html
+++ b/src/app/components/annotations/pages/verification/verification.component.html
@@ -68,6 +68,23 @@
     (focus)="verificationGridFocused = true"
     (blur)="verificationGridFocused = false"
   ></oe-verification>
+
+  @if (hasCorrectionTask()) {
+    <oe-verification
+      verified="skip"
+      shortcut="S"
+      (focus)="verificationGridFocused = true"
+      (blur)="verificationGridFocused = false"
+    ></oe-verification>
+
+    <oe-tag-prompt
+      #tagPrompt
+      verified="unsure"
+      shortcut="C"
+      (focus)="verificationGridFocused = true"
+      (blur)="verificationGridFocused = false"
+    ></oe-tag-prompt>
+  }
 </oe-verification-grid>
 
 <ng-template #searchFiltersModal let-filtersModal>

--- a/src/app/components/annotations/pages/verification/verification.component.html
+++ b/src/app/components/annotations/pages/verification/verification.component.html
@@ -50,6 +50,16 @@
     <baw-grid-tile-content></baw-grid-tile-content>
   </template>
 
+  <oe-tag-prompt
+    #tagPrompt
+    verified="unsure"
+    shortcut="C"
+    (focus)="verificationGridFocused = true"
+    (blur)="verificationGridFocused = false"
+  >
+    Correct Tag
+  </oe-tag-prompt>
+
   <oe-verification
     verified="true"
     shortcut="Y"
@@ -68,25 +78,6 @@
     (focus)="verificationGridFocused = true"
     (blur)="verificationGridFocused = false"
   ></oe-verification>
-
-  @if (hasCorrectionTask()) {
-    <oe-verification
-      verified="skip"
-      shortcut="S"
-      (focus)="verificationGridFocused = true"
-      (blur)="verificationGridFocused = false"
-    ></oe-verification>
-
-    <oe-tag-prompt
-      #tagPrompt
-      verified="unsure"
-      shortcut="C"
-      (focus)="verificationGridFocused = true"
-      (blur)="verificationGridFocused = false"
-    >
-      Correct Tag
-    </oe-tag-prompt>
-  }
 </oe-verification-grid>
 
 <ng-template #searchFiltersModal let-filtersModal>

--- a/src/app/components/annotations/pages/verification/verification.component.html
+++ b/src/app/components/annotations/pages/verification/verification.component.html
@@ -83,7 +83,9 @@
       shortcut="C"
       (focus)="verificationGridFocused = true"
       (blur)="verificationGridFocused = false"
-    ></oe-tag-prompt>
+    >
+      Correct Tag
+    </oe-tag-prompt>
   }
 </oe-verification-grid>
 

--- a/src/app/components/annotations/pages/verification/verification.component.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.ts
@@ -140,7 +140,7 @@ class VerificationComponent
     }
 
     this.hasCorrectionTask.set(
-      this.searchParameters.taskBehavior === "verify-and-correct",
+      this.searchParameters.taskBehavior === "verify-and-correct-tag",
     );
   }
 

--- a/src/app/components/annotations/pages/verification/verification.component.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.ts
@@ -308,7 +308,6 @@ class VerificationComponent
           return;
         }
 
-        // If the verification exists, we delete it
         this.verificationApi.destroy(verification.id);
       }),
       first(),

--- a/src/app/services/baw-api/audio-event/audio-events.service.ts
+++ b/src/app/services/baw-api/audio-event/audio-events.service.ts
@@ -140,5 +140,5 @@ export const audioEventResolvers = new Resolvers<
   AudioEvent,
   [IdOr<AudioRecording>]
 >([AudioEventsService], "audioEventId", ["audioRecordingId"]).create(
-  "AudioEvent"
+  "AudioEvent",
 );

--- a/src/app/services/baw-api/tag/taggings.service.spec.ts
+++ b/src/app/services/baw-api/tag/taggings.service.spec.ts
@@ -1,5 +1,4 @@
 import { IdOr } from "@baw-api/api-common";
-import { AnalysisJob } from "@models/AnalysisJob";
 import { AudioEvent } from "@models/AudioEvent";
 import { Tagging } from "@models/Tagging";
 import { createServiceFactory, SpectatorService } from "@ngneat/spectator";
@@ -8,10 +7,11 @@ import {
   mockServiceProviders,
   validateStandardApi,
 } from "@test/helpers/api-common";
+import { AudioRecording } from "@models/AudioRecording";
 import { TaggingsService } from "./taggings.service";
 
 type Model = Tagging;
-type Params = [IdOr<AnalysisJob>, IdOr<AudioEvent>];
+type Params = [IdOr<AudioRecording>, IdOr<AudioEvent>];
 type Service = TaggingsService;
 
 describe("TaggingsService", (): void => {

--- a/src/app/services/baw-api/tag/taggings.service.ts
+++ b/src/app/services/baw-api/tag/taggings.service.ts
@@ -1,9 +1,9 @@
-import { Injectable } from "@angular/core";
 import { stringTemplate } from "@helpers/stringTemplate/stringTemplate";
-import { AnalysisJob } from "@models/AnalysisJob";
+import { Injectable } from "@angular/core";
 import { AudioEvent } from "@models/AudioEvent";
 import { Tagging } from "@models/Tagging";
 import { Observable } from "rxjs";
+import { AudioRecording } from "@models/AudioRecording";
 import {
   emptyParam,
   filterParam,
@@ -17,89 +17,89 @@ import {
 import { BawApiService, Filters } from "../baw-api.service";
 import { Resolvers } from "../resolver-common";
 
-const analysisJobId: IdParam<AnalysisJob> = id;
+const audioRecordingId: IdParam<AudioRecording> = id;
 const audioEventId: IdParam<AudioEvent> = id;
 const taggingId: IdParamOptional<Tagging> = id;
-const endpoint = stringTemplate`/audio_recordings/${analysisJobId}/audio_events/${audioEventId}/taggings/${taggingId}${option}`;
+const endpoint = stringTemplate`/audio_recordings/${audioRecordingId}/audio_events/${audioEventId}/taggings/${taggingId}${option}`;
 
 @Injectable()
 export class TaggingsService
-  implements StandardApi<Tagging, [IdOr<AnalysisJob>, IdOr<AudioEvent>]>
+  implements StandardApi<Tagging, [IdOr<AudioRecording>, IdOr<AudioEvent>]>
 {
   public constructor(private api: BawApiService<Tagging>) {}
 
   public list(
-    analysisJob: IdOr<AnalysisJob>,
+    audioRecording: IdOr<AudioRecording>,
     audioEvent: IdOr<AudioEvent>
   ): Observable<Tagging[]> {
     return this.api.list(
       Tagging,
-      endpoint(analysisJob, audioEvent, emptyParam, emptyParam)
+      endpoint(audioRecording, audioEvent, emptyParam, emptyParam)
     );
   }
 
   public filter(
     filters: Filters<Tagging>,
-    analysisJob: IdOr<AnalysisJob>,
+    audioRecording: IdOr<AudioRecording>,
     audioEvent: IdOr<AudioEvent>
   ): Observable<Tagging[]> {
     return this.api.filter(
       Tagging,
-      endpoint(analysisJob, audioEvent, emptyParam, filterParam),
+      endpoint(audioRecording, audioEvent, emptyParam, filterParam),
       filters
     );
   }
 
   public show(
     model: IdOr<Tagging>,
-    analysisJob: IdOr<AnalysisJob>,
+    audioRecording: IdOr<AudioRecording>,
     audioEvent: IdOr<AudioEvent>
   ): Observable<Tagging> {
     return this.api.show(
       Tagging,
-      endpoint(analysisJob, audioEvent, model, emptyParam)
+      endpoint(audioRecording, audioEvent, model, emptyParam)
     );
   }
 
   public create(
     model: Tagging,
-    analysisJob: IdOr<AnalysisJob>,
+    audioRecording: IdOr<AudioRecording>,
     audioEvent: IdOr<AudioEvent>
   ): Observable<Tagging> {
     return this.api.create(
       Tagging,
-      endpoint(analysisJob, audioEvent, emptyParam, emptyParam),
-      (tagging) => endpoint(analysisJob, audioEvent, tagging, emptyParam),
+      endpoint(audioRecording, audioEvent, emptyParam, emptyParam),
+      (tagging) => endpoint(audioRecording, audioEvent, tagging, emptyParam),
       model
     );
   }
 
   public update(
     model: Tagging,
-    analysisJob: IdOr<AnalysisJob>,
+    audioRecording: IdOr<AudioRecording>,
     audioEvent: IdOr<AudioEvent>
   ): Observable<Tagging> {
     return this.api.update(
       Tagging,
-      endpoint(analysisJob, audioEvent, model, emptyParam),
+      endpoint(audioRecording, audioEvent, model, emptyParam),
       model
     );
   }
 
   public destroy(
     model: IdOr<Tagging>,
-    analysisJob: IdOr<AnalysisJob>,
+    audioRecording: IdOr<AudioRecording>,
     audioEvent: IdOr<AudioEvent>
   ): Observable<Tagging | void> {
     return this.api.destroy(
-      endpoint(analysisJob, audioEvent, model, emptyParam)
+      endpoint(audioRecording, audioEvent, model, emptyParam)
     );
   }
 }
 
 export const taggingResolvers = new Resolvers<
   Tagging,
-  [IdOr<AnalysisJob>, IdOr<AudioEvent>]
->([TaggingsService], "taggingId", ["analysisJobId", "audioEventId"]).create(
+  [IdOr<AudioRecording>, IdOr<AudioEvent>]
+>([TaggingsService], "taggingId", ["audioRecordingId", "audioEventId"]).create(
   "Tagging"
 );

--- a/src/app/services/baw-api/verification/verification.service.spec.ts
+++ b/src/app/services/baw-api/verification/verification.service.spec.ts
@@ -151,7 +151,7 @@ describe("ShallowVerificationService", () => {
           },
         } as const satisfies Filters<Verification>;
 
-        spec.service.audioEventUserVerification(mockAudioEvent, mockUser);
+        spec.service.audioEventUserVerification(mockAudioEvent);
 
         expect(api.filter).toHaveBeenCalledOnceWith(
           Verification,
@@ -162,7 +162,7 @@ describe("ShallowVerificationService", () => {
 
       it("should return the verification if the audio event is verified", async () => {
         const response = await firstValueFrom(
-          spec.service.audioEventUserVerification(mockAudioEvent, mockUser)
+          spec.service.audioEventUserVerification(mockAudioEvent)
         );
 
         expect(response).toEqual(mockFilterResponse[0]);
@@ -172,7 +172,7 @@ describe("ShallowVerificationService", () => {
         mockFilterResponse = [];
 
         const response = await firstValueFrom(
-          spec.service.audioEventUserVerification(mockAudioEvent, mockUser)
+          spec.service.audioEventUserVerification(mockAudioEvent)
         );
 
         expect(response).toBeNull();
@@ -182,7 +182,7 @@ describe("ShallowVerificationService", () => {
     describe("createOrUpdate", () => {
       it("should emit a create request if the verification does not exist", () => {
         spec.service
-          .createOrUpdate(mockModel, mockAudioEvent, mockUser)
+          .createOrUpdate(mockModel, mockAudioEvent)
           .subscribe();
         expect(api.create).toHaveBeenCalledTimes(1);
       });
@@ -195,7 +195,7 @@ describe("ShallowVerificationService", () => {
         );
 
         const response = await firstValueFrom(
-          spec.service.createOrUpdate(mockModel, mockAudioEvent, mockUser)
+          spec.service.createOrUpdate(mockModel, mockAudioEvent)
         );
 
         expect(api.create).toHaveBeenCalledTimes(1);
@@ -212,7 +212,7 @@ describe("ShallowVerificationService", () => {
         );
 
         const response = await firstValueFrom(
-          spec.service.createOrUpdate(mockModel, mockAudioEvent, mockUser).pipe(
+          spec.service.createOrUpdate(mockModel, mockAudioEvent).pipe(
             catchError(() => of(null))
           )
         );

--- a/src/app/services/baw-api/verification/verification.service.spec.ts
+++ b/src/app/services/baw-api/verification/verification.service.spec.ts
@@ -17,6 +17,9 @@ import { BawApiService, Filters } from "@baw-api/baw-api.service";
 import { BawApiError } from "@helpers/custom-errors/baw-api-error";
 import { CONFLICT, INTERNAL_SERVER_ERROR } from "http-status";
 import { catchError, firstValueFrom, of, throwError } from "rxjs";
+import { Tag } from "@models/Tag";
+import { generateTag } from "@test/fakes/Tag";
+import { BawSessionService } from "@baw-api/baw-session.service";
 import {
   ShallowVerificationService,
   VerificationService,
@@ -98,6 +101,7 @@ describe("ShallowVerificationService", () => {
   describe("custom methods", () => {
     let mockModel: Model;
     let mockAudioEvent: AudioEvent;
+    let mockTag: Tag;
     let mockUser: User;
     let api: BawApiService<Model>;
 
@@ -110,11 +114,15 @@ describe("ShallowVerificationService", () => {
       mockAudioEvent = new AudioEvent(
         generateAudioEvent({ id: mockModel.audioEventId })
       );
+      mockTag = new Tag(generateTag());
       mockUser = new User(generateUser({ id: mockModel.creatorId }));
 
       mockCreateResponse = createModel();
       mockUpdateResponse = createModel();
       mockFilterResponse = modelData.randomArray(1, 10, () => createModel());
+
+      const sessionMock = spec.inject(BawSessionService);
+      spyOnProperty(sessionMock, "currentUser").and.returnValue(mockUser);
 
       api = spec.inject<BawApiService<Model>>(BawApiService);
 
@@ -139,19 +147,20 @@ describe("ShallowVerificationService", () => {
 
     describe("audioEventUserVerification", () => {
       it("should call the filter api with the correct data", () => {
-        const expectedFilters = {
+        const expectedFilters: Filters<Verification> = {
           filter: {
             and: [
               { audioEventId: { eq: mockAudioEvent.id } },
+              { tagId: { eq: mockTag.id } },
               { creatorId: { eq: mockUser.id } },
             ],
           },
           paging: {
             items: 1,
           },
-        } as const satisfies Filters<Verification>;
+        };
 
-        spec.service.audioEventUserVerification(mockAudioEvent);
+        spec.service.audioEventUserVerification(mockAudioEvent, mockTag);
 
         expect(api.filter).toHaveBeenCalledOnceWith(
           Verification,
@@ -162,7 +171,7 @@ describe("ShallowVerificationService", () => {
 
       it("should return the verification if the audio event is verified", async () => {
         const response = await firstValueFrom(
-          spec.service.audioEventUserVerification(mockAudioEvent)
+          spec.service.audioEventUserVerification(mockAudioEvent, mockTag)
         );
 
         expect(response).toEqual(mockFilterResponse[0]);
@@ -172,7 +181,7 @@ describe("ShallowVerificationService", () => {
         mockFilterResponse = [];
 
         const response = await firstValueFrom(
-          spec.service.audioEventUserVerification(mockAudioEvent)
+          spec.service.audioEventUserVerification(mockAudioEvent, mockTag)
         );
 
         expect(response).toBeNull();
@@ -182,7 +191,7 @@ describe("ShallowVerificationService", () => {
     describe("createOrUpdate", () => {
       it("should emit a create request if the verification does not exist", () => {
         spec.service
-          .createOrUpdate(mockModel, mockAudioEvent)
+          .createOrUpdate(mockModel, mockAudioEvent, mockTag)
           .subscribe();
         expect(api.create).toHaveBeenCalledTimes(1);
       });
@@ -195,7 +204,7 @@ describe("ShallowVerificationService", () => {
         );
 
         const response = await firstValueFrom(
-          spec.service.createOrUpdate(mockModel, mockAudioEvent)
+          spec.service.createOrUpdate(mockModel, mockAudioEvent, mockTag)
         );
 
         expect(api.create).toHaveBeenCalledTimes(1);
@@ -212,7 +221,7 @@ describe("ShallowVerificationService", () => {
         );
 
         const response = await firstValueFrom(
-          spec.service.createOrUpdate(mockModel, mockAudioEvent).pipe(
+          spec.service.createOrUpdate(mockModel, mockAudioEvent, mockTag).pipe(
             catchError(() => of(null))
           )
         );

--- a/src/app/services/baw-api/verification/verification.service.spec.ts
+++ b/src/app/services/baw-api/verification/verification.service.spec.ts
@@ -17,6 +17,7 @@ import { BawApiService, Filters } from "@baw-api/baw-api.service";
 import { BawApiError } from "@helpers/custom-errors/baw-api-error";
 import { CONFLICT, INTERNAL_SERVER_ERROR } from "http-status";
 import { catchError, firstValueFrom, of, throwError } from "rxjs";
+import { provideMockBawApi } from "@baw-api/provide-baw-ApiMock";
 import {
   ShallowVerificationService,
   VerificationService,
@@ -48,7 +49,7 @@ describe("VerificationService", () => {
 
   const createService = createServiceFactory({
     service: VerificationService,
-    providers: mockServiceProviders,
+    providers: [provideMockBawApi(), ...mockServiceProviders],
   });
 
   beforeEach(() => {

--- a/src/app/services/baw-api/verification/verification.service.spec.ts
+++ b/src/app/services/baw-api/verification/verification.service.spec.ts
@@ -49,7 +49,7 @@ describe("VerificationService", () => {
 
   const createService = createServiceFactory({
     service: VerificationService,
-    providers: [provideMockBawApi(), ...mockServiceProviders],
+    providers: mockServiceProviders,
   });
 
   beforeEach(() => {

--- a/src/app/services/baw-api/verification/verification.service.spec.ts
+++ b/src/app/services/baw-api/verification/verification.service.spec.ts
@@ -17,7 +17,6 @@ import { BawApiService, Filters } from "@baw-api/baw-api.service";
 import { BawApiError } from "@helpers/custom-errors/baw-api-error";
 import { CONFLICT, INTERNAL_SERVER_ERROR } from "http-status";
 import { catchError, firstValueFrom, of, throwError } from "rxjs";
-import { provideMockBawApi } from "@baw-api/provide-baw-ApiMock";
 import {
   ShallowVerificationService,
   VerificationService,

--- a/src/app/services/baw-api/verification/verification.service.ts
+++ b/src/app/services/baw-api/verification/verification.service.ts
@@ -11,16 +11,12 @@ import {
   StandardApi,
 } from "@baw-api/api-common";
 import { BawApiService, Filters } from "@baw-api/baw-api.service";
-import { BawSessionService } from "@baw-api/baw-session.service";
 import { Resolvers } from "@baw-api/resolver-common";
-import { TaggingsService } from "@baw-api/tag/taggings.service";
 import { stringTemplate } from "@helpers/stringTemplate/stringTemplate";
-import { Id } from "@interfaces/apiInterfaces";
 import { AudioEvent } from "@models/AudioEvent";
 import { AudioRecording } from "@models/AudioRecording";
-import { Tagging } from "@models/Tagging";
 import { User } from "@models/User";
-import { ConfirmedStatus, Verification } from "@models/Verification";
+import { Verification } from "@models/Verification";
 import { CONFLICT } from "http-status";
 import { catchError, map, mergeMap, Observable } from "rxjs";
 

--- a/src/app/services/baw-api/verification/verification.service.ts
+++ b/src/app/services/baw-api/verification/verification.service.ts
@@ -76,11 +76,7 @@ export class VerificationService
 export class ShallowVerificationService
   implements StandardApi<Verification, []>
 {
-  public constructor(
-    private api: BawApiService<Verification>,
-    private taggingsApi: TaggingsService,
-    private session: BawSessionService,
-  ) {}
+  public constructor(private api: BawApiService<Verification>) {}
 
   public list(): Observable<Verification[]> {
     return this.api.list(Verification, endpointShallow(emptyParam, emptyParam));
@@ -197,36 +193,6 @@ export class ShallowVerificationService
     return this.filter(filter).pipe(
       map((results) => (results.length > 0 ? results[0] : null))
     );
-  }
-
-  /**
-   * Corrects an incorrect tag on an audio event by verifying the existing tag
-   * as "incorrect", creating a new tag that is correct, and submitting a
-   * "correct" verification decision.
-   */
-  public correctTag(audioEvent: AudioEvent, newTagId: Id) {
-    const correctTag = new Tagging({
-      audioEventId: audioEvent.id,
-      tagId: newTagId,
-    });
-
-    return this.taggingsApi
-      .create(correctTag, audioEvent.audioRecordingId, audioEvent.id)
-      .pipe(
-        mergeMap(() => {
-          const correctVerification = new Verification({
-            audioEventId: audioEvent.id,
-            confirmed: ConfirmedStatus.Correct,
-            tagId: newTagId,
-          });
-
-          return this.createOrUpdate(
-            correctVerification,
-            audioEvent,
-            this.session.currentUser,
-          );
-        }),
-      );
   }
 }
 

--- a/src/app/services/baw-api/verification/verification.service.ts
+++ b/src/app/services/baw-api/verification/verification.service.ts
@@ -11,6 +11,7 @@ import {
   StandardApi,
 } from "@baw-api/api-common";
 import { BawApiService, Filters } from "@baw-api/baw-api.service";
+import { BawSessionService } from "@baw-api/baw-session.service";
 import { Resolvers } from "@baw-api/resolver-common";
 import { stringTemplate } from "@helpers/stringTemplate/stringTemplate";
 import { AudioEvent } from "@models/AudioEvent";
@@ -72,7 +73,10 @@ export class VerificationService
 export class ShallowVerificationService
   implements StandardApi<Verification, []>
 {
-  public constructor(private api: BawApiService<Verification>) {}
+  public constructor(
+    private api: BawApiService<Verification>,
+    private session: BawSessionService,
+  ) {}
 
   public list(): Observable<Verification[]> {
     return this.api.list(Verification, endpointShallow(emptyParam, emptyParam));
@@ -120,7 +124,6 @@ export class ShallowVerificationService
   public createOrUpdate(
     model: Verification,
     audioEvent: AudioEvent,
-    user: User
   ): Observable<Verification> {
     return this.api
       .create(
@@ -137,7 +140,7 @@ export class ShallowVerificationService
           if (err.status === CONFLICT) {
             const verificationModel = this.audioEventUserVerification(
               audioEvent,
-              user
+              this.session.currentUser,
             );
             return verificationModel.pipe(
               mergeMap((verification) => {

--- a/src/app/test/fakes/data/AnnotationSearchParameters.ts
+++ b/src/app/test/fakes/data/AnnotationSearchParameters.ts
@@ -38,6 +38,9 @@ export function generateAnnotationSearchParameters(
     verificationStatus: modelData.helpers.arrayElement(
       ["unverified-for-me", "unverified", "any"],
     ),
+    taskBehavior: modelData.helpers.arrayElement(
+      ["verify", "verify-and-correct"],
+    ),
     ...data,
   };
 }

--- a/src/app/test/fakes/data/AnnotationSearchParameters.ts
+++ b/src/app/test/fakes/data/AnnotationSearchParameters.ts
@@ -39,7 +39,7 @@ export function generateAnnotationSearchParameters(
       ["unverified-for-me", "unverified", "any"],
     ),
     taskBehavior: modelData.helpers.arrayElement(
-      ["verify", "verify-and-correct"],
+      ["verify", "verify-and-correct-tag"],
     ),
     ...data,
   };


### PR DESCRIPTION
# Verification Compound Tasks

## Changes

- Adds `?task=verify-and-correct` url parameter that adds a `tag-prompt` component to the verification grid that is triggered when a `false` decision is made
- Fixes typing for `tagging` endpoint to take an `AudioRecording/AudioRecordingId` instead of `AnalysisJob/AnalysisJobId`
	- API controller: https://github.com/QutEcoacoustics/baw-server/blob/master/app/controllers/taggings_controller.rb#L37
	- `routes.rb`: https://github.com/QutEcoacoustics/baw-server/blob/master/config/routes.rb#L741

## Issues

Fixes: #2383

## Visual Changes

<img width="1372" height="796" alt="image" src="https://github.com/user-attachments/assets/5cd7d8a6-7568-4628-8661-4976e2f9338d" />

_New "verify + correct tag" task behavior in annotation search form_

---

<img width="1891" height="958" alt="image" src="https://github.com/user-attachments/assets/51a3332b-033c-43f5-abfe-193a897e8e99" />

_Verification grid with new "Correct Tag" button_

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
