### PR TITLE
Omit model filters from date/time filter component

### DIFF
--- a/src/app/components/audio-recordings/pages/download/download.component.html
+++ b/src/app/components/audio-recordings/pages/download/download.component.html
@@ -51,12 +51,7 @@
   </div>
 }
 
-<baw-date-time-filter
-  [project]="project"
-  [region]="region"
-  [site]="site"
-  [constructedFilters]="filters$"
-></baw-date-time-filter>
+<baw-date-time-filter [constructedFilters]="filters$"></baw-date-time-filter>
 
 <div class="clearfix">
   <a
@@ -164,7 +159,7 @@
       <i><a [strongRoute]="loginStrongRoute">Log in</a> to see this command.</i>
     </div>
   }
-  
+
   @if (session.authToken) {
     <baw-hidden-copy
       tooltip="Show/Hide command"

--- a/src/app/components/audio-recordings/pages/download/download.component.ts
+++ b/src/app/components/audio-recordings/pages/download/download.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild } from "@angular/core";
-import { NgForm, FormsModule } from "@angular/forms";
+import { FormsModule, NgForm } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
 import { AudioRecordingsService } from "@baw-api/audio-recording/audio-recordings.service";
 import { Filters } from "@baw-api/baw-api.service";
@@ -14,6 +14,8 @@ import {
   audioRecordingsCategory,
 } from "@components/audio-recordings/audio-recording.menus";
 import { myAccountMenuItem } from "@components/profile/profile.menus";
+import { StrongRouteDirective } from "@directives/strongRoute/strong-route.directive";
+import { filterModel } from "@helpers/filters/filters";
 import { PageComponent } from "@helpers/page/pageComponent";
 import { IPageInfo } from "@helpers/page/pageInfo";
 import { StrongRoute } from "@interfaces/strongRoute";
@@ -25,12 +27,11 @@ import { Project } from "@models/Project";
 import { Region } from "@models/Region";
 import { Site } from "@models/Site";
 import { NgbDate } from "@ng-bootstrap/ng-bootstrap";
+import { DateTimeFilterComponent } from "@shared/date-time-filter/date-time-filter.component";
+import { HiddenCopyComponent } from "@shared/hidden-copy/hidden-copy.component";
 import { List } from "immutable";
 import { BehaviorSubject, takeUntil } from "rxjs";
 import { loginMenuItem } from "src/app/components/security/security.menus";
-import { DateTimeFilterComponent } from "@shared/date-time-filter/date-time-filter.component";
-import { StrongRouteDirective } from "@directives/strongRoute/strong-route.directive";
-import { HiddenCopyComponent } from "@shared/hidden-copy/hidden-copy.component";
 import { DownloadTableComponent } from "../../components/download-table/download-table.component";
 import { SitesWithoutTimezonesComponent } from "../../components/sites-without-timezones/sites-without-timezones.component";
 
