### PR TITLE
Use environment.json timeout in verification grid

### DIFF
--- a/src/app/components/annotations/pages/verification/verification.component.html
+++ b/src/app/components/annotations/pages/verification/verification.component.html
@@ -39,6 +39,7 @@
 <oe-verification-grid
   #verificationGrid
   id="verification-grid"
+  [loadingTimeout]="loadingTimeout"
   (grid-loaded)="handleGridLoaded()"
   (decision-made)="handleDecision($event)"
   (focus)="verificationGridFocused.set(true)"

--- a/src/app/components/annotations/pages/verification/verification.component.spec.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.spec.ts
@@ -70,6 +70,8 @@ import { Tagging } from "@models/Tagging";
 import { generateVerification } from "@test/fakes/Verification";
 import { generateTagging } from "@test/fakes/Tagging";
 import { ScrollService } from "@services/scroll/scroll.service";
+import { provideMockConfig } from "@services/config/provide-configMock";
+import { ConfigService } from "@services/config/config.service";
 import {
   AnnotationSearchParameters,
   VerificationStatusKey,
@@ -154,6 +156,7 @@ describe("VerificationComponent", () => {
     ],
     providers: [
       provideMockBawApi(),
+      provideMockConfig(),
 
       // The verification grid will automatically scroll into view once it has
       // loaded. However, I disable this behavior for testing because it can be
@@ -530,6 +533,12 @@ describe("VerificationComponent", () => {
   it("should create", async () => {
     await setup();
     expect(spec.component).toBeInstanceOf(VerificationComponent);
+  });
+
+  fit("should set the loading timeout to the value in the environment.json config", async () => {
+    await setup();
+    const expectedTimeout = spec.inject(ConfigService).environment.browserTimeout;
+    expect(verificationGrid().loadingTimeout).toEqual(expectedTimeout);
   });
 
   describe("no initial search parameters", () => {

--- a/src/app/components/annotations/pages/verification/verification.component.spec.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.spec.ts
@@ -535,7 +535,7 @@ describe("VerificationComponent", () => {
     expect(spec.component).toBeInstanceOf(VerificationComponent);
   });
 
-  fit("should set the loading timeout to the value in the environment.json config", async () => {
+  it("should set the loading timeout to the value in the environment.json config", async () => {
     await setup();
     const expectedTimeout = spec.inject(ConfigService).environment.browserTimeout;
     expect(verificationGrid().loadingTimeout).toEqual(expectedTimeout);

--- a/src/app/components/annotations/pages/verification/verification.component.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.ts
@@ -61,6 +61,7 @@ import { TaggingCorrectionsService } from "@services/models/tagging-corrections/
 import { ScrollService } from "@services/scroll/scroll.service";
 import { Annotation } from "@models/data/Annotation";
 import { PageFetcherContext } from "@ecoacoustics/web-components/@types/services/gridPageFetcher/gridPageFetcher";
+import { ConfigService } from "@services/config/config.service";
 import { AnnotationSearchParameters } from "../annotationSearchParameters";
 
 interface PagingContext extends PageFetcherContext {
@@ -106,6 +107,7 @@ class VerificationComponent
     private route: ActivatedRoute,
     private router: Router,
     private location: Location,
+    private config: ConfigService,
     @Inject(ASSOCIATION_INJECTOR) private injector: AssociationInjector,
   ) {
     super();
@@ -126,9 +128,11 @@ class VerificationComponent
   protected readonly hasCorrectionTask = signal(false);
   private readonly doneInitialScroll = signal(false);
 
-  public readonly project = signal<Project | null>(null);
-  public readonly region = signal<Region | null>(null);
-  public readonly site = signal<Site | null>(null);
+  protected readonly project = signal<Project | null>(null);
+  protected readonly region = signal<Region | null>(null);
+  protected readonly site = signal<Site | null>(null);
+
+  protected readonly loadingTimeout = this.config.environment.browserTimeout;
 
   // TODO: Remove this once the corrections endpoint is finished
   /**


### PR DESCRIPTION
# Use environment.json timeout in verification grid

The default timeout for the verification grid is 8 seconds.

However, this doesn't match our `environment.json` timeouts which are much higher (20 seconds)

Note that I made browser timeouts a soft/recoverable error, meaning that if the request ends up completing, the verification grid will correctly leave the error state, and render the first page.
The drawback here is that if the request takes > 20 seconds, users will see an incorrect error state flash.

## Changes

- Uses environment.json timeout for verification grid
- Increases `loadingTimeout` from 8 seconds to 20

## Visual Changes

NA

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [ ] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
