### PR TITLE
Fix verification parameter model parsing url tags

### DIFF
--- a/src/app/components/annotations/components/modals/search-verification-filters/search-verification-filters.component.html
+++ b/src/app/components/annotations/components/modals/search-verification-filters/search-verification-filters.component.html
@@ -10,7 +10,10 @@
 
   <hr />
 
-  <baw-verification-form [(verificationParameters)]="verificationFormValue" />
+  <baw-verification-form
+    [(verificationParameters)]="verificationFormValue"
+    [searchParameters]="searchFormValue()"
+  />
 </div>
 
 <div class="modal-footer justify-content-end">

--- a/src/app/components/annotations/components/modals/verification-filters/verification-filters.component.html
+++ b/src/app/components/annotations/components/modals/verification-filters/verification-filters.component.html
@@ -3,7 +3,10 @@
 </div>
 
 <div class="filters-modal-body modal-body modal-large">
-  <baw-verification-form [(verificationParameters)]="formValue" />
+  <baw-verification-form
+    [(verificationParameters)]="formValue"
+    [searchParameters]="searchParameters()"
+  />
 </div>
 
 <div class="modal-footer justify-content-end">
@@ -15,11 +18,7 @@
     >
       Cancel
     </button>
-    <button
-      id="update-filters-btn"
-      class="btn btn-primary"
-      (click)="success()"
-    >
+    <button id="update-filters-btn" class="btn btn-primary" (click)="success()">
       Start Verification
     </button>
   </div>

--- a/src/app/components/annotations/components/modals/verification-filters/verification-filters.component.ts
+++ b/src/app/components/annotations/components/modals/verification-filters/verification-filters.component.ts
@@ -9,15 +9,18 @@ import { NgbActiveModal } from "@ng-bootstrap/ng-bootstrap";
 import { ModalComponent } from "@menu/widget.component";
 import { VerificationParameters } from "../../verification-form/verificationParameters";
 import { VerificationFormComponent } from "../../verification-form/verification-form.component";
