### PR TITLE
Add loading state to annotation import

### DIFF
--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
@@ -12,8 +12,8 @@
         type="file"
         accept=".csv, .tsv, .selections.txt, .json"
         class="form-control border"
-        [ngClass]="{ 'is-invalid': !ngForm.valid }"
-        [disabled]="isUploading"
+        [class.is-invalid]="!ngForm.valid"
+        [disabled]="isUploading()"
         (change)="handleFileChange($event)"
         multiple
       />
@@ -66,7 +66,7 @@
                       inputPlaceholder="Add tags"
                       [searchCallback]="tagsApi.typeaheadCallback()"
                       [resultTemplate]="tagsTypeaheadTemplate"
-                      [inputDisabled]="isUploading"
+                      [inputDisabled]="isUploading()"
                       (modelChange)="
                         updateFileAdditionalTagIds(
                           fileModel,
@@ -80,7 +80,7 @@
                       class="file-provenance"
                       inputPlaceholder="Add provenance"
                       [searchCallback]="provenanceApi.typeaheadCallback()"
-                      [inputDisabled]="isUploading"
+                      [inputDisabled]="isUploading()"
                       [multipleInputs]="false"
                       (modelChange)="
                         updateFileProvenance(fileModel, $event?.[0]?.id)
@@ -138,14 +138,14 @@
     <!-- we use attr.ngbTooltip because we want to conditionally add a tooltip -->
     <span
       class="d-inline-block mt-2"
-      [ngbTooltip]="uploadTooltip"
-      [attr.ngbTooltip]="uploadTooltip !== null"
+      [ngbTooltip]="uploadTooltip()"
+      [attr.ngbTooltip]="uploadTooltip() !== null"
     >
       <button
         id="import-btn"
         type="submit"
         class="btn btn-primary"
-        [disabled]="!canCommitUploads"
+        [disabled]="!canCommitUploads()"
         (click)="commitImports()"
       >
         Import Annotations
@@ -170,8 +170,8 @@
 
   <div
     class="annotation-preview-table"
-    [class.preview-disabled]="isUploading"
-    [attr.inert]="isUploading ? 'true' : null"
+    [class.preview-disabled]="isUploading()"
+    [attr.inert]="isUploading() ? 'true' : null"
   >
     <ngx-datatable
       bawDatatableCompact

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.html
@@ -34,6 +34,13 @@
                     </button>
 
                     <span class="file-name">{{ fileModel.file.name }}</span>
+
+                    @if (fileModel.isUploading) {
+                      <baw-loading
+                        class="file-upload-spinner"
+                        [size]="'sm'"
+                      />
+                    }
                   </span>
 
                   <baw-error-card
@@ -161,7 +168,11 @@
     Annotations" button.
   </p>
 
-  <div>
+  <div
+    class="annotation-preview-table"
+    [class.preview-disabled]="isUploading"
+    [attr.inert]="isUploading ? 'true' : null"
+  >
     <ngx-datatable
       bawDatatableCompact
       [bawVirtualDatatablePagination]="getEventModels"

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.scss
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.scss
@@ -40,6 +40,7 @@
 
 .file-actions {
   display: flex;
+  align-items: center;
 
   .remove-file-btn {
     display: flex;
@@ -60,8 +61,22 @@
     // start overflowing content.
     overflow-wrap: break-word anywhere;
   }
+
+  .file-upload-spinner {
+    margin-left: 0.5rem;
+    display: inline-flex;
+  }
 }
 
 .event-errors {
   height: 100%;
+}
+
+.annotation-preview-table {
+  transition: opacity 0.2s ease-in-out;
+
+  &.preview-disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
 }

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.scss
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.scss
@@ -2,6 +2,10 @@
   &:not(:last-child) {
     margin-bottom: 0.5em;
   }
+
+  baw-typeahead-input {
+    margin-bottom: 0;
+  }
 }
 
 .file-list-item-content {
@@ -63,8 +67,8 @@
   }
 
   .file-upload-spinner {
+    display: inline;
     margin-left: 0.5rem;
-    display: inline-flex;
   }
 }
 
@@ -76,7 +80,8 @@
   transition: opacity 0.2s ease-in-out;
 
   &.preview-disabled {
-    opacity: 0.5;
+    opacity: 0.75;
     pointer-events: none;
+    cursor: wait;
   }
 }

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.ts
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.ts
@@ -111,7 +111,8 @@ interface QueuedFile {
   provenanceId: Id;
 
   /**
-   * Tracks whether the file is currently being uploaded or validated.
+   * Tracks whether the file is currently being uploaded to the server for
+   * a dry or wet run.
    */
   isUploading: boolean;
 }

--- a/src/app/components/shared/datatypes/number/number.component.html
+++ b/src/app/components/shared/datatypes/number/number.component.html
@@ -14,10 +14,9 @@
     </span>
   }
 } @else {
-  <!-- We don't use typeof value() here because null is an object  -->
   <span
     class="text-muted tooltip-hint"
-    [ngbTooltip]="`Expected a number type. Found '${value()}'.`"
+    [ngbTooltip]="'Expected a number type'"
   >
     {{ missingValueText() }}
   </span>

--- a/src/app/components/shared/datatypes/number/number.component.spec.ts
+++ b/src/app/components/shared/datatypes/number/number.component.spec.ts
@@ -53,7 +53,7 @@ describe("SafeNumberComponent", () => {
   });
 
   it("should have the correct tooltip for a null value", () => {
-    const expectedTooltip = "Expected a number type. Found 'null'.";
+    const expectedTooltip = "Expected a number type";
     setup(null);
 
     const tooltipHint = spec.query(".tooltip-hint")!;

--- a/src/app/components/shared/error-card/error-card.component.scss
+++ b/src/app/components/shared/error-card/error-card.component.scss
@@ -12,6 +12,7 @@
 
 .error-output {
   flex: 1 1;
+  align-content: center;
 
   &:not(:last-child) {
     margin-bottom: 1em;


### PR DESCRIPTION
# Add loading state to annotation import

## Changes

### Loading Spinner

Adds loading spinner to each file in the upload indicating if it is still uploading (at the moment each file shares the same uploading state) because each file is uploaded as one batch.

I made a spinner for each file because I remember talking about uploading large files individually because one of our stakeholders needed to upload multiple large files which did not work, so we had to upload each file individually.

In this case, I'm hoping that each file would progressively complete.

However, I haven't added this functionality in this PR, but I have made it compatible with future expansion.

### Disabled table

While uploading, the "Annotation Preview" table gets grayed out & disabled (`inert`).

### Misc

- Fixes vertical alignment issues in `baw-error-card` component
- Fixes vertical alignment issues with the `baw-typeahead-input` usage on the `/add_annotations` page
- Rewords the `baw-safe-number.component` when an `undefined` / missing value is encountered to now show "Expected a number type" instead of "Expected a number type. Found 'undefined'". Seeing `undefined`s is confusing because it simply means that the value didn't exist (e.g. due to an empty csv cell) so showing "Found 'undefined'" doesn't make much sense when there wasn't any undefined's in the original dataset

## Issues

Fixes: #2299

## Visual Changes

<img width="1364" height="934" alt="image" src="https://github.com/user-attachments/assets/f66c4e59-fd1d-462d-9fe8-fbc5d8ff5280" />

_New loading indicator + grayed out table_

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
