### PR TITLE
Bump web components to version 6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/platform-server": "19.2.5",
         "@angular/router": "19.2.5",
         "@angular/ssr": "19.2.19",
-        "@ecoacoustics/web-components": "^6.0.5",
+        "@ecoacoustics/web-components": "^6.1.0",
         "@fortawesome/angular-fontawesome": "^1.0.0",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
@@ -3566,9 +3566,9 @@
       }
     },
     "node_modules/@ecoacoustics/web-components": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@ecoacoustics/web-components/-/web-components-6.0.5.tgz",
-      "integrity": "sha512-+7yRmuOQVwrIarTn53zMW4OSDiwz6KDqR3kfP1Ki3VODp08Hn5nbzoS8b7V2p78ugRO+fwMdLKZLyjkAO7zlfQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@ecoacoustics/web-components/-/web-components-6.1.0.tgz",
+      "integrity": "sha512-2cWh5b8W6InY+QnoOEhxoM9ceOoTj8Cwgogey7S+w9Rc1cOEtiIOCc9dsGbeKRfxuLg5I2IFIq7455dM4fg6bw==",
       "dependencies": {
         "@json2csv/plainjs": "7.0.6",
         "@lit-labs/preact-signals": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@angular/platform-server": "19.2.5",
     "@angular/router": "19.2.5",
     "@angular/ssr": "19.2.19",
-    "@ecoacoustics/web-components": "^6.0.5",
+    "@ecoacoustics/web-components": "^6.1.0",
     "@fortawesome/angular-fontawesome": "^1.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",


### PR DESCRIPTION
# Bump web components to version 6.1.0

This adds support for entering a loading state when an API response takes a long time to populate the verification grids subjects.

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
