### PR TITLE
chore: take ng-http-caching 22.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "just-camel-case": "^6.0.1",
         "just-snake-case": "^3.0.1",
         "luxon": "^3.4.4",
-        "ng-http-caching": "^20.0.1",
+        "ng-http-caching": "^22.2.0",
         "ngx-captcha": "^14.0.0",
         "ngx-clipboard": "^16.0.0",
         "ngx-cookie-service": "^20.1.0",
@@ -17889,16 +17889,22 @@
       "license": "MIT"
     },
     "node_modules/ng-http-caching": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/ng-http-caching/-/ng-http-caching-20.0.1.tgz",
-      "integrity": "sha512-a1DsC9KQKYHZqlEwGFFe5ToBeuD3X6/1JlLftLGwPgmEHfcuMhPuCwFg9xUf72RQXJ6Zt0ZXCQ9Mvy5UC//prQ==",
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/ng-http-caching/-/ng-http-caching-22.2.0.tgz",
+      "integrity": "sha512-ByXCSeud5iA0XzxXhrl3AWczWxTsoT/0X8hAA8X8ANJqSEU7HqTbKMgLOHBoOzTCFqDI7DWMRFqSqBvQ7Sj1Lg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "@angular/common": ">15.0.0",
-        "@angular/core": ">15.0.0"
+        "@angular/core": ">15.0.0",
+        "ng-simple-state": ">=21.1.4"
+      },
+      "peerDependenciesMeta": {
+        "ng-simple-state": {
+          "optional": true
+        }
       }
     },
     "node_modules/ng-mocks": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "just-camel-case": "^6.0.1",
     "just-snake-case": "^3.0.1",
     "luxon": "^3.4.4",
-    "ng-http-caching": "^20.0.1",
+    "ng-http-caching": "^22.2.0",
     "ngx-captcha": "^14.0.0",
     "ngx-clipboard": "^16.0.0",
     "ngx-cookie-service": "^20.1.0",

--- a/src/app/services/cache/ngHttpCachingConfig.ts
+++ b/src/app/services/cache/ngHttpCachingConfig.ts
@@ -55,19 +55,17 @@ export const defaultCachingConfig = {
   //   by the user. E.g. paging through a list of items
   // see: https://github.com/QutEcoacoustics/workbench-client/pull/2171#issuecomment-2484676601
   //
-  // I have temporarily set the cache lifetime to 0 seconds because the
-  // @bawReadonlyConvertCase decorator attempts to modify frozen cached objects
-  // when recalling items from the cache
-  // this causes an an error similar to "status is read-only"
-  // by setting the cache lifetime to 0 seconds, we can get the performance
-  // gains of request debouncing without having potential errors due to items
-  // being recalled from the cache
-  //
-  // in the future we should use a 10 second cache lifetime in the hope that
-  // users doing any quick succession actions, they'll see a benefit from the
-  // cache e.g. flicking through a page of results
+  // we use a 10 second cache lifetime in the hope that users doing any quick
+  // succession actions, they'll see a benefit from the cache e.g. flicking
+  // through a page of results
   // while users who perform actions on a page are likely to take longer than 10
   // seconds, which will hopefully prevent stale caching issues
+  //
+  // note: up to ng-http-caching 21 a cached response was frozen as a whole, the
+  // HttpResponse and its HttpHeaders included, so reading one back could throw
+  // an error similar to "status is read-only"
+  // since version 22.2.0 only the body is frozen, and a `responseSerializer`
+  // can be set here if we ever need to modify a cached body in place
   lifetime: secondsToMilliseconds(10),
 
   // by setting the workbench clients version as the cache version,


### PR DESCRIPTION
Hi, I am the author of ng-http-caching. Every now and then I look at the projects that depend on my libraries, to see how they are used, and this is how I found this one.

The comment in `ngHttpCachingConfig.ts` about `@bawReadonlyConvertCase` getting a "status is read-only" error on cached objects was my fault: up to version 21 the library froze the whole cached response, the `HttpResponse` and its `HttpHeaders` included, so `status`, `ok` and `url` became read only, and even reading a header from a cached response could throw. Version 22 freezes only the body, and 22.2.0 adds a `responseSerializer` option that gives every cache hit its own copy of the body, if you ever need to modify one in place.

## Changes

- bump `ng-http-caching` from 20.0.1 to 22.2.0
- the same comment said the lifetime was "temporarily set to 0 seconds", but it is 10 seconds since #2171, so I rewrote it

## Problems

The 22.x public API is a superset of the 20.x one, and the new `clearCacheOnMutation` option defaults to no invalidation, so the behaviour should not change. I could not run `npm run test:all` here, so please let the CI check it.

Not fixed here: `buildCachingOptions` spreads the whole config into `withNgHttpCachingContext`, but the context only honours `getKey`, `isCacheable`, `isExpired`, `isValid`, `clearCacheOnMutation` and `responseSerializer`. So a per request `cacheOptions: { lifetime: ... }` is ignored today.

## Issues

None open for this. Tell me if you want me to create one.
