### PR TITLE
Fix annotation import file download link

### DIFF
--- a/src/app/components/import-annotations/pages/details/details.component.html
+++ b/src/app/components/import-annotations/pages/details/details.component.html
@@ -158,7 +158,7 @@
               -->
                 <a
                   class="btn btn-sm btn-primary"
-                  [bawUrl]="value.path"
+                  [href]="value.path"
                   target="_blank"
                 >
                   Download

--- a/src/app/components/import-annotations/pages/details/details.component.spec.ts
+++ b/src/app/components/import-annotations/pages/details/details.component.spec.ts
@@ -75,6 +75,7 @@ describe("AnnotationsDetailsComponent", () => {
   let expectedFilesTable: any;
 
   const fileVerifyLinks = () => spec.queryAll(StrongRouteDirective);
+  const fileDownloadLinks = () => getElementByTextContent(spec, "Download");
 
   const createComponent = createRoutingFactory({
     component: AnnotationImportDetailsComponent,
@@ -374,6 +375,19 @@ describe("AnnotationsDetailsComponent", () => {
         expect(link.routeParams).toEqual(expectedResult.routeParams);
         expect(link.queryParams).toEqual(expectedResult.queryParams);
       });
+    });
+
+    // If you are incorrectly using a bawUrl directive instead of a href, this
+    // test will fail because the url will attempt to point to a client route
+    // instead of an external download link.
+    it("should have the correct download link", () => {
+      // We only make an assertion over the first download link which will
+      // correspond to the first file in the table.
+      const downloadLink = fileDownloadLinks();
+      const firstFile = mockAudioEventImportFiles[0];
+
+      expect(downloadLink).toBeDefined();
+      expect(downloadLink.getAttribute("href")).toEqual(firstFile.path);
     });
   });
 });

--- a/src/app/components/import-annotations/pages/details/details.component.spec.ts
+++ b/src/app/components/import-annotations/pages/details/details.component.spec.ts
@@ -75,7 +75,7 @@ describe("AnnotationsDetailsComponent", () => {
   let expectedFilesTable: any;
 
   const fileVerifyLinks = () => spec.queryAll(StrongRouteDirective);
-  const fileDownloadLinks = () => getElementByTextContent(spec, "Download");
+  const fileDownloadLink = () => getElementByTextContent(spec, "Download");
 
   const createComponent = createRoutingFactory({
     component: AnnotationImportDetailsComponent,
@@ -383,7 +383,7 @@ describe("AnnotationsDetailsComponent", () => {
     it("should have the correct download link", () => {
       // We only make an assertion over the first download link which will
       // correspond to the first file in the table.
-      const downloadLink = fileDownloadLinks();
+      const downloadLink = fileDownloadLink();
       const firstFile = mockAudioEventImportFiles[0];
 
       expect(downloadLink).toBeDefined();


### PR DESCRIPTION
# Fix annotation import file download link

## Changes

- Fixes external pointing annotation import file link to use `href` instead of internally pointing `bawUrl`
- Adds test for download button url

## Visual Changes

N.A.

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
