### PR TITLE
Fix redirect when editing annotation imports

### DIFF
--- a/src/app/components/import-annotations/pages/edit/edit.component.ts
+++ b/src/app/components/import-annotations/pages/edit/edit.component.ts
@@ -50,7 +50,7 @@ class EditAnnotationsComponent
     super(notifications, route, router, {
       getModel: (models) => models[audioEventImportKey] as AudioEventImport,
       successMsg: (model) => defaultSuccessMsg("updated", model.name),
-      redirectUser: (model) => this.router.navigateByUrl(model.viewUrl),
+      redirectUser: (model) => this.router.navigateByUrl(model.createViewUrl(this.project.id)),
     });
   }
 


### PR DESCRIPTION
# Fix redirect when editing annotation imports

## Changes

- Fixes redirect for annotation import "edit" page
- Adds tests for the annotation import "edit" redirect

## Issues

Fixes: #2450 

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
By serving this dependency through the Angular server, we don't have to
establish another connection, and can hopefully serve this dependency
through the existing keep-alive connection.

[skip ci]