### PR TITLE
Ensure unique ids in mock data

### DIFF
--- a/src/app/test/helpers/faker.ts
+++ b/src/app/test/helpers/faker.ts
@@ -23,7 +23,9 @@ const specialCharRegex = /[^\w\s]/gi;
 function* idIterator(): Generator<number, number, unknown> {
   // To retain some randomness in the tests, we start the ID generator from a
   // random number between 0 and 100.
-  const startingId = faker.datatype.number(100);
+  const maxStartingId = 100;
+  const startingId = faker.datatype.number(maxStartingId);
+
   let lastId = startingId;
 
   while (true) {
@@ -42,7 +44,8 @@ function* idIterator(): Generator<number, number, unknown> {
 }
 
 /**
- * Generates random and unique ids for models that can be used in tests.
+ * Generates spare, unique, and incrementing ids for models that can be used in
+ * tests.
  * This generator ensures that ids do not collide within a single test run,
  * reducing the flakiness of tests that rely on unique ids.
  */


### PR DESCRIPTION
# Ensure unique ids in mock data

Some tests were flaky because there was a ~1/100 probability to generate mock data with the same id.

I have observed this causing issues when models attempt to get the ids of sub-models, use a Set() constructor, then some of the expected ids disappear.

Note that this doesn't fix all the flaky tests, it just fixes one potential flake point.

## Issues

Related to: #2495

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
