### PR TITLE
Do not debounce initial typeahead focus query

### DIFF
--- a/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
+++ b/src/app/components/annotations/components/annotation-search-form/annotation-search-form.component.ts
@@ -102,8 +102,8 @@ export class AnnotationSearchFormComponent implements OnInit {
 
   protected readonly recordingDateTimeFilters = signal<DateTimeFilterModel>({});
   protected readonly hideAdvancedFilters = signal(true);
-  protected createSearchCallback = createSearchCallback;
-  protected createIdSearchCallback = createIdSearchCallback;
+  protected readonly createSearchCallback = createSearchCallback;
+  protected readonly createIdSearchCallback = createIdSearchCallback;
 
   protected scoreRangeBounds = ScoreRangeBounds;
   protected verifiedStatusOptions = signal<

--- a/src/app/components/shared/typeahead-input/typeahead-input.component.spec.ts
+++ b/src/app/components/shared/typeahead-input/typeahead-input.component.spec.ts
@@ -263,6 +263,18 @@ describe("TypeaheadInputComponent", () => {
     expect(dropdownItems).toHaveLength(0);
   }));
 
+  it("should not debounce on the initial focus event", fakeAsync(() => {
+    spec.component.searchCallback = () => of(defaultFakeSites);
+    spec.detectChanges();
+
+    // Note that we don't tick or flush the async queue here because we should
+    // see that the focus events results are immediate and not debounced.
+    spec.focus(inputBox());
+
+    const dropdownItems = dropdownOptions();
+    expect(dropdownItems).toHaveLength(defaultFakeSites.length);
+  }));
+
   describe("single input mode", () => {
     beforeEach(() => {
       spec.component.multipleInputs = false;

--- a/src/app/helpers/typeahead/typeaheadCallbacks.spec.ts
+++ b/src/app/helpers/typeahead/typeaheadCallbacks.spec.ts
@@ -1,10 +1,10 @@
 import { firstValueFrom, of } from "rxjs";
 import { modelData } from "@test/helpers/faker";
 import { Tag } from "@models/Tag";
-import { createItemSearchCallback, createSearchCallback } from "./typeaheadCallbacks";
 import { generateTag } from "@test/fakes/Tag";
 import { InnerFilter, Projection } from "@baw-api/baw-api.service";
 import { TagsService } from "@baw-api/tag/tags.service";
+import { createItemSearchCallback, createSearchCallback } from "./typeaheadCallbacks";
 
 describe("typeaheadCallbacks", () => {
   describe("createSearchCallback", () => {

--- a/src/app/helpers/typeahead/typeaheadCallbacks.spec.ts
+++ b/src/app/helpers/typeahead/typeaheadCallbacks.spec.ts
@@ -1,8 +1,8 @@
 import { firstValueFrom, of } from "rxjs";
 import { modelData } from "@test/helpers/faker";
 import { Tag } from "@models/Tag";
-import { generateTag } from "@test/fakes/Tag";
 import { createItemSearchCallback, createSearchCallback } from "./typeaheadCallbacks";
+import { generateTag } from "@test/fakes/Tag";
 import { InnerFilter, Projection } from "@baw-api/baw-api.service";
 import { TagsService } from "@baw-api/tag/tags.service";
 

--- a/src/app/helpers/typeahead/typeaheadCallbacks.ts
+++ b/src/app/helpers/typeahead/typeaheadCallbacks.ts
@@ -2,8 +2,8 @@ import { ApiFilter } from "@baw-api/api-common";
 import { AbstractModelWithoutId } from "@models/AbstractModel";
 import { contains, filterAnd, notIn } from "@helpers/filters/filters";
 import { Observable, of } from "rxjs";
-import { InnerFilter } from "@baw-api/baw-api.service";
-import { TypeaheadSearchCallback } from "../../components/shared/typeahead-input/typeahead-input.component";
+import { InnerFilter, Projection } from "@baw-api/baw-api.service";
+import { TypeaheadInputComponent, TypeaheadSearchCallback } from "../../components/shared/typeahead-input/typeahead-input.component";
 
 // create a callback that can be used to filter for items in a typeahead
 // TODO: Places that use this helper should be replaced with a service method
@@ -12,7 +12,8 @@ import { TypeaheadSearchCallback } from "../../components/shared/typeahead-input
 export function createSearchCallback<T extends AbstractModelWithoutId>(
   api: ApiFilter<T>,
   key: keyof T,
-  filters: InnerFilter<T> = {}
+  filters: InnerFilter<T> = {},
+  projection?: Projection<T>,
 ): TypeaheadSearchCallback<T> {
   return (text: any, activeItems: T[]): Observable<T[]> =>
     api.filter({
@@ -23,6 +24,8 @@ export function createSearchCallback<T extends AbstractModelWithoutId>(
         // selected
         notIn<T>(key, activeItems)
       ),
+      paging: { items: TypeaheadInputComponent.maximumResults },
+      projection,
     });
 }
 
@@ -30,7 +33,8 @@ export function createSearchCallback<T extends AbstractModelWithoutId>(
 export function createIdSearchCallback<T extends AbstractModelWithoutId>(
   api: ApiFilter<T>,
   key: keyof T,
-  filters: InnerFilter<T> = {}
+  filters: InnerFilter<T> = {},
+  projection?: Projection<T>,
 ): TypeaheadSearchCallback<T> {
   return (text: any): Observable<T[]> => {
     const id = Number(text);
@@ -40,6 +44,8 @@ export function createIdSearchCallback<T extends AbstractModelWithoutId>(
 
     return api.filter({
       filter: filterAnd({ [key]: { eq: id } } as any, filters),
+      paging: { items: TypeaheadInputComponent.maximumResults },
+      projection,
     });
   };
 }
@@ -51,7 +57,7 @@ export function createIdSearchCallback<T extends AbstractModelWithoutId>(
 export function createItemSearchCallback<T>(
   items: T[]
 ): TypeaheadSearchCallback<T> {
-  const maxResults = 10;
+  const maxResults = TypeaheadInputComponent.maximumResults;
   return (searchTerm: string) => {
     const filteredItems = items.filter((item) => {
       const itemText = item.toString().toLowerCase();

--- a/src/app/services/baw-api/baw-api.service.ts
+++ b/src/app/services/baw-api/baw-api.service.ts
@@ -1100,6 +1100,21 @@ export type InnerFilter<Model = unknown> = Combinations<Writeable<Model>> &
   };
 
 /**
+ * @description
+ * A partial body that can be used to include or exclude keys from an API
+ * response.
+ */
+export interface Projection<
+  Model = unknown,
+  K extends keyof Model = keyof Model,
+> {
+  /** Include keys in response */
+  include?: K[];
+  /** Exclude keys from response */
+  exclude?: K[];
+}
+
+/**
  * Filter metadata from api response
  * https://github.com/QutEcoacoustics/baw-server/wiki/API:-Filtering
  */
@@ -1107,12 +1122,7 @@ export interface Filters<Model = unknown, K extends keyof Model = keyof Model> {
   /** Filter settings */
   filter?: InnerFilter<Writeable<Model>>;
   /** Include or exclude keys from response */
-  projection?: {
-    /** Include keys in response */
-    include?: K[];
-    /** Exclude keys from response */
-    exclude?: K[];
-  };
+  projection?: Projection<Model>;
   /** Current sorting options */
   sorting?: Sorting<K>;
   /** Current page data */

--- a/src/app/services/baw-api/tag/tags.service.ts
+++ b/src/app/services/baw-api/tag/tags.service.ts
@@ -77,7 +77,9 @@ export class TagsService implements StandardApi<Tag> {
   }
 
   public typeaheadCallback(): TypeaheadSearchCallback<Tag> {
-    return createSearchCallback(this, "text");
+    return createSearchCallback(this, "text", {}, {
+      include: ["id", "text"],
+    });
   }
 
   /**


### PR DESCRIPTION
# Do not debounce initial typeahead focus query

When a user focuses the typeahead input, we perform an initial query to show results.

However, this initial query was debounced, meaning that there was a noticeable 200ms delay for these first results to be shown.
Additionally, because this isn't a `input` event, we weren't getting much benefit from the debounce, because it's unlikely that the user is going to focus & defocus this input in less than 200ms enough times to create load problems in the server.

## Changes

- Only debounce the `$text` typeahead observable
- Use paging filters to reduce the number of results returned by typeaheads from 25 items to the required 10
- Add a `projection` option to the `createSearchCallback` helper
- Adds tests for the `typeaheadCallbacks.ts` helpers

## Issues

Fixes: #2486

## Visual Changes

[Screencast from 2025-11-19 10-55-53.webm](https://github.com/user-attachments/assets/35e5c6cf-e167-405c-bfc7-bf905af2553c)

_Before changes_

---

[Screencast from 2025-11-19 10-54-59.webm](https://github.com/user-attachments/assets/0f0f5c0b-b2b5-4554-8b07-cbfa67fdbd51)

_After changes_

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
