### PR TITLE
Fix parsing undefined verificationSummary's

### DIFF
--- a/src/app/models/AudioEvent.ts
+++ b/src/app/models/AudioEvent.ts
@@ -143,38 +143,38 @@ export class AudioEvent
     // array.
     //
     // see: https://github.com/QutEcoacoustics/baw-server/issues/869
-    if (this.verificationSummary === null) {
+    if (!this.verificationSummary) {
       this.verificationSummary = [];
-    } else {
-      // Tags that do not have any verifications do not show up in the
-      // verification summary returned by the server.
-      // This means that you can have a partially complete verification summary
-      // if some tags have verifications and others do not.
-      // Therefore, we need to fill in any missing tags with an empty "default"
-      // verification summary with all zero counts.
-      //
-      // see: https://github.com/QutEcoacoustics/baw-server/issues/869
-      const tagIds = this.tagIds ?? [];
-      for (const tagId of tagIds) {
-        const hasSummary = this.verificationSummary.some(
-          (summary) => summary.tagId === tagId,
-        );
+    }
 
-        if (hasSummary) {
-          continue;
-        }
+    // Tags that do not have any verifications do not show up in the
+    // verification summary returned by the server.
+    // This means that you can have a partially complete verification summary
+    // if some tags have verifications and others do not.
+    // Therefore, we need to fill in any missing tags with an empty "default"
+    // verification summary with all zero counts.
+    //
+    // see: https://github.com/QutEcoacoustics/baw-server/issues/869
+    const tagIds = this.tagIds ?? [];
+    for (const tagId of tagIds) {
+      const hasSummary = this.verificationSummary.some(
+        (summary) => summary.tagId === tagId,
+      );
 
-        const defaultSummary = new VerificationSummary({
-          tagId,
-          count: 0,
-          correct: 0,
-          incorrect: 0,
-          unsure: 0,
-          skip: 0,
-        });
-
-        this.verificationSummary.push(defaultSummary);
+      if (hasSummary) {
+        continue;
       }
+
+      const defaultSummary = new VerificationSummary({
+        tagId,
+        count: 0,
+        correct: 0,
+        incorrect: 0,
+        unsure: 0,
+        skip: 0,
+      });
+
+      this.verificationSummary.push(defaultSummary);
     }
   }
 


### PR DESCRIPTION
# Fix parsing undefined verificationSummary's

If the verification was `undefined` instead of explicitly set to `null` the AudioEvent model would fail to create

## Changes

- Fix `cannot read some of undefined` error on annotation search page

## Visual Changes

<img width="1221" height="862" alt="image" src="https://github.com/user-attachments/assets/d39db3cb-2e00-4621-b443-beca0d92e797" />

_Ecosounds "Eavesdropping on Wetland Birds" project which previously failed to load_

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
