### PR TITLE
Fix leading underlines on audio event cards

### DIFF
--- a/src/app/components/shared/audio-event-card/annotation-event-card.component.html
+++ b/src/app/components/shared/audio-event-card/annotation-event-card.component.html
@@ -62,25 +62,21 @@
 
     <span class="info-line">
       <fa-icon class="me-2" [icon]="['fas', 'chart-simple']"></fa-icon>
-      <span>
+      <span class="tag-score">
         @if (annotation().score | isInstantiated) {
           {{ annotation().score | number }}
         } @else {
           <span
             class="no-score-placeholder tooltip-hint"
             [ngbTooltip]="'This event does not have a score assigned'"
-          >
-            No score available
-          </span>
+          >No score available</span>
         }
       </span>
     </span>
 
     <span class="info-line">
       <fa-icon class="me-2" [icon]="['fas', 'circle-info']"></fa-icon>
-      <a class="more-information-link" [href]="annotation().viewUrl">
-        More information
-      </a>
+      <a class="more-information-link" [href]="annotation().viewUrl">More information</a>
     </span>
   </div>
 </div>

--- a/src/app/components/shared/audio-event-card/annotation-event-card.component.spec.ts
+++ b/src/app/components/shared/audio-event-card/annotation-event-card.component.spec.ts
@@ -100,8 +100,6 @@ describe("AudioEventCardComponent", () => {
   const scoreElement = () => spectator.query(".tag-score");
   const noScoreElement = () => spectator.query(".no-score-placeholder");
 
-  const moreInfoLink = () => spectator.query(".more-information-link");
-
   beforeEach(() => {
     setup();
   });
@@ -119,6 +117,10 @@ describe("AudioEventCardComponent", () => {
   it("should have the correct link to the listen page", () => {
     const expectedHref = mockAnnotation.viewUrl;
     expect(listenLink()).toHaveAttribute("href", expectedHref);
+
+    // We use "toHaveExactText" here to ensure there are no extraneous spaces
+    // or newlines.
+    expect(moreInfoLink()).toHaveExactText("More information");
   });
 
   it("should have the tag text and link in the info", () => {
@@ -145,12 +147,6 @@ describe("AudioEventCardComponent", () => {
     spectator.setInput("annotation", mockAnnotation);
 
     expect(noScoreElement()).toHaveExactText("No score available");
-  });
-
-  it("should have the correct 'More Information' link", () => {
-    // We use "toHaveExactText" here to ensure there are no extraneous spaces
-    // or newlines.
-    expect(moreInfoLink()).toHaveExactText("More information");
   });
 
   xit("should be able to play the spectrogram", () => {});

--- a/src/app/components/shared/audio-event-card/annotation-event-card.component.spec.ts
+++ b/src/app/components/shared/audio-event-card/annotation-event-card.component.spec.ts
@@ -120,7 +120,7 @@ describe("AudioEventCardComponent", () => {
 
     // We use "toHaveExactText" here to ensure there are no extraneous spaces
     // or newlines.
-    expect(moreInfoLink()).toHaveExactText("More information");
+    expect(listenLink()).toHaveExactText("More information");
   });
 
   it("should have the tag text and link in the info", () => {

--- a/src/app/components/shared/audio-event-card/annotation-event-card.component.spec.ts
+++ b/src/app/components/shared/audio-event-card/annotation-event-card.component.spec.ts
@@ -97,6 +97,11 @@ describe("AudioEventCardComponent", () => {
     spectator.query<HTMLAnchorElement>(".more-information-link");
   const tagInfoElement = () => spectator.query(".tag-information");
 
+  const scoreElement = () => spectator.query(".tag-score");
+  const noScoreElement = () => spectator.query(".no-score-placeholder");
+
+  const moreInfoLink = () => spectator.query(".more-information-link");
+
   beforeEach(() => {
     setup();
   });
@@ -119,6 +124,33 @@ describe("AudioEventCardComponent", () => {
   it("should have the tag text and link in the info", () => {
     const expectedText = mockTag.text;
     expect(tagInfoElement()).toHaveText(expectedText);
+  });
+
+  it("should display scores correctly", () => {
+    const expectedText = mockAnnotation.score?.toString();
+
+    expect(scoreElement()).toHaveExactTrimmedText(expectedText);
+    expect(noScoreElement()).not.toExist();
+  });
+
+  it("should have the correct content if there is no score", () => {
+    mockAnnotation = new Annotation(
+      generateAnnotation({
+        audioRecording: mockAudioRecording,
+        score: null,
+      }),
+      injectorSpy
+    );
+
+    spectator.setInput("annotation", mockAnnotation);
+
+    expect(noScoreElement()).toHaveExactText("No score available");
+  });
+
+  it("should have the correct 'More Information' link", () => {
+    // We use "toHaveExactText" here to ensure there are no extraneous spaces
+    // or newlines.
+    expect(moreInfoLink()).toHaveExactText("More information");
   });
 
   xit("should be able to play the spectrogram", () => {});


### PR DESCRIPTION
# Fix leading underlines on audio event cards

## Changes

- Fixes leading spaces on audio event card underlines
- Adds tests for audio event score & more information links

## Issues

Fixes: #2413

## Visual Changes

<img width="1239" height="422" alt="image" src="https://github.com/user-attachments/assets/f2770d49-fdbc-47fa-85d4-9ff13e0c331d" />

_Audio event cards with corrected underlines_

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
