### PR TITLE
Refine verification grid navigation confirmation

### DIFF
--- a/src/app/components/annotations/pages/verification/verification.component.spec.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.spec.ts
@@ -1135,7 +1135,7 @@ describe("VerificationComponent", () => {
       await clickDecisionButton(DecisionOptions.TRUE);
 
       expect(spec.component.confirmNavigation).toBeTrue();
-      expect(spec.component.confirmationHardBlock()).toBeFalse();
+      expect(spec.component.blockNavigation()).toBeFalse();
       expect(spec.component.confirmNavigationMessage()).toEqual(
         "Are you sure you want to leave this page?",
       );
@@ -1150,7 +1150,7 @@ describe("VerificationComponent", () => {
       await clickDecisionButton(DecisionOptions.TRUE);
 
       expect(spec.component.confirmNavigation).toBeTrue();
-      expect(spec.component.confirmationHardBlock()).toBeTrue();
+      expect(spec.component.blockNavigation()).toBeTrue();
       expect(spec.component.confirmNavigationMessage()).toEqual(
         "Some changes are still being saved. Please wait one moment.",
       );

--- a/src/app/components/annotations/pages/verification/verification.component.spec.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.spec.ts
@@ -9,7 +9,7 @@ import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
 import { Params, Router } from "@angular/router";
-import { of } from "rxjs";
+import { Observable, of } from "rxjs";
 import { generateProject } from "@test/fakes/Project";
 import { generateRegion } from "@test/fakes/Region";
 import { generateSite } from "@test/fakes/Site";
@@ -81,7 +81,7 @@ import { generateVerificationUrlParams } from "@test/fakes/data/verificationPara
 import { exampleBase64 } from "../../../../../test-assets/example-0.5s.base64";
 import { VerificationComponent } from "./verification.component";
 
-enum DecisionOptions {
+const enum DecisionOptions {
   TRUE = "true",
   FALSE = "false",
   UNSURE = "unsure",
@@ -1118,6 +1118,42 @@ describe("VerificationComponent", () => {
         const realizedTileCount = verificationGrid().pageSize;
         expect(realizedTileCount).toBeGreaterThan(0);
       });
+    });
+  });
+
+  describe("navigation confirmations", () => {
+    beforeEach(async () => {
+      await setup();
+    });
+
+    it("should not show a navigation confirmation if the user has not made a decision", () => {
+      expect(spec.component.confirmNavigation).toBeFalse();
+    });
+
+    it("should show a navigation confirmation if the user has made a decision", async () => {
+      await makeSelection(0, 0);
+      await clickDecisionButton(DecisionOptions.TRUE);
+
+      expect(spec.component.confirmNavigation).toBeTrue();
+      expect(spec.component.confirmationHardBlock()).toBeFalse();
+      expect(spec.component.confirmNavigationMessage()).toEqual(
+        "Are you sure you want to leave this page?",
+      );
+    });
+
+    it("should show an alert if the user tries to navigate away while requests are still processing", async () => {
+      // Mock the verification api to return an observable that never completes
+      // so that the component thinks that there are still requests processing.
+      verificationApiSpy.createOrUpdate.and.returnValue(new Observable(() => {}));
+
+      await makeSelection(0, 0);
+      await clickDecisionButton(DecisionOptions.TRUE);
+
+      expect(spec.component.confirmNavigation).toBeTrue();
+      expect(spec.component.confirmationHardBlock()).toBeTrue();
+      expect(spec.component.confirmNavigationMessage()).toEqual(
+        "Some changes are still being saved. Please wait one moment.",
+      );
     });
   });
 });

--- a/src/app/components/annotations/pages/verification/verification.component.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.ts
@@ -48,7 +48,9 @@ import { SubjectWrapper } from "@ecoacoustics/web-components/@types/models/subje
 import { DecisionOptions } from "@ecoacoustics/web-components/@types/models/decisions/decision";
 import { FaIconComponent } from "@fortawesome/angular-fontawesome";
 import { RenderMode } from "@angular/ssr";
