### PR TITLE
Fix verification grid preview spectrogram height

### DIFF
--- a/src/app/components/web-components/grid-tile-content/grid-tile-content.component.scss
+++ b/src/app/components/web-components/grid-tile-content/grid-tile-content.component.scss
@@ -7,10 +7,6 @@
   height: 100%;
 }
 
-oe-spectrogram {
-  height: 317px;
-}
-
 .content-wrapper {
   display: flex;
   justify-content: space-between;
@@ -67,4 +63,6 @@ oe-spectrogram {
 .context-card-elements {
   display: flex;
   flex-direction: column;
+
+  height: 317px;
 }


### PR DESCRIPTION
# Fix verification grid preview spectrogram height

## Changes

- Sets `height` on preview containers height (instead of spectrogram)

## Issues

Fixes: #2553

## Visual Changes

<img width="1917" height="966" alt="image" src="https://github.com/user-attachments/assets/7d7e0eec-9be6-4089-b6db-84ff5bd5a67a" />

## Final Checklist

- [ ] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [x] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
