### PR TITLE
Fix duplicate verification requests

### DIFF
--- a/src/app/components/annotations/pages/verification/verification.component.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.ts
@@ -410,26 +410,18 @@ class VerificationComponent
 
     const verification = new Verification(verificationData, this.injector);
 
-    const apiRequest = this.trackPendingRequests(
+    this.trackPendingRequests(
       this.verificationApi.createOrUpdate(verification),
     );
-
-    // I use firstValueFrom so that the observable is evaluated
-    // but I don't have to subscribe or unsubscribe.
-    // Additionally, notice that the function is not awaited so that the
-    // render thread can continue to run while the request is being made
-    firstValueFrom(apiRequest);
   }
 
   private deleteVerificationDecision(subjectWrapper: SubjectWrapper): void {
     const audioEvent = subjectWrapper.subject as any as AudioEvent;
     const newTag = subjectWrapper.newTag as any;
 
-    const apiRequest = this.trackPendingRequests(
+    this.trackPendingRequests(
       this.verificationApi.destroyUserVerification(audioEvent, newTag),
     );
-
-    firstValueFrom(apiRequest);
   }
 
   /**

--- a/src/app/components/annotations/pages/verification/verification.component.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.ts
@@ -434,7 +434,7 @@ class VerificationComponent
     const annotation = subjectWrapper.subject as any as Annotation;
     const newTag = ((subjectWrapper.newTag as any).tag as Tag).id;
 
-    const apiRequest = this.trackPendingRequests(
+    this.trackPendingRequests(
       this.tagCorrections.create(annotation, newTag).pipe(
         map((correctTagging: Tagging) => {
           this.sessionTagCorrections.set(annotation.id, correctTagging);
@@ -442,8 +442,6 @@ class VerificationComponent
         }),
       ),
     );
-
-    firstValueFrom(apiRequest);
   }
 
   private deleteTagCorrectionDecision(
@@ -462,11 +460,9 @@ class VerificationComponent
       return;
     }
 
-    const apiRequest = this.trackPendingRequests(
+    this.trackPendingRequests(
       this.tagCorrections.destroy(annotation, tagToRemove.id),
     );
-
-    firstValueFrom(apiRequest);
   }
 
   // TODO: this function can be improved with instanceof checks once we export


### PR DESCRIPTION
# Fix duplicate verification requests

## Changes

- Fixes bug where a double `PUT /verification` request would be sent out for a verification decision

## Issues

Fixes: #2502

## Final Checklist

- [ ] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
