### PR TITLE
Fix annotation search filters for regions

### DIFF
--- a/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
@@ -51,7 +51,7 @@ describe("annotationSearchParameters", () => {
     const dataModel = new AnnotationSearchParameters(params, mockUser);
 
     const mockProjectId = modelData.id();
-    dataModel.routeProjectId = modelData.id();
+    dataModel.routeProjectId = mockProjectId;
 
     const mockSiteIds = modelData.ids();
     routeProject = new Project({
@@ -90,8 +90,8 @@ describe("annotationSearchParameters", () => {
         filter: {
           and: [
             {
-              "audioRecordings.siteId": {
-                in: Array.from(routeProject.siteIds),
+              "audioRecordings.project.id": {
+                in: [routeProject.id],
               },
             },
             myUnverifiedFilters,
@@ -192,8 +192,8 @@ describe("annotationSearchParameters", () => {
         filter: {
           and: [
             {
-              "audioRecordings.siteId": {
-                in: Array.from(routeProject.siteIds),
+              "audioRecordings.project.id": {
+                in: [routeProject.id],
               },
             },
             { score: { gteq: 0.2 } },
@@ -212,8 +212,8 @@ describe("annotationSearchParameters", () => {
         filter: {
           and: [
             {
-              "audioRecordings.siteId": {
-                in: Array.from(routeProject.siteIds),
+              "audioRecordings.project.id": {
+                in: [routeProject.id],
               },
             },
             { score: { lteq: 0.9 } },
@@ -232,8 +232,8 @@ describe("annotationSearchParameters", () => {
         filter: {
           and: [
             {
-              "audioRecordings.siteId": {
-                in: Array.from(routeProject.siteIds),
+              "audioRecordings.project.id": {
+                in: [routeProject.id],
               },
             },
             {

--- a/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.spec.ts
@@ -32,7 +32,7 @@ describe("annotationSearchParameters", () => {
     const expectedFilters = {
       filter: {
         and: [
-          { "audioRecordings.siteId": { in: [] } },
+          { "sites.id": { in: [] } },
           { "verifications.id": { eq: null } },
         ],
       },
@@ -90,7 +90,7 @@ describe("annotationSearchParameters", () => {
         filter: {
           and: [
             {
-              "audioRecordings.project.id": {
+              "projects.id": {
                 in: [routeProject.id],
               },
             },
@@ -129,7 +129,7 @@ describe("annotationSearchParameters", () => {
             { "audioRecordings.id": { in: [11, 12, 13] } },
             { audioEventImportFileId: { in: [1, 12, 23] } },
             {
-              "audioRecordings.siteId": {
+              "sites.id": {
                 in: [6, 7, 8, 9],
               },
             },
@@ -166,7 +166,7 @@ describe("annotationSearchParameters", () => {
               },
             },
             { "audioRecordings.id": { in: [11, 12, 13] } },
-            { "audioRecordings.siteId": { in: [6, 7, 8, 9] } },
+            { "sites.id": { in: [6, 7, 8, 9] } },
             { score: { gteq: 0.5 } },
             { score: { lteq: 0.9 } },
             {
@@ -192,7 +192,7 @@ describe("annotationSearchParameters", () => {
         filter: {
           and: [
             {
-              "audioRecordings.project.id": {
+              "projects.id": {
                 in: [routeProject.id],
               },
             },
@@ -212,7 +212,7 @@ describe("annotationSearchParameters", () => {
         filter: {
           and: [
             {
-              "audioRecordings.project.id": {
+              "projects.id": {
                 in: [routeProject.id],
               },
             },
@@ -232,7 +232,7 @@ describe("annotationSearchParameters", () => {
         filter: {
           and: [
             {
-              "audioRecordings.project.id": {
+              "projects.id": {
                 in: [routeProject.id],
               },
             },

--- a/src/app/components/annotations/pages/annotationSearchParameters.ts
+++ b/src/app/components/annotations/pages/annotationSearchParameters.ts
@@ -410,7 +410,7 @@ export class AnnotationSearchParameters
     const modelSiteIds = this.siteIds();
     if (modelSiteIds.length > 0) {
       return {
-        "audioRecordings.siteId": {
+        "sites.id": {
           in: modelSiteIds,
         },
       } as InnerFilter<AudioEvent>;
@@ -419,7 +419,7 @@ export class AnnotationSearchParameters
     const modelRegionIds = this.regionIds();
     if (modelRegionIds.length > 0) {
       return {
-        "audioRecordings.region.id": {
+        "regions.id": {
           in: modelRegionIds,
         },
       } as InnerFilter<AudioEvent>;
@@ -428,7 +428,7 @@ export class AnnotationSearchParameters
     const modelProjectIds = this.projectIds();
     if (modelProjectIds.length > 0) {
       return {
-        "audioRecordings.project.id": {
+        "projects.id": {
           in: modelProjectIds,
         },
       } as InnerFilter<AudioEvent>;

--- a/src/app/components/annotations/pages/search/search.component.spec.ts
+++ b/src/app/components/annotations/pages/search/search.component.spec.ts
@@ -182,7 +182,7 @@ describe("AnnotationSearchComponent", () => {
               },
             },
             {
-              "audioRecordings.siteId": {
+              "sites.id": {
                 in: Array.from(mockSearchParameters.sites),
               },
             },


### PR DESCRIPTION
# Fix annotation search filters for regions

## Changes

- Use new association model filter conditions for audio event filtering on annotation search & verification pages

## Filter conditions

<img width="932" height="426" alt="image" src="https://github.com/user-attachments/assets/cdbfd6ef-dc61-4657-851b-8e93b1c04f7b" />

_Route with region in parameters_

---

<img width="932" height="426" alt="image" src="https://github.com/user-attachments/assets/0e32829e-1897-4565-8637-9b5f3a4303bf" />

_Route with region in qsps_

---

<img width="932" height="426" alt="image" src="https://github.com/user-attachments/assets/276ca12c-b21a-4205-a358-4e0963735338" />

_Route with site + point in route parameters_

---

<img width="932" height="426" alt="image" src="https://github.com/user-attachments/assets/f4e506f6-4ab3-4133-9af4-bf3e0300b769" />

_Route with site route parameter + point in qsps_

---

<img width="932" height="426" alt="image" src="https://github.com/user-attachments/assets/6d99f3ca-df39-4be3-b017-597b2489fdbd" />

_Route with point in QSP_

## Issues

Fixes: #2417

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
