### PR TITLE
Update docker image to node22

### DIFF
--- a/.github/workflows/differ.yml
+++ b/.github/workflows/differ.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
         run: git lfs checkout
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v5
         with:
+          # We use an old version of node here because this step is building the
+          # old baw-client which only supports up to node version 12.
           node-version: "12"
           cache: "npm"
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout Baw Client
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: QutEcoacoustics/baw-client
           ref: migration
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "12"
           cache: "npm"
@@ -93,7 +93,7 @@ jobs:
           - FirefoxHeadless
     steps:
       - name: Checkout Workbench Client
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # macos latest points to the arm MacOS runner that doesn't come with
       # Firefox installed. Therefore, we install Firefox manually
@@ -102,13 +102,13 @@ jobs:
         run: brew install --cask firefox
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: baw-client
 
@@ -167,7 +167,7 @@ jobs:
         run: git lfs checkout
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"
@@ -195,7 +195,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts
       - name: Publish Unit Test Results

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -108,7 +108,7 @@ jobs:
           cache: "npm"
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v4
         with:
           path: baw-client
 
@@ -195,7 +195,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Publish Unit Test Results

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:20-alpine as BUILD_IMAGE
+# Check that this version matches the node versions in CI
+FROM node:22-alpine as BUILD_IMAGE
 
 ARG GIT_COMMIT
 ARG WORKBENCH_CLIENT_VERSION


### PR DESCRIPTION
# Update docker image to node22

## Changes

- Update docker image to node version 22
- Update ci `actions/checkout` to `v5`
- Update ci `actions/setup-node` to `v5` (enables caching npm packages between runs for faster setup)

## Issues

Fixes: #2427

## Visual Changes

If the PR has any visual changes to the website, post pictures of the new pages and how they look. Label any images if more than one is given.

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