-import { annotationSearchParametersResolvers } from "@components/annotations/components/annotation-search-form/annotation-search-parameters.resolver";
+import {
+  annotationSearchParametersResolvers,
+} from "@components/annotations/components/annotation-search-form/annotation-search-parameters.resolver";
 import {
   TagPromptComponent,
   TypeaheadCallback,
@@ -68,7 +70,9 @@ import { AnnotationSearchParameters } from "@components/annotations/components/a
 import { VerificationParameters } from "@components/annotations/components/verification-form/verificationParameters";
 import { verificationParametersResolvers } from "@components/annotations/components/verification-form/verification-parameters.resolver";
 import { filterAnd } from "@helpers/filters/filters";
-import { SearchVerificationFiltersModalComponent } from "@components/annotations/components/modals/search-verification-filters/search-verification-filters.component";
+import {
+  SearchVerificationFiltersModalComponent,
+} from "@components/annotations/components/modals/search-verification-filters/search-verification-filters.component";
 import { mergeParameters } from "@helpers/parameters/merge";
 
 interface PagingContext extends PageFetcherContext {

--- a/src/app/guards/confirmation/confirmation.guard.spec.ts
+++ b/src/app/guards/confirmation/confirmation.guard.spec.ts
@@ -1,0 +1,117 @@
+import { TestBed } from "@angular/core/testing";
+import { signal } from "@angular/core";
+import {
+  NavigationConfirmationGuard,
+  WithNavigationConfirmation,
+} from "./confirmation.guard";
+
+const defaultMessage = "Are you sure you want to leave this page?";
+
+describe("NavigationConfirmationGuard", () => {
+  let guard: NavigationConfirmationGuard;
+
+  function spyOnConfirm(confirmation: boolean) {
+    spyOn(window, "confirm").and.returnValue(confirmation);
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [NavigationConfirmationGuard],
+    }).compileComponents();
+
+    guard = TestBed.inject(NavigationConfirmationGuard);
+  });
+
+  it("should not navigate if the confirmation is rejected", () => {
+    spyOnConfirm(false);
+
+    const component: WithNavigationConfirmation = {
+      confirmNavigation: true,
+    };
+
+    const canNavigate = guard.canDeactivate(component);
+
+    expect(canNavigate).toBeFalse();
+    expect(window.confirm).toHaveBeenCalledOnceWith(defaultMessage);
+  });
+
+  it("should use a custom confirmation message if provided", () => {
+    const customMessage = "Custom confirmation message";
+    spyOnConfirm(true);
+
+    const component: WithNavigationConfirmation = {
+      confirmNavigation: true,
+      confirmNavigationMessage: customMessage,
+    };
+
+    const canNavigate = guard.canDeactivate(component);
+    expect(canNavigate).toBeTrue();
+    expect(window.confirm).toHaveBeenCalledOnceWith(customMessage);
+  });
+
+  describe("confirmNavigation", () => {
+    it("should handle a component that does not have a confirmation property", () => {
+      spyOnConfirm(true);
+
+      const component: WithNavigationConfirmation = {};
+      const canNavigate = guard.canDeactivate(component);
+
+      // We expect that canNavigate is true because we spied on the confirm dialog
+      // to always accept the navigation confirmation.
+      expect(canNavigate).toBeTrue();
+      expect(window.confirm).not.toHaveBeenCalledOnceWith(defaultMessage);
+    });
+
+    it("should handle static 'false' boolean properties", () => {
+      spyOnConfirm(true);
+
+      const component: WithNavigationConfirmation = {
+        confirmNavigation: false,
+      };
+
+      const canNavigate = guard.canDeactivate(component);
+
+      expect(canNavigate).toBeTrue();
+      expect(window.confirm).not.toHaveBeenCalled();
+    });
+
+    it("should handle static 'true' boolean properties", () => {
+      spyOnConfirm(true);
+
+      const component: WithNavigationConfirmation = {
+        confirmNavigation: true,
+      };
+
+      const canNavigate = guard.canDeactivate(component);
+
+      expect(canNavigate).toBeTrue();
+      expect(window.confirm).toHaveBeenCalledOnceWith(defaultMessage);
+    });
+
+    it("should handle signals that return 'false'", () => {
+      spyOnConfirm(true);
+
+      const component: WithNavigationConfirmation = {
+        confirmNavigation: signal(false),
+      };
+
+      const canNavigate = guard.canDeactivate(component);
+
+      expect(canNavigate).toBeTrue();
+      expect(window.confirm).not.toHaveBeenCalled();
+    });
+
+    it("should handle signals that return 'true'", () => {
+      spyOnConfirm(true);
+
+      const component: WithNavigationConfirmation = {
+        confirmNavigation: signal(true),
+      };
+
+      const canNavigate = guard.canDeactivate(component);
+
+      expect(canNavigate).toBeTrue();
+      expect(window.confirm).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/guards/confirmation/confirmation.guard.ts
+++ b/src/app/guards/confirmation/confirmation.guard.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
 import { CanDeactivate } from "@angular/router";
-import { PotentiallySignal, unwrapPotentialSignal } from "@helpers/signals/signals";
+import { SignalOr, unwrapPotentialSignal } from "@helpers/signals/signals";
 
 /**
  * Allows interaction with the confirmation.guard to confirm navigation away
@@ -16,7 +16,7 @@ export interface WithNavigationConfirmation {
    *
    * @default false
    */
-  confirmNavigation?: PotentiallySignal<boolean>;
+  confirmNavigation?: SignalOr<boolean>;
 
   /**
    * A custom message to show in the confirmation dialog.
@@ -24,7 +24,7 @@ export interface WithNavigationConfirmation {
    *
    * @default "Are you sure you want to leave this page?"
    */
-  confirmNavigationMessage?: PotentiallySignal<string>;
+  confirmNavigationMessage?: SignalOr<string>;
 
   /**
    * Whether to hard block navigation without confirmation.
@@ -33,10 +33,13 @@ export interface WithNavigationConfirmation {
    * instead of a confirmation dialog.
    * This should only be used in extreme cases where navigation must not be
    * allowed or we need to wait for something to complete on the main thread.
+   * Note that blocking user navigation is generally considered a bad user
+   * experience and browser restrictions sometime cause the browser to ignore
+   * repeated attempts to block navigation using an alert dialog.
    *
    * @default false
    */
-  confirmationHardBlock?: PotentiallySignal<boolean>;
+  blockNavigation?: SignalOr<boolean>;
 }
 
 /**
@@ -73,7 +76,7 @@ export class NavigationConfirmationGuard
       unwrapPotentialSignal(component.confirmNavigationMessage) ??
       "Are you sure you want to leave this page?";
 
-    const hardBlock = unwrapPotentialSignal(component.confirmationHardBlock);
+    const hardBlock = unwrapPotentialSignal(component.blockNavigation);
     if (hardBlock) {
       alert(confirmationMessage);
       return false;

--- a/src/app/guards/confirmation/confirmation.guard.ts
+++ b/src/app/guards/confirmation/confirmation.guard.ts
@@ -1,0 +1,84 @@
+import { Injectable } from "@angular/core";
+import { CanDeactivate } from "@angular/router";
+import { PotentiallySignal, unwrapPotentialSignal } from "@helpers/signals/signals";
+
+/**
+ * Allows interaction with the confirmation.guard to confirm navigation away
+ * from the current page if the confirmNavigation property is set to true.
+ */
+export interface WithNavigationConfirmation {
+  /**
+   * Whether to confirm navigation away from the current page.
+   *
+   * This defaults false, but can be set to true to show a confirmation.
+   * E.g. If the user has not performed an action that would require unload
+   * confirmation.
+   *
+   * @default false
+   */
+  confirmNavigation?: PotentiallySignal<boolean>;
+
+  /**
+   * A custom message to show in the confirmation dialog.
+   * If not provided, a default message will be used.
+   *
+   * @default "Are you sure you want to leave this page?"
+   */
+  confirmNavigationMessage?: PotentiallySignal<string>;
+
+  /**
+   * Whether to hard block navigation without confirmation.
+   *
+   * If set to `true`, navigation will be blocked, and just show an alert
+   * instead of a confirmation dialog.
+   * This should only be used in extreme cases where navigation must not be
+   * allowed or we need to wait for something to complete on the main thread.
+   *
+   * @default false
+   */
+  confirmationHardBlock?: PotentiallySignal<boolean>;
+}
+
+/**
+ * If the components confirmNavigation property is set to true, the user will be
+ * prompted to confirm navigation before leaving the current page.
+ *
+ * This route guard should be used with a page component that implements the
+ * {@link WithNavigationConfirmation} interface.
+ *
+ * This guard differs from the {@link UnsavedInputGuard} both semantically and
+ * in its intended use cases.
+ * The UnsavedInputGuard is intended to be used specifically for inputs that
+ * will lose their value after navigation.
+ * This distinction is made so that the UnsavedInputGuard can be easily changed
+ * in the future without having to consider how it will affect other non-input
+ * related navigation confirmations.
+ * Additionally, because this guard is more generic, it accepts a
+ * `confirmNavigation` property to customize the confirmation message.
+ */
+@Injectable({ providedIn: "root" })
+export class NavigationConfirmationGuard
+  implements CanDeactivate<WithNavigationConfirmation>
+{
+  public canDeactivate(component: WithNavigationConfirmation): boolean {
+    // canDeactivate guards can be called with null components: https://github.com/angular/angular/issues/40545
+    if (!component) {
+      return true;
+    }
+
+    const confirmNavigation =
+      unwrapPotentialSignal(component.confirmNavigation) ?? false;
+
+    const confirmationMessage: string =
+      unwrapPotentialSignal(component.confirmNavigationMessage) ??
+      "Are you sure you want to leave this page?";
+
+    const hardBlock = unwrapPotentialSignal(component.confirmationHardBlock);
+    if (hardBlock) {
+      alert(confirmationMessage);
+      return false;
+    }
+
+    return confirmNavigation ? confirm(confirmationMessage) : true;
+  }
+}

--- a/src/app/guards/input/input.guard.ts
+++ b/src/app/guards/input/input.guard.ts
@@ -1,12 +1,12 @@
 import { Injectable } from "@angular/core";
 import { CanDeactivate } from "@angular/router";
 import {
-  PotentiallySignal,
+  SignalOr,
   unwrapPotentialSignal,
 } from "@helpers/signals/signals";
 
 export interface UnsavedInputCheckingComponent {
-  hasUnsavedChanges: PotentiallySignal<boolean>;
+  hasUnsavedChanges: SignalOr<boolean>;
 }
 
 /**

--- a/src/app/guards/input/input.guard.ts
+++ b/src/app/guards/input/input.guard.ts
@@ -1,8 +1,12 @@
-import { Injectable, Signal } from "@angular/core";
+import { Injectable } from "@angular/core";
 import { CanDeactivate } from "@angular/router";
+import {
+  PotentiallySignal,
+  unwrapPotentialSignal,
+} from "@helpers/signals/signals";
 
 export interface UnsavedInputCheckingComponent {
-  hasUnsavedChanges: boolean | Signal<boolean>;
+  hasUnsavedChanges: PotentiallySignal<boolean>;
 }
 
 /**
@@ -20,12 +24,11 @@ export class UnsavedInputGuard
       return true;
     }
 
-    const isUnsaved =
-      typeof component.hasUnsavedChanges === "function"
-        ? component.hasUnsavedChanges()
-        : component.hasUnsavedChanges;
+    const hasUnsavedChanges = unwrapPotentialSignal(
+      component.hasUnsavedChanges,
+    );
 
-    return isUnsaved
+    return hasUnsavedChanges
       ? confirm(
           "Changes to this page will be lost! Are you sure you want to leave?",
         )

--- a/src/app/helpers/page/pageRouting.ts
+++ b/src/app/helpers/page/pageRouting.ts
@@ -7,6 +7,7 @@ import { StrongRoute } from "@interfaces/strongRoute";
 import { UnsavedInputGuard } from "@guards/input/input.guard";
 import { RenderMode, ServerRoute } from "@angular/ssr";
 import { getPageInfos } from "./pageComponent";
+import { NavigationConfirmationGuard } from "@guards/confirmation/confirmation.guard";
 
 export function splitIndexedStrongRoutes(
   routes: Record<string, StrongRoute>,
@@ -52,7 +53,11 @@ function createClientRoute(strongRoute: StrongRoute): Option<Route> {
         path: "",
         pathMatch: "full",
         component: pageInfo.component,
-        canDeactivate: [FormTouchedGuard, UnsavedInputGuard],
+        canDeactivate: [
+          FormTouchedGuard,
+          UnsavedInputGuard,
+          NavigationConfirmationGuard,
+        ],
       },
       {
         path: "",

--- a/src/app/helpers/page/pageRouting.ts
+++ b/src/app/helpers/page/pageRouting.ts
@@ -1,13 +1,13 @@
 import { Route, Routes } from "@angular/router";
 import { ResolverHandlerComponent } from "@components/error/resolver-handler.component";
 import { FormTouchedGuard } from "@guards/form/form.guard";
+import { NavigationConfirmationGuard } from "@guards/confirmation/confirmation.guard";
 import { Option } from "@helpers/advancedTypes";
 import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { StrongRoute } from "@interfaces/strongRoute";
 import { UnsavedInputGuard } from "@guards/input/input.guard";
 import { RenderMode, ServerRoute } from "@angular/ssr";
 import { getPageInfos } from "./pageComponent";
-import { NavigationConfirmationGuard } from "@guards/confirmation/confirmation.guard";
 
 export function splitIndexedStrongRoutes(
   routes: Record<string, StrongRoute>,

--- a/src/app/helpers/signals/signals.spec.ts
+++ b/src/app/helpers/signals/signals.spec.ts
@@ -1,0 +1,30 @@
+import { computed, signal } from "@angular/core";
+import { unwrapPotentialSignal } from "./signals";
+
+describe("unwrapPotentialSignal", () => {
+  it("should return a value as-is", () => {
+    const falsyValue = 0;
+    expect(unwrapPotentialSignal(falsyValue)).toEqual(falsyValue);
+
+    const truthyValue = "Hello World!";
+    expect(unwrapPotentialSignal(truthyValue)).toEqual(truthyValue);
+  });
+
+  it("should unwrap a signal value", () => {
+    const falsySignalValue = signal(0);
+    expect(unwrapPotentialSignal(falsySignalValue)).toEqual(0);
+
+    const truthySignalValue = signal(42);
+    expect(unwrapPotentialSignal(truthySignalValue)).toEqual(42);
+  });
+
+  it("should work with computed signals", () => {
+    const baseSignal = signal(10);
+    const computedSignal = computed(() => baseSignal() * 2);
+
+    expect(unwrapPotentialSignal(computedSignal)).toEqual(20);
+    baseSignal.set(25);
+
+    expect(unwrapPotentialSignal(computedSignal)).toEqual(50);
+  })
+});

--- a/src/app/helpers/signals/signals.spec.ts
+++ b/src/app/helpers/signals/signals.spec.ts
@@ -26,5 +26,5 @@ describe("unwrapPotentialSignal", () => {
     baseSignal.set(25);
 
     expect(unwrapPotentialSignal(computedSignal)).toEqual(50);
-  })
+  });
 });

--- a/src/app/helpers/signals/signals.ts
+++ b/src/app/helpers/signals/signals.ts
@@ -6,7 +6,7 @@ import { isSignal, Signal } from "@angular/core";
  * This is useful for route guards and directives that want to work in static,
  * zone.js, and signal-based components/environments.
  */
-export type PotentiallySignal<T> = T | Signal<T>;
+export type SignalOr<T> = T | Signal<T>;
 
 /**
  * Allows you to unwrap a value that may be a signal or a direct value.

--- a/src/app/helpers/signals/signals.ts
+++ b/src/app/helpers/signals/signals.ts
@@ -1,0 +1,22 @@
+import { isSignal, Signal } from "@angular/core";
+
+/**
+ * A type that can either be a direct value of type T or a Signal that
+ * produces a value of type T.
+ * This is useful for route guards and directives that want to work in static,
+ * zone.js, and signal-based components/environments.
+ */
+export type PotentiallySignal<T> = T | Signal<T>;
+
+/**
+ * Allows you to unwrap a value that may be a signal or a direct value.
+ * This is useful for handling inputs that may be provided as either as a signal
+ * or a direct value.
+ */
+export function unwrapPotentialSignal<T>(value: T | Signal<T>): T {
+  if (isSignal(value)) {
+    return value();
+  }
+
+  return value;
+}


### PR DESCRIPTION
# Refine verification grid navigation confirmation

## Changes

- When all verifications are saved, you now get a more generic "Are you sure you want to leave this page?" instead of the scary "Changes to this page will be lost! Are you sure you want to leave?" message
- When not all verification requests have completed, you now get the more descriptive "Some changes are still being saved. Please wait one moment." message
- Adds new `confirmation.guard` that can be used to show a confirmation/alert dialog on pages with a custom message

### Dev Concerns

- Adds new `SignalOr<T>` and `unwrapPotentialSignal` helpers that can be used to and unwrap inputs/values that can either be signals or regular variables. I suspect this will be useful in the future for directives as well

## Issues

Fixes: #2487

## Visual Changes

<img width="1918" height="1071" alt="image" src="https://github.com/user-attachments/assets/9c7b80b8-6376-4833-a738-3ae111728b96" />

_New navigation warning that is shown if there are no pending requests_

---

<img width="1918" height="1071" alt="image" src="https://github.com/user-attachments/assets/b5289cb9-233b-4419-90e8-f7c32d0b3a9d" />

_New warning that is shown if there are pending requests_

---

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
