### PR TITLE
Don't emit initial empty filters from date/time filter component

### DIFF
--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.html
@@ -1,6 +1,6 @@
 <form #form="ngForm">
   <baw-date-time-filter
-    [(model)]="recordingDateTimeFilters"
+    [model]="recordingDateTimeFilters()"
     (modelChange)="updateRecordingDateTime($event)"
     [disableStartDate]="true"
     [disableStartTime]="true"

--- a/src/app/components/audio-recordings/pages/list/list.component.html
+++ b/src/app/components/audio-recordings/pages/list/list.component.html
@@ -11,7 +11,7 @@
     [region]="region"
     [site]="site"
     [constructedFilters]="filters$"
-  ></baw-date-time-filter>
+  />
 
   <ngx-datatable
     #table

--- a/src/app/components/shared/date-time-filter/date-time-filter.component.spec.ts
+++ b/src/app/components/shared/date-time-filter/date-time-filter.component.spec.ts
@@ -330,9 +330,6 @@ describe("AudioRecordingsFilter", () => {
       toggleDateFilters();
       toggleTimeOfDayFilters();
 
-      // there is a filter update event emitted when the component is initialized
-      // this is done for the batch downloading component which needs the initial filter state for its batch downloading script
-      // therefore, if the user has not input any filters, there should only be the initial filter update
       expect(filterChangeSpy).not.toHaveBeenCalled();
     }));
 

