### PR TITLE
Fix model-list.component jank when searching

### DIFF
--- a/src/app/components/shared/model-list/model-list.component.html
+++ b/src/app/components/shared/model-list/model-list.component.html
@@ -39,12 +39,14 @@
 <div [ngbNavOutlet]="nav" class="mt-2"></div>
 
 <ng-template #tilesTab>
-  @if (models().length > 0) {
-    <baw-model-cards [models]="models()"></baw-model-cards>
-  } @else {
-    <h4 class="text-center">
-      <ng-template [ngTemplateOutlet]="noResultsTemplate()"></ng-template>
-    </h4>
+  @if (!doneInitialLoad) {
+    @if (models().length > 0) {
+      <baw-model-cards [models]="models()"></baw-model-cards>
+    } @else {
+      <h4 class="text-center">
+        <ng-template [ngTemplateOutlet]="noResultsTemplate()"></ng-template>
+      </h4>
+    }
   }
 
   @if (displayPagination) {

--- a/src/app/components/shared/model-list/model-list.component.html
+++ b/src/app/components/shared/model-list/model-list.component.html
@@ -39,7 +39,7 @@
 <div [ngbNavOutlet]="nav" class="mt-2"></div>
 
 <ng-template #tilesTab>
-  @if (!doneInitialLoad) {
+  @if (doneInitialLoad) {
     @if (models().length > 0) {
       <baw-model-cards [models]="models()"></baw-model-cards>
     } @else {

--- a/src/app/components/shared/model-list/model-list.component.html
+++ b/src/app/components/shared/model-list/model-list.component.html
@@ -39,14 +39,12 @@
 <div [ngbNavOutlet]="nav" class="mt-2"></div>
 
 <ng-template #tilesTab>
-  @if (!loading) {
-    @if (models().length > 0) {
-      <baw-model-cards [models]="models()"></baw-model-cards>
-    } @else {
-      <h4 class="text-center">
-        <ng-template [ngTemplateOutlet]="noResultsTemplate()"></ng-template>
-      </h4>
-    }
+  @if (models().length > 0) {
+    <baw-model-cards [models]="models()"></baw-model-cards>
+  } @else {
+    <h4 class="text-center">
+      <ng-template [ngTemplateOutlet]="noResultsTemplate()"></ng-template>
+    </h4>
   }
 
   @if (displayPagination) {

--- a/src/app/helpers/paginationTemplate/paginationTemplate.ts
+++ b/src/app/helpers/paginationTemplate/paginationTemplate.ts
@@ -56,6 +56,16 @@ export abstract class PaginationTemplate<M extends AbstractModel>
    */
   public loading: boolean;
   /**
+   * Tracks whether we are currently waiting for the first api request to
+   * complete.
+   * This is useful because if you have no results because you are still waiting
+   * for the API to return the initial results, we don't want to show a
+   * "no results" message.
+   * However, if we have already done a request and there are no results, we can
+   * conclude that there are actually no results to show.
+   */
+  public doneInitialLoad = false;
+  /**
    * Tracks the current user filter input
    */
   public filter: string;
@@ -124,10 +134,12 @@ export abstract class PaginationTemplate<M extends AbstractModel>
           this.collectionSize = models?.[0]?.getMetadata()?.paging?.total || 0;
           this.displayPagination = this.collectionSize > defaultApiPageSize;
           this.apiUpdate(models);
+          this.doneInitialLoad = true;
         },
         error: (error: BawApiError) => {
           this.error = error;
           this.loading = false;
+          this.doneInitialLoad = true;
         },
       });
 


### PR DESCRIPTION
# Fix model-list.component jank when searching

This PR is 99% a nerd snipe to show that not unloading the search table on query results in a much smoother search experience

## Changes

- Do not unload the current results on `paginationTemplate` loading state

## Issues

Fixes: #2480

## Visual Changes

[Screencast from 2025-10-21 10-47-39.webm](https://github.com/user-attachments/assets/03532e6c-19e2-44ab-9a0b-03058fa8714b)

_Example of no unloading the search results on a search query, which results in less jank_

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
