### PR TITLE
Use SHOW requests for single tag annotations

### DIFF
--- a/src/app/services/models/annotations/annotation.service.spec.ts
+++ b/src/app/services/models/annotations/annotation.service.spec.ts
@@ -20,10 +20,13 @@ import { Tagging } from "@models/Tagging";
 import { generateTagging } from "@test/fakes/Tagging";
 import { generateTag } from "@test/fakes/Tag";
 import { AnnotationService } from "./annotation.service";
+import { modelData } from "@test/helpers/faker";
 
 describe("AnnotationService", () => {
   let spec: SpectatorService<AnnotationService>;
   let injector: SpyObject<AssociationInjector>;
+  let tagApiSpy: SpyObject<TagsService>;
+
 
   let mockAudioEvent: AudioEvent;
   let mockRecording: AudioRecording;
@@ -40,7 +43,10 @@ describe("AnnotationService", () => {
   });
 
   function mockTagsService() {
-    return { filter: () => of(mockTags) };
+    return {
+      filter: () => of(mockTags),
+      show: () => of(mockTags[0]),
+    };
   }
 
   function mockRecordingsService() {
@@ -51,7 +57,24 @@ describe("AnnotationService", () => {
     spec = createService();
     injector = spec.inject(ASSOCIATION_INJECTOR);
 
-    mockAudioEvent = new AudioEvent(generateAudioEvent(), injector);
+    tagApiSpy = spec.inject(TagsService);
+    spyOn(tagApiSpy, "show").and.callThrough();
+    spyOn(tagApiSpy, "filter").and.callThrough();
+
+    // The default generateAudioEvent mock has a chance to not have any taggings
+    // Because we want to test tag fetching, we ensure there are some taggings
+    // in the default mock.
+    mockAudioEvent = new AudioEvent(
+      generateAudioEvent({
+        taggings: modelData.randomArray(
+          1,
+          25,
+          () => new Tagging(generateTagging(), injector),
+        ),
+      }),
+      injector,
+    );
+
     mockRecording = new AudioRecording(generateAudioRecording(), injector);
     mockTags = Array.from(
       { length: 5 },
@@ -70,9 +93,7 @@ describe("AnnotationService", () => {
   describe("show", () => {
     it("should have all the same property values as the original audio event model", async () => {
       const result = await spec.service.show(mockAudioEvent, []);
-      expect(result).toEqual(
-        jasmine.objectContaining(mockAudioEvent as any),
-      );
+      expect(result).toEqual(jasmine.objectContaining(mockAudioEvent as any));
     });
 
     it("should resolve the associated audio recording model", async () => {
@@ -112,8 +133,8 @@ describe("AnnotationService", () => {
         new Tag(generateTag({ id: 8, typeOfTag: "common_name" })),
       ];
 
-      const taggings = mockTags.map((tag) =>
-        new Tagging(generateTagging({ tagId: tag.id }), injector),
+      const taggings = mockTags.map(
+        (tag) => new Tagging(generateTagging({ tagId: tag.id }), injector),
       );
 
       const testedEvent = new AudioEvent(
@@ -128,10 +149,68 @@ describe("AnnotationService", () => {
       // Meaning that relative order is maintained for the filtered tags.
       const expectedIds = [3, 1, 2, 4, 6, 8, 7, 5];
 
-      const realizedResult = await spec.service.show(testedEvent, dataModel.tagPriority);
+      const realizedResult = await spec.service.show(
+        testedEvent,
+        dataModel.tagPriority,
+      );
 
-      const realizedIds = realizedResult.tags.map(tag => tag.id);
+      const realizedIds = realizedResult.tags.map((tag) => tag.id);
       expect(realizedIds).toEqual(expectedIds);
+    });
+  });
+
+  describe("tag fetching", () => {
+    it("should not make any api calls if there are no taggings", async () => {
+      const audioEvent = new AudioEvent(
+        generateAudioEvent({ taggings: [] }),
+        injector,
+      );
+
+      const result = await spec.service.show(audioEvent, []);
+
+      expect(result.tags).toEqual([]);
+      expect(tagApiSpy.show).not.toHaveBeenCalled();
+      expect(tagApiSpy.filter).not.toHaveBeenCalled();
+    });
+
+    it("should make a single SHOW api call if there is one tagging", async () => {
+      const audioEvent = new AudioEvent(
+        generateAudioEvent({
+          taggings: [
+            new Tagging(generateTagging({ tagId: 42 }), injector),
+          ],
+        }),
+        injector,
+      );
+
+      await spec.service.show(audioEvent, []);
+
+      expect(tagApiSpy.show).toHaveBeenCalledOnceWith(42);
+      expect(tagApiSpy.filter).not.toHaveBeenCalled();
+    });
+
+    it("should make a single FILTER api call if there are multiple taggings", async () => {
+      const audioEvent = new AudioEvent(
+        generateAudioEvent({
+          taggings: [
+            new Tagging(generateTagging({ tagId: 1 }), injector),
+            new Tagging(generateTagging({ tagId: 2 }), injector),
+            new Tagging(generateTagging({ tagId: 3 }), injector),
+          ],
+        }),
+        injector,
+      );
+
+      await spec.service.show(audioEvent, []);
+
+      expect(tagApiSpy.show).not.toHaveBeenCalled();
+      expect(tagApiSpy.filter).toHaveBeenCalledOnceWith({
+        filter: {
+          id: {
+            in: [1, 2, 3],
+          },
+        },
+      });
     });
   });
 });

--- a/src/app/services/models/annotations/annotation.service.spec.ts
+++ b/src/app/services/models/annotations/annotation.service.spec.ts
@@ -19,8 +19,8 @@ import { AnnotationSearchParameters } from "@components/annotations/pages/annota
 import { Tagging } from "@models/Tagging";
 import { generateTagging } from "@test/fakes/Tagging";
 import { generateTag } from "@test/fakes/Tag";
-import { AnnotationService } from "./annotation.service";
 import { modelData } from "@test/helpers/faker";
+import { AnnotationService } from "./annotation.service";
 
 describe("AnnotationService", () => {
   let spec: SpectatorService<AnnotationService>;


### PR DESCRIPTION
# Use SHOW requests for single tag annotations

## Changes

- use a SHOW request for annotations with one tag
- Do not make an API request for annotations without any tags

## Issues

Fixes: #2460

## Visual Changes

NA.

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
