### PR TITLE
Bump web components to version 6.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/platform-server": "19.2.5",
         "@angular/router": "19.2.5",
         "@angular/ssr": "19.2.19",
-        "@ecoacoustics/web-components": "^6.1.0",
+        "@ecoacoustics/web-components": "^6.1.1",
         "@fortawesome/angular-fontawesome": "^1.0.0",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
@@ -3568,9 +3568,9 @@
       }
     },
     "node_modules/@ecoacoustics/web-components": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@ecoacoustics/web-components/-/web-components-6.1.0.tgz",
-      "integrity": "sha512-2cWh5b8W6InY+QnoOEhxoM9ceOoTj8Cwgogey7S+w9Rc1cOEtiIOCc9dsGbeKRfxuLg5I2IFIq7455dM4fg6bw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@ecoacoustics/web-components/-/web-components-6.1.1.tgz",
+      "integrity": "sha512-+Va89Yo33IwRtqOnNTt9uExLlkKgyAWuTdG4bAaaqAOtqjC4rh3Vgbn0lXJCYx3N5TIXClOsa1om0qTGPtQHBw==",
       "dependencies": {
         "@json2csv/plainjs": "7.0.6",
         "@lit-labs/preact-signals": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@angular/platform-server": "19.2.5",
     "@angular/router": "19.2.5",
     "@angular/ssr": "19.2.19",
-    "@ecoacoustics/web-components": "^6.1.0",
+    "@ecoacoustics/web-components": "^6.1.1",
     "@fortawesome/angular-fontawesome": "^1.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",


### PR DESCRIPTION
# Bump web components to version 6.1.1

This version has some performance improvements for the media controls, meaning that the annotation search page & verification grid are now much faster to load.

## Changes

- Web components: `oe-media-controls` sub-menus now conditionally render, meaning that we avoid a lot of reflow on creation

## Final Checklist

- [ ] Assign reviewers if you have permission
- [x] Assign labels if you have permission
- [ ] Link issues related to PR
- [x] Ensure project linter is not producing any warnings (`npm run lint`)
- [x] Ensure build is passing on all browsers (`npm run test:all`)
- [x] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