+import { AnnotationSearchParameters } from "../../annotation-search-form/annotationSearchParameters";
+import { DatatablePaginationDirective } from "@directives/datatable/pagination/pagination.directive";
 
 @Component({
   selector: "baw-verification-filters-modal",
   templateUrl: "./verification-filters.component.html",
-  imports: [VerificationFormComponent],
+  imports: [VerificationFormComponent, DatatablePaginationDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class VerificationFiltersModalComponent implements ModalComponent {
   public readonly formValue = model.required<VerificationParameters>();
+  public readonly searchParameters = input.required<AnnotationSearchParameters>();
   public readonly modal = input<NgbActiveModal>();
 
   // TODO: Migrate this to a signal once we add support for signals to the

--- a/src/app/components/annotations/components/modals/verification-filters/verification-filters.component.ts
+++ b/src/app/components/annotations/components/modals/verification-filters/verification-filters.component.ts
@@ -10,12 +10,11 @@ import { ModalComponent } from "@menu/widget.component";
 import { VerificationParameters } from "../../verification-form/verificationParameters";
 import { VerificationFormComponent } from "../../verification-form/verification-form.component";
 import { AnnotationSearchParameters } from "../../annotation-search-form/annotationSearchParameters";
-import { DatatablePaginationDirective } from "@directives/datatable/pagination/pagination.directive";
 
 @Component({
   selector: "baw-verification-filters-modal",
   templateUrl: "./verification-filters.component.html",
-  imports: [VerificationFormComponent, DatatablePaginationDirective],
+  imports: [VerificationFormComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class VerificationFiltersModalComponent implements ModalComponent {

--- a/src/app/components/annotations/components/verification-form/verification-form.component.html
+++ b/src/app/components/annotations/components/verification-form/verification-form.component.html
@@ -3,8 +3,8 @@
     id="task-tag-input"
     label="Tag to Verify"
     [inputPlaceholder]="
-      verificationParameters().tagModels.length > 0
-        ? $any(verificationParameters().tagModels)
+      searchParameters().tagModels.length > 0
+        ? $any(searchParameters().tagModels)
         : 'First Tag'
     "
     [searchCallback]="tagsApi.typeaheadCallback()"

--- a/src/app/components/annotations/components/verification-form/verification-form.component.ts
+++ b/src/app/components/annotations/components/verification-form/verification-form.component.ts
@@ -1,7 +1,7 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   inject,
+  input,
   model,
   output,
 } from "@angular/core";
@@ -15,6 +15,7 @@ import { Tag } from "@models/Tag";
 import { FormsModule } from "@angular/forms";
 import { TagsService } from "@baw-api/tag/tags.service";
 import { NgbHighlight } from "@ng-bootstrap/ng-bootstrap";
+import { AnnotationSearchParameters } from "../annotation-search-form/annotationSearchParameters";
 import { TypeaheadInputComponent } from "../../../shared/typeahead-input/typeahead-input.component";
 import {
   TaskBehaviorKey,
@@ -22,6 +23,11 @@ import {
   VerificationStatusKey,
 } from "./verificationParameters";
 
+// This component cannot be OnPush because it uses associations which rely on
+// mutable state changes.
+//
+// TODO: Migrate this to OnPush when associations are refactored
+// see: https://github.com/QutEcoacoustics/workbench-client/issues/2148
 @Component({
   selector: "baw-verification-form",
   templateUrl: "./verification-form.component.html",
@@ -31,11 +37,11 @@ import {
     SelectableItemsComponent,
     NgbHighlight,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class VerificationFormComponent {
   protected readonly tagsApi = inject(TagsService);
 
+  public readonly searchParameters = input.required<AnnotationSearchParameters>();
   public readonly verificationParameters = model.required<VerificationParameters>();
   public readonly verificationParametersChange = output<VerificationParameters>();
 

--- a/src/app/components/annotations/components/verification-form/verificationParameters.ts
+++ b/src/app/components/annotations/components/verification-form/verificationParameters.ts
@@ -1,6 +1,5 @@
 import { Params } from "@angular/router";
 import { TAG } from "@baw-api/ServiceTokens";
-import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import {
   IQueryStringParameterSpec,
   jsNumber,
@@ -8,7 +7,7 @@ import {
   serializeObjectToParams,
   withDefault,
 } from "@helpers/query-string-parameters/queryStringParameters";
-import { CollectionIds, Id } from "@interfaces/apiInterfaces";
+import { Id } from "@interfaces/apiInterfaces";
 import { hasOne } from "@models/AssociationDecorators";
 import { AudioEvent } from "@models/AudioEvent";
 import { IParameterModel, ParameterModel } from "@models/data/parametersModel";
@@ -52,21 +51,6 @@ export class VerificationParameters
     public injector?: AssociationInjector,
   ) {
     super(queryStringParameters);
-  }
-
-  // We cannot use a set here because we use the index of tags as the priority.
-  // Meaning that if we used a set, we could not use indexOf to find the
-  // priority of a tag.
-  // While we could convert to an Array for the indexOf call, I'd like to
-  // convert as early as possible so we don't have types changing depending on
-  // the context.
-  public tagPriority(searchTags: CollectionIds<Tag>): Id<Tag>[] {
-    if (isInstantiated(this.taskTag)) {
-      const uniqueIds = new Set([this.taskTag, ...searchTags]);
-      return Array.from(uniqueIds);
-    }
-
-    return Array.from(searchTags);
   }
 
   @hasOne(TAG, "taskTag")

--- a/src/app/components/annotations/components/verification-search-form/verificationSearchParameters.spec.ts
+++ b/src/app/components/annotations/components/verification-search-form/verificationSearchParameters.spec.ts
@@ -1,38 +1,8 @@
-import { Params } from "@angular/router";
-import { User } from "@models/User";
-import { generateUser } from "@test/fakes/User";
 import { VerificationParameters } from "../verification-form/verificationParameters";
 
 describe("VerificationSearchParameters", () => {
-  let mockUser: User;
-
-  function createParameterModel(params?: Params): VerificationParameters {
-    mockUser = new User(generateUser({ id: 42 }));
-    return new VerificationParameters(params, mockUser);
-  }
-
   it("should create", () => {
     const dataModel = new VerificationParameters();
     expect(dataModel).toBeInstanceOf(VerificationParameters);
-  });
-
-  describe("tag priority", () => {
-    it("should handle an empty array of tags", () => {
-      const dataModel = createParameterModel();
-      const realizedResult = dataModel.tagPriority;
-      expect(realizedResult).toEqual([]);
-    });
-
-    it("should handle an array of tags with no task tag", () => {
-      const dataModel = createParameterModel({ tags: "1,2,3,4" });
-      const realizedResult = dataModel.tagPriority;
-      expect(realizedResult).toEqual([1, 2, 3, 4]);
-    });
-
-    it("should handle an array of tags with a task tag", () => {
-      const dataModel = createParameterModel({ tags: "1,2,3,4", taskTag: "3" });
-      const realizedResult = dataModel.tagPriority;
-      expect(realizedResult).toEqual([3, 1, 2, 4]);
-    });
   });
 });

--- a/src/app/components/annotations/pages/search/search.component.html
+++ b/src/app/components/annotations/pages/search/search.component.html
@@ -76,6 +76,7 @@
   <baw-verification-filters-modal
     [modal]="filtersModal"
     [formValue]="verificationParameters()"
+    [searchParameters]="searchParameters()"
     [successCallback]="navigateToVerificationGrid.bind(this)"
   />
 </ng-template>

--- a/src/app/components/annotations/pages/search/search.component.ts
+++ b/src/app/components/annotations/pages/search/search.component.ts
@@ -88,13 +88,12 @@ class AnnotationSearchComponent
 
         const results = await Promise.all(
           newResults.map(
-            async (result) =>
-              await annotationService.show(
-                result,
-                this.verificationParameters().tagPriority(
-                  this.searchParameters().tags ?? [],
-                ),
-              ),
+            async (result) => {
+              // Because the ordering of the "tags" property is not important on
+              // the annotation search page, we do not need to provide any
+              // priority tag ids.
+              return await annotationService.show(result);
+            },
           ),
         );
 

--- a/src/app/components/annotations/pages/search/search.component.ts
+++ b/src/app/components/annotations/pages/search/search.component.ts
@@ -91,7 +91,9 @@ class AnnotationSearchComponent
             async (result) =>
               await annotationService.show(
                 result,
-                this.verificationParameters().tagPriority,
+                this.verificationParameters().tagPriority(
+                  this.searchParameters().tags ?? [],
+                ),
               ),
           ),
         );

--- a/src/app/components/annotations/pages/verification/verification.component.html
+++ b/src/app/components/annotations/pages/verification/verification.component.html
@@ -14,7 +14,7 @@
           [ngbTooltip]="'Shortcut keys are disabled because the verification grid has lost focus. Select a verification grid tile to enable shortcut keys.'"
           [icon]="['fas', 'triangle-exclamation']"
           class="inline text-warning"
-        ></fa-icon>
+        />
       } Annotation Verification
     </h2>
   </div>
@@ -49,18 +49,18 @@
 >
   <template>
     <div class="tile-spacing">
-      <oe-subject-tag></oe-subject-tag>
-      <oe-media-controls for="spectrogram"></oe-media-controls>
+      <oe-subject-tag />
+      <oe-media-controls for="spectrogram" />
     </div>
 
     <oe-axes>
       <oe-indicator>
-        <oe-spectrogram id="spectrogram" color-map="grayscale"></oe-spectrogram>
+        <oe-spectrogram id="spectrogram" color-map="grayscale" />
       </oe-indicator>
     </oe-axes>
 
     <div class="tile-block">
-      <oe-task-meter></oe-task-meter>
+      <oe-task-meter />
       <baw-grid-tile-content />
     </div>
   </template>
@@ -71,21 +71,21 @@
     shortcut="Y"
     (focus)="verificationGridFocused.set(true)"
     (blur)="verificationGridFocused.set(false)"
-  ></oe-verification>
+  />
   <oe-verification
     #verificationDecision
     verified="false"
     shortcut="N"
     (focus)="verificationGridFocused.set(true)"
     (blur)="verificationGridFocused.set(false)"
-  ></oe-verification>
+  />
   <oe-verification
     #verificationDecision
     verified="unsure"
     shortcut="U"
     (focus)="verificationGridFocused.set(true)"
     (blur)="verificationGridFocused.set(false)"
-  ></oe-verification>
+  />
 
   @if (hasCorrectionTask()) {
     <oe-tag-prompt

--- a/src/app/components/annotations/pages/verification/verification.component.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.ts
@@ -21,7 +21,6 @@ import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
 import { ActivatedRoute, Router } from "@angular/router";
-import { Location } from "@angular/common";
 import { firstValueFrom, map, Observable } from "rxjs";
 import { annotationMenuItems } from "@components/annotations/annotation.menu";
 import { Filters, Paging, Sorting } from "@baw-api/baw-api.service";
@@ -127,7 +126,6 @@ class VerificationComponent
   private readonly modals = inject(NgbModal);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
-  private readonly location = inject(Location);
   private readonly config = inject(ConfigService);
   private readonly injector: AssociationInjector = inject(ASSOCIATION_INJECTOR);
 

--- a/src/app/components/annotations/pages/verification/verification.component.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.ts
@@ -164,8 +164,11 @@ class VerificationComponent
   );
 
   protected readonly verificationGridFocused = signal(true);
-  protected readonly hasCorrectionTask = signal(false);
   private readonly doneInitialScroll = signal(false);
+  protected readonly hasCorrectionTask = computed(
+    () =>
+      this.verificationParameters().taskBehavior === "verify-and-correct-tag",
+  );
 
   protected readonly project = signal<Project | null>(null);
   protected readonly region = signal<Region | null>(null);
@@ -214,10 +217,6 @@ class VerificationComponent
       newModel.injector = this.injector;
       return newModel;
     });
-
-    this.hasCorrectionTask.set(
-      this.verificationParameters().taskBehavior === "verify-and-correct-tag",
-    );
   }
 
   public ngAfterViewInit(): void {
@@ -294,7 +293,9 @@ class VerificationComponent
         items.map((item) =>
           this.annotationsService.show(
             item,
-            this.verificationParameters().tagPriority,
+            this.verificationParameters().tagPriority(
+              this.searchParameters().tags ?? [],
+            ),
           ),
         ),
       );
@@ -316,10 +317,6 @@ class VerificationComponent
     this.verificationGridElement().nativeElement.getPage =
       this.getPageCallback();
     this.updateUrlParameters();
-
-    this.hasCorrectionTask.set(
-      this.verificationParameters().taskBehavior === "verify-and-correct-tag",
-    );
   }
 
   protected handleDecision(decisionEvent: Event): void {
@@ -519,8 +516,7 @@ class VerificationComponent
       verificationParameters,
     );
 
-    const urlTree = this.router.createUrlTree([], { queryParams });
-    this.location.replaceState(urlTree.toString());
+    this.router.navigate([], { queryParams });
   }
 
   private tagSearchCallback(): TypeaheadCallback<any> {

--- a/src/app/components/annotations/pages/verification/verification.component.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.ts
@@ -163,11 +163,8 @@ class VerificationComponent
   );
 
   protected readonly verificationGridFocused = signal(true);
+  protected readonly hasCorrectionTask = signal(false);
   private readonly doneInitialScroll = signal(false);
-  protected readonly hasCorrectionTask = computed(
-    () =>
-      this.verificationParameters().taskBehavior === "verify-and-correct-tag",
-  );
 
   protected readonly project = signal<Project | null>(null);
   protected readonly region = signal<Region | null>(null);
@@ -216,6 +213,10 @@ class VerificationComponent
       newModel.injector = this.injector;
       return newModel;
     });
+
+    this.hasCorrectionTask.set(
+      this.verificationParameters().taskBehavior === "verify-and-correct-tag",
+    );
   }
 
   public ngAfterViewInit(): void {
@@ -314,6 +315,10 @@ class VerificationComponent
     this.verificationGridElement().nativeElement.getPage =
       this.getPageCallback();
     this.updateUrlParameters();
+
+    this.hasCorrectionTask.set(
+      this.verificationParameters().taskBehavior === "verify-and-correct-tag",
+    );
   }
 
   protected handleDecision(decisionEvent: Event): void {

--- a/src/app/components/annotations/pages/verification/verification.component.ts
+++ b/src/app/components/annotations/pages/verification/verification.component.ts
@@ -65,6 +65,8 @@ import { ScrollService } from "@services/scroll/scroll.service";
 import { Annotation } from "@models/data/Annotation";
 import { PageFetcherContext } from "@ecoacoustics/web-components/@types/services/gridPageFetcher/gridPageFetcher";
 import { ConfigService } from "@services/config/config.service";
+import { mergeParameters } from "@helpers/parameters/merge";
+import { isInstantiated } from "@helpers/isInstantiated/isInstantiated";
 import { Id } from "@interfaces/apiInterfaces";
 import { AnnotationSearchParameters } from "@components/annotations/components/annotation-search-form/annotationSearchParameters";
 import { VerificationParameters } from "@components/annotations/components/verification-form/verificationParameters";
@@ -73,7 +75,6 @@ import { filterAnd } from "@helpers/filters/filters";
 import {
   SearchVerificationFiltersModalComponent,
 } from "@components/annotations/components/modals/search-verification-filters/search-verification-filters.component";
-import { mergeParameters } from "@helpers/parameters/merge";
 
 interface PagingContext extends PageFetcherContext {
   page: number;
@@ -293,9 +294,7 @@ class VerificationComponent
         items.map((item) =>
           this.annotationsService.show(
             item,
-            this.verificationParameters().tagPriority(
-              this.searchParameters().tags ?? [],
-            ),
+            this.tagPriority(),
           ),
         ),
       );
@@ -387,6 +386,23 @@ class VerificationComponent
         }
       }
     }
