### PR TITLE
Improve search page re-filtering performance

### DIFF
--- a/src/app/components/annotations/pages/search/search.component.html
+++ b/src/app/components/annotations/pages/search/search.component.html
@@ -34,7 +34,32 @@
   @if (!error) {
     @if (loading) {
       <baw-loading />
-    } @else {
+    }
+
+    <!--
+      We use a "hidden" attribute instead of using an if condition so that when
+      the user changes the search parameters, the previous card components and
+      spectrograms are hidden instead of removed/destroyed from the DOM.
+
+      I have done this because creating a new card component including a
+      spectrogram, axes, indicator, etc... is quite an expensive operation.
+      More expensive than just visibly hiding/showing the components because
+      it has to re-initialize and spin create new web workers.
+
+      Because we know it's likely that the user will see new results once we
+      loading completes, we optimistically preserve same spectrogram components
+      for re-use by re-showing the same card components and updating their
+      inputs once loading completes.
+
+      I use the "hidden" attribute instead of using CSS display: none because:
+      1. It is more semantically correct
+      2. It helps with accessibility because screen readers will ignore this
+         content while the new data is being fetched.
+      3. It does not remove the element from the browsers compositor, meaning
+         that we should (in theory) have slightly better performance when
+         re-displaying the elements. (although I have not measured this).
+    -->
+    <div [hidden]="loading">
       <p>
         Displaying
         <span class="fw-bold">{{ searchResults().length }}</span> of
@@ -46,7 +71,29 @@
         <h2 class="no-results-error">No annotations found</h2>
       } @else {
         <div class="annotations-grid my-2">
-          @for (annotationModel of searchResults(); track annotationModel.id) {
+          <!--
+            We track by index instead of something more descriptive like the
+            annotation ID because it's unlikely that the user will see the same
+            annotation twice when they are paginating through results, meaning
+            that we would not get much performance benefit from tracking by ID.
+
+            Additionally, tracking by index is actually faster because it stops
+            Angular from destroying old card elements and creating new ones for
+            new annotations. We don't want to do this because creating new card
+            components is an expensive operation because destroying and
+            re-creating the spectrogram component involves destroying & spinning
+            up new web workers.
+
+            By tracking by index, we lose a bit of potential performance when
+            seeing the same annotation twice (which is unlikely), in the trade
+            off of being able to re-use the same card components.
+
+            You might be seeing warnings in the console because Angular thinks
+            this is an anti-pattern (which it usually is). However, in this
+            specific use case, I have measured it to be the best performing
+            option.
+          -->
+          @for (annotationModel of searchResults(); track $index) {
             <baw-annotation-event-card [annotation]="annotationModel" />
           }
         </div>
@@ -59,7 +106,7 @@
           [(page)]="page"
         />
       }
-    }
+    </div>
   } @else {
     <baw-error-handler [error]="error" />
   }

--- a/src/app/components/annotations/pages/search/search.component.spec.ts
+++ b/src/app/components/annotations/pages/search/search.component.spec.ts
@@ -43,6 +43,7 @@ import { AnnotationSearchParameters } from "@components/annotations/components/a
 import { VerificationParameters, VerificationStatusKey } from "@components/annotations/components/verification-form/verificationParameters";
 import { BawSessionService } from "@baw-api/baw-session.service";
 import { AnnotationSearchComponent } from "./search.component";
+import { generateMeta } from "@test/fakes/Meta";
 
 describe("AnnotationSearchComponent", () => {
   const responsePageSize = 24;
@@ -316,7 +317,7 @@ describe("AnnotationSearchComponent", () => {
       spec.detectChanges();
 
       const element = getElementByTextContent(spec, expectedText);
-      expect(element).toExist();
+      expect(element).toBeVisible();
     });
 
     it("should not display an error if the search results are still loading", () => {
@@ -327,7 +328,7 @@ describe("AnnotationSearchComponent", () => {
       spec.detectChanges();
 
       const element = getElementByTextContent(spec, expectedText);
-      expect(element).not.toExist();
+      expect(element).toBeHidden();
     });
 
     it("should display a page of search results", () => {
@@ -336,6 +337,42 @@ describe("AnnotationSearchComponent", () => {
       const expectedResults = mockAudioEventsResponse.length;
       const realizedResults = spectrogramElements().length;
       expect(realizedResults).toEqual(expectedResults);
+    });
+
+    it("should re-use the event cards when search results are updated", () => {
+      spec.detectChanges();
+
+      const initialSpectrogram = spectrogramElements()[0];
+
+      // We override the returned audio events to make this test harder to pass
+      // because we can't track by anything on the audio event since it would
+      // have changed.
+      mockAudioEventsResponse = modelData.randomArray(
+        responsePageSize,
+        responsePageSize,
+        () => {
+          // generateAudioEvent() uses our modelData.id iterator which ensures
+          // that each generated audio event has a unique ID.
+          // Therefore, there is no risk of this being a flaky test because each
+          // id will always be unique.
+          const model = new AudioEvent(generateAudioEvent(), injector);
+          model.addMetadata(generateMeta());
+
+          return model;
+        },
+      );
+
+      // By changing the "verification status" filter, we should re-enter a
+      // loading state, but should not have destroyed the spectrograms elements.
+      clickVerificationStatusFilter("unverified-for-me");
+      spec.detectChanges();
+
+      const updatedSpectrogram = spectrogramElements()[0];
+
+      // We use a toBe comparison here so that we compare the spectrogram
+      // elements by reference instead of by value.
+      // If the reference is the same, then we know the elements were reused.
+      expect(updatedSpectrogram).toBe(initialSpectrogram);
     });
 
     xit("should have a disabled 'verify' button if there are no search results", () => {

--- a/src/app/components/annotations/pages/search/search.component.spec.ts
+++ b/src/app/components/annotations/pages/search/search.component.spec.ts
@@ -41,9 +41,9 @@ import { ShallowSitesService } from "@baw-api/site/sites.service";
 import { exampleBase64 } from "src/test-assets/example-0.5s.base64";
 import { AnnotationSearchParameters } from "@components/annotations/components/annotation-search-form/annotationSearchParameters";
 import { VerificationParameters, VerificationStatusKey } from "@components/annotations/components/verification-form/verificationParameters";
+import { generateMeta } from "@test/fakes/Meta";
 import { BawSessionService } from "@baw-api/baw-session.service";
 import { AnnotationSearchComponent } from "./search.component";
-import { generateMeta } from "@test/fakes/Meta";
 
 describe("AnnotationSearchComponent", () => {
   const responsePageSize = 24;


### PR DESCRIPTION
# Improve search page re-filtering performance

We used to conditionally render the event cards on the annotation search page depending on if we were in a `loading` state.

However, this caused the event cards to be destroyed every time we entered the loading state (e.g. from changing the search filters).

Instead of using an `if` block, we now use a html `hidden` attribute to conditionally show/hide the same event card element references, but change the event-card `model` attribute.

---

Note: This does **NOT** fix the reflow issues caused by the media controls component on first load, however, it does remove the reflow caused by the media controls when changing the search conditions.

## Changes

- Do not destroy event cards when entering a `loading` state on the annotation search page

## Issues

Fixes: #2519

## Performance benchmarks

<img width="1685" height="861" alt="image" src="https://github.com/user-attachments/assets/8bdcd1a2-8413-48d5-a992-b05f4573ef5e" />

_Refiltering before change_

---

<img width="1685" height="861" alt="image" src="https://github.com/user-attachments/assets/3c9b237a-7551-4064-9177-f6088f7039c8" />

_Refiltering after change_

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
