### PR TITLE
Bump web components to v6.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/platform-server": "19.2.5",
         "@angular/router": "19.2.5",
         "@angular/ssr": "19.2.6",
-        "@ecoacoustics/web-components": "^6.0.3",
+        "@ecoacoustics/web-components": "^6.0.5",
         "@fortawesome/angular-fontawesome": "^1.0.0",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
@@ -3566,9 +3566,9 @@
       }
     },
     "node_modules/@ecoacoustics/web-components": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@ecoacoustics/web-components/-/web-components-6.0.3.tgz",
-      "integrity": "sha512-XH1le3u8gU4aGf2LdjEJV0nYHIB1Q0Iqaq1ILXXBQMv0Olh1ElF16E60z6LHbGKFVdexlX5TnDM7wN1BwL6c7A==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@ecoacoustics/web-components/-/web-components-6.0.5.tgz",
+      "integrity": "sha512-+7yRmuOQVwrIarTn53zMW4OSDiwz6KDqR3kfP1Ki3VODp08Hn5nbzoS8b7V2p78ugRO+fwMdLKZLyjkAO7zlfQ==",
       "dependencies": {
         "@json2csv/plainjs": "7.0.6",
         "@lit-labs/preact-signals": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@angular/platform-server": "19.2.5",
     "@angular/router": "19.2.5",
     "@angular/ssr": "19.2.6",
-    "@ecoacoustics/web-components": "^6.0.3",
+    "@ecoacoustics/web-components": "^6.0.5",
     "@fortawesome/angular-fontawesome": "^1.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",


### PR DESCRIPTION
# Bump web components to v6.0.5

What is the purpose of this PR?

## Changes

- Fixes clicking on whitespace not causing verification grid to focus
- Fixes grayscale spectrograms resetting to audacity color map after paging

## Visual Changes

[Screencast_20251017_115835.webm](https://github.com/user-attachments/assets/8766ab2f-5e70-4640-b177-2266313109f2)

_Video showing the spectrograms no longer revert back to "audacity" after paging_

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [ ] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
