### PR TITLE
Fix layout reflow in loading spinner

### DIFF
--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.spec.ts
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.spec.ts
@@ -424,7 +424,7 @@ describe("AddAnnotationsComponent", () => {
         const expectedRowValues = [
           `1:${i + 1}`,
           // event.audioRecordingId.toLocaleString(),
-          "Loading...",
+          "",
           event.startTimeSeconds.toLocaleString(),
           event.endTimeSeconds.toLocaleString(),
           event.lowFrequencyHertz.toLocaleString(),

--- a/src/app/components/shared/loading/loading.component.html
+++ b/src/app/components/shared/loading/loading.component.html
@@ -1,0 +1,3 @@
+<div class="d-flex justify-content-center m-0 p-0">
+  <div id="spinner" role="status" [class]="spinnerClass()" aria-label="Loading"></div>
+</div>

--- a/src/app/components/shared/loading/loading.component.spec.ts
+++ b/src/app/components/shared/loading/loading.component.spec.ts
@@ -6,6 +6,12 @@ import { NgbModule } from "@ng-bootstrap/ng-bootstrap";
 import { createComponentFactory, Spectator } from "@ngneat/spectator";
 import { LoadingComponent } from "./loading.component";
 
+interface LoadingComponentProps {
+  color: BootstrapColorTypes;
+  size: BootstrapScreenSizes;
+  type: "border" | "grower";
+}
+
 describe("LoadingComponent", () => {
   let spec: Spectator<LoadingComponent>;
   const createComponent = createComponentFactory({
@@ -13,11 +19,11 @@ describe("LoadingComponent", () => {
     imports: [NgbModule],
   });
 
-  function getSpinner(klass: string) {
-    return spec.query(`#spinner.${klass}`);
+  function getSpinner(className: string) {
+    return spec.query(`#spinner.${className}`);
   }
 
-  function setup(props: Partial<LoadingComponent>) {
+  function setup(props: Partial<LoadingComponentProps>) {
     spec = createComponent({
       detectChanges: false,
       props,

--- a/src/app/components/shared/loading/loading.component.ts
+++ b/src/app/components/shared/loading/loading.component.ts
@@ -1,36 +1,32 @@
-import { Component, Input, OnInit } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from "@angular/core";
 import {
   BootstrapColorTypes,
   BootstrapScreenSizes,
 } from "@helpers/bootstrapTypes";
-import { NgClass } from "@angular/common";
 
 /**
  * Loading Animation
  */
 @Component({
   selector: "baw-loading",
-  template: `
-    <div class="d-flex justify-content-center m-0 p-0">
-      <div id="spinner" role="status" [ngClass]="spinnerClass">
-        <span class="visually-hidden">Loading...</span>
-      </div>
-    </div>
-  `,
-  imports: [NgClass],
+  templateUrl: "./loading.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LoadingComponent implements OnInit {
-  @Input() public color: BootstrapColorTypes = "info";
-  @Input() public size: BootstrapScreenSizes = "md";
-  @Input() public type: "border" | "grower" = "border";
+export class LoadingComponent {
+  public readonly color = input<BootstrapColorTypes>("info");
+  public readonly size = input<BootstrapScreenSizes>("md");
+  public readonly type = input<"border" | "grower">("border");
 
-  public spinnerClass: { [klass: string]: true };
-
-  public ngOnInit(): void {
-    this.spinnerClass = {
-      [`spinner-${this.type}`]: true,
-      [`spinner-${this.type}-${this.size}`]: true,
-      [`text-${this.color}`]: true,
+  protected readonly spinnerClass = computed(() => {
+    return {
+      [`spinner-${this.type()}`]: true,
+      [`spinner-${this.type()}-${this.size()}`]: true,
+      [`text-${this.color()}`]: true,
     };
-  }
+  });
 }


### PR DESCRIPTION
# Fix layout reflow in loading spinner

## Changes

- Fixes reflow in loading.component
- Migrates loading.component to signals
- Moves loading template into its own file

## Issues

Fixes: #2457

## Visual Changes

None

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
