### PR TITLE
Defer event card spectrograms until in viewport

### DIFF
--- a/src/app/components/annotations/pages/search/search.component.spec.ts
+++ b/src/app/components/annotations/pages/search/search.component.spec.ts
@@ -15,7 +15,6 @@ import { generateProject } from "@test/fakes/Project";
 import { generateRegion } from "@test/fakes/Region";
 import { generateSite } from "@test/fakes/Site";
 import { fakeAsync } from "@angular/core/testing";
-import { SpectrogramComponent } from "@ecoacoustics/web-components/@types/components/spectrogram/spectrogram";
 import { clickButton, getElementByTextContent } from "@test/helpers/html";
 import { Filters, Meta } from "@baw-api/baw-api.service";
 import { ShallowAudioEventsService } from "@baw-api/audio-event/audio-events.service";
@@ -43,6 +42,7 @@ import { AnnotationSearchParameters } from "@components/annotations/components/a
 import { VerificationParameters, VerificationStatusKey } from "@components/annotations/components/verification-form/verificationParameters";
 import { generateMeta } from "@test/fakes/Meta";
 import { BawSessionService } from "@baw-api/baw-session.service";
+import { AnnotationEventCardComponent } from "@shared/audio-event-card/annotation-event-card.component";
 import { AnnotationSearchComponent } from "./search.component";
 
 describe("AnnotationSearchComponent", () => {
@@ -66,7 +66,7 @@ describe("AnnotationSearchComponent", () => {
 
   const createComponent = createRoutingFactory({
     component: AnnotationSearchComponent,
-    imports: [IconsModule, AnnotationSearchFormComponent],
+    imports: [IconsModule, AnnotationSearchFormComponent, AnnotationEventCardComponent],
     providers: [
       provideMockBawApi(),
       mockProvider(AnnotationService, {
@@ -159,8 +159,8 @@ describe("AnnotationSearchComponent", () => {
   }
 
   const verifyButton = () => spec.query<HTMLButtonElement>(".verify-button");
-  const spectrogramElements = () =>
-    spec.queryAll<SpectrogramComponent>("oe-spectrogram");
+  const eventCards = () =>
+    spec.queryAll(AnnotationEventCardComponent);
 
   function clickVerificationStatusFilter(value: VerificationStatusKey) {
     const target = document.querySelector(`[aria-valuetext="${value}"]`);
@@ -334,15 +334,14 @@ describe("AnnotationSearchComponent", () => {
     it("should display a page of search results", () => {
       spec.detectChanges();
 
-      const expectedResults = mockAudioEventsResponse.length;
-      const realizedResults = spectrogramElements().length;
-      expect(realizedResults).toEqual(expectedResults);
+      const expectedCount = mockAudioEventsResponse.length;
+      expect(eventCards()).toHaveLength(expectedCount);
     });
 
     it("should re-use the event cards when search results are updated", () => {
       spec.detectChanges();
 
-      const initialSpectrogram = spectrogramElements()[0];
+      const initialCard = eventCards()[0];
 
       // We override the returned audio events to make this test harder to pass
       // because we can't track by anything on the audio event since it would
@@ -367,12 +366,12 @@ describe("AnnotationSearchComponent", () => {
       clickVerificationStatusFilter("unverified-for-me");
       spec.detectChanges();
 
-      const updatedSpectrogram = spectrogramElements()[0];
+      const updatedCard = eventCards()[0];
 
       // We use a toBe comparison here so that we compare the spectrogram
       // elements by reference instead of by value.
       // If the reference is the same, then we know the elements were reused.
-      expect(updatedSpectrogram).toBe(initialSpectrogram);
+      expect(updatedCard).toBe(initialCard);
     });
 
     xit("should have a disabled 'verify' button if there are no search results", () => {

--- a/src/app/components/shared/audio-event-card/annotation-event-card.component.html
+++ b/src/app/components/shared/audio-event-card/annotation-event-card.component.html
@@ -1,22 +1,26 @@
 <div class="card-container card p-2">
   <div class="spectrogram-container">
-    <!--
-      Use the same spectrogram settings that the baw-server uses for spectrograms
-      so that there is consistency across the website.
-      see: QutEcoacoustics/baw-server > config/settings/default.yml#L243-L244
-    -->
-    <oe-axes class="axes">
-      <oe-indicator>
-        <oe-spectrogram
-          #spectrogram
-          [src]="annotation().audioLink"
-          scaling="stretch"
-          color-map="grayscale"
-          window-size="512"
-          window-function="hamming"
-        ></oe-spectrogram>
-      </oe-indicator>
-    </oe-axes>
+    @defer (on viewport) {
+      <!--
+        Use the same spectrogram settings that the baw-server uses for spectrograms
+        so that there is consistency across the website.
+        see: QutEcoacoustics/baw-server > config/settings/default.yml#L243-L244
+      -->
+      <oe-axes class="axes">
+        <oe-indicator>
+          <oe-spectrogram
+            #spectrogram
+            [src]="annotation().audioLink"
+            scaling="stretch"
+            color-map="grayscale"
+            window-size="512"
+            window-function="hamming"
+          ></oe-spectrogram>
+        </oe-indicator>
+      </oe-axes>
+    } @placeholder {
+      <div class="spectrogram-placeholder"></div>
+    }
   </div>
 
   <div class="card-header">
@@ -64,14 +68,17 @@
           <span
             class="no-score-placeholder tooltip-hint"
             [ngbTooltip]="'This event does not have a score assigned'"
-          >No score available</span>
+            >No score available</span
+          >
         }
       </span>
     </span>
 
     <span class="info-line">
       <fa-icon class="me-2" [icon]="['fas', 'circle-info']"></fa-icon>
-      <a class="more-information-link" [bawUrl]="annotation().viewUrl">More information</a>
+      <a class="more-information-link" [bawUrl]="annotation().viewUrl"
+        >More information</a
+      >
     </span>
   </div>
 </div>

--- a/src/app/components/shared/audio-event-card/annotation-event-card.component.html
+++ b/src/app/components/shared/audio-event-card/annotation-event-card.component.html
@@ -15,7 +15,7 @@
             color-map="grayscale"
             window-size="512"
             window-function="hamming"
-          ></oe-spectrogram>
+          />
         </oe-indicator>
       </oe-axes>
     } @placeholder {
@@ -24,43 +24,43 @@
   </div>
 
   <div class="card-header">
-    <oe-media-controls #mediaControls></oe-media-controls>
+    <oe-media-controls #mediaControls />
   </div>
 
   <div class="card-body">
     <span class="info-line tag-information">
-      <fa-icon class="me-2" [icon]="['fas', 'tags']"></fa-icon>
+      <fa-icon class="me-2" [icon]="['fas', 'tags']" />
 
       <baw-inline-list
         [items]="annotation().tags"
         [itemKey]="'text'"
         [emptyTemplate]="noTagsTemplate"
-      ></baw-inline-list>
+      />
     </span>
 
     <span class="info-line">
-      <fa-icon class="me-2" [icon]="['fas', 'location-dot']"></fa-icon>
+      <fa-icon class="me-2" [icon]="['fas', 'location-dot']" />
 
       @let siteModel = annotation().audioRecording.site;
       @if (siteModel | isUnresolved) {
-        <baw-loading class="inline-spinner" size="sm"></baw-loading>
+        <baw-loading class="inline-spinner" size="sm" />
       } @else {
         <a [bawUrl]="siteModel.viewUrl">{{ siteModel.name }}</a>
       }
     </span>
 
     <span class="info-line">
-      <fa-icon class="me-2" [icon]="['fas', 'record-vinyl']"></fa-icon>
+      <fa-icon class="me-2" [icon]="['fas', 'record-vinyl']" />
       <a [bawUrl]="annotation().listenViewUrl">
         <baw-zoned-datetime
           [value]="annotation().audioRecording.recordedDate"
           [timezone]="annotation().audioRecording.recordedDateTimezone"
-        ></baw-zoned-datetime>
+        />
       </a>
     </span>
 
     <span class="info-line">
-      <fa-icon class="me-2" [icon]="['fas', 'chart-simple']"></fa-icon>
+      <fa-icon class="me-2" [icon]="['fas', 'chart-simple']" />
       <span class="tag-score">
         @if (annotation().score | isInstantiated) {
           {{ annotation().score | number }}
@@ -75,7 +75,7 @@
     </span>
 
     <span class="info-line">
-      <fa-icon class="me-2" [icon]="['fas', 'circle-info']"></fa-icon>
+      <fa-icon class="me-2" [icon]="['fas', 'circle-info']" />
       <a class="more-information-link" [bawUrl]="annotation().viewUrl"
         >More information</a
       >

--- a/src/app/components/shared/audio-event-card/annotation-event-card.component.scss
+++ b/src/app/components/shared/audio-event-card/annotation-event-card.component.scss
@@ -60,6 +60,16 @@
 
 .spectrogram-placeholder {
   display: block;
+
+  // Our spectrograms have a minimum height of 180px, so I therefore set the
+  // placeholder to be 180px high too.
+  // I do this to prevent layout shift and to prevent the scroll bar from
+  // growing / shrinking depending on if the spectrogram has been created yet.
+  //
+  // E.g. If we did not include a minimum height on the spectrogram placeholder,
+  // the scroll bar would grow as the user scrolled down on the annotation
+  // search page because each card component would grow the size of the page as
+  // they entered the viewport.
   min-height: 180px;
 }
 

--- a/src/app/components/shared/audio-event-card/annotation-event-card.component.scss
+++ b/src/app/components/shared/audio-event-card/annotation-event-card.component.scss
@@ -58,6 +58,11 @@
   min-height: 0;
 }
 
+.spectrogram-placeholder {
+  display: block;
+  min-height: 180px;
+}
+
 .card-container {
   display: flex block;
   flex-direction: column;

--- a/src/app/components/shared/audio-event-card/annotation-event-card.component.spec.ts
+++ b/src/app/components/shared/audio-event-card/annotation-event-card.component.spec.ts
@@ -19,7 +19,6 @@ import { of } from "rxjs";
 import { ShallowSitesService } from "@baw-api/site/sites.service";
 import { Site } from "@models/Site";
 import { generateSite } from "@test/fakes/Site";
-import { SpectrogramComponent } from "@ecoacoustics/web-components/@types/components/spectrogram/spectrogram";
 import { Annotation } from "@models/data/Annotation";
 import { generateAnnotation } from "@test/fakes/data/Annotation";
 import { MediaService } from "@services/media/media.service";
@@ -94,8 +93,8 @@ describe("AnnotationEventCardComponent", () => {
     spectator.setInput("annotation", mockAnnotation);
   }
 
-  const spectrogram = () =>
-    spectator.query<SpectrogramComponent>("oe-spectrogram");
+  // const spectrogram = () =>
+  //   spectator.query<SpectrogramComponent>("oe-spectrogram");
   const listenLink = () =>
     spectator.query<HTMLAnchorElement>(".more-information-link");
   const tagInfoElement = () => spectator.query(".tag-information");
@@ -111,11 +110,22 @@ describe("AnnotationEventCardComponent", () => {
     expect(spectator.component).toBeInstanceOf(AnnotationEventCardComponent);
   });
 
-  it("should have the correct spectrogram source", () => {
-    const expectedSource = mockAnnotation.audioLink;
-    const realizedSource = spectrogram().src;
-    expect(realizedSource).toEqual(expectedSource);
-  });
+  // TODO: We cannot test defer blocks until ng-mocks supports them.
+  // At the moment, they will fail when any ng-mock components are present
+  // inside any of the tests.
+  // This means that if you just run this test file alone, this test will appear
+  // to work, but as soon as you add any other tests that use ng-mocks, this
+  // test will begin to fail.
+  // see: https://github.com/help-me-mom/ng-mocks/issues/7742
+  //
+  // xit("should have the correct spectrogram source", async () => {
+  //   const deferBlock = (await spectator.fixture.getDeferBlocks())[0];
+  //   await deferBlock.render(DeferBlockState.Complete);
+  //
+  //   const expectedSource = mockAnnotation.audioLink;
+  //   const realizedSource = spectrogram().src;
+  //   expect(realizedSource).toEqual(expectedSource);
+  // });
 
   it("should have the correct link to the listen page", () => {
     const expectedHref = mockAnnotation.viewUrl;

--- a/src/app/components/shared/audio-event-card/annotation-event-card.component.ts
+++ b/src/app/components/shared/audio-event-card/annotation-event-card.component.ts
@@ -58,8 +58,8 @@ export class AnnotationEventCardComponent {
       const spectrogramElement = this.spectrogram();
       const mediaControlsElement = this.mediaControls();
 
-      if (spectrogramEl && mediaControlsEl) {
-        mediaControlsEl.nativeElement.for = spectrogramEl.nativeElement;
+      if (spectrogramElement && mediaControlsElement) {
+        mediaControlsElement.nativeElement.for = spectrogramElement.nativeElement;
       }
     });
   }

--- a/src/app/components/shared/audio-event-card/annotation-event-card.component.ts
+++ b/src/app/components/shared/audio-event-card/annotation-event-card.component.ts
@@ -1,7 +1,7 @@
 import {
-  AfterViewInit,
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
+  effect,
   ElementRef,
   input,
   viewChild,
@@ -38,7 +38,7 @@ import { IsUnresolvedPipe } from "../../../pipes/is-unresolved/is-unresolved.pip
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
-export class AnnotationEventCardComponent implements AfterViewInit {
+export class AnnotationEventCardComponent {
   public readonly annotation = input.required<Annotation>();
 
   // Note that there is no { static: true } option for viewChild signals.
@@ -50,9 +50,17 @@ export class AnnotationEventCardComponent implements AfterViewInit {
   private readonly spectrogram =
     viewChild<ElementRef<SpectrogramComponent>>("spectrogram");
 
-  public ngAfterViewInit(): void {
-    setTimeout(() => {
-      this.mediaControls().nativeElement.for = this.spectrogram().nativeElement;
-    }, 0);
+  public constructor() {
+    // Use effect() to link media controls to the spectrogram when it becomes
+    // available. This is necessary because the spectrogram is inside a @defer
+    // block and won't exist until the element enters the viewport.
+    effect(() => {
+      const spectrogramElement = this.spectrogram();
+      const mediaControlsElement = this.mediaControls();
+
+      if (spectrogramEl && mediaControlsEl) {
+        mediaControlsEl.nativeElement.for = spectrogramEl.nativeElement;
+      }
+    });
   }
 }


### PR DESCRIPTION
# Defer event card spectrograms until in viewport

## Changes

- Adds `@defer (on viewport)` to event card spectrograms
	- Effects the annotation search page & the event map so that the spectrograms are only created when they reach the viewport

## Issues

Fixes: #2538

## Visual Changes



## Final Checklist

- [x] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