@@ -76,6 +77,17 @@ class DownloadAudioRecordingsComponent extends PageComponent implements OnInit {
 
   public ngOnInit(): void {
     this.models = retrieveResolvers(this.route.snapshot.data);
+
+    const filters: Filters<AudioRecording> = {};
+    if (this.site) {
+      filters.filter = filterModel<Site, AudioRecording>("sites", this.site, filters.filter);
+    } else if (this.region) {
+      filters.filter = filterModel<Region, AudioRecording>("regions", this.region, filters.filter);
+    } else if (this.project) {
+      filters.filter = filterModel<Project, AudioRecording>("projects", this.project, filters.filter);
+    }
+
+    this.filters$.next(filters);
 
     this.filters$
       .pipe(takeUntil(this.unsubscribe))

--- a/src/app/components/audio-recordings/pages/download/download.component.ts
+++ b/src/app/components/audio-recordings/pages/download/download.component.ts
@@ -78,16 +78,16 @@ class DownloadAudioRecordingsComponent extends PageComponent implements OnInit {
   public ngOnInit(): void {
     this.models = retrieveResolvers(this.route.snapshot.data);
 
-    const filters: Filters<AudioRecording> = {};
+    const initialFilters: Filters<AudioRecording> = {};
     if (this.site) {
-      filters.filter = filterModel<Site, AudioRecording>("sites", this.site, filters.filter);
+      initialFilters.filter = filterModel<Site, AudioRecording>("sites", this.site, initialFilters.filter);
     } else if (this.region) {
-      filters.filter = filterModel<Region, AudioRecording>("regions", this.region, filters.filter);
+      initialFilters.filter = filterModel<Region, AudioRecording>("regions", this.region, initialFilters.filter);
     } else if (this.project) {
-      filters.filter = filterModel<Project, AudioRecording>("projects", this.project, filters.filter);
+      initialFilters.filter = filterModel<Project, AudioRecording>("projects", this.project, initialFilters.filter);
     }
 
-    this.filters$.next(filters);
+    this.filters$.next(initialFilters);
 
     this.filters$
       .pipe(takeUntil(this.unsubscribe))

--- a/src/app/components/audio-recordings/pages/list/list.component.html
+++ b/src/app/components/audio-recordings/pages/list/list.component.html
@@ -6,12 +6,7 @@
     <strong>all {{ totalModels }}</strong> audio recordings.
   </p>
 
-  <baw-date-time-filter
-    [project]="project"
-    [region]="region"
-    [site]="site"
-    [constructedFilters]="filters$"
-  />
+  <baw-date-time-filter [constructedFilters]="filters$" />
 
   <ngx-datatable
     #table

--- a/src/app/components/shared/date-time-filter/date-time-filter.component.ts
+++ b/src/app/components/shared/date-time-filter/date-time-filter.component.ts
@@ -10,7 +10,6 @@ import {
 import { NgForm, FormsModule } from "@angular/forms";
 import { Filters, InnerFilter } from "@baw-api/baw-api.service";
 import { filterDate, filterTime } from "@helpers/filters/audioRecordingFilters";
-import { filterModel } from "@helpers/filters/filters";
 import { withUnsubscribe } from "@helpers/unsubscribe/unsubscribe";
 import { AudioRecording } from "@models/AudioRecording";
 import { Project } from "@models/Project";
@@ -60,9 +59,6 @@ export class DateTimeFilterComponent
   implements AfterViewInit
 {
   @ViewChild(NgForm) public form: NgForm;
-  @Input() public project: Project;
-  @Input() public region: Region;
-  @Input() public site: Site;
   @Input() public constructedFilters: BehaviorSubject<Filters<AudioRecording>>;
 
   @Input() public disableStartDate = false;
@@ -107,7 +103,6 @@ export class DateTimeFilterComponent
   private generateFilters(previousFilters: FromJS<Filters<AudioRecording>>, model: DateTimeFilterModel): [boolean, Filters] {
     let newInnerFilters: InnerFilter<AudioRecording> = {};
 
-    newInnerFilters = this.setModelFilters(newInnerFilters);
     newInnerFilters = this.setDateFilters(model, newInnerFilters);
     newInnerFilters = this.setTimeOfDayFilters(model, newInnerFilters);
 
@@ -120,18 +115,6 @@ export class DateTimeFilterComponent
     const changed = !fromJS(newFilters)?.equals(previousFilters) && newFilters !== previousFilters;
 
     return [changed, newFilters];
-  }
-
-  private setModelFilters(filters: InnerFilter<AudioRecording>): InnerFilter<AudioRecording> {
-    if (this.site) {
-      filters = filterModel<Site, AudioRecording>("sites", this.site, filters);
-    } else if (this.region) {
-      filters = filterModel<Region, AudioRecording>("regions", this.region, filters);
-    } else if (this.project) {
-      filters = filterModel<Project, AudioRecording>("projects", this.project, filters);
-    }
-
-    return filters;
   }
 
   private setDateFilters(model: DateTimeFilterModel, filters: InnerFilter<AudioRecording>): InnerFilter<AudioRecording> {

--- a/src/app/directives/datatable/pagination/pagination.directive.spec.ts
+++ b/src/app/directives/datatable/pagination/pagination.directive.spec.ts
@@ -7,8 +7,7 @@ import {
   DatatableComponent,
   DataTableHeaderCellComponent,
   DataTablePagerComponent,
-  NgxDatatableModule,
-  SortDirection,
+  NgxDatatableModule
 } from "@swimlane/ngx-datatable";
 import { modelData } from "@test/helpers/faker";
 import { BehaviorSubject, delay, Observable, of } from "rxjs";
@@ -275,10 +274,7 @@ describe("DatatablePaginationDirective", () => {
   });
 
   describe("sorting", () => {
-    function assertSort(
-      sortKey: string,
-      direction: Direction = SortDirection.asc,
-    ): void {
+    function assertSort(sortKey: string, direction: Direction = "asc") {
       expect(spec.directive["pageAndSort$"].getValue().sort).toEqual({
         direction,
         orderBy: sortKey as keyof MockModel,

--- a/src/app/directives/datatable/pagination/pagination.directive.spec.ts
+++ b/src/app/directives/datatable/pagination/pagination.directive.spec.ts
@@ -8,11 +8,12 @@ import {
   DataTableHeaderCellComponent,
   DataTablePagerComponent,
   NgxDatatableModule,
+  SortDirection,
 } from "@swimlane/ngx-datatable";
 import { modelData } from "@test/helpers/faker";
 import { BehaviorSubject, delay, Observable, of } from "rxjs";
-import { DatatableSortKeyDirective } from "../sort-key/sort-key.directive";
 import { DatatableDefaultsDirective } from "../defaults/defaults.directive";
+import { DatatableSortKeyDirective } from "../sort-key/sort-key.directive";
 import { DatatablePaginationDirective } from "./pagination.directive";
 
 describe("DatatablePaginationDirective", () => {
@@ -274,7 +275,10 @@ describe("DatatablePaginationDirective", () => {
   });
 
   describe("sorting", () => {
-    function assertSort(sortKey: string, direction: Direction = "asc") {
+    function assertSort(
+      sortKey: string,
+      direction: Direction = SortDirection.asc,
+    ): void {
       expect(spec.directive["pageAndSort$"].getValue().sort).toEqual({
         direction,
         orderBy: sortKey as keyof MockModel,

--- a/src/app/directives/datatable/pagination/pagination.directive.ts
+++ b/src/app/directives/datatable/pagination/pagination.directive.ts
@@ -152,7 +152,7 @@ export class DatatablePaginationDirective<Model extends AbstractModel>
 
       // Otherwise, use the sort from the filter observable as the default
       this.datatable.sorts = [
-        { prop: filters.sorting.orderBy, dir: filters.sorting.direction },
+        { prop: filters.sorting.orderBy as any, dir: filters.sorting.direction },
       ];
       this.pageAndSort$.next({ page: pageAndSort.page, sort: filters.sorting });
     });

--- a/src/app/directives/datatable/pagination/pagination.directive.ts
+++ b/src/app/directives/datatable/pagination/pagination.directive.ts
@@ -152,7 +152,7 @@ export class DatatablePaginationDirective<Model extends AbstractModel>
 
       // Otherwise, use the sort from the filter observable as the default
       this.datatable.sorts = [
-        { prop: filters.sorting.orderBy as any, dir: filters.sorting.direction },
+        { prop: filters.sorting.orderBy, dir: filters.sorting.direction },
       ];
       this.pageAndSort$.next({ page: pageAndSort.page, sort: filters.sorting });
     });

--- a/src/app/helpers/tableTemplate/pagedTableTemplate.spec.ts
+++ b/src/app/helpers/tableTemplate/pagedTableTemplate.spec.ts
@@ -2,9 +2,9 @@ import { Component } from "@angular/core";
 import { fakeAsync } from "@angular/core/testing";
 import { ActivatedRoute } from "@angular/router";
 import { defaultApiPageSize } from "@baw-api/baw-api.service";
-import { provideMockBawApi } from "@baw-api/provide-baw-ApiMock";
 import { MockModel } from "@baw-api/mock/baseApiMock.service";
 import { ProjectsService } from "@baw-api/project/projects.service";
+import { provideMockBawApi } from "@baw-api/provide-baw-ApiMock";
 import { Errorable } from "@helpers/advancedTypes";
 import {
   BawApiError,
@@ -227,7 +227,10 @@ describe("PagedTableTemplate", () => {
         limit: 25,
         pageSize: defaultApiPageSize,
       });
-      expect(api.filter).toHaveBeenCalledWith({ paging: { page: 1 } });
+
+      // If we make an initial call to offset 0, no paging parameter should be
+      // sent because it is the default value, and we can therefore omit it.
+      expect(api.filter).toHaveBeenCalledWith({ });
     });
 
     it("should handle 1 offset", async () => {

--- a/src/app/helpers/tableTemplate/pagedTableTemplate.ts
+++ b/src/app/helpers/tableTemplate/pagedTableTemplate.ts
@@ -62,7 +62,7 @@ export abstract class PagedTableTemplate<TableRow, M extends AbstractModel>
   public models: ResolvedModelList = {};
   public pageNumber: number = 0;
   public filterEvent$ = new Subject<string>();
-  protected filters: Filters<M>;
+  protected filters: Filters<M> = {};
 
   public constructor(
     protected api: ApiFilter<any, any>,
@@ -72,8 +72,6 @@ export abstract class PagedTableTemplate<TableRow, M extends AbstractModel>
     private preselectRows: (rows: TableRow[]) => void = () => {}
   ) {
     super();
-    this.pageNumber = 0;
-    this.filters = {};
 
     this.filterEvent$
       .pipe(

--- a/src/app/helpers/tableTemplate/pagedTableTemplate.ts
+++ b/src/app/helpers/tableTemplate/pagedTableTemplate.ts
@@ -60,7 +60,7 @@ export abstract class PagedTableTemplate<TableRow, M extends AbstractModel>
   public failure: boolean;
   public loadingData: boolean;
   public models: ResolvedModelList = {};
-  public pageNumber: number;
+  public pageNumber: number = 0;
   public filterEvent$ = new Subject<string>();
   protected filters: Filters<M>;
 
@@ -104,6 +104,10 @@ export abstract class PagedTableTemplate<TableRow, M extends AbstractModel>
   }
 
   public setPage(pageInfo: TablePage) {
+    if (pageInfo.offset === this.pageNumber) {
+      return;
+    }
+
     this.pageNumber = pageInfo.offset;
     this.filters.paging = {
       page: pageInfo.offset + 1,


### PR DESCRIPTION
# Omit model filters from date/time filters

These changes were originally a part of the ng20 update.

Some of our tests started failing because the ngb-datatable was emitting multiple updates on load. I used the audio recording list page as a development page, and fixed what I thought was the issue.

However, it turns out that this is a different issue that also exists in the current production version.

Therefore, I've broken these changes out into their own PR to help maintain a clean version history.

The audio recording list page is currently making a lot of duplicate requests, however, this addresses some of the duplicate requests while keeping the scope small.

## Changes

- `baw-date-time-filter` component no longer adds model (project, region, site) filters
- Do not emit filter request if `pagedTableTemplate` `setPage` is updated to the same page

## Issues

Fixes: #2573

## Final Checklist

- [ ] Assign reviewers if you have permission
- [ ] Assign labels if you have permission
- [ ] Link issues related to PR
- [ ] Ensure project linter is not producing any warnings (`npm run lint`)
- [ ] Ensure build is passing on all browsers (`npm run test:all`)
- [ ] Ensure CI build is passing
- [ ] Ensure docker container is passing ([docs](https://github.com/QutEcoacoustics/workbench-client#docker))
