### PR TITLE
Fix flaky add-annotations tests

### DIFF
--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.spec.ts
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.spec.ts
@@ -35,7 +35,7 @@ import { ASSOCIATION_INJECTOR } from "@services/association-injector/association
 import { AudioRecordingsService } from "@baw-api/audio-recording/audio-recordings.service";
 import { AudioRecording } from "@models/AudioRecording";
 import { generateAudioRecording } from "@test/fakes/AudioRecording";
-import { fakeAsync } from "@angular/core/testing";
+import { fakeAsync, flush } from "@angular/core/testing";
 import { IconsModule } from "@shared/icons/icons.module";
 import { provideMockBawApi } from "@baw-api/provide-baw-ApiMock";
 import { Project } from "@models/Project";
@@ -106,6 +106,20 @@ describe("AddAnnotationsComponent", () => {
 
   function addFiles(files: File[]): void {
     inputFile(spec, fileInput(), files);
+
+    // We have to flush the async queue so that the associations inside of the
+    // preview table finish resolving.
+    flush();
+    spec.detectChanges();
+  }
+
+  function removeFile(index: number): void {
+    clickButton(spec, removeFileButtons()[index]);
+
+    // We have to flush the async queue so that the associations inside of the
+    // preview table finish resolving.
+    flush();
+    spec.detectChanges();
   }
 
   function addExtraTag(tag: string): void {
@@ -120,10 +134,6 @@ describe("AddAnnotationsComponent", () => {
 
   function commitImport(): void {
     clickButton(spec, importFilesButton());
-  }
-
-  function removeFile(index: number): void {
-    clickButton(spec, removeFileButtons()[index]);
   }
 
   function addTagToFile(index: number, tag: string): void {
@@ -229,16 +239,16 @@ describe("AddAnnotationsComponent", () => {
     "Add New Annotations",
   );
 
-  it("should create", () => {
+  it("should create", fakeAsync(() => {
     expect(spec.component).toBeInstanceOf(AddAnnotationsComponent);
-  });
+  }));
 
-  it("should disable the import button if no files are uploaded", () => {
+  it("should disable the import button if no files are uploaded", fakeAsync(() => {
     expect(importFilesButton()).toBeDisabled();
-  });
+  }));
 
   describe("file type correction", () => {
-    it("should not convert the type of a correct csv file", () => {
+    it("should not convert the type of a correct csv file", fakeAsync(() => {
       const testFile = modelData.file({ name: "test.csv", type: "text/csv" });
 
       addFiles([testFile]);
@@ -250,9 +260,9 @@ describe("AddAnnotationsComponent", () => {
         audioEventImport,
         null,
       );
-    });
+    }));
 
-    it("should correctly convert the type for a incorrectly typed csv", () => {
+    it("should correctly convert the type for a incorrectly typed csv", fakeAsync(() => {
       // There is a "feature" in Windows where the uploading a csv file through
       // the HTML file input will emit the type as "application/vnd.ms-excel"
       // this can cause server side issues where the server tries to parse the
@@ -274,9 +284,9 @@ describe("AddAnnotationsComponent", () => {
         audioEventImport,
         null,
       );
-    });
+    }));
 
-    it("should not change the type of an excel file", () => {
+    it("should not change the type of an excel file", fakeAsync(() => {
       const testFile = modelData.file({
         name: "test.xlsx",
         type: "application/vnd.ms-excel",
@@ -291,11 +301,11 @@ describe("AddAnnotationsComponent", () => {
         audioEventImport,
         null,
       );
-    });
+    }));
   });
 
   describe("removing files", () => {
-    it("should remove files from the file input if the remove button is clicked", () => {
+    it("should remove files from the file input if the remove button is clicked", fakeAsync(() => {
       addFiles([modelData.file(), modelData.file()]);
 
       removeFile(0);
@@ -303,9 +313,9 @@ describe("AddAnnotationsComponent", () => {
       const expectedFileCount = 1;
       expect(fileInput().files).toHaveLength(expectedFileCount);
       expect(fileListItems()).toHaveLength(expectedFileCount);
-    });
+    }));
 
-    it("should perform a dry run when a file is removed", () => {
+    it("should perform a dry run when a file is removed", fakeAsync(() => {
       const testedFiles = [modelData.file(), modelData.file()];
       addFiles(testedFiles);
 
@@ -313,9 +323,9 @@ describe("AddAnnotationsComponent", () => {
       removeFile(0);
 
       expect(fileImportSpy.dryCreate).toHaveBeenCalledTimes(1);
-    });
+    }));
 
-    it("should not perform a dry run if all files are removed", () => {
+    it("should not perform a dry run if all files are removed", fakeAsync(() => {
       addFiles([modelData.file()]);
 
       fileImportSpy.dryCreate.calls.reset();
@@ -328,12 +338,12 @@ describe("AddAnnotationsComponent", () => {
       expect(eventTableRows()).toHaveLength(0);
       expect(fileListItems()).toHaveLength(0);
       expect(fileInput().files).toHaveLength(0);
-    });
+    }));
 
     // Because all files are uploaded together, removing a file causes all of
     // the remaining files to be re-uploaded (dry run).
     // Therefore, we should see that the loading spinner is shown again.
-    it("should enter a loading state after removing a file", () => {
+    it("should enter a loading state after removing a file", fakeAsync(() => {
       addFiles([modelData.file(), modelData.file()]);
 
       // Delay the observable completing so that we can check the loading state
@@ -351,7 +361,7 @@ describe("AddAnnotationsComponent", () => {
       // After the observable completes emits a value for the dry run, we should
       // see that the loading spinner is removed.
       expect(fileListItems()[0]).not.toHaveDescendant("baw-loading");
-    });
+    }));
   });
 
   // the navigation warning depends on the UnsavedInputGuard
@@ -360,24 +370,27 @@ describe("AddAnnotationsComponent", () => {
   // the assertions to check that this guard works correctly can be found in
   // the UnsavedInputGuard spec file
   describe("navigation warning", () => {
-    it("should warn if the navigates without committing an uploaded file", () => {
+    it("should warn if the navigates without committing an uploaded file", fakeAsync(() => {
       addFiles([modelData.file()]);
 
       expect(spec.component.hasUnsavedChanges).toBeTrue();
-    });
+    }));
 
-    it("should not warn if the user has not staged files", () => {
+    // This test is run in a fake async zone (even though it doesn't need to be)
+    // so that this test is run in a similar environment to the other tests in
+    // this suite.
+    it("should not warn if the user has not staged files", fakeAsync(() => {
       expect(spec.component.hasUnsavedChanges).toBeFalse();
-    });
+    }));
 
-    it("should not warn if the user has committed their files", () => {
+    it("should not warn if the user has committed their files", fakeAsync(() => {
       addFiles([modelData.file()]);
       commitImport();
 
       expect(spec.component.hasUnsavedChanges).toBeFalse();
-    });
+    }));
 
-    it("should warn if the user fails to commit their files", () => {
+    it("should warn if the user fails to commit their files", fakeAsync(() => {
       addFiles([modelData.file()]);
 
       // We simulate the dry run succeeding, but the commit failing.
@@ -398,11 +411,11 @@ describe("AddAnnotationsComponent", () => {
       commitImport();
 
       expect(spec.component.hasUnsavedChanges).toBeTrue();
-    });
+    }));
   });
 
   describe("dry run", () => {
-    it("should dry run a single file correctly", () => {
+    it("should dry run a single file correctly", fakeAsync(() => {
       const file = modelData.file();
       addFiles([file]);
 
@@ -411,9 +424,9 @@ describe("AddAnnotationsComponent", () => {
         audioEventImport,
         null,
       );
-    });
+    }));
 
-    it("should dry run multiple files correctly", () => {
+    it("should dry run multiple files correctly", fakeAsync(() => {
       const testedFiles = [modelData.file(), modelData.file()];
       addFiles(testedFiles);
 
@@ -427,9 +440,9 @@ describe("AddAnnotationsComponent", () => {
           null,
         );
       });
-    });
+    }));
 
-    it("should update the identified event table when a dry run completes", () => {
+    it("should update the identified event table when a dry run completes", fakeAsync(() => {
       addFiles([modelData.file()]);
 
       const mockResponse = mockImportResponse as AudioEventImportFile;
@@ -455,7 +468,7 @@ describe("AddAnnotationsComponent", () => {
         const expectedRowValues = [
           `1:${i + 1}`,
           // event.audioRecordingId.toLocaleString(),
-          "",
+          mockRecordingsResponse.id.toString(),
           event.startTimeSeconds.toLocaleString(),
           event.endTimeSeconds.toLocaleString(),
           event.lowFrequencyHertz.toLocaleString(),
@@ -470,17 +483,17 @@ describe("AddAnnotationsComponent", () => {
 
         assertDatatableRow(row, expectedRowValues);
       });
-    });
+    }));
 
-    it("should enable the import button when a dry run completes", () => {
+    it("should enable the import button when a dry run completes", fakeAsync(() => {
       // because the default mock of the dry run api return an observable for a
       // valid dry run, we expect that the import button will be enabled
       // directly after adding files
       addFiles([modelData.file()]);
       expect(importFilesButton()).not.toBeDisabled();
-    });
+    }));
 
-    it("should disable the import button when performing a dry run", () => {
+    it("should disable the import button when performing a dry run", fakeAsync(() => {
       // we create an observable that never completes to simulate a dry run
       // that is still waiting for an api response
       fileImportSpy.dryCreate.and.callFake(() => new Observable());
@@ -488,9 +501,9 @@ describe("AddAnnotationsComponent", () => {
       addFiles([modelData.file()]);
 
       expect(importFilesButton()).toBeDisabled();
-    });
+    }));
 
-    it("should disable the import button if there are errors in the dry run", () => {
+    it("should disable the import button if there are errors in the dry run", fakeAsync(() => {
       mockImportResponse = new BawApiError(
         UNPROCESSABLE_ENTITY,
         "Unprocessable Content",
@@ -501,9 +514,9 @@ describe("AddAnnotationsComponent", () => {
       addFiles([modelData.file()]);
 
       expect(importFilesButton()).toBeDisabled();
-    });
+    }));
 
-    it("should remove the loading spinner when the dry run completes", () => {
+    it("should remove the loading spinner when the dry run completes", fakeAsync(() => {
       // We provide a observable that we manually trigger so that we can assert
       // that the loading spinner is correctly shown when a dry run is in
       // progress and that it is removed when the dry run errors.
@@ -520,7 +533,7 @@ describe("AddAnnotationsComponent", () => {
       // After we send the dry run response, we should see that the loading
       // spinner is removed.
       expect(fileListItems()[0]).not.toHaveDescendant("baw-loading");
-    });
+    }));
   });
 
   describe("additional tags", () => {
@@ -559,10 +572,10 @@ describe("AddAnnotationsComponent", () => {
         );
       }));
 
-      it("should start with no additional tags", () => {
+      it("should start with no additional tags", fakeAsync(() => {
         addFiles([modelData.file(), modelData.file()]);
         expect(fileAdditionalTags(0)).toHaveLength(0);
-      });
+      }));
 
       it("should enter a loading state when additional tags are added to a file", fakeAsync(() => {
         addFiles([modelData.file()]);
@@ -635,10 +648,10 @@ describe("AddAnnotationsComponent", () => {
         );
       }));
 
-      it("should start with no provenance", () => {
+      it("should start with no provenance", fakeAsync(() => {
         addFiles([modelData.file(), modelData.file()]);
         expect(fileProvenance(0)).toEqual("");
-      });
+      }));
 
       it("should enter a loading state when a provenance is added to a file", fakeAsync(() => {
         addFiles([modelData.file()]);
@@ -682,7 +695,7 @@ describe("AddAnnotationsComponent", () => {
   });
 
   describe("committing an annotation import", () => {
-    it("should commit a single file correctly", () => {
+    it("should commit a single file correctly", fakeAsync(() => {
       addFiles([modelData.file()]);
 
       // we want to test that the commit api has not been called until we click
@@ -695,9 +708,9 @@ describe("AddAnnotationsComponent", () => {
       //   jasmine.any(AudioEventImportFile),
       //   audioEventImport
       // );
-    });
+    }));
 
-    it("should commit multiple files correctly", () => {
+    it("should commit multiple files correctly", fakeAsync(() => {
       const testedFiles = [modelData.file(), modelData.file()];
       addFiles(testedFiles);
 
@@ -715,26 +728,26 @@ describe("AddAnnotationsComponent", () => {
           null,
         );
       });
-    });
+    }));
 
-    it("should navigate to the import details page when an import completes", () => {
+    it("should navigate to the import details page when an import completes", fakeAsync(() => {
       const expectedRoute = `/projects/${routeProject.id}/import_annotations/${audioEventImport.id}`;
 
       addFiles([modelData.file()]);
       commitImport();
 
       expect(routerSpy.navigateByUrl).toHaveBeenCalledWith(expectedRoute);
-    });
+    }));
 
-    it("should display a toast notification when an import completes", () => {
+    it("should display a toast notification when an import completes", fakeAsync(() => {
       addFiles([modelData.file()]);
       commitImport();
       expect(notificationsSpy.success).toHaveBeenCalledOnceWith(
         "Successfully imported annotations",
       );
-    });
+    }));
 
-    it("should enter a loading state when committing an import", () => {
+    it("should enter a loading state when committing an import", fakeAsync(() => {
       addFiles([modelData.file()]);
 
       const response = new Subject();
@@ -751,7 +764,7 @@ describe("AddAnnotationsComponent", () => {
 
       // after the create completes, the loading spinner should be removed
       expect(fileListItems()[0]).not.toHaveDescendant("baw-loading");
-    });
+    }));
   });
 
   describe("error handling", () => {
@@ -760,7 +773,7 @@ describe("AddAnnotationsComponent", () => {
     // However, because we support more descriptive error messages in the
     // identified events table, we do not want to raise an error notification
     // if a dry run fails, and instead show the errors in the table.
-    it("should not raise error notifications if a dry run fails", () => {
+    it("should not raise error notifications if a dry run fails", fakeAsync(() => {
       mockImportResponse = new BawApiError(
         UNPROCESSABLE_ENTITY,
         "Unprocessable Content",
@@ -775,14 +788,14 @@ describe("AddAnnotationsComponent", () => {
 
       expect(notificationsSpy.error).not.toHaveBeenCalledTimes(1);
       expect(notificationsSpy.error).not.toHaveBeenCalled();
-    });
+    }));
 
     // We have error alerts for files because sometimes the server will fail
     // a dry run for reasons other than contents of the file.
     // e.g. an unsupported file type
     // In these cases, we want to show the error next to the file in the form
     // of an error alert.
-    it("should show a single error alert if single file import fails", () => {
+    it("should show a single error alert if single file import fails", fakeAsync(() => {
       const mockErrorMessage =
         "is not unique. Duplicate recording found with id: 191";
       mockImportResponse = new BawApiError(
@@ -798,9 +811,9 @@ describe("AddAnnotationsComponent", () => {
       expect(fileAlerts()).toHaveLength(1);
 
       expect(fileAlerts()[0]).toHaveExactTrimmedText(mockErrorMessage);
-    });
+    }));
 
-    it("should show multiple error alerts if multiple file import fails", () => {
+    it("should show multiple error alerts if multiple file import fails", fakeAsync(() => {
       const mockErrorMessage = "validation failed";
       mockImportResponse = new BawApiError(
         UNPROCESSABLE_ENTITY,
@@ -824,9 +837,9 @@ describe("AddAnnotationsComponent", () => {
       for (const fileAlert of fileAlerts()) {
         expect(fileAlert).toHaveExactTrimmedText(mockErrorMessage);
       }
-    });
+    }));
 
-    it("should show type errors if a field has an incorrect data type", () => {
+    it("should show type errors if a field has an incorrect data type", fakeAsync(() => {
       const testEvent: IImportedAudioEvent = generateImportedAudioEvent({
         // We use "as any" here to bypass type checking because we want to
         // test invalid types being sent to the client from the server.
@@ -854,7 +867,7 @@ describe("AddAnnotationsComponent", () => {
       const row = eventTableRows()[0];
       assertDatatableRow(row, [
         "1:1",
-        "",
+        mockRecordingsResponse.id.toString(),
         testEvent.startTimeSeconds.toLocaleString(),
         testEvent.endTimeSeconds.toLocaleString(),
         testEvent.lowFrequencyHertz.toLocaleString(),
@@ -866,9 +879,9 @@ describe("AddAnnotationsComponent", () => {
         mockProvenanceResponse[0].toString(),
         "channel: Channel must be a number",
       ]);
-    });
+    }));
 
-    it("should transition out of an uploading state if the dry run fails", () => {
+    it("should transition out of an uploading state if the dry run fails", fakeAsync(() => {
       // We provide a observable that we manually trigger so that we can assert
       // that the loading spinner is correctly shown when a dry run is in
       // progress and that it is removed when the dry run errors.
@@ -892,7 +905,7 @@ describe("AddAnnotationsComponent", () => {
       // After we send the error response, we should see that the loading
       // spinner is removed.
       expect(fileListItems()[0]).not.toHaveDescendant("baw-loading");
-    });
+    }));
   });
 
   describe("identified events table", () => {

--- a/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.spec.ts
+++ b/src/app/components/import-annotations/pages/add-annotations/add-annotations.component.spec.ts
@@ -125,11 +125,13 @@ describe("AddAnnotationsComponent", () => {
   function addExtraTag(tag: string): void {
     const target = extraTagsTypeahead();
     selectFromTypeahead(spec, target, tag);
+    spec.detectChanges();
   }
 
   function addExtraProvenance(tag: string): void {
     const target = extraProvenanceTypeahead();
     selectFromTypeahead(spec, target, tag);
+    spec.detectChanges();
   }
 
   function commitImport(): void {
@@ -839,12 +841,13 @@ describe("AddAnnotationsComponent", () => {
       }
     }));
 
-    it("should show type errors if a field has an incorrect data type", fakeAsync(() => {
+    fit("should show type errors if a field has an incorrect data type", fakeAsync(() => {
       const testEvent: IImportedAudioEvent = generateImportedAudioEvent({
         // We use "as any" here to bypass type checking because we want to
         // test invalid types being sent to the client from the server.
         channel: "this is a string" as any,
         errors: [{ channel: ["Channel must be a number"] }],
+        tags: modelData.randomArray(1, 3, () => new Tag(generateTag())),
       });
 
       const testFile = new AudioEventImportFile(


### PR DESCRIPTION
# Fix flaky add-annotations tests

I found a flaky tests that was caused by not correctly awaiting association resolution.

Associations are resolved in async, but because these tests were not run in a fakeAsync zone, there was no guarantee that the promises would resolve before the assertion, meaning that sometimes the associations would (rarely) not resolve, meaning that the "annotation preview" table was partially incomplete, causing the test to fail.

## Changes

- Flush the microtask queue when uploading/removing files in the add-anntoations test to force resolve all associations
- Always populate `ImportedAudioEvent.tags` for tests that expect the `ImportedAudioEvents` model to have tags

## Issues

Related to: #2495

## Final Checklist

- [ ] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
