### PR TITLE
Refactor linting to its own job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,9 +36,6 @@ jobs:
         # Retrieve annotated tags.
         run: git fetch --tags --force
 
-      - name: Checkout LFS objects
-        run: git lfs checkout
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -167,6 +167,9 @@ jobs:
           node-version: "22"
           cache: "npm"
 
+      - name: Install project dependencies
+        run: npm ci --force
+
       - name: Lint project
         run: npm run lint
         env:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -135,24 +135,12 @@ jobs:
           name: Unit Test Results (OS ${{ matrix.os }} ${{ matrix.browsers }})
           path: TESTS-*.xml
 
-      - name: Lint project
-        run: npm run lint
-        env:
-          # We were running out of memory in the lint step, so I increased it.
-          # This is an indication that there is a memory leak somewhere, but I
-          # don't want to invest time into tracking it down right now.
-          # TODO: We should track down the memory leak and remove this hack.
-          NODE_OPTIONS: --max-old-space-size="8192"
-
   ssr:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Workbench Client
         uses: nschloe/action-cached-lfs-checkout@v1
-
-      - name: Checkout LFS objects
-        run: git lfs checkout
 
       - name: Build container
         run: docker build -t qutecoacoustics/workbench-client . --build-arg GIT_COMMIT="a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0" --build-arg WORKBENCH_CLIENT_VERSION="70.1.1+test.a0a0a0a0"
@@ -164,15 +152,29 @@ jobs:
         shell: pwsh
         run: ./scripts/ssr-tests.ps1
 
-  build:
+  # Linting is in its own job instead of in the test matrix so that
+  lint:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Workbench Client
         uses: nschloe/action-cached-lfs-checkout@v1
 
-      - name: Checkout LFS objects
-        run: git lfs checkout
+      - name: Lint project
+        run: npm run lint
+        env:
+          # We were running out of memory in the lint step, so I increased it.
+          # This is an indication that there is a memory leak somewhere, but I
+          # don't want to invest time into tracking it down right now.
+          # TODO: We should track down the memory leak and remove this hack.
+          NODE_OPTIONS: --max-old-space-size="8192"
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Workbench Client
+        uses: nschloe/action-cached-lfs-checkout@v1
 
       - name: Install Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -152,7 +152,8 @@ jobs:
         shell: pwsh
         run: ./scripts/ssr-tests.ps1
 
-  # Linting is in its own job instead of in the test matrix so that
+  # Linting is in its own job instead of in the test matrix so that it only runs
+  # once per workflow invocation, saving compute resources and cost.
   lint:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -161,6 +161,12 @@ jobs:
       - name: Checkout Workbench Client
         uses: nschloe/action-cached-lfs-checkout@v1
 
+      - name: Install Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+
       - name: Lint project
         run: npm run lint
         env:


### PR DESCRIPTION
# Refactor linting to its own job

This PR also requires workspace branch protection updates to require the lint action to pass before merging.

## Changes

- Refactor linting into its own workflow job to save compute time
- Do not perform noop `git lfs checkout` in workflow actions

## Issues

Fixes: #2426

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