--- a/src/app/components/shared/date-time-filter/date-time-filter.component.spec.ts
+++ b/src/app/components/shared/date-time-filter/date-time-filter.component.spec.ts
@@ -323,13 +323,17 @@ describe("AudioRecordingsFilter", () => {
     }
 
     // date events where a filter update should not be emitted
-    it("should only emit one filter update event if the user hasn't input anything into the filter condition fields", fakeAsync(() => {
+    it("should not emit a filter update event if the user hasn't input anything into the filter condition fields", fakeAsync(() => {
+      // We act by opening the date and time of day filters so that we can
+      // assert that opening these accordion sections without inputting any
+      // values does not emit an update.
       toggleDateFilters();
       toggleTimeOfDayFilters();
+
       // there is a filter update event emitted when the component is initialized
       // this is done for the batch downloading component which needs the initial filter state for its batch downloading script
       // therefore, if the user has not input any filters, there should only be the initial filter update
-      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
+      expect(filterChangeSpy).not.toHaveBeenCalled();
     }));
 
     it("should not emit a filter update if the start date is a bad format", fakeAsync(() => {
@@ -337,21 +341,20 @@ describe("AudioRecordingsFilter", () => {
       // if this test is failing, the raw input from the input field is being passed to the date filter without its type being validated
       const malformedStartDate = "testing";
 
-      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
-
       toggleDateFilters();
       typeInElement(getDateStartedAfterInput(), malformedStartDate);
-      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
+
+      expect(filterChangeSpy).not.toHaveBeenCalled();
     }));
 
     it("should not emit a filter update if the end date is a bad format", fakeAsync(() => {
       // in this test, the day (12) and month (20) are swapped. It should not reformat the date or emit a filter update event in this case
       const malformedEndDate = "2021-20-12";
 
-      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
       toggleDateFilters();
       typeInElement(getDateStartedAfterInput(), malformedEndDate);
-      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
+
+      expect(filterChangeSpy).not.toHaveBeenCalled();
     }));
 
     it("should not emit a filter update if the dates are out of bounds", fakeAsync(() => {
@@ -359,12 +362,17 @@ describe("AudioRecordingsFilter", () => {
       const endDate = "2021-09-02";
 
       toggleDateFilters();
+
+      // After the start date is entered, we should see that a filter update is
+      // emitted. However, because we don't want the out of bounds date to emit
+      // a filter, we need to reset the spy calls after entering the start date.
       typeInElement(getDateStartedAfterInput(), startDate);
+      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
+      filterChangeSpy.calls.reset();
+
       typeInElement(getDateFinishedBeforeInput(), endDate);
 
-      // a filter change event would have been emitted once due to the correctly formatted and valid start date
-      // we therefore have to assert that two filter events didn't get emitted from the second date input (which is out of bounds)
-      expect(filterChangeSpy).toHaveBeenCalledTimes(2);
+      expect(filterChangeSpy).not.toHaveBeenCalled();
     }));
 
     // date filter update events
@@ -440,22 +448,19 @@ describe("AudioRecordingsFilter", () => {
     it("should not emit a filter update if the start time is a bad format", fakeAsync(() => {
       const startTime = "25:00";
 
-      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
       toggleTimeOfDayFilters();
       typeInElement(getTimeOfDayStartedAfterInput(), startTime);
 
-      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
+      expect(filterChangeSpy).not.toHaveBeenCalled();
     }));
 
     it("should not emit a filter update if the end time is a bad format", fakeAsync(() => {
       const endTime = "01:98";
 
-      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
-
       toggleTimeOfDayFilters();
       typeInElement(getTimeOfDayFinishedBeforeInput(), endTime);
 
-      expect(filterChangeSpy).toHaveBeenCalledTimes(1);
+      expect(filterChangeSpy).not.toHaveBeenCalled();
     }));
 
     it("should emit an empty filter update if the time condition is set, then unset", fakeAsync(() => {

--- a/src/app/components/shared/date-time-filter/date-time-filter.component.ts
+++ b/src/app/components/shared/date-time-filter/date-time-filter.component.ts
@@ -1,5 +1,4 @@
 import {
-  AfterContentChecked,
   AfterViewInit,
   Component,
   Input,
@@ -8,6 +7,7 @@ import {
   EventEmitter,
   Output,
   ChangeDetectionStrategy,
+  inject,
 } from "@angular/core";
 import { NgForm, FormsModule } from "@angular/forms";
 import { Filters, InnerFilter } from "@baw-api/baw-api.service";
@@ -59,11 +59,9 @@ export interface DateTimeFilterModel {
 })
 export class DateTimeFilterComponent
   extends withUnsubscribe()
-  implements AfterViewInit, AfterContentChecked
+  implements AfterViewInit
 {
-  public constructor(private changeDetector: ChangeDetectorRef) {
-    super();
-  }
+  private readonly changeDetector = inject(ChangeDetectorRef);
 
   @ViewChild(NgForm) public form: NgForm;
   @Input() public project: Project;
@@ -80,7 +78,7 @@ export class DateTimeFilterComponent
   @Output() public modelChange = new EventEmitter<DateTimeFilterModel>();
   @Input() public model: DateTimeFilterModel = { ignoreDaylightSavings: true };
 
-  private previousFilters: FromJS<Filters<AudioRecording>>;
+  private previousFilters: FromJS<Filters<AudioRecording>> = fromJS({});
 
   public ngAfterViewInit(): void {
     this.form.valueChanges
@@ -90,15 +88,6 @@ export class DateTimeFilterComponent
         takeUntil(this.unsubscribe)
       )
       .subscribe((model: DateTimeFilterModel) => this.emitFilterUpdate(model));
-  }
-
-  // TODO: Refactor the following hacky code block
-  // without this code block, the ExpressionChangedAfterItHasBeenCheckedError warning is thrown in development mode
-  public ngAfterContentChecked(): void {
-    // since we are using angular form validation & bootstrap validation, the errors attribute of the form is updated with change detection
-    // this causes the form state to update with change detection so we need to add an extra change detection cycle
-    // to ensure the updated form state (with errors) is a part of the model at end of change detection
-    this.changeDetector.detectChanges();
   }
 
   public emitFilterUpdate(model: DateTimeFilterModel): void {
@@ -133,10 +122,6 @@ export class DateTimeFilterComponent
     // to prevent duplicate filters from being emitted, we compare the new filter to the previous filter's value
     // e.g. if a user types in a valid filter condition, inputs an invalid filter condition, then inputs a valid filter condition
     const changed = !fromJS(newFilters)?.equals(previousFilters) && newFilters !== previousFilters;
-
-    if (Object.keys(newInnerFilters).length === 0) {
-      return [changed, newFilters];
-    }
 
     return [changed, newFilters];
   }

--- a/src/app/components/shared/date-time-filter/date-time-filter.component.ts
+++ b/src/app/components/shared/date-time-filter/date-time-filter.component.ts
@@ -3,11 +3,9 @@ import {
   Component,
   Input,
   ViewChild,
-  ChangeDetectorRef,
   EventEmitter,
   Output,
   ChangeDetectionStrategy,
-  inject,
 } from "@angular/core";
 import { NgForm, FormsModule } from "@angular/forms";
 import { Filters, InnerFilter } from "@baw-api/baw-api.service";
@@ -61,8 +59,6 @@ export class DateTimeFilterComponent
   extends withUnsubscribe()
   implements AfterViewInit
 {
-  private readonly changeDetector = inject(ChangeDetectorRef);
-
   @ViewChild(NgForm) public form: NgForm;
   @Input() public project: Project;
   @Input() public region: Region;


### PR DESCRIPTION
# Don't emit initial empty filters from date/time filter component

Do not emit an initial filter update from the date/time filter component if there are no filter conditions.

This was causing some components to update twice because the filter component would cause the filter conditions to update, even when nothing changed.

## Changes

- Fix annotation search page performing initial query twice

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