+  }
+
+  /**
+   * @description
+   * An ordered array of tag IDs representing what tags should be prioritized
+   * when displaying the tag that is being verified.
+   */
+  private tagPriority(): Id<Tag>[] {
+    const taskTag = this.verificationParameters().taskTag;
+    const searchTags = this.searchParameters().tags ?? [];
+
+    if (isInstantiated(taskTag)) {
+      const uniqueIds = new Set([taskTag, ...searchTags]);
+      return Array.from(uniqueIds);
+    }
+
+    return Array.from(searchTags);
   }
 
   private handleVerificationDecision(subjectWrapper: SubjectWrapper): void {

--- a/src/app/services/models/annotations/annotation.service.spec.ts
+++ b/src/app/services/models/annotations/annotation.service.spec.ts
@@ -108,13 +108,13 @@ describe("AnnotationService", () => {
   });
 
   describe("tag priority", () => {
-    it("should order an array of tags correctly", async () => {
+    fit("should order an array of tags correctly", async () => {
       // Although we are filtering by 4 tags (1,2,3,4), we have explicitly
       // specified that we want to verify tag 3.
       // Therefore, when the tags are ordered from highest priority to lowest,
       // we should see that tag 3 is preferred.
-      const dataModel = new VerificationParameters({
-        tags: "1,2,3,4",
+      const filteredTags = [1, 2, 3, 4];
+      const verificationParameters = new VerificationParameters({
         taskTag: "3",
       });
 
@@ -148,8 +148,9 @@ describe("AnnotationService", () => {
       // Note that the sorting algorithm is stable.
       // Meaning that relative order is maintained for the filtered tags.
       const expectedIds = [3, 1, 2, 4, 6, 8, 7, 5];
+      const tagPriority = [ verificationParameters.taskTag, ...filteredTags];
 
-      const realizedResult = await spec.service.show(testedEvent, dataModel.tagPriority);
+      const realizedResult = await spec.service.show(testedEvent, tagPriority);
       const realizedIds = realizedResult.tags.map((tag) => tag.id);
 
       expect(realizedIds).toEqual(expectedIds);

--- a/src/app/services/models/annotations/annotation.service.spec.ts
+++ b/src/app/services/models/annotations/annotation.service.spec.ts
@@ -108,7 +108,7 @@ describe("AnnotationService", () => {
   });
 
   describe("tag priority", () => {
-    fit("should order an array of tags correctly", async () => {
+    it("should order an array of tags correctly", async () => {
       // Although we are filtering by 4 tags (1,2,3,4), we have explicitly
       // specified that we want to verify tag 3.
       // Therefore, when the tags are ordered from highest priority to lowest,

--- a/src/app/services/models/annotations/annotation.service.ts
+++ b/src/app/services/models/annotations/annotation.service.ts
@@ -16,7 +16,7 @@ export class AnnotationService {
   private readonly tagsApi = inject(TagsService);
   private readonly audioRecordingsApi = inject(AudioRecordingsService);
 
-  public async show(audioEvent: AudioEvent, priorityTags: Id<Tag>[]): Promise<Annotation> {
+  public async show(audioEvent: AudioEvent, priorityTags: Id<Tag>[] = []): Promise<Annotation> {
     const audioRecording = await this.showAudioRecording(audioEvent);
     const audioEventTags = await this.showTags(audioEvent);
 


### PR DESCRIPTION
# Fix verification parameter model parsing url tags

What is the purpose of this PR?

## Changes

- Removes `tags` from verification parameter model so that there is only one source of truth for the filtered tags (now `annotationSearchParameters`)
- Refactors `tagPriority` into a `verification.component` method so that the parameter models can work independently and without knowledge of the other
- Changes verification search form component change detection strategy from `OnPush` to `Default` so that associations can resolve in the template
- Adds `searchFilters` to verification form component so that it can use the `searchFilters().tagModels` as the "tags to verify" placeholder value

## Issues

Fixes: #2512

## Visual Changes

If the PR has any visual changes to the website, post pictures of the new pages and how they look. Label any images if more than one is given.

## Final Checklist

- [ ] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
