### PR TITLE
Add support for new projection fields

### DIFF
--- a/src/app/services/baw-api/baw-api.service.ts
+++ b/src/app/services/baw-api/baw-api.service.ts
@@ -1099,6 +1099,9 @@ export type InnerFilter<Model = unknown> = Combinations<Writeable<Model>> &
       Subsets;
   };
 
+/**
+ * @see https://github.com/QutEcoacoustics/baw-server/wiki/API:-Spec#projection-for-resource
+ */
 interface NewProjection<Model = unknown, K extends keyof Model = keyof Model> {
   /**
    * The `only` parameter specifies the base set of keys to include.
@@ -1111,18 +1114,19 @@ interface NewProjection<Model = unknown, K extends keyof Model = keyof Model> {
   only?: K[];
 
   /**
-   * All default keys not filtered out by `remove` will be included in the
-   * response along with any non-default keys specified by `add`.
+   * Adds additional fields to the projection, on top of the default/only fields
    */
   add?: K[];
 
   /**
-   * Exclude the following keys from the response.
-   * All other non-matching keys will be included.
+   * remove the following fields from the set default/only+add fields
    */
   remove?: K[];
 }
 
+/**
+ * @see https://github.com/QutEcoacoustics/baw-server/wiki/API:-Spec#projection-for-resource
+ */
 interface OldProjection<Model = unknown, K extends keyof Model = keyof Model> {
   /** Include keys in response */
   include?: K[];
@@ -1135,6 +1139,8 @@ interface OldProjection<Model = unknown, K extends keyof Model = keyof Model> {
  * @description
  * A partial body that can be used to include or exclude keys from an API
  * response.
+ *
+ * @see https://github.com/QutEcoacoustics/baw-server/wiki/API:-Spec#projection-for-resource
  */
 export type Projection<Model = unknown> = XOR<
   OldProjection<Model>,

--- a/src/app/services/baw-api/baw-api.service.ts
+++ b/src/app/services/baw-api/baw-api.service.ts
@@ -1099,20 +1099,47 @@ export type InnerFilter<Model = unknown> = Combinations<Writeable<Model>> &
       Subsets;
   };
 
+interface NewProjection<Model = unknown, K extends keyof Model = keyof Model> {
+  /**
+   * The `only` parameter specifies the base set of keys to include.
+   * This means that `add` and `remove` operations will be performed on top of
+   * the keys specified in `only`.
+   *
+   * If `add` and `remove` are not specified, only the keys in `only` field will
+   * be included in the response.
+   */
+  only?: K[];
+
+  /**
+   * All default keys not filtered out by `remove` will be included in the
+   * response along with any non-default keys specified by `add`.
+   */
+  add?: K[];
+
+  /**
+   * Exclude the following keys from the response.
+   * All other non-matching keys will be included.
+   */
+  remove?: K[];
+}
+
+interface OldProjection<Model = unknown, K extends keyof Model = keyof Model> {
+  /** Include keys in response */
+  include?: K[];
+
+  /** Exclude keys from response */
+  exclude?: K[];
+}
+
 /**
  * @description
  * A partial body that can be used to include or exclude keys from an API
  * response.
  */
-export interface Projection<
-  Model = unknown,
-  K extends keyof Model = keyof Model,
-> {
-  /** Include keys in response */
-  include?: K[];
-  /** Exclude keys from response */
-  exclude?: K[];
-}
+export type Projection<Model = unknown> = XOR<
+  OldProjection<Model>,
+  NewProjection<Model>
+>;
 
 /**
  * Filter metadata from api response


### PR DESCRIPTION
# Add support for new projection fields

I'm going to wait for a review from @atruskie until I merge this PR so that I can be sure my understanding is correct.

## Changes

- The filter "projection" field can now take either a new projection object or an old projection object (XOR relationship).

## Issues

Fixes: #2525

## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
